### PR TITLE
feat(api): ルート提案API v1 を実装

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,3 +10,6 @@ Pillow==11.3.0
 python-dotenv==1.1.1
 # ↑ dotenv と decouple はどちらか一方に統一推奨。decoupleを使うなら下行を有効化してdotenvを削除。
 # python-decouple==3.8
+djangorestframework-simplejwt>=5.3
+requests>=2.32
+djangorestframework-simplejwt>=5.3

--- a/backend/shrine_project/settings.py
+++ b/backend/shrine_project/settings.py
@@ -69,7 +69,7 @@ INSTALLED_APPS = [
 
     # 3rd-party
     "rest_framework",
-    "rest_framework_simplejwt",
+    #"rest_framework_simplejwt",
     "corsheaders",
 
     # Local apps

--- a/backend/shrine_project/urls.py
+++ b/backend/shrine_project/urls.py
@@ -4,26 +4,26 @@ from django.conf import settings
 from rest_framework_simplejwt.views import (
     TokenObtainPairView,
     TokenRefreshView,
-    TokenVerifyView,  # 使わないなら削除OK
+    TokenVerifyView,
 )
 
 urlpatterns = [
     path("admin/", admin.site.urls),
 
-    # アプリのAPI
-    path("api/", include("temples.urls")),  # 既存のAPI
-    path("api/", include("users.urls")),    # /api/users/me/ を提供（users/urls.py 側で定義）
-
-    # JWT エンドポイント（/api/token/... で固定）
+    # ✅ JWT 認証API
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("api/token/verify/", TokenVerifyView.as_view(), name="token_verify"),
+
+    # ✅ アプリAPI
+    path("api/", include("temples.urls")),
+    path("api/", include("users.urls")),
 ]
 
 # デバッグ用
 if settings.DEBUG:
     try:
-        from temples import debug_views  # optional
+        from temples import debug_views
     except Exception:
         debug_views = None
     if debug_views and hasattr(debug_views, "whoami"):

--- a/backend/temples/api/serializers/__init__.py
+++ b/backend/temples/api/serializers/__init__.py
@@ -1,1 +1,8 @@
 from .favorites import FavoriteSerializer
+from rest_framework import serializers
+from .models import Shrine
+
+class ShrineSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Shrine
+        fields = ["id", "name_jp", "address", "latitude", "longitude"]  # 必要に応じて拡張

--- a/backend/temples/api_views.py
+++ b/backend/temples/api_views.py
@@ -1,28 +1,55 @@
-# backend/temples/api_views.py
 from rest_framework import viewsets, permissions, status
 from rest_framework.response import Response
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
-from .models import Favorite
-from .serializers import FavoriteSerializer
+from .models import Shrine, Favorite          # ← Shrine を追加
+from .serializers import ShrineSerializer, FavoriteSerializer
+
+
+class ShrineViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    GET /api/shrines/
+    GET /api/shrines/{id}/
+    匿名閲覧OK（書き込みなし）
+    """
+    queryset = Shrine.objects.all().order_by("id")
+    serializer_class = ShrineSerializer
+    authentication_classes = [JWTAuthentication]   # 読み取り専用なのであっても可
+    permission_classes = [permissions.AllowAny]    # or IsAuthenticatedOrReadOnly
+
 
 class FavoriteViewSet(viewsets.ModelViewSet):
+    """
+    /api/favorites/ で自分のお気に入りをCRUD
+    POST: {"shrine_id": <int>} を受け付ける（serializerで shrine にマップせず、ここで処理）
+    """
     serializer_class = FavoriteSerializer
-    authentication_classes = (JWTAuthentication,)
-    permission_classes = (permissions.IsAuthenticated,)
+    authentication_classes = [JWTAuthentication]
+    permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        # 自分の分だけ
-        return Favorite.objects.filter(user=self.request.user).select_related("shrine")
+        # 自分の分だけ（神社を同時取得）
+        return (
+            Favorite.objects
+            .select_related("shrine")
+            .filter(user=self.request.user)
+            .order_by("-id")
+        )
 
-    # 冪等にしたい場合（重複時に 200/OK で返す）
+    # 冪等: 既存があれば 200、無ければ作成して 201
     def create(self, request, *args, **kwargs):
         shrine_id = request.data.get("shrine_id")
         if shrine_id is None:
-            return Response({"detail": "shrine_id is required"}, status=400)
+            return Response(
+                {"detail": "shrine_id is required"},
+                status=status.HTTP_400_BAD_REQUEST
+            )
 
         obj, created = Favorite.objects.get_or_create(
             user=request.user, shrine_id=shrine_id
         )
         serializer = self.get_serializer(obj)
-        return Response(serializer.data, status=status.HTTP_201_CREATED if created else status.HTTP_200_OK)
+        return Response(
+            serializer.data,
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        )

--- a/backend/temples/tests/test_route_api.py
+++ b/backend/temples/tests/test_route_api.py
@@ -1,0 +1,59 @@
+import pytest
+from rest_framework.test import APIClient
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+def test_route_api_ok(api_client):
+    payload = {
+        "mode": "walking",
+        "origin": {"lat": 35.68, "lng": 139.76},
+        "destinations": [
+            {"lat": 35.67, "lng": 139.71},
+            {"lat": 35.66, "lng": 139.70}
+        ]
+    }
+    res = api_client.post("/api/route/", data=payload, format="json")
+    assert res.status_code == 200, res.content
+    body = res.json()
+    assert body["mode"] == "walking"
+    assert len(body["legs"]) == 2
+    assert body["distance_m_total"] > 0
+    assert body["duration_s_total"] > 0
+    assert body["provider"] in {"dummy", "mapbox", "google"}
+
+def test_route_api_requires_destinations(api_client):
+    payload = {
+        "mode": "walking",
+        "origin": {"lat": 35.68, "lng": 139.76},
+        "destinations": []
+    }
+    res = api_client.post("/api/route/", data=payload, format="json")
+    assert res.status_code == 400  # allow_empty=False によりバリデーションエラー
+
+def test_route_api_max_destinations(api_client):
+    # 6件（上限5を超える）で 400
+    payload = {
+        "mode": "walking",
+        "origin": {"lat": 35.68, "lng": 139.76},
+        "destinations": [{"lat": 35.67 + i*0.001, "lng": 139.71} for i in range(6)]
+    }
+    res = api_client.post("/api/route/", data=payload, format="json")
+    assert res.status_code == 400
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        {"lat": 100.0, "lng": 139.76},  # lat 範囲外
+        {"lat": 35.68, "lng": 200.0},   # lng 範囲外
+    ],
+)
+def test_route_api_latlng_range_validation(api_client, origin):
+    payload = {
+        "mode": "walking",
+        "origin": origin,
+        "destinations": [{"lat": 35.67, "lng": 139.71}]
+    }
+    res = api_client.post("/api/route/", data=payload, format="json")
+    assert res.status_code == 400

--- a/backend/temples/tests/test_route_service.py
+++ b/backend/temples/tests/test_route_service.py
@@ -1,0 +1,30 @@
+import pytest
+from temples.route_service import Point, build_route
+
+@pytest.mark.parametrize("mode", ["walking", "driving"])
+def test_build_route_returns_legs_and_totals(mode):
+    origin = Point(lat=35.68, lng=139.76)  # 東京駅あたり
+    destinations = [
+        Point(lat=35.67, lng=139.71),      # 目的地1
+        Point(lat=35.66, lng=139.70),      # 目的地2
+    ]
+
+    result = build_route(mode, origin, destinations)
+
+    assert result["mode"] == mode
+    assert result["provider"] in {"dummy", "mapbox", "google"}
+    assert isinstance(result["legs"], list) and len(result["legs"]) == len(destinations)
+
+    # 各 leg の基本形を確認
+    for leg in result["legs"]:
+        assert set(leg.keys()) == {"from", "to", "distance_m", "duration_s", "geometry"}
+        assert isinstance(leg["distance_m"], int) and leg["distance_m"] >= 0
+        assert isinstance(leg["duration_s"], int) and leg["duration_s"] >= 0
+        assert isinstance(leg["geometry"], list) and len(leg["geometry"]) >= 2
+        # [[lat, lng], ...] の形を軽く検査
+        first = leg["geometry"][0]
+        assert isinstance(first, (list, tuple)) and len(first) == 2
+
+    # 合計値が 0 より大きい
+    assert result["distance_m_total"] > 0
+    assert result["duration_s_total"] > 0

--- a/backend/temples/urls.py
+++ b/backend/temples/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
 from . import views
-from .api_views import FavoriteViewSet, ShrineViewSet  # ← ShrineViewSet を忘れず import
+from .api_views import FavoriteViewSet, ShrineViewSet
 from .views import RouteView
 
 router = DefaultRouter()
@@ -12,15 +12,28 @@ router.register(r"shrines", ShrineViewSet, basename="shrine")
 app_name = "temples"
 
 urlpatterns = [
-    # ✅ API（/api/shrines/, /api/favorites/）
+    # ✅ テスト互換: /api/shrines/ に name='shrine_list' を付与
+    #   これが reverse('temples:shrine_list') の解決先になる
+    path(
+        "shrines/",
+        ShrineViewSet.as_view({"get": "list"}),
+        name="shrine_list",
+    ),
+
+    # ルーターの自動生成ルート（/api/shrines/ など）も残す
     path("", include(router.urls)),
 
-    # ✅ ルートAPI（POST /api/route/）
+    # ルートAPI
     path("route/", RouteView.as_view(), name="route"),
 
-    # ✅ HTMLビューは /api/pages/shrines/ 以下（必要な場合のみ残す）
-    path("pages/shrines/", views.shrine_list, name="shrine_list"),
-    path("pages/shrines/<int:pk>/", views.shrine_detail, name="shrine_detail"),
+    # HTMLビュー（name 衝突を避けるため _page に改名）
+    path("pages/shrines/", views.shrine_list, name="shrine_list_page"),
+
     path("pages/shrines/<int:pk>/route/", views.shrine_route, name="shrine_route"),
+    path("pages/shrines/<int:pk>/route/", views.shrine_route, name="shrine_route_page"),
+
+    path("pages/shrines/<int:pk>/", views.shrine_detail, name="shrine_detail"),
     path("pages/shrines/<int:pk>/favorite/", views.favorite_toggle, name="favorite_toggle"),
+
+
 ]

--- a/backend/temples/views.py
+++ b/backend/temples/views.py
@@ -36,10 +36,8 @@ class RouteView(APIView):
 
         result = build_route(data["mode"], origin, destinations)
 
-        # レスポンス形式を軽く検証
-        out = RouteResponseSerializer(data=result)
-        out.is_valid(raise_exception=True)
-        return Response(out.validated_data, status=status.HTTP_200_OK)
+        # API 仕様は `from` キーのまま返す（Serializer 検証は行わない）
+        return Response(result, status=status.HTTP_200_OK)
 
 
 def _is_shrine_owner(user, shrine) -> bool:


### PR DESCRIPTION
- POST /api/route/ を追加
- route_service.py でダミー計算
- serializers/views/urls 修正
- shrine_list/shrine_route の URL 名互換を調整
- テスト追加