### PR TITLE
feat(api): /api/geocode を追加（曖昧住所は candidates、確定時は result）

### DIFF
--- a/backend/temples/api/serializers/geocode.py
+++ b/backend/temples/api/serializers/geocode.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+class GeocodeResultSerializer(serializers.Serializer):
+    lat = serializers.FloatField()
+    lon = serializers.FloatField()
+    formatted = serializers.CharField()
+    precision = serializers.ChoiceField(choices=["rooftop", "street", "city", "region", "approx"])
+    provider = serializers.CharField()
+
+class GeocodeResponseSerializer(serializers.Serializer):
+    result = GeocodeResultSerializer(required=False)
+    candidates = GeocodeResultSerializer(many=True, required=False)
+    message = serializers.CharField(required=False)

--- a/backend/temples/api/urls.py
+++ b/backend/temples/api/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 from temples.api.views.concierge import ConciergeAPIView, ConciergeHistoryListView
-
+from temples.api.views.geocode import GeocodeView
 from .views import (
     ShrineViewSet,
     GoriyakuTagViewSet,
@@ -30,5 +30,6 @@ urlpatterns = [
     path("route/", RouteView.as_view(), name="route"),
     path("concierge/", ConciergeAPIView.as_view(), name="concierge"),
     path("concierge/history/", ConciergeHistoryListView.as_view(), name="concierge_history"),
+    path("geocode/", GeocodeView.as_view(), name="geocode"),
 ]
 

--- a/backend/temples/api/views/geocode.py
+++ b/backend/temples/api/views/geocode.py
@@ -1,0 +1,41 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from temples.geocoding.client import GeocodingClient, GeocodingError
+from temples.api.serializers.geocode import GeocodeResultSerializer, GeocodeResponseSerializer
+
+_GOOD_PRECISIONS = {"rooftop", "street"}
+
+class GeocodeView(APIView):
+    authentication_classes = []
+    permission_classes = []
+
+    def get(self, request, *args, **kwargs):
+        q = (request.query_params.get("q") or "").strip()
+        try:
+            limit = int(request.query_params.get("limit") or 5)
+        except Exception:
+            limit = 5
+        limit = max(1, min(limit, 10))
+
+        if not q:
+            return Response({"message": "q は必須です。"}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            client = GeocodingClient()
+            candidates = client.geocode_candidates(q, limit=limit)
+        except GeocodingError as e:
+            return Response({"message": f"geocoding failed: {e}"}, status=status.HTTP_200_OK)
+        except Exception as e:
+            return Response({"message": f"unexpected error: {e}"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        if not candidates:
+            data = {"candidates": [], "message": "not found"}
+            return Response(GeocodeResponseSerializer(data).data, status=status.HTTP_200_OK)
+
+        if len(candidates) == 1 and (candidates[0].precision in _GOOD_PRECISIONS):
+            data = {"result": GeocodeResultSerializer(candidates[0]).data}
+            return Response(GeocodeResponseSerializer(data).data, status=status.HTTP_200_OK)
+
+        data = {"candidates": [GeocodeResultSerializer(c).data for c in candidates]}
+        return Response(GeocodeResponseSerializer(data).data, status=status.HTTP_200_OK)

--- a/backend/temples/geocoding/client.py
+++ b/backend/temples/geocoding/client.py
@@ -24,6 +24,7 @@ class GeocodingClient:
         if not self.api_key:
             raise GeocodingError("GEOCODER_API_KEY が設定されていません。")
 
+    # --- 単発（もっとも確からしい1件） -------------------------------------
     def geocode(self, address: str) -> GeocodeResult:
         address = (address or "").strip()
         if not address:
@@ -32,27 +33,44 @@ class GeocodingClient:
             return self._geocode_opencage(address)
         raise GeocodingError(f"未対応のプロバイダ: {self.provider}")
 
+    # --- 複数候補（あいまい検索） -------------------------------------------
+    def geocode_candidates(self, address: str, limit: int = 5) -> list[GeocodeResult]:
+        address = (address or "").strip()
+        if not address:
+            raise ValueError("address は必須です。")
+        if self.provider == "opencage":
+            return self._geocode_opencage_multi(address, limit=limit)
+        raise GeocodingError(f"未対応のプロバイダ: {self.provider}")
+
+    # --- OpenCage 実装：単発 ---------------------------------------------------
     def _geocode_opencage(self, address: str) -> GeocodeResult:
         url = "https://api.opencagedata.com/geocode/v1/json"
-        params = {"q": address, "key": self.api_key, "language": "ja", "limit": 1, "no_annotations": 1, "countrycode": "jp"}
+        params = {
+            "q": address,
+            "key": self.api_key,
+            "language": "ja",
+            "limit": 1,
+            "no_annotations": 1,
+            "countrycode": "jp",
+        }
         resp = self.session.get(url, params=params, timeout=10)
         if resp.status_code != 200:
             text = getattr(resp, "text", "")[:200]
             raise GeocodingError(f"OpenCage HTTP {resp.status_code}: {text}")
 
         data = resp.json()
-        results = data.get("results", [])
+        results = data.get("results", []) or []
         if not results:
             raise GeocodingError("該当するジオコーディング結果が見つかりませんでした。")
 
         top = results[0]
-        geom = top.get("geometry", {})
+        geom = top.get("geometry") or {}
         lat, lng = geom.get("lat"), geom.get("lng")
         if lat is None or lng is None:
             raise GeocodingError("座標を抽出できませんでした。")
 
-        components = top.get("components", {})
-        confidence = top.get("confidence", None)  # 1-10
+        components = top.get("components") or {}
+        confidence = top.get("confidence")  # 1-10 or None
         precision = self._infer_precision_from_opencage(components, confidence)
         formatted = top.get("formatted") or address
 
@@ -65,6 +83,46 @@ class GeocodingClient:
             raw=top,
         )
 
+    # --- OpenCage 実装：複数候補 ----------------------------------------------
+    def _geocode_opencage_multi(self, address: str, limit: int = 5) -> list[GeocodeResult]:
+        url = "https://api.opencagedata.com/geocode/v1/json"
+        params = {
+            "q": address,
+            "key": self.api_key,
+            "language": "ja",
+            "limit": max(1, min(int(limit or 1), 10)),  # 1..10
+            "no_annotations": 1,
+            "countrycode": "jp",
+        }
+        resp = self.session.get(url, params=params, timeout=10)
+        if resp.status_code != 200:
+            text = getattr(resp, "text", "")[:200]
+            raise GeocodingError(f"OpenCage HTTP {resp.status_code}: {text}")
+
+        data = resp.json()
+        out: list[GeocodeResult] = []
+        for top in (data.get("results") or []):
+            geom = top.get("geometry") or {}
+            lat, lng = geom.get("lat"), geom.get("lng")
+            if lat is None or lng is None:
+                continue
+            components = top.get("components") or {}
+            conf = top.get("confidence")  # 1-10 or None
+            precision = self._infer_precision_from_opencage(components, conf)
+            formatted = top.get("formatted") or address
+            out.append(
+                GeocodeResult(
+                    lat=float(lat),
+                    lon=float(lng),
+                    formatted=formatted,
+                    precision=precision,
+                    provider="opencage",
+                    raw=top,
+                )
+            )
+        return out
+
+    # --- 共通：精度の推定 ------------------------------------------------------
     @staticmethod
     def _infer_precision_from_opencage(components: dict, confidence: t.Optional[int]) -> str:
         if "house_number" in components or "building" in components:


### PR DESCRIPTION
## 概要
ジオコーディング API `/api/geocode` を新規追加しました。  
OpenCage API を利用し、住所が曖昧な場合は複数候補を返し、確定できる場合は単一結果を返すよう設計しています。

## 変更内容
- `GeocodingClient` に `geocode_candidates` を追加  
  - 複数候補を返す内部メソッド `_geocode_opencage_multi` を実装
- `GeocodeResultSerializer / GeocodeResponseSerializer` を追加
- `GeocodeView` を追加し、`GET /api/geocode` で利用可能に
- `urls.py` にルートを追加

## レスポンス仕様
- 候補なし → `{"candidates": [], "message": "not found"}`
- 候補1件かつ精度 `rooftop` or `street` → `{"result": {...}}`
- それ以外（複数件や精度低い場合） → `{"candidates": [...]}`

## 動作確認
- `GET /api/geocode?q=東京都渋谷区代々木神園町1-1 明治神宮`
  - 高精度な単一結果が返ることを確認
- `GET /api/geocode?q=明治神宮`
  - 複数候補（渋谷区/市区町村レベル）が返ることを確認

## 背景
- モデル `Shrine` の非NULL制約と signals により、住所から座標が必須になった
- その前段で住所が曖昧なケースを UI に誘導できるように API レイヤーで candidates を返す必要があった
- TODO リストの「シリアライザ更新」「API拡張」にも対応:contentReference[oaicite:2]{index=2}

## 関連
- README.md のアーキテクチャ記載:contentReference[oaicite:3]{index=3}
- TODO.md サポート機能／バックエンド作業:contentReference[oaicite:4]{index=4}

---

