### PR TITLE
検索/Plan入力に「現在地を使う」導線を追加（locationbias対応）

### DIFF
--- a/apps/web/src/app/plan/page.tsx
+++ b/apps/web/src/app/plan/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import UseMyLocationButton from "@/components/UseMyLocationButton";
+import { buildLocationBias } from "@/lib/locationBias";
+
+export default function PlanPage() {
+  const [query, setQuery] = useState("浅草神社");
+  const [mode, setMode] = useState<"walk" | "car">("walk");
+  const [lat, setLat] = useState<number | undefined>();
+  const [lng, setLng] = useState<number | undefined>();
+
+  const lb = buildLocationBias(lat, lng, 1500);
+
+  return (
+    <main className="p-4 max-w-xl mx-auto space-y-4">
+      <h1 className="text-xl font-bold">参拝プラン（簡易デモ）</h1>
+
+      <div className="flex gap-2">
+        <input
+          className="border rounded p-2 flex-1"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="神社名や地名"
+        />
+        <select
+          className="border rounded p-2"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as "walk" | "car")}
+        >
+          <option value="walk">徒歩</option>
+          <option value="car">車</option>
+        </select>
+        <UseMyLocationButton
+          onPick={(la, ln) => {
+            setLat(la);
+            setLng(ln);
+          }}
+        />
+      </div>
+
+      <p className="text-xs text-gray-500">
+        locationbias: {lb || "(未設定)"}
+      </p>
+
+      {/* 実API連携は後続PRで */}
+    </main>
+  );
+}


### PR DESCRIPTION
検索や参拝プラン作成時に、ユーザーの現在地を Google Places の locationbias に反映し、近隣ヒット精度を上げる。

## 変更点
- apps/web/src/components/UseMyLocationButton.tsx
  - ブラウザ Geolocation API で現在地を取得し、親に `lat/lng` を返す汎用ボタン
- apps/web/src/lib/locationBias.ts
  - `circle:<radius>@<lat>,<lng>` 形式の locationbias 文字列を生成
- apps/web/src/app/page.tsx（トップ）
  - 検索フォームに「現在地を使う」ボタンを追加
  - 検索遷移 `/search?keyword=...&locationbias=...` に対応
- apps/web/src/app/plan/page.tsx（簡易デモ）
  - クエリ・移動手段・現在地入力（ボタン）を配置し、生成された locationbias を確認可能
  - ※ 実際の concierge/plan API 呼び出しは後続PRで実装予定