### PR TITLE
feat: タグ選択をボタン押下で確定する検索UIに変更

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -74,12 +74,12 @@ export default function HomePage() {
     fetchTags()
   }, [])
 
-  // タグ選択が変わったら検索実行
-  useEffect(() => {
-    if (selectedTags.length > 0) {
-      fetchShrines({ tags: selectedTags })
-    }
-  }, [selectedTags])
+  //  ボタン押下で検索を確定
+const handleSearch = () => {
+  fetchShrines({ name: query, tags: selectedTags })
+}
+
+
 
   return (
     <main className="p-4">
@@ -95,12 +95,18 @@ export default function HomePage() {
           className="border rounded p-2 flex-1"
         />
         <button
-          onClick={() => fetchShrines({ name: query })}
+          onClick={handleSearch}
           className="bg-blue-500 text-white px-4 py-2 rounded"
         >
           検索
         </button>
       </div>
+
+
+      
+
+
+
 
       {/* ご利益タグ検索 */}
       <div className="flex flex-wrap gap-2 mb-4">


### PR DESCRIPTION
## 概要
- 神社検索UIを改善し、タグ選択時に即検索されないよう変更
- 名前入力・タグ選択を組み合わせ、検索ボタン押下でのみ検索確定する仕様に統一
- `useEffect([selectedTags])` を削除し、`handleSearch` にロジックを集約

## 動作確認
- タグを選択しても検索が走らず、状態だけ更新される
- 名前だけ／タグだけ／名前＋タグで検索できる
- エラーハンドリングは従来通り動作
