### PR TITLE
feat(frontend): add shrines, favorites, visits API with axios client

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.3",
+        "axios": "^1.11.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.541.0",
@@ -2170,6 +2171,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2194,6 +2201,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2260,7 +2278,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2416,6 +2433,18 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2567,6 +2596,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
@@ -2594,7 +2632,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2699,7 +2736,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2709,7 +2745,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2747,7 +2782,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2760,7 +2794,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3367,6 +3400,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3383,11 +3436,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3428,7 +3496,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3453,7 +3520,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3541,7 +3607,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3620,7 +3685,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3633,7 +3697,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3649,7 +3712,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4572,7 +4634,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4600,6 +4661,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5102,6 +5184,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",
+    "axios": "^1.11.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.541.0",

--- a/frontend/src/app/ranking/page.tsx
+++ b/frontend/src/app/ranking/page.tsx
@@ -1,39 +1,32 @@
-"use client"
-import { useEffect, useState } from "react"
-import Link from "next/link"
-import { getRanking, RankingItem } from "@/lib/api/ranking"
+"use client";
+import { useEffect, useState } from "react";
+import { getRanking, RankingItem } from "@/lib/api/ranking";
+import ShrineCard from "@/components/ShrineCard";
 
 export default function RankingPage() {
-  const [ranking, setRanking] = useState<RankingItem[]>([])
-  const [error, setError] = useState<string | null>(null)
+  const [ranking, setRanking] = useState<RankingItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    getRanking()
+    getRanking() // 年間ランキングを取得（MVPはこれだけ）
       .then(setRanking)
-      .catch(() => setError("ランキングの取得に失敗しました"))
-  }, [])
+      .catch(() => setError("ランキングの取得に失敗しました"));
+  }, []);
 
   return (
     <main className="p-4">
-      <h1 className="text-xl font-bold mb-4">人気神社ランキング</h1>
+      <h1 className="text-xl font-bold mb-4">年間人気神社ランキング</h1>
 
       {error && <p className="text-red-500">{error}</p>}
 
-      <ol className="space-y-2">
-        {ranking.map((item, index) => (
-          <li key={item.id} className="border p-3 rounded">
-            <span className="mr-2 font-bold">{index + 1}位</span>
-            <Link
-              href={`/shrines/${item.id}`}
-              className="text-blue-600 hover:underline"
-            >
-              {item.name_jp}
-            </Link>
-            <p className="text-sm text-gray-500">{item.address}</p>
-            <p className="text-sm">スコア: {item.score}</p>
+      <ol className="space-y-4">
+        {ranking.map((shrine, idx) => (
+          <li key={shrine.id} className="flex items-start gap-2">
+            <span className="text-xl font-bold w-6">{idx + 1}</span>
+            <ShrineCard shrine={shrine} />
           </li>
         ))}
       </ol>
     </main>
-  )
+  );
 }

--- a/frontend/src/app/shrines/page.tsx
+++ b/frontend/src/app/shrines/page.tsx
@@ -1,0 +1,4 @@
+<li key={shrine.id}>
+  <h2>{shrine.name_jp}</h2>
+  <p>{shrine.address}</p>
+</li>

--- a/frontend/src/components/ShrineCard.tsx
+++ b/frontend/src/components/ShrineCard.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+
+type Shrine = {
+  id: number;
+  name_jp: string;
+  address: string;
+  goriyaku?: string; // ご利益
+};
+
+export default function ShrineCard({ shrine }: { shrine: Shrine }) {
+  return (
+    <Card className="hover:shadow-md transition">
+      <CardHeader>
+        <CardTitle>
+          <Link
+            href={`/shrines/${shrine.id}`}
+            className="text-blue-600 hover:underline"
+          >
+            {shrine.name_jp}
+          </Link>
+        </CardTitle>
+        <CardDescription>{shrine.address}</CardDescription>
+      </CardHeader>
+      {shrine.goriyaku && (
+        <CardContent>
+          <p className="text-sm">ご利益: {shrine.goriyaku}</p>
+        </CardContent>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,14 +1,18 @@
-// src/lib/api/client.ts
-export async function apiFetch<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}${url}`, {
-    headers: { "Content-Type": "application/json" },
-    ...options,
-  })
+import axios from "axios";
 
-  if (!res.ok) {
-    const errorText = await res.text()
-    throw new Error(`API Error: ${res.status} ${errorText}`)
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000/api",
+  timeout: 5000,
+  headers: { "Content-Type": "application/json" },
+});
+
+// 必要ならトークンを自動で付与
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
   }
+  return config;
+});
 
-  return res.json()
-}
+export default api;

--- a/frontend/src/lib/api/favorites.ts
+++ b/frontend/src/lib/api/favorites.ts
@@ -1,0 +1,20 @@
+import api from "./client";
+import { Shrine } from "./shrines";
+
+// お気に入り一覧
+export async function getFavorites(): Promise<Shrine[]> {
+  const res = await api.get("/favorites/");
+  return res.data;
+}
+
+// お気に入り追加
+export async function addFavorite(shrineId: number) {
+  const res = await api.post("/favorites/", { shrine: shrineId });
+  return res.data;
+}
+
+// お気に入り削除
+export async function removeFavorite(shrineId: number) {
+  const res = await api.delete(`/favorites/${shrineId}/`);
+  return res.data;
+}

--- a/frontend/src/lib/api/ranking.ts
+++ b/frontend/src/lib/api/ranking.ts
@@ -1,15 +1,20 @@
-// frontend/lib/api/ranking.ts
+import api from "./client";
+
 export type RankingItem = {
-  id: number
-  name_jp: string
-  address: string
-  score: number
+  id: number;
+  name_jp: string;
+  address: string;
+  score: number;
+};
+
+// 年間/月間を選べるAPI（拡張用）
+export async function fetchRanking(type: "monthly" | "yearly") {
+  const res = await api.get(`/ranking/${type}/`);
+  return res.data;
 }
 
+// 年間ランキング固定（MVP用）
 export async function getRanking(): Promise<RankingItem[]> {
-  const res = await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/api/ranking/`)
-  if (!res.ok) {
-    throw new Error("ランキングデータ取得に失敗しました")
-  }
-  return res.json()
+  const res = await api.get("/ranking/");
+  return res.data;
 }

--- a/frontend/src/lib/api/shrines.ts
+++ b/frontend/src/lib/api/shrines.ts
@@ -1,36 +1,23 @@
-// src/lib/api/shrines.ts
-import { apiFetch } from "./client"
+import api from "./client";
 
-// 共通のタグ型
-export type GoriyakuTag = { id: number; name: string }
-
-// 一覧用（軽量）
-export type ShrineListItem = {
-  id: number
-  name_jp: string
-  address: string
-  score?: number  // ランキング用（任意）
-}
-
-// 詳細用（フルデータ）
-export type ShrineDetail = {
-  id: number
-  name_jp: string
-  name_romaji?: string
-  address: string
-  latitude: number
-  longitude: number
-  goriyaku?: string
-  sajin?: string
-  goriyaku_tags: GoriyakuTag[]
-}
+export type Shrine = {
+  id: number;
+  name_jp: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  goriyaku?: string;
+  sajin?: string;
+};
 
 // 一覧取得
-export async function fetchShrines(): Promise<ShrineListItem[]> {
-  return apiFetch<ShrineListItem[]>("/api/shrines/")
+export async function getShrines(): Promise<Shrine[]> {
+  const res = await api.get("/shrines/");
+  return res.data;
 }
 
 // 詳細取得
-export async function getShrineDetail(id: number): Promise<ShrineDetail> {
-  return apiFetch<ShrineDetail>(`/api/shrines/${id}/`)
+export async function getShrine(id: number): Promise<Shrine> {
+  const res = await api.get(`/shrines/${id}/`);
+  return res.data;
 }

--- a/frontend/src/lib/api/visits.ts
+++ b/frontend/src/lib/api/visits.ts
@@ -1,0 +1,20 @@
+import api from "./client";
+import { Shrine } from "./shrines";
+
+export type Visit = {
+  id: number;
+  shrine: Shrine;
+  visited_at: string;
+};
+
+// 参拝チェックイン
+export async function addVisit(shrineId: number) {
+  const res = await api.post(`/shrines/${shrineId}/visit/`);
+  return res.data;
+}
+
+// 参拝履歴一覧
+export async function getVisits(): Promise<Visit[]> {
+  const res = await api.get("/visits/");
+  return res.data;
+}


### PR DESCRIPTION
- 共通 axios クライアントを利用して shrines, favorites, visits API を新規追加
- ranking API を axios に統一済み
- 今後のフロントエンドの API 通信を axios に統一
