### PR TITLE
chore: ignore __pycache__, pyc, venv, .env, db.sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ __pycache__/
 .env
 .DS_Store
 NUL
+__pycache__/
+*.py[cod]
+.venv/
+.env
+db.sqlite3


### PR DESCRIPTION
目的
- ビルド生成物/秘匿ファイルの誤コミット防止

変更点
- .gitignore に以下を追加
  - __pycache__/
  - *.py[cod]
  - .venv/
  - .env
  - db.sqlite3

影響範囲
- 追跡対象のみ（アプリ挙動への影響なし）
