### PR TITLE
chore(deps): add whitenoise for static files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv==1.1.1
 sqlparse==0.5.3
 tzdata==2025.2
 whitenoise==6.9.0
+whitenoise==6.9.0


### PR DESCRIPTION
目的
- settings 側で設定済みの WhiteNoise に対応し、静的ファイル配信を安定化するための依存を追加。

変更点
- requirements.txt: whitenoise==6.9.0 を追加

確認方法
1) 依存インストール
   pip install -r requirements.txt
2) 収集
   python manage.py collectstatic --noinput
3) 動作
   python manage.py runserver
   - /static/admin/css/base.css が 200
   - 画面（/、/accounts/login、/shrines）が表示される

影響
- アプリ機能への影響なし（コード変更なし）
- 本番では collectstatic の実行が前提

ロールアウト
- develop へマージ後、通常のデプロイフローで反映
