### PR TITLE
feat(mypage): tweak mypage template

### DIFF
--- a/templates/accounts/mypage.html
+++ b/templates/accounts/mypage.html
@@ -9,12 +9,12 @@
   </ul>
 
   <!-- ログアウトは POST 必須（Django 5 仕様） -->
-  <form action="{% url 'logout' %}" method="post">
+  <form action="{% url 'logout' %}" method="post" style="display:inline;">
     {% csrf_token %}
-    <button type="submit">ログアウト</button>
+    <button type="submit" style="background:none;border:none;color:#1a73e8;cursor:pointer;">ログアウト</button>
   </form>
 
-  
+
   <h3 style="margin-top:16px;">お気に入り神社</h3>
   {% if favorite_shrines %}
     <div class="grid">


### PR DESCRIPTION
目的
- マイページのUI/導線を微調整して可読性と操作性を向上

変更点
- templates/accounts/mypage.html のレイアウト/文言を調整
- （ログアウト導線は POST フォームを維持）

確認
- ログイン後 /mypage が 200 で表示
- ログアウト POST → 302 → / へ遷移
- 未ログインで /accounts/mypage/ アクセス時は /accounts/login/?next=… へリダイレクト

影響範囲
- テンプレートのみ（バックエンドロジック変更なし）
