### PR TITLE
feat: 神社新規登録フォームの最小実装を追加

### DIFF
--- a/frontend/src/app/shrines/new/page.tsx
+++ b/frontend/src/app/shrines/new/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { createShrine } from "@/lib/api/shrines";
+
+export default function NewShrinePage() {
+  const router = useRouter();
+  const [form, setForm] = useState({
+    name_jp: "",
+    address: "",
+    latitude: 0,
+    longitude: 0,
+    goriyaku: "",
+    sajin: "",
+  });
+  const [error, setError] = useState("");
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      const shrine = await createShrine(form);
+      router.push(`/shrines/${shrine.id}`);
+    } catch (err) {
+      setError("登録に失敗しました。入力内容を確認してください。");
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-xl font-bold mb-4">神社新規登録</h1>
+      {error && <p className="text-red-500">{error}</p>}
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input name="name_jp" placeholder="神社名" onChange={handleChange} className="border p-2 w-full" />
+        <input name="address" placeholder="住所" onChange={handleChange} className="border p-2 w-full" />
+        <input name="latitude" placeholder="緯度" type="number" onChange={handleChange} className="border p-2 w-full" />
+        <input name="longitude" placeholder="経度" type="number" onChange={handleChange} className="border p-2 w-full" />
+        <input name="goriyaku" placeholder="ご利益" onChange={handleChange} className="border p-2 w-full" />
+        <input name="sajin" placeholder="祭神" onChange={handleChange} className="border p-2 w-full" />
+        <button type="submit" className="bg-blue-500 text-white p-2 w-full rounded">登録する</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/shrines.ts
+++ b/frontend/src/lib/api/shrines.ts
@@ -30,3 +30,15 @@ export async function getShrine(id: number): Promise<Shrine> {
   const res = await api.get(`/shrines/${id}/`);
   return res.data;
 }
+
+export async function createShrine(data: {
+  name_jp: string;
+  address: string;
+  latitude: number;
+  longitude: number;
+  goriyaku?: string;
+  sajin?: string;
+}) {
+  const res = await api.post("/shrines/", data);
+  return res.data;
+}


### PR DESCRIPTION
### 概要
- 神社新規登録機能を追加しました
  - バックエンド: Shrine API に POST を実装・調整
  - フロントエンド: `/shrines/new` にフォームページを追加

### 変更内容
#### バックエンド
- `temples/models.py` Shrine モデルに登録用フィールドを確認・調整
- `temples/api/serializers/shrine.py` 新規登録用シリアライザを追加／修正
- `temples/api/views/shrine.py` に `create` エンドポイント実装
- `urls.py` に `/api/shrines/` の POST をルーティング

#### フロントエンド
- `frontend/src/lib/api/shrines.ts` : `createShrine` 関数を追加
- `frontend/src/app/shrines/new/page.tsx` : 新規登録フォームを追加
- 登録成功時は `/shrines/[id]` にリダイレクト

### 今後の拡張予定
- ご利益タグをプルダウンで選択可能にする
- Mapbox API を使った地図 UI での緯度経度入力
- バリデーション強化・エラーメッセージ改善

### 確認方法
1. フロントエンドで `http://localhost:3000/shrines/new` にアクセス
2. フォームに入力して「登録する」
3. バックエンド DB に神社が保存され、詳細ページに遷移することを確認
