### PR TITLE
ci: speed up by enabling pip cache

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'                  # ← これが内蔵キャッシュ
+          cache-dependency-path: 'requirements.txt'
       - name: Install deps
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
目的
- CIの依存インストールを高速化し、PRのフィードバックを短縮

変更点
- .github/workflows/django.yml
  - actions/setup-python@v5 に cache: 'pip' を設定
  - cache-dependency-path: requirements.txt を指定

期待効果
- 2回目以降のCIで pip キャッシュがヒットし、Install deps の時間短縮

影響範囲
- CIのみ（アプリの挙動変更なし）
