### PR TITLE
feat(frontend): Shrine詳細でサーバ返却座標のピン表示

### DIFF
--- a/frontend/src/app/shrines/[id]/page.tsx
+++ b/frontend/src/app/shrines/[id]/page.tsx
@@ -1,81 +1,97 @@
 "use client"
+import dynamic from "next/dynamic";
 import { useEffect, useState } from "react"
 import { useParams } from "next/navigation"
 import { getShrine, Shrine } from "@/lib/api/shrines"
-import RouteMap from "@/components/maps/RouteMap"
+
+// Map はブラウザAPI依存なので動的 import（SSR 無効)
+const Map = dynamic(() => import("@/components/maps/Map"), { ssr: false });
+
 
 export default function ShrineDetailPage() {
   const params = useParams()
+  const raw = params?.id;
   const id = Number(params?.id)
 
   const [shrine, setShrine] = useState<Shrine | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
-  // 仮の現在地（東京駅）
-  const [origin] = useState({ lat: 35.681236, lng: 139.767125 })
-
   useEffect(() => {
-    if (!id) return
+    if (!id) return;
+    setLoading(true);
     getShrine(id)
       .then((data) => setShrine(data))
       .catch(() => setError("神社データの取得に失敗しました"))
-      .finally(() => setLoading(false))
-  }, [id])
+      .finally(() => setLoading(false));
+  }, [id]);
 
-  if (loading) return <p className="p-4">読み込み中...</p>
-  if (error) return <p className="p-4 text-red-500">{error}</p>
-  if (!shrine) return <p className="p-4">神社が見つかりません</p>
+    if (!Number.isFinite(id)) return <p className="p-4">無効なIDです</p>;
+    if (loading) return <p className="p-4">読み込み中...</p>;
+    if (error) return <p className="p-4 text-red-500">{error}</p>;
+    if (!shrine) return <p className="p-4">神社が見つかりません</p>;
 
-  return (
-    <main className="p-4">
-      <h1 className="text-2xl font-bold mb-2">{shrine.name_jp}</h1>
-      <p className="text-gray-600 mb-4">{shrine.address}</p>
+    const hasCoords =
+      shrine.latitude != null &&
+      shrine.longitude != null &&
+      !Number.isNaN(Number(shrine.latitude)) &&
+      !Number.isNaN(Number(shrine.longitude));
 
-      {shrine.goriyaku && (
-        <section className="mb-4">
-          <h2 className="font-semibold">ご利益</h2>
-          <p>{shrine.goriyaku}</p>
-        </section>
-      )}
+    return (
+      <main className="p-4">
+        <h1 className="text-2xl font-bold mb-2">{shrine.name_jp}</h1>
+        <p className="text-gray-600 mb-4">{shrine.address}</p>
 
-      {shrine.sajin && (
-        <section className="mb-4">
-          <h2 className="font-semibold">祭神</h2>
-          <p>{shrine.sajin}</p>
-        </section>
-      )}
 
-      {shrine.goriyaku_tags?.length > 0 && (
-        <section className="mb-4">
-          <h2 className="font-semibold">タグ</h2>
-          <ul className="flex flex-wrap gap-2 mt-1">
-            {shrine.goriyaku_tags.map((tag) => (
-              <li
-                key={tag.id}
-                className="px-2 py-1 bg-gray-200 rounded text-sm"
-              >
-                {tag.name}
-              </li>
-            ))}
-          </ul>
-        </section>
-      )}
 
-      {/* --- ✅ Google Maps のルート表示 --- */}
-      <section className="mt-6">
-        <h2 className="font-semibold mb-2">ルート案内</h2>
-        <RouteMap
-          origin={origin}
-          destination={
-            shrine.latitude && shrine.longitude
-              ? { lat: shrine.latitude, lng: shrine.longitude }
-              : undefined
-          }
-        />
+        {shrine.goriyaku && (
+          <section className="mb-4">
+            <h2 className="font-semibold">ご利益</h2>
+            <p>{shrine.goriyaku}</p>
+          </section>
+        )}
 
-      </section>
-    </main>
-  )
+        {shrine.sajin && (
+          <section className="mb-4">
+            <h2 className="font-semibold">祭神</h2>
+            <p>{shrine.sajin}</p>
+          </section>
+        )}
+        {Array.isArray(shrine.goriyaku_tags) && shrine.goriyaku_tags.length > 0 && (
+          <section className="mb-4">
+            <h2 className="font-semibold">タグ</h2>
+            <ul className="flex flex-wrap gap-2 mt-1">
+              {shrine.goriyaku_tags.map((tag) => (
+                <li
+                  key={tag.id}
+                  className="px-2 py-1 bg-gray-200 rounded text-sm"
+                >
+                  {tag.name}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+
+        {/* --- ✅ Google Maps のルート表示 --- */}
+          <section className="mt-6">
+            <h2 className="font-semibold mb-2">所在地</h2>
+
+            {hasCoords ? (
+              <Map
+                lat={Number(shrine.latitude)}
+                lon={Number(shrine.longitude)}
+                title={shrine.name_jp}
+              />
+            ) : (
+              <div className="p-3 bg-yellow-50 border border-yellow-200 rounded">
+                座標情報が未登録です（住所を編集して保存すると自動付与されます）
+              </div>
+            )}
+
+          </section>
+      </main>
+    );
 }
 

--- a/frontend/src/components/maps/Map.tsx
+++ b/frontend/src/components/maps/Map.tsx
@@ -1,0 +1,60 @@
+import { Loader } from "@googlemaps/js-api-loader";
+import { useEffect, useRef } from "react";
+
+type MapProps = {
+  lat: number;
+  lon: number; // backend の longitude
+  zoom?: number;
+  height?: string;
+};
+
+export default function Map({ lat, lon, zoom = 16, height = "360px" }: MapProps) {
+  const divRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const apiKey = process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!;
+    const mapId = process.env.NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID; // 任意
+    if (!apiKey) {
+      // 開発時の見落としを防ぐ
+      console.warn("NEXT_PUBLIC_GOOGLE_MAPS_API_KEY が設定されていません");
+      return;
+    }
+
+    const loader = new Loader({
+      apiKey,
+      version: "weekly",
+      libraries: [], // 追加ライブラリ不要なら空
+    });
+
+    let map: google.maps.Map | null = null;
+    let marker: google.maps.Marker | null = null;
+
+    loader.load().then(() => {
+      if (!divRef.current) return;
+      const center = { lat, lng: lon };
+      map = new google.maps.Map(divRef.current, {
+        center,
+        zoom,
+        mapId, // スタイル適用（設定されていれば）
+        gestureHandling: "greedy",
+        streetViewControl: false,
+        mapTypeControl: false,
+        fullscreenControl: false,
+      });
+      marker = new google.maps.Marker({
+        position: center,
+        map,
+        title: "Shrine",
+      });
+    });
+
+    return () => {
+      // 明示破棄（GC任せでもOKだが念のため）
+      marker?.setMap(null);
+      // @ts-expect-error destroy がないので参照解放のみ
+      map = null;
+    };
+  }, [lat, lon, zoom]);
+
+  return <div ref={divRef} style={{ width: "100%", height }} />;
+}


### PR DESCRIPTION
## 概要
- Shrine 詳細ページに Google Maps を組み込み、サーバが返す `latitude` / `longitude` をピン表示するようにしました。
- 既存のルート表示 (`RouteMap`) とは分離し、ピン専用の `Map` コンポーネントを新規追加しました。

## 変更点
- `src/components/maps/Map.tsx` を追加
  - @googlemaps/js-api-loader を用いてブラウザ側で Google Maps を初期化
  - 単一マーカーを表示するシンプルな責務
- `src/app/shrines/[id]/page.tsx` を修正
  - Shrine 詳細ページにて `Map` を利用し、座標があればピン表示
  - 座標が未登録の場合は注意文言を表示
- `.env` に設定済みの `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` / `NEXT_PUBLIC_GOOGLE_MAPS_MAP_ID` を利用

## 動作確認
- `docker compose up` でフロント起動
- `http://localhost:3000/shrines/:id` にアクセス
- サーバから返る `latitude` / `longitude` が存在する場合に Google Map 上にピンが表示されることを確認
- 未設定の Shrine では警告メッセージが表示されることを確認

## 補足
- ナビゲーション用途の経路表示 (`RouteMap`) は `/navi`, `/concierge` ページで利用予定
- 詳細ページはピン表示に限定して責務分離しました
