### PR TITLE
共通APIレイヤ追加（axiosラッパ・TokenStore・usersApi）

### DIFF
--- a/apps/web/packages/shared/api.ts
+++ b/apps/web/packages/shared/api.ts
@@ -1,0 +1,12 @@
+import axios, { AxiosInstance } from "axios";
+import type { TokenStore } from "./tokenStore";
+
+export function createApi(baseURL: string, tokens: TokenStore): AxiosInstance {
+  const api = axios.create({ baseURL });
+  api.interceptors.request.use(async (config) => {
+    const t = await tokens.get();
+    if (t) config.headers.Authorization = `Bearer ${t}`;
+    return config;
+  });
+  return api;
+}

--- a/apps/web/packages/shared/index.ts
+++ b/apps/web/packages/shared/index.ts
@@ -1,0 +1,3 @@
+export * from "./api";
+export * from "./tokenStore";
+export * from "./users";

--- a/apps/web/packages/shared/package.json
+++ b/apps/web/packages/shared/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@shared/core",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./index.ts",
+  "private": true
+}

--- a/apps/web/packages/shared/tokenStore.ts
+++ b/apps/web/packages/shared/tokenStore.ts
@@ -1,0 +1,4 @@
+export interface TokenStore {
+  get(): Promise<string | null>;
+  set(token: string | null): Promise<void>;
+}

--- a/apps/web/packages/shared/tsconfig.json
+++ b/apps/web/packages/shared/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../apps/web/tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "emitDeclarationOnly": false
+  },
+  "include": ["./**/*.ts"]
+}

--- a/apps/web/packages/shared/users.ts
+++ b/apps/web/packages/shared/users.ts
@@ -1,0 +1,21 @@
+import type { AxiosInstance } from "axios";
+
+export type User = { id: number; username: string; email?: string };
+export type UserProfile = User & {
+  display_name?: string | null;
+  avatar_url?: string | null;
+  home_location?: { lat: number; lng: number } | null;
+};
+
+export function usersApi(api: AxiosInstance) {
+  return {
+    async me() {
+      const { data } = await api.get<UserProfile>("/users/me/");
+      return data;
+    },
+    async update(payload: Partial<Omit<UserProfile, "id" | "username">>) {
+      const { data } = await api.patch<UserProfile>("/users/me/", payload);
+      return data;
+    },
+  };
+}


### PR DESCRIPTION
## 目的
モバイル/ウェブで共通利用できる API レイヤを追加し、トークン付与・ユーザーAPI呼び出しの重複を解消するため。

## 変更点
- packages/shared/
  - api.ts: Axios の共通ファクトリ（TokenStore から Authorization を自動付与）
  - tokenStore.ts: トークン保存の抽象インターフェイス
  - users.ts: /users/me/ の取得・更新ラッパ（User/UserProfile型付け）
  - index.ts, package.json, tsconfig.json
