### PR TITLE
東京主要神社にvisit_style_tagsを追加

### DIFF
--- a/backend/temples/data/shrines_seed_clean.json
+++ b/backend/temples/data/shrines_seed_clean.json
@@ -638,6 +638,11 @@
     "astro_elements": [
       "水"
     ],
+    "visit_style_tags": [
+      "quiet",
+      "urban",
+      "love"
+    ],
     "location": {
       "lat": 35.7006,
       "lng": 139.7454
@@ -652,6 +657,11 @@
     "kyusei": null,
     "astro_elements": [
       "風"
+    ],
+    "visit_style_tags": [
+      "classic",
+      "urban",
+      "business"
     ],
     "location": {
       "lat": 35.6581,
@@ -668,6 +678,11 @@
     "astro_elements": [
       "火"
     ],
+    "visit_style_tags": [
+      "reset",
+      "urban",
+      "business"
+    ],
     "location": {
       "lat": 35.6627,
       "lng": 139.7487
@@ -682,6 +697,11 @@
     "kyusei": null,
     "astro_elements": [
       "土"
+    ],
+    "visit_style_tags": [
+      "classic",
+      "urban",
+      "study"
     ],
     "location": {
       "lat": 35.7034,
@@ -698,6 +718,11 @@
     "astro_elements": [
       "水"
     ],
+    "visit_style_tags": [
+      "quiet",
+      "classic",
+      "nature"
+    ],
     "location": {
       "lat": 35.7174,
       "lng": 139.7603
@@ -713,6 +738,11 @@
     "astro_elements": [
       "土"
     ],
+    "visit_style_tags": [
+      "classic",
+      "urban",
+      "business"
+    ],
     "location": {
       "lat": 35.6733,
       "lng": 139.7967
@@ -727,6 +757,11 @@
     "kyusei": null,
     "astro_elements": [
       "火"
+    ],
+    "visit_style_tags": [
+      "reset",
+      "urban",
+      "business"
     ],
     "location": {
       "lat": 35.6229,
@@ -857,6 +892,7 @@
     "goriyaku": "仕事運・勝運・家内安全",
     "kyusei": null,
     "astro_elements": ["土"],
+    "visit_style_tags": ["quiet", "urban", "classic"],
     "location": { "lat": 35.6698, "lng": 139.7268 }
   },
   {

--- a/backend/temples/domain/extra_condition_tags.py
+++ b/backend/temples/domain/extra_condition_tags.py
@@ -14,6 +14,8 @@ EXTRA_TAG_META: Dict[str, Dict[str, str]] = {
     "nature": {"kind": "visit_style"},
     "reset": {"kind": "visit_style"},
     "classic": {"kind": "visit_style"},
+    "business": {"kind": "visit_style"},
+    "study": {"kind": "visit_style"},
 
     "energize": {"kind": "soft_signal"},
     "calm": {"kind": "soft_signal"},
@@ -51,6 +53,8 @@ EXTRA_TAGS: Dict[str, List[str]] = {
     "nature": ["自然", "緑", "木々", "森", "庭", "水辺", "空気が良い"],
     "reset": ["気持ちを切り替え", "切り替え", "リセット", "気分転換", "前向き", "流れを変え"],
     "classic": ["有名", "定番", "安心", "評判", "知名度", "初めてでも行きやすい"],
+    "business": ["ビジネス", "仕事向き", "商売", "成果", "出世"],
+    "study": ["学業", "勉強", "合格", "受験", "試験"],
 
     # 気分・エネルギー
     "energize": ["前向き", "活力", "元気", "やる気", "パワー", "エネルギー", "背中を押", "勇気"],


### PR DESCRIPTION
## 概要
- 東京主要神社に visit_style_tags を追加
- business / study を visit_style として抽出できるように追加

## 確認
- import_shrines_seed --dry-run: updated=0 / skipped=100
- quiet 条件で visit_style contribution=0.35 を確認
- business 条件で business 一致を確認
- study 条件で study 一致を確認