### PR TITLE
ci: add workflow-level concurrency (cancel in-progress)

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ develop, main ]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -24,3 +28,4 @@ jobs:
         env:
           DJANGO_SETTINGS_MODULE: jinja_project.settings
         run: python manage.py test -v 2
+  


### PR DESCRIPTION
同じブランチ/PRでコミットを連投した際、古いCI実行を自動キャンセルして最新だけを残す