### PR TITLE
feat(mobile): 人気神社 API クライアントと型追加（fetchPopular）

### DIFF
--- a/apps/mobile/lib/http.ts
+++ b/apps/mobile/lib/http.ts
@@ -1,0 +1,17 @@
+const BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api";
+
+export async function get<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+// テストやデバッグ用
++export const __internal = { BASE_URL };

--- a/apps/mobile/lib/shrines.ts
+++ b/apps/mobile/lib/shrines.ts
@@ -1,0 +1,55 @@
+import { get } from "./http";
+import type { ShrineSummary } from "../types/shrine";
+
+export type FetchPopularParams = {
+  limit?: number; // default 10
+  near?: { lat: number; lng: number }; // 位置許可時
+  radius_km?: number; // default 10 when near given
+};
+
+/** 人気の神社一覧を取得（近場指定対応、フェイルセーフ付き） */
+export async function fetchPopular(
+  params: FetchPopularParams = {}
+): Promise<ShrineSummary[]> {
+  const limit = params.limit ?? 10;
+  const qs = new URLSearchParams({ limit: String(limit) });
+
+  if (params.near) {
+    qs.set("near", `${params.near.lat},${params.near.lng}`);
+    qs.set("radius_km", String(params.radius_km ?? 10));
+  }
+
+  try {
+    return await get<ShrineSummary[]>(`/shrines/popular?${qs.toString()}`);
+  } catch (e) {
+    // モックフォールバック：UI開発を止めない
+    console.warn("fetchPopular failed, returning fallback mock.", e);
+    const mock: ShrineSummary[] = [
+      {
+        id: "mock-1",
+        name: "明神社",
+        address: "東京都千代田区…",
+        popularity: 92,
+        lat: 35.702,
+        lng: 139.765,
+      },
+      {
+        id: "mock-2",
+        name: "天満宮",
+        address: "東京都文京区…",
+        popularity: 88,
+        lat: 35.715,
+        lng: 139.752,
+      },
+      {
+        id: "mock-3",
+        name: "住吉神社",
+        address: "東京都中央区…",
+        popularity: 81,
+        lat: 35.667,
+        lng: 139.779,
+      },
+    ];
+    return mock;
+  }
+}

--- a/apps/mobile/types/shrine.ts
+++ b/apps/mobile/types/shrine.ts
@@ -1,0 +1,10 @@
+export type ShrineId = string;
+
+export type ShrineSummary = {
+  id: ShrineId;
+  name: string;
+  address: string;
+  popularity: number; // 0-100 スコア想定
+  lat?: number;
+  lng?: number;
+};


### PR DESCRIPTION
## 概要
モバイル側に「人気の神社」取得用の API クライアントを追加しました。  
近場検索（位置許可あり）/ 全国人気（位置許可なし）の両方に対応しています。

## 変更内容
- `apps/mobile/types/shrine.ts`
  - `ShrineSummary` 型を新規追加
- `apps/mobile/lib/http.ts`
  - 共通 GET ラッパを追加（`EXPO_PUBLIC_API_BASE_URL` 対応）
- `apps/mobile/lib/shrines.ts`
  - `fetchPopular()` 実装
  - `?limit=` / `?near=lat,lng&radius_km=10` をサポート
  - 通信失敗時はモックデータにフォールバック

## 動作確認
1. `.env` に API ベースURLを設定
   ```env
   EXPO_PUBLIC_API_BASE_URL=http://localhost:8000/api
