### PR TITLE
docs: update README for permissions/favorites changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,6 @@ conda --version
 conda create -n jinja_app_py311 -c conda-forge python=3.11 gdal pyproj shapely fiona geopandas rtree -y
 conda activate jinja_app_py311
 python -c "from osgeo import gdal; print('GDAL VersionInfo:', gdal.VersionInfo())"
+
+## Backend tests:
+  docker compose exec -T web pytest -q


### PR DESCRIPTION
概要:
- 所有者判定を `_is_shrine_owner` に集約（任意User FK / M2M / owner属性 / Favorite フォールバック対応）
- Favorites API のシリアライザ/ビュー分離・認可強化
- テスト補助（`make_shrine` が name/name_jp・owner差異を吸収）
- ルートに `pytest.ini` を統合、旧 app/pytest.ini を撤去
- マイグレーション 0007–0014：レガシー name 系を完全撤去

確認方法:
- `docker compose exec -T web pytest -q` → 11 passed, 1 skipped
- `python manage.py showmigrations temples` → 全て [X]