### PR TITLE
feat(frontend): 神社新規登録フォームにご利益タグ選択を追加

### DIFF
--- a/frontend/src/lib/api/tags.ts
+++ b/frontend/src/lib/api/tags.ts
@@ -5,7 +5,7 @@ export type GoriyakuTag = {
   name: string
 }
 
-export async function getTags() {
-  const res = await api.get("/goriyaku-tags/"); // ✅ バックエンドに合わせる
+export async function getGoriyakuTags() {
+  const res = await api.get("/goriyaku-tags/");
   return res.data;
 }


### PR DESCRIPTION
### 概要
- 神社新規登録フォームに「ご利益タグ」選択 UI を追加
- API `/goriyaku-tags/` からタグ一覧を取得し、複数選択可能なボタンとして表示
- 選択したタグ ID を `goriyaku_tags: number[]` として Shrine 作成 API に送信

### 変更内容
- `frontend/src/lib/api/tags.ts` に `getGoriyakuTags` を追加
- `frontend/src/app/shrines/new/page.tsx` にご利益タグ UI を実装
- Shrine 登録時に `goriyaku_tags` を送信

### 確認方法
1. `/shrines/new` にアクセス
2. ご利益タグ一覧が表示されることを確認
3. タグを選択して登録すると、API 側に `goriyaku_tags` が送信されることを確認
