### PR TITLE
Feat/backend route api v1

### DIFF
--- a/backend/temples/route_service.py
+++ b/backend/temples/route_service.py
@@ -1,0 +1,73 @@
+# ルート取得サービス（Adapterパターン）
+
+import math
+from typing import List, Dict, Literal, Tuple
+from dataclasses import dataclass
+from os import getenv
+
+Mode = Literal["walking", "driving"]
+
+@dataclass
+class Point:
+    lat: float
+    lng: float
+
+def _interp_line(a: Point, b: Point, segments: int = 10) -> List[Tuple[float, float]]:
+    # 直線補間（ダミー用）
+    return [
+        (a.lat + (b.lat - a.lat) * t / segments,
+         a.lng + (b.lng - a.lng) * t / segments)
+        for t in range(segments + 1)
+    ]
+
+def _haversine_m(a: Point, b: Point) -> float:
+    R = 6371000
+    from math import radians, sin, cos, atan2, sqrt
+    dlat = radians(b.lat - a.lat)
+    dlng = radians(b.lng - a.lng)
+    x = sin(dlat/2)**2 + cos(radians(a.lat))*cos(radians(b.lat))*sin(dlng/2)**2
+    return 2*R*atan2(sqrt(x), sqrt(1-x))
+
+class BaseRouteAdapter:
+    def get_leg(self, mode: Mode, a: Point, b: Point) -> Dict:
+        raise NotImplementedError()
+
+class DummyAdapter(BaseRouteAdapter):
+    def get_leg(self, mode: Mode, a: Point, b: Point) -> Dict:
+        distance = _haversine_m(a, b)
+        # 超ざっくり速度: 徒歩=4.5km/h, 車=30km/h
+        speed_mps = 1.25 if mode == "walking" else 8.33
+        duration = int(distance / speed_mps)
+        geometry = _interp_line(a, b, segments=12)
+        return {
+            "from": {"lat": a.lat, "lng": a.lng},
+            "to":   {"lat": b.lat, "lng": b.lng},
+            "distance_m": int(distance),
+            "duration_s": duration,
+            "geometry": geometry,
+        }
+
+def get_adapter() -> Tuple[str, BaseRouteAdapter]:
+    provider = (getenv("ROUTE_PROVIDER") or "dummy").lower()
+    # 実装予定:
+    # if provider == "mapbox": return provider, MapboxAdapter(getenv("MAPBOX_TOKEN"))
+    # if provider == "google": return provider, GoogleRoutesAdapter(getenv("GOOGLE_API_KEY"))
+    return provider, DummyAdapter()
+
+def build_route(mode: Mode, origin: Point, destinations: List[Point]) -> Dict:
+    provider, adapter = get_adapter()
+    legs = []
+    current = origin
+    for dest in destinations:
+        leg = adapter.get_leg(mode, current, dest)
+        legs.append(leg)
+        current = dest
+    distance_total = sum(l["distance_m"] for l in legs)
+    duration_total = sum(l["duration_s"] for l in legs)
+    return {
+        "mode": mode,
+        "legs": legs,
+        "distance_m_total": distance_total,
+        "duration_s_total": duration_total,
+        "provider": provider,
+    }

--- a/backend/temples/serializers.py
+++ b/backend/temples/serializers.py
@@ -1,20 +1,82 @@
+# RouteRequest/Response の簡易Serializer
+from typing import List, Tuple
 from rest_framework import serializers
 from .models import Shrine, Favorite
 
+
+# ---- Shrine / Favorite（既存APIのI/Oを維持） ----
 class ShrineSerializer(serializers.ModelSerializer):
     class Meta:
         model = Shrine
         fields = ["id", "name_jp", "address", "latitude", "longitude"]
 
+
 class FavoriteSerializer(serializers.ModelSerializer):
+    # レスポンスで shrine の中身を返す
     shrine = ShrineSerializer(read_only=True)
+    # リクエストでは shrine_id を受けて shrine にマップ
     shrine_id = serializers.PrimaryKeyRelatedField(
         queryset=Shrine.objects.all(),
         source="shrine",
-        write_only=True
+        write_only=True,
     )
 
     class Meta:
         model = Favorite
         fields = ["id", "shrine", "shrine_id", "created_at"]
         read_only_fields = ["id", "created_at"]
+
+
+# ---- Route API 用 ----
+class PointSerializer(serializers.Serializer):
+    lat = serializers.FloatField(min_value=-90.0, max_value=90.0)
+    lng = serializers.FloatField(min_value=-180.0, max_value=180.0)
+
+
+class RouteRequestSerializer(serializers.Serializer):
+    """
+    例:
+    {
+      "mode": "walking",
+      "origin": {"lat": 35.68, "lng": 139.76},
+      "destinations": [{"lat": 35.67, "lng": 139.71}, ...]
+    }
+    """
+    mode = serializers.ChoiceField(choices=["walking", "driving"], default="walking")
+    origin = PointSerializer()
+    destinations = PointSerializer(many=True, allow_empty=False)
+
+    # 追加の軽量バリデーション
+    def validate_destinations(self, value: List[dict]) -> List[dict]:
+        # 過剰な座標リストを防止（UI想定は最大3件：メイン+近隣2）
+        if len(value) > 5:
+            raise serializers.ValidationError("destinations は最大 5 件までにしてください。")
+        return value
+
+
+class RouteLegGeometrySerializer(serializers.ListSerializer):
+    """
+    geometry: [[lat, lng], ...] を軽く検証（各要素2要素の数値配列）
+    """
+    child = serializers.ListField(
+        child=serializers.FloatField(),
+        min_length=2,
+        max_length=2,
+    )
+
+
+class RouteLegSerializer(serializers.Serializer):
+    from_ = PointSerializer(source="from")
+    to = PointSerializer()
+    distance_m = serializers.IntegerField(min_value=0)
+    duration_s = serializers.IntegerField(min_value=0)
+    geometry = RouteLegGeometrySerializer()
+
+
+class RouteResponseSerializer(serializers.Serializer):
+    # 検証とドキュメント用（Strict すぎない程度）
+    mode = serializers.ChoiceField(choices=["walking", "driving"])
+    legs = RouteLegSerializer(many=True)
+    distance_m_total = serializers.IntegerField(min_value=0)
+    duration_s_total = serializers.IntegerField(min_value=0)
+    provider = serializers.CharField()

--- a/backend/temples/urls.py
+++ b/backend/temples/urls.py
@@ -2,17 +2,25 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 from . import views
-from .api_views import FavoriteViewSet
+from .api_views import FavoriteViewSet, ShrineViewSet  # ← ShrineViewSet を忘れず import
+from .views import RouteView
 
 router = DefaultRouter()
 router.register(r"favorites", FavoriteViewSet, basename="favorite")
+router.register(r"shrines", ShrineViewSet, basename="shrine")
 
 app_name = "temples"
 
 urlpatterns = [
-    path("shrines/", views.shrine_list, name="shrine_list"),
-    path("shrines/<int:pk>/", views.shrine_detail, name="shrine_detail"),
-    path("shrines/<int:pk>/route/", views.shrine_route, name="shrine_route"),
-    path("shrines/<int:pk>/favorite/", views.favorite_toggle, name="favorite_toggle"),
-    path("", include(router.urls)),  # => /favorites/ が有効に
+    # ✅ API（/api/shrines/, /api/favorites/）
+    path("", include(router.urls)),
+
+    # ✅ ルートAPI（POST /api/route/）
+    path("route/", RouteView.as_view(), name="route"),
+
+    # ✅ HTMLビューは /api/pages/shrines/ 以下（必要な場合のみ残す）
+    path("pages/shrines/", views.shrine_list, name="shrine_list"),
+    path("pages/shrines/<int:pk>/", views.shrine_detail, name="shrine_detail"),
+    path("pages/shrines/<int:pk>/route/", views.shrine_route, name="shrine_route"),
+    path("pages/shrines/<int:pk>/favorite/", views.favorite_toggle, name="favorite_toggle"),
 ]

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,44 +1,55 @@
 # 開発TODOリスト（最新版）
 
-## ✅ コア機能（AI参拝ナビ）
-- [ ] ルート提案API …
-- [ ] 人気神社推薦 …
+## 🧭 コア機能（AI参拝ナビ）
+- [ ] ルート提案API（徒歩/車の経路算出）
+- [ ] 人気神社推薦（閲覧/お気に入りスコアで30日集計）
 
-## サポート機能
-- [ ] 御朱印投稿API …
-- [ ] お気に入りAPI …
-- [ ] ランキングAPI …
-- [ ] ユーザー認証／設定API …
+## ⭐ サポート機能
+- [ ] 御朱印投稿API（画像アップロード／公開切替／編集／削除）
+- [x] お気に入りAPI（追加・削除・一覧取得） → JWT 認証で動作確認済み
+- [ ] ランキングAPI（月間・年間TOP10）
+- [ ] ユーザー認証／設定API（プロフィール編集・公開設定）
 
 ## ⚙️ バックエンド作業
-- [ ] モデル追加 …
-- [ ] シリアライザ更新 …
-- [ ] 管理画面拡張 …
-- [ ] バッチ処理 …
+- [x] JWT 認証エンドポイント `/api/token/*` 実装・確認済み
+- [x] Shrine API（一覧・詳細JSON、`/api/shrines/`）
+- [x] Favorite API（`/api/favorites/`、冪等POST、DELETE動作確認済み）
+- [ ] モデル追加（ご利益・祭神フィールドなど拡張）
+- [ ] シリアライザ更新（詳細情報／関連リソース拡張）
+- [ ] 管理画面拡張（神社・御朱印・ランキング管理UI）
+- [ ] バッチ処理（ランキング集計）
 
-## フロントエンド作業
-- [ ] ホームページ …
-- [ ] 神社詳細ページ …
-- [ ] マイページ …
-- [ ] ランキングページ …
-- [ ] コンポーネント …
+## 🎨 フロントエンド（Web / Next.js）
+- [x] `axios` 導入（`apps/web`）
+- [ ] 共通APIクライアント `apps/web/lib/api.ts` 実装（Baseはルート、呼び出しは `/api/...`）
+- [ ] お気に入りラッパ `apps/web/lib/favorites.ts` 実装（add/list/remove）
+- [ ] 神社カード/詳細に「お気に入り」トグルボタン設置
+- [ ] ホームページ（検索フォーム・AIコンシェルジュ入口）
+- [ ] 神社詳細ページ（住所・ご利益・祭神・ルート表示）
+- [ ] マイページ（お気に入り・御朱印投稿管理）
+- [ ] ランキングページ（月間・年間TOP10表示）
+- [ ] コンポーネント追加（MapRoute・ConciergeMessage）
 
-## インフラ作業
-- [ ] Docker環境調整 …
-- [ ] PostgreSQL + PostGIS …
-- [ ] AWS S3連携 …
-- [ ] AWS ECS/Fargate …
-- [ ] SSM Parameter Store …
-- [ ] ALB + ACM …
+## 📱 モバイル（Expo）
+- [ ] APIクライアント同期（`EXPO_PUBLIC_API_BASE`）
+- [ ] 近隣神社リスト（expo-location）
+- [ ] 御朱印画像投稿（expo-image-picker）
+
+## 🛠 インフラ作業
+- [x] Docker 環境起動・DB 接続確認済み
+- [ ] CORS/CSRF の本番方針整理（同一オリジン + リバプロで最小化）
+- [ ] PostgreSQL + PostGIS 拡張確認
+- [ ] AWS S3 連携（御朱印画像保存先）
+- [ ] AWS ECS/Fargate デプロイ設定
+- [ ] SSM Parameter Store（秘密情報管理）
+- [ ] ALB + ACM（HTTPS化）
 - [ ] Miniforge インストール＆初期化（powershell / bash）
-- [ ] conda --version が出る
-- [ ] 環境 jinja_app_py311 を作成（-c conda-forge, python=3.11）
-- [ ] gdal/pyproj/shapely/fiona/geopandas/rtree が import OK
-- [ ] VS Code/Cursor の Python Interpreter を jinja_app_py311 に切替
+- [ ] conda 環境 `jinja_app_py311` 作成（python=3.11, gdal/pyproj/shapely/fiona/geopandas/rtree）
+- [ ] VS Code/Cursor の Python Interpreter を切替
 
-## 今後の拡張
-- [ ] 多言語対応 …
-- [ ] Push通知 …
-- [ ] SNS共有 …
-- [ ] 御朱印帳クラウド同期 …
-
+## 🚀 今後の拡張
+- [ ] 多言語対応（英語／中国語）
+- [ ] Push通知（参拝リマインダー）
+- [ ] SNS共有（Instagram/TikTok）
+- [ ] 御朱印帳クラウド同期
+- [ ] ランキング自動集計バッチ処理


### PR DESCRIPTION
PointSerializer に緯度経度の 範囲バリデーション を追加。

RouteRequestSerializer に 目的地件数の上限（5件） を追加。

RouteResponseSerializer で Leg の構造（from/to/distance/duration/geometry）を検証できるように RouteLegSerializer と RouteLegGeometrySerializer を追加。

RouteView は DRF 流儀で I/O を 厳密すぎない範囲で検証して返却。

既存の HTML ビューはそのまま（/api/pages/...）で、オーナー判定のコメント整備。