### PR TITLE
ci: run Django tests on push/PR via GitHub Actions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,0 +1,24 @@
+name: Django CI
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    branches: [ develop, main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run Django tests
+        env:
+          DJANGO_SETTINGS_MODULE: jinja_project.settings
+        run: python manage.py test -v 2


### PR DESCRIPTION
目的
- push / PR をトリガに CI 上で Django テストを自動実行し、回帰を防止

内容
- .github/workflows/django.yml を追加
  - ubuntu-latest で Python 3.11 をセットアップ
  - requirements.txt をインストール
  - python manage.py test -v 2 を実行

想定結果
- develop / main への push / PR で Actions が走り、合否が見える化される
- 失敗したPRを早期に検知できる（任意でブランチ保護の必須チェックにも設定可）

影響範囲
- CI のみ。アプリ挙動への影響なし
