### PR TITLE
feat: add ranking API with visit_count, favorite_count and goriyaku_tags

### DIFF
--- a/backend/logs/django.log
+++ b/backend/logs/django.log
@@ -1504,3 +1504,14 @@ django.core.exceptions.FieldError: Cannot resolve keyword 'visit' into field. Ch
 Watching for file changes with StatReloader
 /app/temples/api/views/ranking.py changed, reloading.
 Watching for file changes with StatReloader
+/app/temples/api/serializers.py changed, reloading.
+Watching for file changes with StatReloader
+/app/temples/api/serializers.py changed, reloading.
+Watching for file changes with StatReloader
+Watching for file changes with StatReloader
+/app/temples/api/serializers.py changed, reloading.
+Watching for file changes with StatReloader
+/app/temples/api/serializers.py changed, reloading.
+Watching for file changes with StatReloader
+Watching for file changes with StatReloader
+Watching for file changes with StatReloader

--- a/backend/temples/api/serializers.py
+++ b/backend/temples/api/serializers.py
@@ -10,9 +10,21 @@ class GoriyakuTagSerializer(serializers.ModelSerializer):
 
 # 一覧用（軽量）
 class ShrineListSerializer(serializers.ModelSerializer):
+    goriyaku_tags = GoriyakuTagSerializer(many=True, read_only=True)
+    
     class Meta:
         model = Shrine
-        fields = ["id", "name_jp", "address"]
+        fields = [
+            "id",
+            "name_jp",
+            "address",
+            "latitude",
+            "longitude",
+            "goriyaku",
+            "sajin",
+            "description",
+            "goriyaku_tags",
+        ]
 
 
 # 詳細用（リッチ）

--- a/frontend/src/app/shrines/page.tsx
+++ b/frontend/src/app/shrines/page.tsx
@@ -34,3 +34,5 @@ export default function ShrinesPage() {
     </main>
   );
 }
+
+これが今の既存のこーど

--- a/frontend/src/components/ShrineCard.tsx
+++ b/frontend/src/components/ShrineCard.tsx
@@ -23,9 +23,29 @@ export default function ShrineCard({ shrine }: { shrine: Shrine }) {
         </CardTitle>
         <CardDescription>{shrine.address}</CardDescription>
       </CardHeader>
+      
+
+      {/* ご利益メモ */}
       {shrine.goriyaku && (
         <CardContent>
           <p className="text-sm">ご利益: {shrine.goriyaku}</p>
+        </CardContent>
+      )}
+
+      {/* ご利益タグ */}
+      {shrine.goriyaku_tags && shrine.goriyaku_tags.length > 0 && (
+        <CardContent>
+          <p className="text-sm text-gray-700">
+            タグ:{" "}
+            {shrine.goriyaku_tags.map((tag) => (
+              <span
+                key={tag.id}
+                className="inline-block bg-gray-200 rounded px-2 py-0.5 text-xs mr-1"
+              >
+                {tag.name}
+              </span>
+            ))}
+          </p>
         </CardContent>
       )}
     </Card>

--- a/frontend/src/lib/api/shrines.ts
+++ b/frontend/src/lib/api/shrines.ts
@@ -13,7 +13,7 @@ export type Shrine = {
   element?: string;
   created_at: string;
   updated_at: string;
-  goriyaku_tags: { id: number; name: string }[];
+  goriyaku_tags?: { id: number; name: string }[];
 };
 
 // 一覧取得


### PR DESCRIPTION
visit_count, favorite_count を集計してスコア化。goriyaku_tags もレスポンスに含めました。

この後、ふろんとのランキング一覧ページに接続します