### PR TITLE
feat(frontend): connect shrine list page with API and display ShrineCard

### DIFF
--- a/frontend/src/app/shrines/page.tsx
+++ b/frontend/src/app/shrines/page.tsx
@@ -1,4 +1,36 @@
-<li key={shrine.id}>
-  <h2>{shrine.name_jp}</h2>
-  <p>{shrine.address}</p>
-</li>
+"use client";
+import { useEffect, useState } from "react";
+import { getShrines, Shrine } from "@/lib/api/shrines";
+import ShrineCard from "@/components/ShrineCard";
+
+export default function ShrinesPage() {
+  const [shrines, setShrines] = useState<Shrine[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+
+  useEffect(() => {
+    getShrines()
+      .then(setShrines)
+      .catch(() => setError("神社データの取得に失敗しました"));
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <p className="p-4">読み込み中...</p>;
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="text-xl font-bold mb-4">神社一覧</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <ul className="grid gap-4">
+        {shrines.map((shrine) => (
+          <li key={shrine.id}>
+            <ShrineCard shrine={shrine} />
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/src/components/ShrineCard.tsx
+++ b/frontend/src/components/ShrineCard.tsx
@@ -7,12 +7,7 @@ import {
   CardContent,
 } from "@/components/ui/card";
 
-type Shrine = {
-  id: number;
-  name_jp: string;
-  address: string;
-  goriyaku?: string; // ご利益
-};
+import { Shrine } from "@/lib/api/shrines";
 
 export default function ShrineCard({ shrine }: { shrine: Shrine }) {
   return (


### PR DESCRIPTION
- /shrines ページを API と接続
- getShrines() で取得したデータを ShrineCard で表示
- 読み込み中・エラー時のメッセージを追加
