### PR TITLE
fix(places): Find Place系の文字化け復元と完全一致注入を安定化

### DIFF
--- a/backend/temples/api_views.py
+++ b/backend/temples/api_views.py
@@ -1,7 +1,8 @@
-# backend/temples/api_views.py（抜粋・置換用）
-import math
+# import math
 import re
-import requests
+# import requests
+import unicodedata
+from urllib.parse import unquote_to_bytes
 from django.http import HttpResponse
 from django.core.cache import cache
 from django.conf import settings
@@ -21,10 +22,250 @@ from .services.places import get_or_sync_place, PlacesError
 from .models import Shrine, Favorite, PlaceRef
 from .api.serializers import ShrineSerializer, FavoriteSerializer, FavoriteUpsertSerializer
 
+REPLACEMENT_CHAR = "\uFFFD"
+
+def _robust_get_query_param(request, name: str) -> str:
+    """
+    request.GET で U+FFFD が混入していたら、
+    生の QUERY_STRING から name の値を bytes として取り直し、
+    UTF-8 → CP932 → Shift_JIS の順に再デコードする。
+    """
+    val = (request.GET.get(name) or "").strip()
+    if val and REPLACEMENT_CHAR not in val:
+        # 置換されてなければ従来の軽い補正だけ
+        return _maybe_fix_mojibake(val)
+
+    raw_qs = request.META.get("QUERY_STRING", "")
+    # name=... を抜き出し
+    m = re.search(r'(?:^|&)' + re.escape(name) + r'=([^&]*)', raw_qs)
+    if not m:
+        return val
+    raw_enc = m.group(1)
+
+    # '+' はスペース扱い、%XX はバイト化
+    try:
+        raw_bytes = unquote_to_bytes(raw_enc.replace('+', ' '))
+    except Exception:
+        return val
+
+    # 正規の UTF-8 ならそれでOK
+    try:
+        return raw_bytes.decode('utf-8')
+    except Exception:
+        pass
+    # Windows/CP932 → Shift_JIS の順で試す
+    for enc in ('cp932', 'shift_jis'):
+        try:
+            return raw_bytes.decode(enc)
+        except Exception:
+            continue
+    return val
+
+
+
+def _parse_locationbias_center_and_radius(lb: str):
+    """
+    locationbias から (center(lat,lng), location="lat,lng", radius(int or None)) を取り出す。
+    circle と point にだけ対応。失敗時は (None, None, None)。
+    """
+    if not lb:
+        return None, None, None
+    try:
+        lb = lb.strip()
+        if lb.startswith("circle:"):
+            # 例: circle:1500@35.715,139.797
+            rest = lb.split("circle:", 1)[1]
+            radius_s, at = rest.split("@", 1)
+            radius_i = int(float(radius_s))
+            lat_s, lng_s = at.split(",", 1)
+            clat, clng = float(lat_s), float(lng_s)
+            return (clat, clng), f"{clat},{clng}", radius_i
+        if lb.startswith("point:"):
+            # 例: point:35.715,139.797
+            coord = lb.split("point:", 1)[1]
+            lat_s, lng_s = coord.split(",", 1)
+            clat, clng = float(lat_s), float(lng_s)
+            return (clat, clng), f"{clat},{clng}", None
+    except Exception:
+        pass
+    return None, None, None
+
+def _is_shinto_shrine_row(r: dict) -> bool:
+    types = set(r.get("types") or [])
+    name = (r.get("name") or "")
+    lname = name.lower()
+
+    if "buddhist_temple" in types:
+        return False
+    
+    # type / 典型和名 / 典型英名
+    jp_keywords = ("神社", "稲荷", "八幡", "天神", "天満宮", "神宮")
+    en_keywords = ("shinto_shrine", "jinja", "jingu", "hachiman", "inari", "tenjin", "shrine")
+
+    if "shinto_shrine" in types:
+        return True
+    if any(k in name for k in jp_keywords):
+        return True
+    if any(k in lname for k in en_keywords) and ("temple" not in lname):
+        return True
+
+    return False
+
+def _normalize_name(s: str) -> str:
+    # 空白除去・小文字化のみの簡易正規化（日本語にも無害）
+    return re.sub(r"\s+", "", (s or "")).lower()
+
+def _name_equals_query(name: str, q: str) -> bool:
+    """
+    完全一致の緩和版：
+    ・全角/半角の括弧で囲まれた注記（例: （本殿）, (Asakusa Shrine)）を削除
+    ・空白を削除
+    ・小文字化
+    """
+    def norm(x: str) -> str:
+        x = x or ""
+        # 全角/半角の括弧内を除去（（…）/(...)）
+        x = re.sub(r"[（(].*?[）)]", "", x)
+        # NFKC 正規化で全半/類似記号を吸収 → 空白削除 → 小文字化
+        x = unicodedata.normalize("NFKC", x)
+        x = re.sub(r"\s+", "", x).lower()
+        return x
+    return norm(name) == norm(q)
+
+
+def _distance2_from(center, r: dict) -> float:
+    """中心(center=(lat,lng))からの簡易距離（二乗）。centerが無ければ0。"""
+    if not center:
+        return 0.0
+    if "lat" in r and "lng" in r:
+        lat, lng = r["lat"], r["lng"]
+    else:
+        loc = (r.get("geometry") or {}).get("location") or {}
+        lat, lng = loc.get("lat"), loc.get("lng")
+    if lat is None or lng is None:
+        return 1e18
+    return (lat - center[0]) ** 2 + (lng - center[1]) ** 2
+
+
+def _match_bucket(name: str, q: str) -> int:
+    """
+    0: 完全一致, 1: 前方一致, 2: 部分一致, 3: その他
+    正規化して判定（大文字小文字・空白の差を吸収）
+    """
+    # ★ 完全一致は最優先
+    if _name_equals_query(name, q):
+        return 0
+    
+    n = _normalize_name(name)
+    qn = _normalize_name(q)
+    if not qn:
+        return 3
+    if n == qn:
+        return 0
+    if n.startswith(qn):
+        return 1
+    if qn in n:
+        return 2
+    return 3
+
+
+def _sort_results_for_query(results, q: str, center=None):
+    """
+    マッチ度 → 距離（近いほど先）→ rating 降順 → user_ratings_total 降順
+    """
+    def key(r):
+        return (
+            _match_bucket(r.get("name") or "", q),
+            _distance2_from(center, r),
+            -(r.get("rating") or 0),
+            -(r.get("user_ratings_total") or 0),
+        )
+    return sorted(results or [], key=key)
+
+def _inject_exact_match(q: str, location: str, radius_i: int, data: dict):
+    """
+    Text Search/Nearby のどちらにも q と（緩和した）完全一致の name が無ければ、
+    候補を探して先頭に挿入。best-effort。
+    """
+    if not (q and location and radius_i and isinstance(data, dict) and isinstance(data.get("results"), list)):
+        return
+
+    results = data["results"]
+
+    # 既に（緩和した）完全一致があるなら何もしない
+    if any(_name_equals_query(r.get("name"), q) for r in results):
+        return
+
+    try:
+        exacts = []
+
+        def _collect(rows):
+            for r in (rows or []):
+                if _is_shinto_shrine_row(r) and _name_equals_query(r.get("name"), q):
+                    exacts.append(r)
+
+        # 0) Find Place（名前に強い）
+        try:
+            fp = gp.find_place_text(
+                q,
+                language="ja",
+                locationbias=f"circle:{radius_i}@{location}",
+                fields="place_id,name,geometry,types,rating,user_ratings_total",
+            )
+            _collect(fp.get("results"))
+        except Exception:
+            pass
+
+        # 1) Text Search（素の q）
+        _collect(gp.text_search(
+            query=q, location=location, radius=radius_i, language="ja", region="jp"
+        ).get("results"))
+
+        # 2) Text Search（神社バイアス）
+        if not exacts and "神社" not in q:
+            _collect(gp.text_search(
+                query=f"{q} 神社", location=location, radius=radius_i, language="ja", region="jp"
+            ).get("results"))
+
+        # 3) Nearby（最後の保険）
+        if not exacts:
+            _collect(gp.nearby_search(
+                location=location, radius=radius_i, keyword=q,
+                opennow=False, type_=None, language="ja",
+            ).get("results"))
+
+        if not exacts:
+            return
+
+        best = max(exacts, key=lambda r: ((r.get("rating") or 0), (r.get("user_ratings_total") or 0)))
+        existing_ids = {r.get("place_id") for r in results}
+        if best.get("place_id") not in existing_ids:
+            results.insert(0, best)  # 先頭固定（ここでは再ソートしない）
+
+    except Exception:
+        pass
+
+
+def _maybe_fix_mojibake(s: str) -> str:
+    """
+    Windows コンソール等からの生 URL で起こる典型的なモジバケを簡易補正。
+    CP932/SJIS バイト列を UTF-8 と誤解して送られたような場合に効く。
+    失敗時はそのまま返す。
+    """
+    try:
+        # 0x80–0x9F の制御領域っぽい文字が混じる場合は怪しいので補正を試みる
+        if any('\x80' <= ch <= '\x9f' for ch in s):
+            return s.encode('latin1', 'ignore').decode('cp932', 'ignore')
+    except Exception:
+        pass
+    return s
+
+
 # Google place_id の簡易フォーマット
 PLACE_ID_RE = re.compile(r"^[A-Za-z0-9._=-]{10,200}$")
 
 
+# PlacesSearchView を神社専用に絞り込み
 class PlacesSearchView(APIView):
     authentication_classes = []
     permission_classes = []
@@ -35,16 +276,66 @@ class PlacesSearchView(APIView):
         q = (request.query_params.get("q") or request.query_params.get("query") or "").strip()
         if not q:
             return Response({"detail": "q is required"}, status=status.HTTP_400_BAD_REQUEST)
+        q = _maybe_fix_mojibake(q)
 
+        # 位置バイアスは明示的指定時のみ
         lat = request.query_params.get("lat")
         lng = request.query_params.get("lng")
-        location = f"{lat},{lng}" if lat and lng else None
-
+        location = f"{lat},{lng}" if (lat and lng) else None
         radius = request.query_params.get("radius")
         radius_i = int(radius) if radius else None
 
+        # 神社にバイアス
+        q_bias = q if ("神社" in q) else f"{q} 神社"
+
         try:
-            data = gp.text_search(query=q, location=location, radius=radius_i, language="ja", region="jp")
+            params = dict(query=q_bias, language="ja", region="jp")
+            if location and radius_i:
+                params.update(location=location, radius=radius_i)
+            else:
+                # 無指定のときだけ settings の既定バイアスを使う（あれば）
+                default_loc = getattr(settings, "PLACES_TEXT_DEFAULT_LOCATION", None)
+                default_radius = getattr(settings, "PLACES_TEXT_DEFAULT_RADIUS_M", None)
+                if default_loc and default_radius:
+                    params.update(location=default_loc, radius=int(default_radius))
+
+            data = gp.text_search(**params)
+
+            # フィルタ
+            filtered = [r for r in (data.get("results") or []) if _is_shinto_shrine_row(r)]
+
+            # center 算出（並べ替え用）
+            center = None
+            if location:
+                try:
+                    lat_s, lng_s = location.split(",")
+                    center = (float(lat_s), float(lng_s))
+                except Exception:
+                    center = None
+
+            # 並べ替え
+            data["results"] = _sort_results_for_query(filtered, q, center=center)
+
+            # 完全一致注入（位置があるときのみ）
+            if location and radius_i:
+                _inject_exact_match(q, location, radius_i, data)
+
+            # それでも空なら nearby フォールバック
+            if not data["results"] and location and radius_i:
+                nb = gp.nearby_search(
+                    location=location,
+                    radius=radius_i,
+                    keyword=q or "神社",
+                    opennow=False,
+                    type_=None,
+                    language="ja",
+                )
+                nb_filtered = [r for r in (nb.get("results") or []) if _is_shinto_shrine_row(r)]
+                nb["results"] = _sort_results_for_query(nb_filtered, q, center=center)
+                if nb["results"] != []:
+                    data = nb
+                    _inject_exact_match(q, location, radius_i, data)
+
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
             return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)
@@ -61,33 +352,67 @@ class PlacesTextSearchPagedView(APIView):
         q = (request.GET.get("q") or "").strip()
         if not pagetoken and not q:
             return Response({"detail": "q is required"}, status=status.HTTP_400_BAD_REQUEST)
+        q = _robust_get_query_param(request, "q") or _robust_get_query_param(request, "query")
 
-        type_ = request.GET.get("type")
-        opennow = (request.GET.get("opennow") or "").lower() in ("1", "true", "yes")
+        # 神社バイアス
+        q_bias = q if ("神社" in q) else f"{q} 神社"
 
         lat = request.GET.get("lat")
         lng = request.GET.get("lng")
         location = f"{lat},{lng}" if (lat and lng) else None
-
         radius = request.GET.get("radius")
         radius_i = int(radius) if radius else None
 
-        # 手動キャッシュ（KEY_FUNCTION により memcached-safe になる）
+        # 実効位置（未指定時は既定値を適用）—キャッシュキーと検索、ソートで統一して使う
+        eff_location = location
+        eff_radius_i = radius_i
+        if not (eff_location and eff_radius_i) and not pagetoken:
+            default_loc = getattr(settings, "PLACES_TEXT_DEFAULT_LOCATION", None)
+            default_radius = getattr(settings, "PLACES_TEXT_DEFAULT_RADIUS_M", None)
+            if default_loc and default_radius:
+                eff_location = default_loc
+                eff_radius_i = int(default_radius)
+
         ttl = getattr(settings, "PLACES_TEXT_CACHE_SECONDS", 300)
-        cache_key = f"places:text:{q}:{location or ''}:{radius_i or ''}:{type_ or ''}:{'1' if opennow else '0'}:{pagetoken or ''}"
+        cache_key = (
+            f"places:text:{q}:{eff_location or ''}:{eff_radius_i or ''}:{pagetoken or ''}:shinto_only"
+        )
         cached = cache.get(cache_key)
         if cached is not None:
             return Response(cached, status=status.HTTP_200_OK)
 
         try:
-            data = gp.text_search(
-                query=q,
-                location=location,
-                radius=radius_i,
-                type_=type_,
-                open_now=opennow,
+            # 検索パラメータ（実効位置をそのまま使う）
+            search_kwargs = dict(
+                query=q_bias,
+                location=eff_location,
+                radius=eff_radius_i,
                 pagetoken=pagetoken,
+                language="ja",
+                region="jp",
             )
+
+            data = gp.text_search(**search_kwargs)
+
+            # フィルタ
+            filtered = [r for r in (data.get("results") or []) if _is_shinto_shrine_row(r)]
+
+            # center 算出（並べ替え用）
+            center = None
+            if eff_location:
+                try:
+                    lat_s, lng_s = eff_location.split(",")
+                    center = (float(lat_s), float(lng_s))
+                except Exception:
+                    center = None
+
+            # 並べ替え
+            data["results"] = _sort_results_for_query(filtered, q, center=center)
+
+            # 完全一致注入（位置があるときのみ・最初のページのみ）
+            if eff_location and eff_radius_i and not pagetoken:
+                _inject_exact_match(q, eff_location, eff_radius_i, data)
+
             cache.set(cache_key, data, ttl)
             return Response(data, status=status.HTTP_200_OK)
         except Exception as e:
@@ -102,10 +427,11 @@ class PlacesNearbySearchView(APIView):
 
     def get(self, request):
         pagetoken = request.GET.get("pagetoken")
-        keyword = request.GET.get("keyword")
-        type_ = request.GET.get("type")
+        keyword = _robust_get_query_param(request, "keyword") or "神社"   # 既定は神社
+        keyword = _maybe_fix_mojibake(keyword)
         opennow = (request.GET.get("opennow") or "").lower() in ("1", "true", "yes")
 
+        center = None
         if not pagetoken:
             lat = request.GET.get("lat")
             lng = request.GET.get("lng")
@@ -116,30 +442,57 @@ class PlacesNearbySearchView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             try:
-                float(lat); float(lng)
+                clat, clng = float(lat), float(lng)
                 radius_i = int(radius)
             except ValueError:
                 return Response({"detail": "lat/lng must be float, radius must be int"},
                                 status=status.HTTP_400_BAD_REQUEST)
             location = f"{lat},{lng}"
+            center = (clat, clng)
         else:
-            # pagetoken がある場合、上流は token のみ見ればOK
             location = None
             radius_i = 0
 
         try:
+            # 1) Nearby 実行 → 神社だけ残す
             data = gp.nearby_search(
                 location=location,
                 radius=radius_i,
                 keyword=keyword,
-                type_=type_,
-                opennow=opennow,   # ← Google側は opennow パラメータ
+                type_=None,
+                opennow=opennow,
                 pagetoken=pagetoken,
+                language="ja",
             )
+            raw = data.get("results") or []
+            filtered = [r for r in raw if _is_shinto_shrine_row(r)]
+
+            # 2) 「マッチ度 → 距離 → rating → 口コミ数」で並べ替え
+            data["results"] = _sort_results_for_query(filtered, keyword, center=center)
+
+            # 3) 完全一致が出ていなければ Nearby で補完して先頭に注入（重複回避）
+            if location and radius_i and not pagetoken and keyword:
+                _inject_exact_match(keyword, location, radius_i, data)
+                # ここでは再ソートしない：注入した完全一致を先頭に固定したいのでそのままにする
+
+            # 4) （依然空なら）Text Search にフォールバック＋並べ替え
+            if not data["results"] and location and radius_i and not pagetoken:
+                q_bias = keyword if ("神社" in keyword) else f"{keyword} 神社"
+                ts = gp.text_search(
+                    query=q_bias,
+                    location=location,
+                    radius=radius_i,
+                    language="ja",
+                    region="jp",
+                )
+                ts_filtered = [r for r in (ts.get("results") or []) if _is_shinto_shrine_row(r)]
+                ts["results"] = _sort_results_for_query(ts_filtered, keyword, center=center)
+                return Response(ts, status=status.HTTP_200_OK)
+
             return Response(data, status=status.HTTP_200_OK)
+
         except Exception as e:
             return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)
-
 
 # ビュー全体をキャッシュ（2回目以降は gp.photo を呼ばない）
 @method_decorator(cache_page(getattr(settings, "PLACES_PHOTO_CACHE_SECONDS", 86400)), name="get")
@@ -264,6 +617,7 @@ class LatLngSerializer(serializers.Serializer):
             raise serializers.ValidationError("lng out of range")
         return v
 
+
 class RouteRequestSerializer(serializers.Serializer):
     mode = serializers.ChoiceField(choices=["walking", "driving", "bicycling", "transit"])
     origin = LatLngSerializer()
@@ -273,6 +627,7 @@ class RouteRequestSerializer(serializers.Serializer):
         if len(value) > 5:
             raise serializers.ValidationError("too many destinations")
         return value
+
 
 class RouteAPIView(APIView):
     authentication_classes = []
@@ -332,5 +687,85 @@ class RouteAPIView(APIView):
         })
 
 
+# --- Find Place API ---
+class PlacesFindPlaceView(APIView):
+    authentication_classes = []
+    permission_classes = []
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "places"
 
+    def get(self, request):
+        # ここは必ず半角スペース4つのインデントにしてください（タブ・全角不可）
+        input_text = _robust_get_query_param(request, "input")
+        if not input_text:
+            return Response({"detail": "input is required"}, status=status.HTTP_400_BAD_REQUEST)
 
+        language = request.GET.get("language", "ja")
+        locationbias = request.GET.get("locationbias")
+        fields = request.GET.get("fields")  # 未指定なら gp 側のデフォルトが効く
+
+        # locationbias のパース（center と radius を抽出）
+        center, location, radius_i = _parse_locationbias_center_and_radius(locationbias)
+
+        # キャッシュ（Text 検索と同じ TTL を流用）
+        ttl = getattr(settings, "PLACES_TEXT_CACHE_SECONDS", 300)
+        lb_norm = f"{center[0]},{center[1]}" if center else ""
+        cache_key = f"places:find:{language}:{input_text}:{lb_norm}:{radius_i or ''}:{fields or ''}"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return Response(cached, status=status.HTTP_200_OK)
+
+        try:
+            data = gp.find_place_text(
+                input_text,
+                language=language,
+                locationbias=locationbias,
+                fields=fields,  # None のときはクライアント側の既定 fields を自動付与
+            )
+
+            # 神社のみ残す
+            filtered = [r for r in (data.get("results") or []) if _is_shinto_shrine_row(r)]
+            data["results"] = _sort_results_for_query(filtered, input_text, center=center)
+
+            if location and radius_i:
+                _inject_exact_match(input_text, location, radius_i, data)
+
+            if not data["results"]:
+                # キーワードに神社バイアス（未指定時のみ付与）
+                q_bias = input_text if ("神社" in input_text) else f"{input_text} 神社"
+
+                # 2a) Text Search
+                ts = gp.text_search(
+                    query=q_bias,
+                    location=location,
+                    radius=radius_i,
+                    language="ja",
+                    region="jp",
+                )
+                ts_filtered = [r for r in (ts.get("results") or []) if _is_shinto_shrine_row(r)]
+                ts["results"] = _sort_results_for_query(ts_filtered, input_text, center=center)
+
+                if ts["results"]:
+                    cache.set(cache_key, ts, ttl)
+                    return Response(ts, status=status.HTTP_200_OK)
+
+                # 2b) Nearby（Text でも出なければ最後の保険）
+                if location and radius_i:
+                    nb = gp.nearby_search(
+                        location=location,
+                        radius=radius_i,
+                        keyword=input_text,
+                        language="ja",
+                        type_=None,
+                        opennow=False,
+                    )
+                    nb_filtered = [r for r in (nb.get("results") or []) if _is_shinto_shrine_row(r)]
+                    nb["results"] = _sort_results_for_query(nb_filtered, input_text, center=center)
+                    cache.set(cache_key, nb, ttl)
+                    return Response(nb, status=status.HTTP_200_OK)
+
+            cache.set(cache_key, data, ttl)
+            return Response(data, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)


### PR DESCRIPTION
robust_get_query_param を導入し、QUERY_STRING からの生バイト復元で
  CP932/Shift_JIS 由来のモジバケを補正
- _name_equals_query を NFKC + 括弧除去 + 空白除去で厳密化（unicodedata使用を統一）
- _is_shinto_shrine_row の判定語を拡充（神社/稲荷/八幡/天神 等、寺は除外）
- 並べ替えを「マッチ度→距離→rating→口コミ数」に統一
- 完全一致候補の注入（FindPlace/Text/Nearby）＋ place_id で重複回避
- _get_param_robust を削除（未使用のため）