### PR TITLE
chore(babel): use react-native-worklets at repo root

### DIFF
--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,7 +1,5 @@
 module.exports = function (api) {
   api.cache(true);
-  // デバッグ用に、読まれていることをログ出し（起動時に一度出ます）
-  console.log("[BABEL] using root babel.config.js");
    return {
     presets: [
       // 旧 reanimated/plugin の自動注入を無効化（Expoの自動設定対策）


### PR DESCRIPTION
モノレポのルートに babel.config.js を追加し、旧  の自動注入を抑止。 を明示して Reanimated v4 以降に対応。