### PR TITLE
auto-geocode: signals + OpenCage JP countrycode & status check

### DIFF
--- a/backend/temples/apps.py
+++ b/backend/temples/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+class TemplesConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "temples"
+    verbose_name = "Temples"
+
+    def ready(self):
+        # signals を import してハンドラ登録
+        from . import signals  # noqa: F401

--- a/backend/temples/geocoding/client.py
+++ b/backend/temples/geocoding/client.py
@@ -34,7 +34,7 @@ class GeocodingClient:
 
     def _geocode_opencage(self, address: str) -> GeocodeResult:
         url = "https://api.opencagedata.com/geocode/v1/json"
-        params = {"q": address, "key": self.api_key, "language": "ja", "limit": 1, "no_annotations": 1}
+        params = {"q": address, "key": self.api_key, "language": "ja", "limit": 1, "no_annotations": 1, "countrycode": "jp"}
         resp = self.session.get(url, params=params, timeout=10)
         if resp.status_code != 200:
             text = getattr(resp, "text", "")[:200]

--- a/backend/temples/signals.py
+++ b/backend/temples/signals.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import logging
+from django.conf import settings
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from .models import Shrine
+from .geocoding.normalizer import normalize_address
+from .geocoding.client import GeocodingClient, GeocodingError
+
+logger = logging.getLogger(__name__)
+
+def _compose_address(obj) -> str | None:
+    """
+    モデルに address 系フィールド名が何であってもベストエフォートで連結。
+    無ければ None を返し、何もしない。
+    """
+    # まず単一フィールド優先
+    for k in ("address", "full_address", "address_text"):
+        if hasattr(obj, k):
+            v = (getattr(obj, k) or "").strip()
+            if v:
+                return v
+
+    # 分割フィールドをいい感じに連結（存在するものだけ）
+    parts = []
+    for k in ("postal_code", "prefecture", "city", "ward", "town", "street", "address1", "address2"):
+        if hasattr(obj, k):
+            v = getattr(obj, k) or ""
+            v = str(v).strip()
+            if v:
+                parts.append(v)
+    return " ".join(parts) if parts else None
+
+def _assign_latlng(obj, lat: float, lng: float) -> bool:
+    """
+    モデル側の緯度経度フィールド名に合わせて代入。
+    変更があれば True。
+    """
+    changed = False
+    for lat_name, lng_name in (("latitude", "longitude"), ("lat", "lon"), ("lat", "lng")):
+        if hasattr(obj, lat_name) and hasattr(obj, lng_name):
+            old_lat = getattr(obj, lat_name, None)
+            old_lng = getattr(obj, lng_name, None)
+            if old_lat != lat or old_lng != lng:
+                setattr(obj, lat_name, lat)
+                setattr(obj, lng_name, lng)
+                changed = True
+            break
+    return changed
+
+@receiver(pre_save, sender=Shrine)
+def auto_geocode_on_save(sender, instance: Shrine, **kwargs):
+    # トグルOFFなら何もしない
+    if not getattr(settings, "AUTO_GEOCODE_ON_SAVE", False):
+        return
+
+    addr = _compose_address(instance)
+    if not addr:
+        return
+
+    addr_n = normalize_address(addr)
+    # すでに座標が埋まっていて、住所がほぼ同じなら skip（大文字小文字/全角半角の違いは無視）
+    try:
+        current_lat = getattr(instance, "latitude", getattr(instance, "lat", None))
+        current_lng = getattr(instance, "longitude", getattr(instance, "lon", getattr(instance, "lng", None)))
+    except Exception:
+        current_lat = current_lng = None
+
+    # 住所変更判定：シンプルに文字列比較（モデル側に old 値が無ければ常に実行でもOK）
+    # pre_save なので旧オブジェクトをDBから読むのはコストがかかるため、まずはベストエフォート
+    try:
+        prev = sender.objects.filter(pk=instance.pk).only().first() if instance.pk else None
+        if prev is not None:
+            prev_addr = _compose_address(prev) or ""
+            if normalize_address(prev_addr) == addr_n:
+                return  # 住所変わってない
+    except Exception:
+        pass
+
+    try:
+        client = GeocodingClient()
+        res = client.geocode(addr_n)
+    except GeocodingError as e:
+        logger.warning("auto_geocode_on_save: geocode failed: %s", e)
+        return
+    except Exception as e:
+        logger.exception("auto_geocode_on_save: unexpected error: %s", e)
+        return
+
+    _assign_latlng(instance, res.lat, res.lon)


### PR DESCRIPTION
概要

神社（Shrine）保存時に住所から緯度経度を自動付与する仕組みを Django signals で実装

ジオコーディングプロバイダ OpenCage を利用し、countrycode=jp を付与して日本国内に絞り込み

OpenCage の status.code をチェックして明確に失敗を検出

設定値 AUTO_GEOCODE_ON_SAVE で 機能ON/OFF を制御（デフォルトOFF）。環境変数で切り替え可能

変更点（主なファイル）

temples/apps.py

TemplesConfig.ready() で temples.signals を読み込み（アプリ起動時にシグナル登録）

temples/signals.py

pre_save で住所系フィールドの変更を検出 → GeocodingClient を呼び出し、latitude / longitude を更新

失敗時はログに警告を出して保存は継続（アプリの書き込みを妨げない）

temples/geocoding/client.py

OpenCage リクエストに countrycode=jp を追加

レスポンスの status.code チェックを追加（200 以外は例外化）

shrine_project/settings.py

INSTALLED_APPS を 'temples.apps.TemplesConfig' に変更

AUTO_GEOCODE_ON_SAVE = os.getenv("AUTO_GEOCODE_ON_SAVE","0").lower() in ("1","true","yes") を追加