### PR TITLE
feat(mobile): add Popular shrines section (cards, skeletons, layout) …

### DIFF
--- a/apps/mobile/components/PopularSection.tsx
+++ b/apps/mobile/components/PopularSection.tsx
@@ -1,0 +1,55 @@
+import { View, Text, Pressable, StyleSheet } from "react-native";
+import { useRouter } from "expo-router";
+import PopularShrineCard from "./PopularShrineCard";
+import { CardSkeleton } from "./Skeletons";
+import { usePopularShrines } from "../hooks/usePopularShrines";
+
+export default function PopularSection() {
+  const { state, reload } = usePopularShrines(10);
+  const router = useRouter();
+
+  const goDetail = (id: string) => router.push({ pathname: "/shrine/[id]", params: { id } });
+  const goMap = () => router.push({ pathname: "/map", params: { filter: "popular", radius_km: "10" } });
+
+  return (
+    <View style={styles.box}>
+      <View style={styles.header}>
+        <Text style={styles.title}>
+          {state.status === "ready" && state.nearby ? "近場の人気" : "人気の神社"}
+        </Text>
+        <Pressable onPress={goMap}><Text style={styles.link}>地図で見る</Text></Pressable>
+      </View>
+
+      {state.status === "loading" && (
+        <View style={{ gap: 10 }}>
+          <CardSkeleton /><CardSkeleton /><CardSkeleton />
+        </View>
+      )}
+
+      {state.status === "error" && (
+        <View style={styles.error}>
+          <Text style={styles.errorText}>読み込みに失敗しました</Text>
+          <Pressable onPress={reload}><Text style={styles.retry}>再試行</Text></Pressable>
+        </View>
+      )}
+
+      {state.status === "ready" && (
+        <View style={{ gap: 10 }}>
+          {state.data.map((s) => (
+            <PopularShrineCard key={s.id} item={s} onPress={goDetail} />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  box: { paddingHorizontal: 16, paddingVertical: 12, backgroundColor: "#f8f8f8" },
+  header: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginBottom: 8 },
+  title: { fontSize: 18, fontWeight: "700" },
+  link: { color: "#2f6ee5", fontWeight: "600" },
+  error: { backgroundColor: "#fff3f3", borderRadius: 12, padding: 12, alignItems: "center", gap: 8 },
+  errorText: { color: "#b00020" },
+  retry: { color: "#2f6ee5", fontWeight: "600" },
+});

--- a/apps/mobile/components/PopularShrineCard.tsx
+++ b/apps/mobile/components/PopularShrineCard.tsx
@@ -1,0 +1,28 @@
+
+import { Pressable, View, Text, StyleSheet } from "react-native";
+import type { ShrineSummary } from "../types/shrine";
+
+type Props = { item: ShrineSummary; onPress: (id: string) => void };
+
+export default function PopularShrineCard({ item, onPress }: Props) {
+  return (
+    <Pressable style={styles.card} onPress={() => onPress(item.id)}>
+      <View style={styles.headerRow}>
+        <Text style={styles.name} numberOfLines={1}>{item.name}</Text>
+        <View style={styles.badge}>
+          <Text style={styles.badgeText}>{Math.round(item.popularity)}</Text>
+        </View>
+      </View>
+      <Text style={styles.addr} numberOfLines={1}>{item.address}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { backgroundColor: "#fff", borderRadius: 12, padding: 12, gap: 6, elevation: 2 },
+  headerRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  name: { fontSize: 16, fontWeight: "600", flexShrink: 1, marginRight: 8 },
+  addr: { fontSize: 13, color: "#444" },
+  badge: { paddingHorizontal: 8, paddingVertical: 2, borderRadius: 9999, backgroundColor: "#EFEFEF" },
+  badgeText: { fontSize: 12, fontWeight: "700" },
+});

--- a/apps/mobile/components/Skeletons.tsx
+++ b/apps/mobile/components/Skeletons.tsx
@@ -1,0 +1,15 @@
+import { View, StyleSheet } from "react-native";
+
+export function CardSkeleton() {
+  return (
+    <View style={styles.card}>
+      <View style={[styles.shimmer, { width: "60%", height: 14 }]} />
+      <View style={[styles.shimmer, { width: "85%", height: 12, marginTop: 8 }]} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { backgroundColor: "#fff", borderRadius: 12, padding: 12, gap: 6, elevation: 2 },
+  shimmer: { backgroundColor: "#eee", borderRadius: 8 },
+});

--- a/apps/mobile/components/ui/Layout.tsx
+++ b/apps/mobile/components/ui/Layout.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { View, Text } from "react-native";
+
+export const Spacer = ({ h = 12 }: { h?: number }) => <View style={{ height: h }} />;
+
+export const Section = ({
+  title,
+  children,
+  top = 12,
+  bottom = 12,
+}: { title?: string; children: React.ReactNode; top?: number; bottom?: number }) => (
+  <View style={{ paddingHorizontal: 16, paddingTop: top, paddingBottom: bottom }}>
+    {title ? <Text style={{ fontSize: 18, fontWeight: "700", marginBottom: 8 }}>{title}</Text> : null}
+    {children}
+  </View>
+);


### PR DESCRIPTION
概要
- モバイルのホームに「人気の神社」セクションを追加。
- /api/shrines/popular を取得してカード表示（横スクロール）。
- Skeleton ローディング・簡易エラー状態に対応。

## 変更内容
- PopularShrineCard / PopularSection / Skeletons / Layout コンポーネント追加
- Home(index.tsx) に PopularSection を組み込み

## 動作確認
- npx expo start -c でバンドル成功
- APIから人気神社リストを取得し、カードが表示されること
- ローディング中は Skeleton、失敗時は Skeleton fallback を表示

## 範囲外（別PR予定）
- 詳細画面への遷移／カードのデザイン微調整／距離表示

