### PR TITLE
docs: README を apps/web 構成 & axios 導入に合わせて更新 / docs/TODO.md を最新化

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,44 +1,55 @@
 # 開発TODOリスト（最新版）
 
-## ✅ コア機能（AI参拝ナビ）
-- [ ] ルート提案API …
-- [ ] 人気神社推薦 …
+## 🧭 コア機能（AI参拝ナビ）
+- [ ] ルート提案API（徒歩/車の経路算出）
+- [ ] 人気神社推薦（閲覧/お気に入りスコアで30日集計）
 
-## サポート機能
-- [ ] 御朱印投稿API …
-- [ ] お気に入りAPI …
-- [ ] ランキングAPI …
-- [ ] ユーザー認証／設定API …
+## ⭐ サポート機能
+- [ ] 御朱印投稿API（画像アップロード／公開切替／編集／削除）
+- [x] お気に入りAPI（追加・削除・一覧取得） → JWT 認証で動作確認済み
+- [ ] ランキングAPI（月間・年間TOP10）
+- [ ] ユーザー認証／設定API（プロフィール編集・公開設定）
 
 ## ⚙️ バックエンド作業
-- [ ] モデル追加 …
-- [ ] シリアライザ更新 …
-- [ ] 管理画面拡張 …
-- [ ] バッチ処理 …
+- [x] JWT 認証エンドポイント `/api/token/*` 実装・確認済み
+- [x] Shrine API（一覧・詳細JSON、`/api/shrines/`）
+- [x] Favorite API（`/api/favorites/`、冪等POST、DELETE動作確認済み）
+- [ ] モデル追加（ご利益・祭神フィールドなど拡張）
+- [ ] シリアライザ更新（詳細情報／関連リソース拡張）
+- [ ] 管理画面拡張（神社・御朱印・ランキング管理UI）
+- [ ] バッチ処理（ランキング集計）
 
-## フロントエンド作業
-- [ ] ホームページ …
-- [ ] 神社詳細ページ …
-- [ ] マイページ …
-- [ ] ランキングページ …
-- [ ] コンポーネント …
+## 🎨 フロントエンド（Web / Next.js）
+- [x] `axios` 導入（`apps/web`）
+- [ ] 共通APIクライアント `apps/web/lib/api.ts` 実装（Baseはルート、呼び出しは `/api/...`）
+- [ ] お気に入りラッパ `apps/web/lib/favorites.ts` 実装（add/list/remove）
+- [ ] 神社カード/詳細に「お気に入り」トグルボタン設置
+- [ ] ホームページ（検索フォーム・AIコンシェルジュ入口）
+- [ ] 神社詳細ページ（住所・ご利益・祭神・ルート表示）
+- [ ] マイページ（お気に入り・御朱印投稿管理）
+- [ ] ランキングページ（月間・年間TOP10表示）
+- [ ] コンポーネント追加（MapRoute・ConciergeMessage）
 
-## インフラ作業
-- [ ] Docker環境調整 …
-- [ ] PostgreSQL + PostGIS …
-- [ ] AWS S3連携 …
-- [ ] AWS ECS/Fargate …
-- [ ] SSM Parameter Store …
-- [ ] ALB + ACM …
+## 📱 モバイル（Expo）
+- [ ] APIクライアント同期（`EXPO_PUBLIC_API_BASE`）
+- [ ] 近隣神社リスト（expo-location）
+- [ ] 御朱印画像投稿（expo-image-picker）
+
+## 🛠 インフラ作業
+- [x] Docker 環境起動・DB 接続確認済み
+- [ ] CORS/CSRF の本番方針整理（同一オリジン + リバプロで最小化）
+- [ ] PostgreSQL + PostGIS 拡張確認
+- [ ] AWS S3 連携（御朱印画像保存先）
+- [ ] AWS ECS/Fargate デプロイ設定
+- [ ] SSM Parameter Store（秘密情報管理）
+- [ ] ALB + ACM（HTTPS化）
 - [ ] Miniforge インストール＆初期化（powershell / bash）
-- [ ] conda --version が出る
-- [ ] 環境 jinja_app_py311 を作成（-c conda-forge, python=3.11）
-- [ ] gdal/pyproj/shapely/fiona/geopandas/rtree が import OK
-- [ ] VS Code/Cursor の Python Interpreter を jinja_app_py311 に切替
+- [ ] conda 環境 `jinja_app_py311` 作成（python=3.11, gdal/pyproj/shapely/fiona/geopandas/rtree）
+- [ ] VS Code/Cursor の Python Interpreter を切替
 
-## 今後の拡張
-- [ ] 多言語対応 …
-- [ ] Push通知 …
-- [ ] SNS共有 …
-- [ ] 御朱印帳クラウド同期 …
-
+## 🚀 今後の拡張
+- [ ] 多言語対応（英語／中国語）
+- [ ] Push通知（参拝リマインダー）
+- [ ] SNS共有（Instagram/TikTok）
+- [ ] 御朱印帳クラウド同期
+- [ ] ランキング自動集計バッチ処理


### PR DESCRIPTION
## 概要
- README を現状の構成（apps/web）に合わせて修正
- フロントエンド技術に axios を追記
- API Base URL 方針（A案：Baseはルート、呼び出しは /api/...）を明記
- docs/TODO.md をチェックリスト形式で最新の進捗に更新

## 背景
- 古い README は frontend/ ディレクトリのままで誤解を招く
- axios 導入が明文化されていなかった
- TODO が更新されておらず進捗が見えにくかった

## 変更内容
- README.md
- docs/TODO.md

## 動作確認
- `cd apps/web && npm i && npm run dev` 起動確認
- `cd apps/mobile && npm i && npm start` 起動確認
- docs/TODO.md が GitHub 上でチェックリスト表示されることを確認

## 備考
- コード変更なし、ドキュメントのみ
- 安全にマージ可能
