### PR TITLE
feat(auth): axios refresh interceptor and 401 retry

### DIFF
--- a/docs/verification/axios-refresh-2025-09-01.txt
+++ b/docs/verification/axios-refresh-2025-09-01.txt
@@ -1,0 +1,6 @@
+[目的] access 期限切れ時に refresh で自動再送されることを確認
+[手順]
+1) ログインして access_token/refresh_token が localStorage に入っている状態にする
+2) access の寿命を短くする or 手動で無効化して保護APIを叩く
+3) 401 → /token/refresh/ → 元リクエスト再送 → 200 の流れを Network で確認
+[期待] refresh は同時に1回だけ実行され、以降のリクエストは新accessで成功する

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,88 +1,95 @@
-import axios from "axios";
+import axios, { InternalAxiosRequestConfig } from "axios";
 
 const isServer = typeof window === "undefined";
+const BASE_URL = isServer
+  ? process.env.NEXT_PUBLIC_API_BASE_SERVER || "http://web:8000/api"
+  : process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000/api";
 
 const api = axios.create({
-  baseURL: isServer
-    ? process.env.NEXT_PUBLIC_API_BASE_SERVER || "http://web:8000/api"
-    : process.env.NEXT_PUBLIC_API_BASE || "http://localhost:8000/api",
+  baseURL: BASE_URL,
   timeout: 10000,
   headers: { "Content-Type": "application/json" },
 });
 
-console.log("DEBUG baseURL =", api.defaults.baseURL);
+const ACCESS_KEY = "access_token";
+const REFRESH_KEY = "refresh_token";
 
-// -------------------------
-// リクエストインターセプター
-// -------------------------
+// 認証不要APIの除外
+const isNoAuth = (url: string) =>
+  url.startsWith("/shrines") ||
+  url.startsWith("/goriyaku-tags") ||
+  url.startsWith("/ranking") ||
+  url === "/concierge" ||
+  url.startsWith("/token"); // /token/, /token/refresh/
+
 api.interceptors.request.use((config) => {
-  console.log("➡️ API Request:", `${config.baseURL}${config.url}`);
+  const url = config.url || "";
+  if (isNoAuth(url)) return config;
 
-  // 認証不要のエンドポイントは除外
-  if (
-    config.url?.startsWith("/shrines") ||
-    config.url?.startsWith("/goriyaku-tags") ||
-    config.url?.startsWith("/ranking") ||
-    config.url === "/concierge"
-  ) {
-    return config;
-  }
-
-  // 認証必要なら Authorization を付与
-  if (typeof window !== "undefined") {
-    const token = localStorage.getItem("access_token");
+  if (!isServer) {
+    const token = window.localStorage.getItem(ACCESS_KEY);
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+      config.headers = config.headers ?? {};
+      (config.headers as any).Authorization = `Bearer ${token}`;
     }
   }
   return config;
 });
 
-// -------------------------
-// レスポンスインターセプター
-// -------------------------
+// 401→refresh→再送（多重refreshを抑止）
+let isRefreshing = false;
+let waitQueue: Array<(t: string) => void> = [];
+
 api.interceptors.response.use(
-  (response) => response,
+  (r) => r,
   async (error) => {
-    // エラーログ
-    console.error("❌ API Error:", error);
+    const status = error?.response?.status;
+    const original: (InternalAxiosRequestConfig & { _retry?: boolean }) | undefined = error?.config;
 
-    // 401 の場合は refresh を試す
-    if (error.response?.status === 401) {
-      const originalRequest = error.config;
-      if (!originalRequest) return Promise.reject(error);
-
-      if (originalRequest._retry) {
-        console.warn("⏩ refresh 試行済み → 再ログインへ");
-        return Promise.reject(error);
-      }
-      originalRequest._retry = true;
-
-      try {
-        const refresh = localStorage.getItem("refresh_token");
-        console.warn("🔄 401発生 → refresh token で再発行を試みます");
-        if (!refresh) throw new Error("No refresh token");
-
-        const res = await axios.post(
-          `${process.env.NEXT_PUBLIC_API_BASE}/token/refresh/`,
-          { refresh }
-        );
-        console.log("✅ refresh 成功", res.data);
-
-        const newAccess = res.data.access;
-        localStorage.setItem("access_token", newAccess);
-
-        originalRequest.headers.Authorization = `Bearer ${newAccess}`;
-        return api(originalRequest); // 再リクエスト
-      } catch (err) {
-        console.error("リフレッシュ失敗", err);
-        localStorage.removeItem("access_token");
-        localStorage.removeItem("refresh_token");
-        window.location.href = "/login";
-      }
+    if (status !== 401 || !original || original._retry) {
+      return Promise.reject(error);
+    }
+    if ((original.url || "").startsWith("/token")) {
+      return Promise.reject(error);
     }
 
-    return Promise.reject(error);
+    if (isRefreshing) {
+      const newToken = await new Promise<string>((resolve) => waitQueue.push(resolve));
+      original.headers = original.headers ?? {};
+      (original.headers as any).Authorization = `Bearer ${newToken}`;
+      original._retry = true;
+      return api(original);
+    }
+
+    isRefreshing = true;
+    original._retry = true;
+
+    try {
+      if (isServer) throw error;
+      const refresh = window.localStorage.getItem(REFRESH_KEY);
+      if (!refresh) throw error;
+
+      const { data } = await axios.post(`${api.defaults.baseURL}/token/refresh/`, { refresh });
+      const newAccess: string = data.access;
+      if (!newAccess) throw new Error("No access token from refresh");
+
+      window.localStorage.setItem(ACCESS_KEY, newAccess);
+      waitQueue.forEach((fn) => fn(newAccess));
+      waitQueue = [];
+
+      original.headers = original.headers ?? {};
+      (original.headers as any).Authorization = `Bearer ${newAccess}`;
+      return api(original);
+    } catch (e) {
+      if (!isServer) {
+        window.localStorage.removeItem(ACCESS_KEY);
+        window.localStorage.removeItem(REFRESH_KEY);
+        if (typeof window !== "undefined") window.location.href = "/login";
+      }
+      throw e;
+    } finally {
+      isRefreshing = false;
+    }
   }
 );
 


### PR DESCRIPTION
[目的] access 期限切れ時に refresh で自動再送されることを確認
[手順]
1) ログインして access_token/refresh_token が localStorage に入っている状態にする
2) access の寿命を短くする or 手動で無効化して保護APIを叩く
3) 401 → /token/refresh/ → 元リクエスト再送 → 200 の流れを Network で確認
[期待] refresh は同時に1回だけ実行され、以降のリクエストは新accessで成功する