### PR TITLE
Rebrand to KAMI MUSUBI and redesign UI for editorial calm

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -44,28 +44,29 @@
 :root {
   --radius: 0.75rem;
   /* KAMI MUSUBI: stone / soft green / muted gold palette */
-  --background: oklch(0.985 0.002 90);
-  --foreground: oklch(0.25 0.02 70);
-  --card: oklch(0.995 0.001 90);
-  --card-foreground: oklch(0.25 0.02 70);
-  --popover: oklch(0.995 0.001 90);
-  --popover-foreground: oklch(0.25 0.02 70);
-  /* muted gold as primary */
-  --primary: oklch(0.55 0.08 85);
-  --primary-foreground: oklch(0.98 0.005 90);
+  /* Refined for calm usability - improved contrast while keeping warmth */
+  --background: oklch(0.98 0.003 85);
+  --foreground: oklch(0.22 0.02 75);
+  --card: oklch(0.995 0.002 85);
+  --card-foreground: oklch(0.22 0.02 75);
+  --popover: oklch(0.995 0.002 85);
+  --popover-foreground: oklch(0.22 0.02 75);
+  /* muted gold as primary - slightly deeper for better visibility */
+  --primary: oklch(0.48 0.09 80);
+  --primary-foreground: oklch(0.98 0.005 85);
   /* warm stone for secondary */
-  --secondary: oklch(0.94 0.01 80);
-  --secondary-foreground: oklch(0.35 0.02 70);
-  /* soft stone muted */
-  --muted: oklch(0.96 0.008 80);
-  --muted-foreground: oklch(0.50 0.02 70);
+  --secondary: oklch(0.93 0.012 80);
+  --secondary-foreground: oklch(0.30 0.02 75);
+  /* soft stone muted - improved contrast */
+  --muted: oklch(0.95 0.008 80);
+  --muted-foreground: oklch(0.42 0.02 75);
   /* soft sage green accent */
-  --accent: oklch(0.92 0.03 145);
-  --accent-foreground: oklch(0.30 0.04 145);
+  --accent: oklch(0.90 0.04 145);
+  --accent-foreground: oklch(0.28 0.04 145);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.91 0.01 80);
-  --input: oklch(0.93 0.01 80);
-  --ring: oklch(0.60 0.06 85);
+  --border: oklch(0.88 0.012 80);
+  --input: oklch(0.92 0.01 80);
+  --ring: oklch(0.55 0.07 80);
   --chart-1: oklch(0.55 0.08 85);
   --chart-2: oklch(0.65 0.06 145);
   --chart-3: oklch(0.50 0.03 70);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -42,38 +42,43 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.129 0.042 264.695);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.129 0.042 264.695);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.129 0.042 264.695);
-  --primary: oklch(0.208 0.042 265.755);
-  --primary-foreground: oklch(0.984 0.003 247.858);
-  --secondary: oklch(0.968 0.007 247.896);
-  --secondary-foreground: oklch(0.208 0.042 265.755);
-  --muted: oklch(0.968 0.007 247.896);
-  --muted-foreground: oklch(0.554 0.046 257.417);
-  --accent: oklch(0.968 0.007 247.896);
-  --accent-foreground: oklch(0.208 0.042 265.755);
+  --radius: 0.75rem;
+  /* KAMI MUSUBI: stone / soft green / muted gold palette */
+  --background: oklch(0.985 0.002 90);
+  --foreground: oklch(0.25 0.02 70);
+  --card: oklch(0.995 0.001 90);
+  --card-foreground: oklch(0.25 0.02 70);
+  --popover: oklch(0.995 0.001 90);
+  --popover-foreground: oklch(0.25 0.02 70);
+  /* muted gold as primary */
+  --primary: oklch(0.55 0.08 85);
+  --primary-foreground: oklch(0.98 0.005 90);
+  /* warm stone for secondary */
+  --secondary: oklch(0.94 0.01 80);
+  --secondary-foreground: oklch(0.35 0.02 70);
+  /* soft stone muted */
+  --muted: oklch(0.96 0.008 80);
+  --muted-foreground: oklch(0.50 0.02 70);
+  /* soft sage green accent */
+  --accent: oklch(0.92 0.03 145);
+  --accent-foreground: oklch(0.30 0.04 145);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.929 0.013 255.508);
-  --input: oklch(0.929 0.013 255.508);
-  --ring: oklch(0.704 0.04 256.788);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.984 0.003 247.858);
-  --sidebar-foreground: oklch(0.129 0.042 264.695);
-  --sidebar-primary: oklch(0.208 0.042 265.755);
-  --sidebar-primary-foreground: oklch(0.984 0.003 247.858);
-  --sidebar-accent: oklch(0.968 0.007 247.896);
-  --sidebar-accent-foreground: oklch(0.208 0.042 265.755);
-  --sidebar-border: oklch(0.929 0.013 255.508);
-  --sidebar-ring: oklch(0.704 0.04 256.788);
+  --border: oklch(0.91 0.01 80);
+  --input: oklch(0.93 0.01 80);
+  --ring: oklch(0.60 0.06 85);
+  --chart-1: oklch(0.55 0.08 85);
+  --chart-2: oklch(0.65 0.06 145);
+  --chart-3: oklch(0.50 0.03 70);
+  --chart-4: oklch(0.70 0.07 85);
+  --chart-5: oklch(0.60 0.05 145);
+  --sidebar: oklch(0.98 0.005 90);
+  --sidebar-foreground: oklch(0.25 0.02 70);
+  --sidebar-primary: oklch(0.55 0.08 85);
+  --sidebar-primary-foreground: oklch(0.98 0.005 90);
+  --sidebar-accent: oklch(0.94 0.01 80);
+  --sidebar-accent-foreground: oklch(0.35 0.02 70);
+  --sidebar-border: oklch(0.91 0.01 80);
+  --sidebar-ring: oklch(0.60 0.06 85);
 }
 
 .dark {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -40,28 +40,41 @@ const geistMono = localFont({
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.NEXT_PUBLIC_SITE_URL ?? "http://localhost:3000"),
-  title: "Shrine Map",
-  description: "Map preview",
+  title: "KAMI MUSUBI - 静かに、自分を整える場所へ",
+  description: "心が少し疲れたとき、ふと立ち寄りたくなる場所がある。あなたの今の気持ちに寄り添う神社を見つけてみませんか。",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-      <body className="min-h-dvh flex flex-col">
+    <html lang="ja" className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background`}>
+      <body className="min-h-dvh flex flex-col bg-background text-foreground">
         <AuthProvider>
           <ClientBootstrap />
 
-          <header className="sticky top-0 z-[100] bg-white">
-            <nav className="mx-auto flex max-w-5xl items-center gap-4 p-3">
+          <header className="sticky top-0 z-[100] bg-background/80 backdrop-blur-sm border-b border-border/30">
+            <nav className="mx-auto flex max-w-3xl items-center gap-4 px-5 py-4 sm:px-6">
               <HomeLogoLink />
 
-              <div className="ml-auto flex items-center gap-4">
+              <div className="ml-auto flex items-center gap-3">
                 <Link
                   href="/map"
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 bg-white text-sm shadow-sm"
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border/50 bg-card text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
                   aria-label="神社を検索"
                 >
-                  <span aria-hidden>🔍</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="16"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <circle cx="11" cy="11" r="8" />
+                    <path d="m21 21-4.3-4.3" />
+                  </svg>
                 </Link>
 
                 <Suspense fallback={null}>

--- a/apps/web/src/components/ConciergeCard.tsx
+++ b/apps/web/src/components/ConciergeCard.tsx
@@ -62,9 +62,9 @@ export default function ConciergeCard(props: BaseCardProps) {
     isPrimary = false,
     badges = [],
     hideBadges = false,
-    hideLeftMark = false,
+    hideLeftMark: _hideLeftMark = false,
     detailHref,
-    detailLabel = "詳細を見る",
+    detailLabel = "この神社を見る",
     headerRight,
     disclosureTitle = "詳細",
     disclosureBody,
@@ -82,13 +82,13 @@ export default function ConciergeCard(props: BaseCardProps) {
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-2xl bg-white ring-1 ring-neutral-200/70",
-        "shadow-sm transition",
-        isPrimary && "shadow-md ring-neutral-200",
+        "overflow-hidden rounded-xl bg-card",
+        "border border-border/40",
+        "transition duration-300",
       )}
     >
-      {/* media */}
-      <div className="relative h-36 w-full">
+      {/* media - より大きく、静かな印象に */}
+      <div className="relative aspect-[16/10] w-full">
         {imageUrl ? (
           <Image
             src={imageUrl}
@@ -100,112 +100,110 @@ export default function ConciergeCard(props: BaseCardProps) {
             unoptimized
           />
         ) : (
-          <div className="h-full w-full bg-gradient-to-br from-neutral-100 to-neutral-50" />
+          <div className="h-full w-full bg-gradient-to-br from-secondary to-muted" />
         )}
 
-        {/* 画像上の薄いレイヤーで「のっぺり」回避 */}
-        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/20 via-black/0 to-black/0" />
-
-        {/* 上部の内側リング */}
-        <div className="pointer-events-none absolute inset-0 ring-1 ring-inset ring-black/5" />
+        {/* 画像上の薄いレイヤー */}
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/15 via-transparent to-transparent" />
       </div>
 
-      <div className={cn("px-4", isPrimary ? "py-4" : "py-3")}>
-        {/* badges row */}
-        {!hideBadges && (badges.length > 0 || headerRight) ? (
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <div className="flex flex-wrap gap-2">
-              {badges.map((badge) => (
-                <span
-                  key={badge}
-                  className={cn(
-                    "inline-flex shrink-0 items-center rounded-full px-2.5 py-1",
-                    "text-[11px] font-semibold",
-                    "bg-neutral-100/80 text-neutral-700 ring-1 ring-inset ring-neutral-200/60",
-                  )}
-                >
-                  {badge}
-                </span>
-              ))}
-            </div>
-            {headerRight ? <div className="shrink-0">{headerRight}</div> : null}
+      <div className="space-y-4 px-5 py-5 sm:px-6 sm:py-6">
+        {/* Header with favorite */}
+        {headerRight && (
+          <div className="flex items-center justify-end">
+            <div className="shrink-0">{headerRight}</div>
           </div>
-        ) : null}
+        )}
 
-        <div className="flex items-start gap-3">
-          {/* left mark */}
-          {!hideLeftMark ? (
-            <div
-              className={cn(
-                "mt-0.5 flex size-9 items-center justify-center rounded-full",
-                "bg-neutral-100 ring-1 ring-inset ring-neutral-200/60",
-              )}
-              aria-hidden="true"
-            >
-              <span className={cn("text-xs font-semibold", isPrimary ? "text-neutral-800" : "text-neutral-600")}>
-                {isPrimary ? "TOP" : "ALT"}
-              </span>
-            </div>
-          ) : null}
-
-          <div className="min-w-0 flex-1">
-            <h3 className="text-[15px] font-semibold leading-snug text-neutral-900">{title}</h3>
-            {address ? <p className="mt-1 truncate text-xs text-neutral-600">{address}</p> : null}
-
-            {sub ? <p className="mt-2 text-sm font-medium leading-relaxed text-neutral-800 line-clamp-1">{sub}</p> : null}
-
-            {desc ? (
-              <p className={cn("mt-2 text-sm leading-relaxed text-neutral-800", clampDesc && "line-clamp-2 text-neutral-700")}>
-                {desc}
-              </p>
-            ) : null}
-
-            {!isPrimary ? (
-              <span className="mt-2 inline-flex items-center rounded-full bg-neutral-50 px-2 py-0.5 text-[10px] text-neutral-600 ring-1 ring-inset ring-neutral-200/60">
-                候補
-              </span>
-            ) : null}
-
-            {detailHref ? (
-              <div className={cn("mt-4", !isPrimary && "mt-3")}>
-                <Link
-                  href={detailHref}
-                  className={cn(
-                    "inline-flex min-h-[44px] w-full items-center justify-center rounded-xl px-3 py-2",
-                    "text-sm font-semibold",
-                    "bg-neutral-900 text-white",
-                    "ring-1 ring-inset ring-black/10",
-                    "transition active:scale-[0.99] hover:bg-neutral-800",
-                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400",
-                  )}
-                >
-                  {detailLabel}
-                </Link>
-              </div>
-            ) : null}
-          </div>
+        {/* Title and address - 静かで読みやすく */}
+        <div className="space-y-2">
+          <h3 className="text-lg font-medium leading-snug tracking-wide text-foreground">
+            {title}
+          </h3>
+          {address && (
+            <p className="text-sm text-muted-foreground">
+              {address}
+            </p>
+          )}
         </div>
+
+        {/* Subtitle if present */}
+        {sub && (
+          <p className="text-sm font-medium leading-relaxed text-foreground/80">
+            {sub}
+          </p>
+        )}
+
+        {/* Description - おすすめ理由を穏やかに伝える */}
+        {desc && (
+          <div className="border-l-2 border-primary/30 pl-4">
+            <p className={cn(
+              "text-sm leading-relaxed text-foreground/70",
+              clampDesc && "line-clamp-3"
+            )}>
+              {desc}
+            </p>
+          </div>
+        )}
+
+        {/* Badges - 控えめに */}
+        {!hideBadges && badges.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-1">
+            {badges.slice(0, 2).map((badge) => (
+              <span
+                key={badge}
+                className="inline-flex items-center rounded-full bg-secondary px-3 py-1 text-xs text-muted-foreground"
+              >
+                {badge}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* CTA - 1つだけ、静かだが明確 */}
+        {detailHref && (
+          <div className="pt-2">
+            <Link
+              href={detailHref}
+              className={cn(
+                "inline-flex min-h-[44px] w-full items-center justify-center rounded-full px-5 py-3",
+                "text-sm font-medium tracking-wide",
+                "border border-primary/40 bg-primary/8 text-foreground/90",
+                "transition-all duration-300",
+                "hover:border-primary/50 hover:bg-primary/12",
+                "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+              )}
+            >
+              {detailLabel}
+            </Link>
+          </div>
+        )}
       </div>
 
-      {disclosureBody ? (
-        <div className="border-t border-neutral-200/70 bg-neutral-50/30">
+      {/* Disclosure - より静かに */}
+      {disclosureBody && (
+        <div className="border-t border-border/30 bg-secondary/30">
           <button
             type="button"
             onClick={() => setOpen((v) => !v)}
             className={cn(
-              "flex w-full items-center justify-between px-4 py-3 text-left",
-              "transition hover:bg-neutral-50",
-              "focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400",
+              "flex w-full items-center justify-between px-5 py-4 text-left sm:px-6",
+              "transition hover:bg-secondary/50",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
             )}
             aria-expanded={open}
           >
-            <span className="text-xs font-semibold text-neutral-800">{disclosureTitle}</span>
+            <span className="text-xs font-medium text-foreground/60">{disclosureTitle}</span>
             <Chevron open={open} />
           </button>
 
-          {open ? <div className="px-4 pb-4 pt-1 text-sm leading-relaxed text-neutral-800">{disclosureBody}</div> : null}
+          {open && (
+            <div className="px-5 pb-5 pt-1 text-sm leading-relaxed text-foreground/70 sm:px-6 sm:pb-6">
+              {disclosureBody}
+            </div>
+          )}
         </div>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/concierge/ConciergeBreakdownBody.tsx
+++ b/apps/web/src/components/concierge/ConciergeBreakdownBody.tsx
@@ -54,38 +54,40 @@ export default function ConciergeBreakdownBody({ breakdown }: Props) {
   const shownTags = matched.slice(0, 2);
 
   if (!hasAny) {
-    return <div className="text-xs text-slate-600">条件情報が少ないため、複数要素を総合して表示しています。</div>;
+    return <div className="text-sm leading-relaxed text-muted-foreground">いくつかの要素を総合してお選びしました。</div>;
   }
 
   return (
-    <ul className="space-y-1 text-xs text-slate-700">
-      {sn > 0 ? (
-        <li className="flex flex-wrap items-center gap-1">
-          <span className="text-slate-600">ご利益：</span>
+    <ul className="space-y-2 text-sm text-foreground/70">
+      {sn > 0 && (
+        <li className="flex flex-wrap items-center gap-2">
+          <span className="text-muted-foreground">ご利益：</span>
           {shownTags.length > 0 ? (
             shownTags.map((t) => (
-              <span key={t} className="rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[11px]">
+              <span key={t} className="rounded-full border border-border/40 bg-secondary px-2.5 py-0.5 text-xs">
                 {t}
               </span>
             ))
           ) : (
-            <span className="text-slate-700">希望条件に合致</span>
+            <span>希望に合う</span>
           )}
-          {matched.length > shownTags.length ? <span className="text-slate-500">ほか</span> : null}
+          {matched.length > shownTags.length && <span className="text-muted-foreground/70">ほか</span>}
         </li>
-      ) : null}
+      )}
 
-      {se > 0 ? (
+      {se > 0 && (
         <li>
-          <span className="text-slate-600">雰囲気・属性：</span>一致
+          <span className="text-muted-foreground">雰囲気：</span>
+          <span>あなたに合いそう</span>
         </li>
-      ) : null}
+      )}
 
-      {sp > 0 ? (
+      {sp > 0 && (
         <li>
-          <span className="text-slate-600">人気：</span>考慮
+          <span className="text-muted-foreground">訪れた方の評価：</span>
+          <span>好評</span>
         </li>
-      ) : null}
+      )}
     </ul>
   );
 }

--- a/apps/web/src/components/layout/HeaderAuthButtons.tsx
+++ b/apps/web/src/components/layout/HeaderAuthButtons.tsx
@@ -13,17 +13,23 @@ export function HeaderAuthButtons() {
   const current = pathname + (sp.toString() ? `?${sp.toString()}` : "");
   const loginHref = `/login?next=${encodeURIComponent(current)}`;
 
-  // ✅ 閲覧入口（固定）
-  const goshuinBookHref = "/mypage?tab=goshuin";
+  // TODO: 御朱印帳リンクはバックエンド実装完了後に復活予定
+  // const goshuinBookHref = "/mypage?tab=goshuin";
 
   return (
     <div className="flex items-center gap-2">
-      <Link href={goshuinBookHref} className="rounded-md bg-emerald-600 px-3 py-2 text-xs font-medium text-white">
-        御朱印帳
-      </Link>
+      {/* 
+        TODO: 御朱印帳リンクはバックエンド実装完了後に復活
+        <Link href={goshuinBookHref} className="rounded-full border border-border/50 bg-card px-3 py-1.5 text-xs font-medium text-foreground/70 transition-colors hover:bg-secondary hover:text-foreground">
+          御朱印帳
+        </Link>
+      */}
 
       {!isLoggedIn && (
-        <Link href={loginHref} className="rounded-md bg-orange-500 px-3 py-2 text-xs font-medium text-white">
+        <Link 
+          href={loginHref} 
+          className="rounded-full border border-primary/30 bg-primary/10 px-4 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/20"
+        >
           ログイン
         </Link>
       )}

--- a/apps/web/src/components/layout/HomeLogoLink.tsx
+++ b/apps/web/src/components/layout/HomeLogoLink.tsx
@@ -27,8 +27,8 @@ export default function HomeLogoLink() {
   );
 
   return (
-    <Link href="/" onClick={onClick} className="text-base font-bold">
-      Jinja
+    <Link href="/" onClick={onClick} className="text-base font-medium tracking-wide text-foreground/80">
+      KAMI MUSUBI
     </Link>
   );
 }

--- a/apps/web/src/components/layout/SectionCard.tsx
+++ b/apps/web/src/components/layout/SectionCard.tsx
@@ -9,19 +9,19 @@ type Props = {
 
 export function SectionCard({ title, description, children }: Props) {
   return (
-    <section className="space-y-6 px-2 py-8 sm:px-4 sm:py-10">
-      {/* 繊細な区切り線 - 和の静けさ */}
-      <div className="mx-auto h-px w-12 bg-gradient-to-r from-transparent via-border/50 to-transparent" />
+    <section className="px-2 py-10 sm:px-4 sm:py-12">
+      {/* 繊細な区切り線 */}
+      <div className="mx-auto mb-8 h-px w-16 bg-border/30 sm:mb-10" />
       
       {(title || description) && (
-        <header className="space-y-2 text-center">
+        <header className="mb-6 space-y-2 text-center sm:mb-8">
           {title && (
-            <h2 className="text-xs font-light uppercase tracking-[0.2em] text-muted-foreground/60">
+            <h2 className="text-xs font-medium uppercase tracking-[0.15em] text-foreground/50">
               {title}
             </h2>
           )}
           {description && (
-            <p className="text-sm font-light leading-relaxed tracking-wide text-foreground/50">
+            <p className="text-sm font-normal leading-relaxed text-muted-foreground">
               {description}
             </p>
           )}

--- a/apps/web/src/components/layout/SectionCard.tsx
+++ b/apps/web/src/components/layout/SectionCard.tsx
@@ -9,11 +9,22 @@ type Props = {
 
 export function SectionCard({ title, description, children }: Props) {
   return (
-    <section className="space-y-5 rounded-xl border border-border/60 bg-card px-5 py-6 sm:px-8 sm:py-8">
+    <section className="space-y-6 px-2 py-8 sm:px-4 sm:py-10">
+      {/* 繊細な区切り線 - 和の静けさ */}
+      <div className="mx-auto h-px w-12 bg-gradient-to-r from-transparent via-border/50 to-transparent" />
+      
       {(title || description) && (
-        <header className="space-y-1">
-          {title && <h2 className="text-sm font-medium text-foreground/70">{title}</h2>}
-          {description && <p className="text-xs text-muted-foreground leading-relaxed">{description}</p>}
+        <header className="space-y-2 text-center">
+          {title && (
+            <h2 className="text-xs font-light uppercase tracking-[0.2em] text-muted-foreground/60">
+              {title}
+            </h2>
+          )}
+          {description && (
+            <p className="text-sm font-light leading-relaxed tracking-wide text-foreground/50">
+              {description}
+            </p>
+          )}
         </header>
       )}
       {children}

--- a/apps/web/src/components/layout/SectionCard.tsx
+++ b/apps/web/src/components/layout/SectionCard.tsx
@@ -9,11 +9,11 @@ type Props = {
 
 export function SectionCard({ title, description, children }: Props) {
   return (
-    <section className="space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
+    <section className="space-y-5 rounded-xl border border-border/60 bg-card px-5 py-6 sm:px-8 sm:py-8">
       {(title || description) && (
-        <header>
-          {title && <h2 className="text-sm font-semibold text-slate-800">{title}</h2>}
-          {description && <p className="mt-1 text-xs text-slate-500">{description}</p>}
+        <header className="space-y-1">
+          {title && <h2 className="text-sm font-medium text-foreground/70">{title}</h2>}
+          {description && <p className="text-xs text-muted-foreground leading-relaxed">{description}</p>}
         </header>
       )}
       {children}

--- a/apps/web/src/components/layout/SectionCard.tsx
+++ b/apps/web/src/components/layout/SectionCard.tsx
@@ -11,17 +11,17 @@ export function SectionCard({ title, description, children }: Props) {
   return (
     <section className="px-2 py-10 sm:px-4 sm:py-12">
       {/* 繊細な区切り線 */}
-      <div className="mx-auto mb-8 h-px w-16 bg-border/30 sm:mb-10" />
+      <div className="mx-auto mb-8 h-px w-16 bg-border/50 sm:mb-10" />
       
       {(title || description) && (
         <header className="mb-6 space-y-2 text-center sm:mb-8">
           {title && (
-            <h2 className="text-xs font-medium uppercase tracking-[0.15em] text-foreground/50">
+            <h2 className="text-xs font-medium uppercase tracking-[0.15em] text-foreground/70">
               {title}
             </h2>
           )}
           {description && (
-            <p className="text-sm font-normal leading-relaxed text-muted-foreground">
+            <p className="text-sm leading-relaxed text-muted-foreground">
               {description}
             </p>
           )}

--- a/apps/web/src/components/shrine/DetailSection.tsx
+++ b/apps/web/src/components/shrine/DetailSection.tsx
@@ -15,10 +15,10 @@ export default function DetailSection({
   className?: string;
 }) {
   return (
-    <section className={`rounded-2xl border bg-white p-4 ${className}`}>
-      <div className="mb-2 flex items-baseline justify-between gap-2">
-        <h2 className="text-xs font-semibold text-slate-500">{title}</h2>
-        {right ? <div className="text-[11px] text-slate-500">{right}</div> : null}
+    <section className={`space-y-4 py-6 ${className}`}>
+      <div className="flex items-baseline justify-between gap-2">
+        <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-foreground/50">{title}</h2>
+        {right ? <div className="text-xs text-muted-foreground">{right}</div> : null}
       </div>
       {children}
     </section>

--- a/apps/web/src/components/shrine/ShrineCard.tsx
+++ b/apps/web/src/components/shrine/ShrineCard.tsx
@@ -37,9 +37,9 @@ type Props = {
 
 function DisclosureSection({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="rounded-xl border border-slate-200 bg-white p-3">
-      <div className="text-xs font-semibold text-slate-500">{title}</div>
-      <div className="mt-2 text-sm leading-6 text-slate-700">{children}</div>
+    <div className="rounded-lg border border-border/30 bg-secondary/30 p-4">
+      <div className="text-xs font-medium text-muted-foreground">{title}</div>
+      <div className="mt-2 text-sm leading-relaxed text-foreground/70">{children}</div>
     </div>
   );
 }
@@ -100,20 +100,20 @@ export default function ShrineCard({
 
   const shouldHideDisclosure = hideDisclosure || variant === "detail";
 
-  const disclosureTitle = shouldHideDisclosure ? undefined : "おすすめ理由を見る";
+  const disclosureTitle = shouldHideDisclosure ? undefined : "なぜこの場所を選んだか";
   const disclosureBody = shouldHideDisclosure ? undefined : (
-    <div className="space-y-3">
-      {breakdown ? (
-        <DisclosureSection title="おすすめ理由（内訳）">
-          <ConciergeBreakdownBody breakdown={breakdown} />
-        </DisclosureSection>
-      ) : null}
-
-      <DisclosureSection title="要点">
-        <p className="text-sm text-slate-700 line-clamp-2">
-          {breakdown ? buildOneLiner(breakdown) : "条件に合う候補から選びました。"}
+    <div className="space-y-4">
+      <DisclosureSection title="選んだ理由">
+        <p className="text-sm leading-relaxed text-foreground/70">
+          {breakdown ? buildOneLiner(breakdown) : "あなたの今の気持ちに合う場所としてお選びしました。"}
         </p>
       </DisclosureSection>
+
+      {breakdown && (
+        <DisclosureSection title="詳しい理由">
+          <ConciergeBreakdownBody breakdown={breakdown} />
+        </DisclosureSection>
+      )}
     </div>
   );
 

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -1,6 +1,10 @@
 import ShrineCard from "@/components/shrine/ShrineCard";
-import PublicGoshuinSection, { type PublicGoshuinItem } from "@/components/shrine/detail/PublicGoshuinSection";
+// TODO: バックエンド実装完了後に復活
+// import PublicGoshuinSection, { type PublicGoshuinItem } from "@/components/shrine/detail/PublicGoshuinSection";
 import ShrineJudgeSection from "@/components/shrine/detail/ShrineJudgeSection";
+
+// 一時的に型だけ残す（propsの型エラー回避）
+type PublicGoshuinItem = { id: string; imageUrl: string; username: string; createdAt: string };
 import DetailDisclosureBlock from "@/components/shrine/DetailDisclosureBlock";
 
 import type { ShrineCardAdapterProps } from "@/components/shrine/buildShrineCardProps";
@@ -74,17 +78,21 @@ export default function ShrineDetailArticle({
         subtitle={subtitle}
       />
 
-      {/* 公開御朱印（3枚 + 条件付きで「すべて見る」） */}
-      <section id="goshuins">
-        <PublicGoshuinSection
-          items={publicGoshuinsPreview}
-          addGoshuinHref={addGoshuinHref}
-          sendingLabel="最新3枚（公開）"
-          hasMore={publicGoshuinsHasMore}
-          seeAllHref={publicGoshuinsHasMore ? publicGoshuinsViewAllHref : null}
-          seeAllLabel="すべて見る"
-        />
-      </section>
+      {/* 
+        TODO: 公開御朱印セクションはバックエンド実装完了後に復活予定
+        優先導線: Hero → コンシェルジュ → 推薦結果 → 神社詳細 → 経路案内
+        
+        <section id="goshuins">
+          <PublicGoshuinSection
+            items={publicGoshuinsPreview}
+            addGoshuinHref={addGoshuinHref}
+            sendingLabel="最新3枚（公開）"
+            hasMore={publicGoshuinsHasMore}
+            seeAllHref={publicGoshuinsHasMore ? publicGoshuinsViewAllHref : null}
+            seeAllLabel="すべて見る"
+          />
+        </section>
+      */}
 
       <div className="space-y-2">
         <DetailDisclosureBlock

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -20,11 +20,11 @@ function AstroCard(props: { sunSign?: string; element?: string; reason?: string 
   const { sunSign, element, reason } = props;
   return (
     <DetailSection title="占星術による選定">
-      <div className="rounded-xl border bg-amber-50 px-4 py-3">
-        <div className="text-sm font-semibold text-slate-900">
+      <div className="rounded-lg border border-primary/20 bg-primary/5 px-5 py-4">
+        <div className="text-sm font-medium text-foreground/80">
           {sunSign || "不明"} / {element || "不明"}
         </div>
-        <div className="mt-1 text-sm text-slate-700">{reason || "（理由なし）"}</div>
+        <div className="mt-2 text-sm leading-relaxed text-muted-foreground">{reason || "（理由なし）"}</div>
       </div>
     </DetailSection>
   );
@@ -74,7 +74,7 @@ export default function ConciergeSectionsRenderer({ payload, onAction, sending =
             const state: ConciergeFilterState = (sec as any).state;
             const title = (sec as any).title ?? "条件を追加して絞る";
 
-            // 閉じ状態（プリセット選択 + 即絞り）
+            // 閉じ状態（プリセット選択 + 即絞り）- 静かなUI
             if (!state.isOpen) {
               const presets = ["静か", "駅近", "ひとり", "階段少なめ"] as const;
 
@@ -92,10 +92,12 @@ export default function ConciergeSectionsRenderer({ payload, onAction, sending =
               const hasAny = selectedPresets.length > 0;
 
               return (
-                <DetailSection key={`filter-${i}`} title="条件で絞る">
-                  <p className="mb-2 text-xs text-slate-500">まずは条件を追加</p>
+                <DetailSection key={`filter-${i}`} title="さらに条件を追加">
+                  <p className="mb-4 text-sm text-muted-foreground">
+                    お気持ちに合わせて絞り込めます
+                  </p>
 
-                  <div className="mb-3 flex flex-wrap gap-2">
+                  <div className="mb-4 flex flex-wrap gap-2">
                     {presets.map((p) => {
                       const active = set.has(p);
                       return (
@@ -103,10 +105,10 @@ export default function ConciergeSectionsRenderer({ payload, onAction, sending =
                           key={p}
                           type="button"
                           className={[
-                            "rounded-full border px-3 py-1 text-xs font-semibold transition",
+                            "rounded-full border px-4 py-2 text-xs font-medium transition-all duration-200",
                             active
-                              ? "bg-emerald-600 text-white border-emerald-600"
-                              : "bg-white text-slate-700 hover:bg-slate-50",
+                              ? "border-primary/50 bg-primary/10 text-foreground"
+                              : "border-border/50 bg-card text-muted-foreground hover:border-primary/30 hover:bg-primary/5",
                           ].join(" ")}
                           onClick={() => togglePreset(p)}
                         >
@@ -117,26 +119,26 @@ export default function ConciergeSectionsRenderer({ payload, onAction, sending =
                   </div>
 
                   {selectedPresets.length > 0 && (
-                    <div className="mb-3 rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
-                      追加済み: {selectedPresets.join(" / ")}
+                    <div className="mb-4 rounded-lg border border-border/30 bg-secondary/50 px-4 py-3 text-sm text-foreground/70">
+                      {selectedPresets.join(" / ")} で探します
                     </div>
                   )}
 
                   <button
                     type="button"
-                    className="w-full rounded-xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
+                    className="w-full rounded-full border border-primary/40 bg-primary/10 px-4 py-3 text-sm font-medium text-foreground/90 transition-all duration-200 hover:bg-primary/15 disabled:opacity-50"
                     disabled={!hasAny || sending}
                     onClick={() => onAction?.({ type: "filter_apply" })}
                   >
-                    {sending ? "絞り込み中…" : "この条件で絞り込む"}
+                    {sending ? "探しています..." : "この条件で探す"}
                   </button>
 
                   <button
                     type="button"
-                    className="mt-2 w-full rounded-xl border px-4 py-3 text-sm font-semibold"
+                    className="mt-3 w-full rounded-full border border-border/40 bg-card px-4 py-3 text-sm font-medium text-muted-foreground transition-all duration-200 hover:bg-secondary hover:text-foreground"
                     onClick={() => onAction?.({ type: "add_condition" })}
                   >
-                    詳細条件を設定する
+                    詳しく設定する
                   </button>
                 </DetailSection>
               );
@@ -168,19 +170,28 @@ export default function ConciergeSectionsRenderer({ payload, onAction, sending =
 
           
 
-          case "recommendations":
+          case "recommendations": {
+            const items = (sec as any).items as (RegisteredShrineItem | PlaceShrineItem)[];
+            const heroItem = items[0]; // 最初の1件をヒーローとして扱う
+            const otherItems = items.slice(1);
+
             return (
-              <DetailSection key={`recs-${i}`} title={(sec as any).title ?? ""}>
-                <div className="mb-2 flex items-center justify-end">
-                  <ModeBadge mode={payload?.meta?.mode} />
+              <div key={`recs-${i}`} className="space-y-8">
+                {/* 相談サマリー - 静かな導入 */}
+                <div className="text-center">
+                  <p className="text-sm leading-relaxed text-muted-foreground">
+                    あなたの今の気持ちに寄り添う場所を
+                    <br />
+                    お探ししました
+                  </p>
                 </div>
 
                 {appliedLabel && (
-                  <div className="mb-2 flex items-center justify-between rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
-                    <span>{appliedLabel}</span>
+                  <div className="flex items-center justify-center gap-3 rounded-lg border border-border/30 bg-secondary/30 px-4 py-3">
+                    <span className="text-sm text-foreground/70">{appliedLabel}</span>
                     <button
                       type="button"
-                      className="rounded-md px-2 py-1 font-semibold text-slate-700 hover:bg-slate-100"
+                      className="text-xs font-medium text-muted-foreground hover:text-foreground"
                       onClick={() => onAction?.({ type: "filter_clear" })}
                     >
                       クリア
@@ -188,42 +199,87 @@ export default function ConciergeSectionsRenderer({ payload, onAction, sending =
                   </div>
                 )}
 
-                <div className="space-y-3">
-                  {(sec as any).items.map((item: RegisteredShrineItem | PlaceShrineItem, idx: number) => {
-                    
+                {/* ヒーロー神社 - 1件を主役に */}
+                {heroItem && (
+                  <div className="space-y-4">
+                    <div className="text-center">
+                      <p className="text-xs font-medium uppercase tracking-[0.15em] text-foreground/50">
+                        おすすめの場所
+                      </p>
+                    </div>
 
-                    if (item.kind === "registered") {
-                      return (
-                        <ShrineCard
-                          key={`rec-${i}-${idx}`}
-                          shrineId={item.shrineId}
-                          title={item.title}
-                          address={item.address}
-                          description={item.description}
-                          imageUrl={item.imageUrl}
-                          breakdown={item.breakdown ?? null} // ✅ registeredのみ
-                          detailHref={item.detailHref}
-                          // isPrimary 使うならここで渡す（ShrineCardが受けるなら）
-                        />
-                      );
-                    }
-
-                    return (
-                      <PlaceShrineCard
-                        key={`rec-${i}-${idx}`}
-                        placeId={item.placeId}
-                        title={item.title}
-                        address={item.address}
-                        description={item.description}
-                        imageUrl={item.imageUrl}
-                        detailHref={item.detailHref}
-                        detailLabel={item.detailLabel}
+                    {heroItem.kind === "registered" ? (
+                      <ShrineCard
+                        shrineId={heroItem.shrineId}
+                        title={heroItem.title}
+                        address={heroItem.address}
+                        description={heroItem.description}
+                        imageUrl={heroItem.imageUrl}
+                        breakdown={heroItem.breakdown ?? null}
+                        detailHref={heroItem.detailHref}
+                        hideLeftMark
+                        hideBadges
                       />
-                    );
-                  })}
-                </div>
-              </DetailSection>
+                    ) : (
+                      <PlaceShrineCard
+                        placeId={heroItem.placeId}
+                        title={heroItem.title}
+                        address={heroItem.address}
+                        description={heroItem.description}
+                        imageUrl={heroItem.imageUrl}
+                        detailHref={heroItem.detailHref}
+                        detailLabel={heroItem.detailLabel}
+                      />
+                    )}
+                  </div>
+                )}
+
+                {/* 他の候補 - 控えめに */}
+                {otherItems.length > 0 && (
+                  <div className="space-y-4">
+                    <div className="mx-auto h-px w-12 bg-border/40" />
+                    <p className="text-center text-xs text-muted-foreground/70">
+                      ほかにも気になる場所があれば
+                    </p>
+
+                    <div className="space-y-4">
+                      {otherItems.map((item, idx) => {
+                        if (item.kind === "registered") {
+                          return (
+                            <ShrineCard
+                              key={`rec-${i}-${idx + 1}`}
+                              shrineId={item.shrineId}
+                              title={item.title}
+                              address={item.address}
+                              description={item.description}
+                              imageUrl={item.imageUrl}
+                              breakdown={item.breakdown ?? null}
+                              detailHref={item.detailHref}
+                              hideLeftMark
+                              hideBadges
+                            />
+                          );
+                        }
+
+                        return (
+                          <PlaceShrineCard
+                            key={`rec-${i}-${idx + 1}`}
+                            placeId={item.placeId}
+                            title={item.title}
+                            address={item.address}
+                            description={item.description}
+                            imageUrl={item.imageUrl}
+                            detailHref={item.detailHref}
+                            detailLabel={item.detailLabel}
+                          />
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
             );
+          }
 
           case "astro":
             return (

--- a/apps/web/src/features/home/HomePage.tsx
+++ b/apps/web/src/features/home/HomePage.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
     <div className="min-h-0 bg-background">
       <HomeToastClient />
 
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-12 px-5 py-12 sm:px-6 sm:py-16">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-16 px-5 py-0 sm:px-6">
         <Suspense fallback={null}>
           <HomeMainClient />
         </Suspense>

--- a/apps/web/src/features/home/HomePage.tsx
+++ b/apps/web/src/features/home/HomePage.tsx
@@ -7,10 +7,10 @@ import { HomeMainClient } from "@/features/home/components/HomeMainClient";
 
 export default function HomePage() {
   return (
-    <div className="min-h-0 bg-slate-50">
+    <div className="min-h-0 bg-background">
       <HomeToastClient />
 
-      <div className="mx-auto flex w-full max-w-4xl flex-col gap-8 px-4 py-8">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-12 px-5 py-12 sm:px-6 sm:py-16">
         <Suspense fallback={null}>
           <HomeMainClient />
         </Suspense>

--- a/apps/web/src/features/home/HomePage.tsx
+++ b/apps/web/src/features/home/HomePage.tsx
@@ -10,7 +10,7 @@ export default function HomePage() {
     <div className="min-h-0 bg-background">
       <HomeToastClient />
 
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-16 px-5 py-0 sm:px-6">
+      <div className="mx-auto flex w-full max-w-3xl flex-col gap-0 px-5 pb-20 sm:px-6 sm:pb-28">
         <Suspense fallback={null}>
           <HomeMainClient />
         </Suspense>

--- a/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
+++ b/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
@@ -43,44 +43,46 @@ export function HomeConciergeInlineClient({ className, open, onOpen, onClose }: 
       <div ref={topRef} />
 
       {!open ? (
-        /* Hero Section - 静かで感情的なデザイン */
-        <div className="flex flex-col items-center text-center">
-          {/* メインコピー */}
-          <h1 className="text-balance text-2xl font-light leading-relaxed tracking-wide text-foreground/90 sm:text-3xl">
+        /* Hero Section - 静かなエディトリアル空間 */
+        <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-16 sm:min-h-[55vh] sm:py-20">
+          {/* 装飾的な縦線 - 神社の鳥居をイメージ */}
+          <div className="mb-12 h-12 w-px bg-gradient-to-b from-transparent via-primary/30 to-primary/50 sm:mb-16 sm:h-16" />
+          
+          {/* メインコピー - 大きく静かに */}
+          <h1 className="text-balance text-center text-2xl font-extralight leading-loose tracking-widest text-foreground/85 sm:text-3xl md:text-4xl">
             静かに、自分を整える場所へ
           </h1>
           
-          <p className="mt-4 max-w-md text-pretty text-sm leading-relaxed text-muted-foreground">
-            心が少し疲れたとき、ふと立ち寄りたくなる場所がある。
-            <br className="hidden sm:inline" />
-            あなたの今の気持ちに寄り添う神社を、見つけてみませんか。
+          {/* サブコピー - 余白を大きく */}
+          <p className="mt-8 max-w-sm text-pretty text-center text-sm font-light leading-loose tracking-wide text-muted-foreground/80 sm:mt-10 sm:max-w-md sm:text-base">
+            心が少し疲れたとき、
+            <br />
+            ふと立ち寄りたくなる場所がある
           </p>
 
-          {/* 単一の主役CTA - soft sage green */}
+          {/* CTA - 控えめだが存在感 */}
           <button
             type="button"
             onClick={handleOpen}
-            className="mt-10 rounded-full border border-accent/40 bg-accent/30 px-8 py-3.5 text-sm font-medium text-accent-foreground transition-all duration-300 hover:border-accent/60 hover:bg-accent/50"
+            className="mt-14 rounded-full border border-primary/25 bg-transparent px-7 py-3 text-sm font-light tracking-wider text-foreground/70 transition-all duration-500 hover:border-primary/40 hover:bg-primary/5 hover:text-foreground/90 sm:mt-16 sm:px-8"
           >
             今の気持ちから探す
           </button>
 
-          {/* サブテキスト */}
-          <p className="mt-4 text-xs text-muted-foreground/70">
-            位置情報から、近くの神社もお探しできます
-          </p>
+          {/* 下部の装飾線 */}
+          <div className="mt-14 h-8 w-px bg-gradient-to-b from-primary/40 to-transparent sm:mt-16 sm:h-10" />
         </div>
       ) : (
-        <div className="relative">
-          <div className="space-y-4">
+        <div className="relative px-1 py-4 sm:px-2 sm:py-6">
+          <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <p className="text-sm font-medium text-foreground/70">今の気持ちから探す</p>
+              <p className="text-sm font-light tracking-wide text-foreground/60">今の気持ちから探す</p>
               <button 
                 type="button" 
                 onClick={onClose} 
-                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+                className="text-xs font-light text-muted-foreground/70 transition-colors hover:text-foreground"
               >
-                閉じる
+                戻る
               </button>
             </div>
 

--- a/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
+++ b/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
@@ -43,34 +43,38 @@ export function HomeConciergeInlineClient({ className, open, onOpen, onClose }: 
       <div ref={topRef} />
 
       {!open ? (
-        /* Hero Section - 静かなエディトリアル空間 */
-        <div className="flex min-h-[60vh] flex-col items-center justify-center px-4 py-16 sm:min-h-[55vh] sm:py-20">
-          {/* 装飾的な縦線 - 神社の鳥居をイメージ */}
-          <div className="mb-12 h-12 w-px bg-gradient-to-b from-transparent via-primary/30 to-primary/50 sm:mb-16 sm:h-16" />
+        /* Hero Section - 静かだが導線が明確 */
+        <div className="flex min-h-[50vh] flex-col items-center justify-center px-4 py-12 sm:min-h-[45vh] sm:py-16">
+          {/* ブランドマーク - 小さく控えめに */}
+          <p className="mb-8 text-[10px] font-light uppercase tracking-[0.3em] text-muted-foreground/40 sm:mb-10">
+            KAMI MUSUBI
+          </p>
           
-          {/* メインコピー - 大きく静かに */}
-          <h1 className="text-balance text-center text-2xl font-extralight leading-loose tracking-widest text-foreground/85 sm:text-3xl md:text-4xl">
+          {/* メインコピー - 読みやすさを上げつつ静けさを保つ */}
+          <h1 className="text-balance text-center text-xl font-light leading-relaxed tracking-wider text-foreground/90 sm:text-2xl md:text-3xl">
             静かに、自分を整える場所へ
           </h1>
           
-          {/* サブコピー - 余白を大きく */}
-          <p className="mt-8 max-w-sm text-pretty text-center text-sm font-light leading-loose tracking-wide text-muted-foreground/80 sm:mt-10 sm:max-w-md sm:text-base">
-            心が少し疲れたとき、
-            <br />
-            ふと立ち寄りたくなる場所がある
+          {/* サブコピー - より具体的な導線を示唆 */}
+          <p className="mt-5 max-w-xs text-pretty text-center text-sm font-normal leading-relaxed text-muted-foreground sm:mt-6 sm:max-w-sm">
+            心が少し疲れたとき、ふと立ち寄りたくなる場所がある。
+            <br className="hidden sm:inline" />
+            あなたの今の気持ちに寄り添う神社を見つけてみませんか。
           </p>
 
-          {/* CTA - 控えめだが存在感 */}
+          {/* CTA - 視認性を上げつつ静けさを保つ */}
           <button
             type="button"
             onClick={handleOpen}
-            className="mt-14 rounded-full border border-primary/25 bg-transparent px-7 py-3 text-sm font-light tracking-wider text-foreground/70 transition-all duration-500 hover:border-primary/40 hover:bg-primary/5 hover:text-foreground/90 sm:mt-16 sm:px-8"
+            className="mt-10 rounded-full border border-primary/40 bg-primary/8 px-7 py-3 text-sm font-normal tracking-wide text-foreground/80 transition-all duration-300 hover:border-primary/50 hover:bg-primary/12 hover:text-foreground sm:mt-12 sm:px-8"
           >
             今の気持ちから探す
           </button>
 
-          {/* 下部の装飾線 */}
-          <div className="mt-14 h-8 w-px bg-gradient-to-b from-primary/40 to-transparent sm:mt-16 sm:h-10" />
+          {/* ヒントテキスト - 次のアクションを示唆 */}
+          <p className="mt-6 text-xs font-light text-muted-foreground/50">
+            または下へスクロールして近くの神社を探す
+          </p>
         </div>
       ) : (
         <div className="relative px-1 py-4 sm:px-2 sm:py-6">

--- a/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
+++ b/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
@@ -6,7 +6,7 @@ import { useEffect, useRef } from "react";
 
 const ConciergeClient = dynamic(() => import("@/app/concierge/ConciergeClient"), {
   ssr: false,
-  loading: () => <div className="rounded-2xl border bg-white p-4 text-sm text-slate-600">読み込み中…</div>,
+  loading: () => <div className="rounded-xl bg-card p-4 text-sm text-muted-foreground">読み込み中…</div>,
 });
 
 type Props = {
@@ -19,7 +19,7 @@ type Props = {
 export function HomeConciergeInlineClient({ className, open, onOpen, onClose }: Props) {
   const topRef = useRef<HTMLDivElement | null>(null);
 
-  // ✅ closeイベント受けたら確実に閉じる（親へ委譲）
+  // closeイベント受けたら確実に閉じる（親へ委譲）
   useEffect(() => {
     const onCloseEvt = () => {
    
@@ -43,19 +43,43 @@ export function HomeConciergeInlineClient({ className, open, onOpen, onClose }: 
       <div ref={topRef} />
 
       {!open ? (
-        <button
-          type="button"
-          onClick={handleOpen}
-          className="w-full rounded-full bg-amber-500 py-3 text-sm font-semibold text-slate-950 transition-colors hover:bg-amber-400"
-        >
-          今の気持ちから神社を探す
-        </button>
+        /* Hero Section - 静かで感情的なデザイン */
+        <div className="flex flex-col items-center text-center">
+          {/* メインコピー */}
+          <h1 className="text-balance text-2xl font-light leading-relaxed tracking-wide text-foreground/90 sm:text-3xl">
+            静かに、自分を整える場所へ
+          </h1>
+          
+          <p className="mt-4 max-w-md text-pretty text-sm leading-relaxed text-muted-foreground">
+            心が少し疲れたとき、ふと立ち寄りたくなる場所がある。
+            <br className="hidden sm:inline" />
+            あなたの今の気持ちに寄り添う神社を、見つけてみませんか。
+          </p>
+
+          {/* 単一の主役CTA - soft sage green */}
+          <button
+            type="button"
+            onClick={handleOpen}
+            className="mt-10 rounded-full border border-accent/40 bg-accent/30 px-8 py-3.5 text-sm font-medium text-accent-foreground transition-all duration-300 hover:border-accent/60 hover:bg-accent/50"
+          >
+            今の気持ちから探す
+          </button>
+
+          {/* サブテキスト */}
+          <p className="mt-4 text-xs text-muted-foreground/70">
+            位置情報から、近くの神社もお探しできます
+          </p>
+        </div>
       ) : (
         <div className="relative">
-          <div className="space-y-2">
+          <div className="space-y-4">
             <div className="flex items-center justify-between">
-              <p className="text-sm font-semibold text-slate-800">今の気持ちから神社を探す</p>
-              <button type="button" onClick={onClose} className="text-xs text-slate-500 hover:text-slate-800">
+              <p className="text-sm font-medium text-foreground/70">今の気持ちから探す</p>
+              <button 
+                type="button" 
+                onClick={onClose} 
+                className="text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
                 閉じる
               </button>
             </div>

--- a/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
+++ b/apps/web/src/features/home/components/HomeConciergeInlineClient.tsx
@@ -43,48 +43,48 @@ export function HomeConciergeInlineClient({ className, open, onOpen, onClose }: 
       <div ref={topRef} />
 
       {!open ? (
-        /* Hero Section - 静かだが導線が明確 */
+        /* Hero Section - 静かだが信頼感のある導線 */
         <div className="flex min-h-[50vh] flex-col items-center justify-center px-4 py-12 sm:min-h-[45vh] sm:py-16">
-          {/* ブランドマーク - 小さく控えめに */}
-          <p className="mb-8 text-[10px] font-light uppercase tracking-[0.3em] text-muted-foreground/40 sm:mb-10">
+          {/* ブランドマーク */}
+          <p className="mb-8 text-[10px] font-medium uppercase tracking-[0.25em] text-muted-foreground/70 sm:mb-10">
             KAMI MUSUBI
           </p>
           
-          {/* メインコピー - 読みやすさを上げつつ静けさを保つ */}
-          <h1 className="text-balance text-center text-xl font-light leading-relaxed tracking-wider text-foreground/90 sm:text-2xl md:text-3xl">
+          {/* メインコピー */}
+          <h1 className="text-balance text-center text-xl font-normal leading-relaxed tracking-wide text-foreground sm:text-2xl md:text-3xl">
             静かに、自分を整える場所へ
           </h1>
           
-          {/* サブコピー - より具体的な導線を示唆 */}
-          <p className="mt-5 max-w-xs text-pretty text-center text-sm font-normal leading-relaxed text-muted-foreground sm:mt-6 sm:max-w-sm">
+          {/* サブコピー */}
+          <p className="mt-5 max-w-xs text-pretty text-center text-sm leading-relaxed text-muted-foreground sm:mt-6 sm:max-w-sm">
             心が少し疲れたとき、ふと立ち寄りたくなる場所がある。
             <br className="hidden sm:inline" />
             あなたの今の気持ちに寄り添う神社を見つけてみませんか。
           </p>
 
-          {/* CTA - 視認性を上げつつ静けさを保つ */}
+          {/* CTA - 明確な視認性 */}
           <button
             type="button"
             onClick={handleOpen}
-            className="mt-10 rounded-full border border-primary/40 bg-primary/8 px-7 py-3 text-sm font-normal tracking-wide text-foreground/80 transition-all duration-300 hover:border-primary/50 hover:bg-primary/12 hover:text-foreground sm:mt-12 sm:px-8"
+            className="mt-10 rounded-full border border-primary/50 bg-primary/10 px-7 py-3 text-sm font-medium tracking-wide text-foreground/90 transition-all duration-300 hover:border-primary/60 hover:bg-primary/15 hover:text-foreground sm:mt-12 sm:px-8"
           >
             今の気持ちから探す
           </button>
 
-          {/* ヒントテキスト - 次のアクションを示唆 */}
-          <p className="mt-6 text-xs font-light text-muted-foreground/50">
+          {/* ヒントテキスト */}
+          <p className="mt-6 text-xs text-muted-foreground/70">
             または下へスクロールして近くの神社を探す
           </p>
         </div>
       ) : (
-        <div className="relative px-1 py-4 sm:px-2 sm:py-6">
+        <div className="relative px-1 py-6 sm:px-2 sm:py-8">
           <div className="space-y-6">
             <div className="flex items-center justify-between">
-              <p className="text-sm font-light tracking-wide text-foreground/60">今の気持ちから探す</p>
+              <p className="text-sm font-medium tracking-wide text-foreground/80">今の気持ちから探す</p>
               <button 
                 type="button" 
                 onClick={onClose} 
-                className="text-xs font-light text-muted-foreground/70 transition-colors hover:text-foreground"
+                className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
               >
                 戻る
               </button>

--- a/apps/web/src/features/home/components/HomeMainClient.tsx
+++ b/apps/web/src/features/home/components/HomeMainClient.tsx
@@ -45,9 +45,8 @@ export function HomeMainClient() {
 
   return (
     <>
-      <SectionCard>
-        <HomeConciergeInlineClient open={conciergeOpen} onOpen={openConcierge} onClose={closeConcierge} />
-      </SectionCard>
+      {/* Hero - カードで囲まず開放的な空間に */}
+      <HomeConciergeInlineClient open={conciergeOpen} onOpen={openConcierge} onClose={closeConcierge} />
 
       {/* 
         TODO: 御朱印フィードは バックエンド実装完了後に復活予定

--- a/apps/web/src/features/home/components/HomeMainClient.tsx
+++ b/apps/web/src/features/home/components/HomeMainClient.tsx
@@ -5,7 +5,8 @@ import { useEffect, useRef, useState } from "react";
 import { SectionCard } from "@/components/layout/SectionCard";
 import { HomeConciergeInlineClient } from "./HomeConciergeInlineClient";
 import { HomeNearbySection } from "./HomeNearbySection";
-import HomeGoshuinFeedSection from "@/features/home/components/HomeGoshuinFeedSection";
+// TODO: バックエンド実装完了後に復活
+// import HomeGoshuinFeedSection from "@/features/home/components/HomeGoshuinFeedSection";
 
 export function HomeMainClient() {
   const [conciergeOpen, setConciergeOpen] = useState(false);
@@ -48,22 +49,25 @@ export function HomeMainClient() {
         <HomeConciergeInlineClient open={conciergeOpen} onOpen={openConcierge} onClose={closeConcierge} />
       </SectionCard>
 
-      {!conciergeOpen && (
-        <>
-          <SectionCard 
-            title="みんなの御朱印" 
-            description="最近記録された御朱印をご覧いただけます"
-          >
-            <HomeGoshuinFeedSection limit={12} />
-          </SectionCard>
+      {/* 
+        TODO: 御朱印フィードは バックエンド実装完了後に復活予定
+        優先導線: Hero → コンシェルジュ → 推薦結果 → 神社詳細 → 経路案内
+        
+        <SectionCard 
+          title="みんなの御朱印" 
+          description="最近記録された御朱印をご覧いただけます"
+        >
+          <HomeGoshuinFeedSection limit={12} />
+        </SectionCard>
+      */}
 
-          <SectionCard
-            title="近くの神社"
-            description="現在地から近い神社をお探しします"
-          >
-            <HomeNearbySection />
-          </SectionCard>
-        </>
+      {!conciergeOpen && (
+        <SectionCard
+          title="近くの神社"
+          description="現在地から近い神社をお探しします"
+        >
+          <HomeNearbySection />
+        </SectionCard>
       )}
     </>
   );

--- a/apps/web/src/features/home/components/HomeMainClient.tsx
+++ b/apps/web/src/features/home/components/HomeMainClient.tsx
@@ -61,10 +61,7 @@ export function HomeMainClient() {
       */}
 
       {!conciergeOpen && (
-        <SectionCard
-          title="近くの神社"
-          description="現在地から近い神社をお探しします"
-        >
+        <SectionCard title="近くの神社">
           <HomeNearbySection />
         </SectionCard>
       )}

--- a/apps/web/src/features/home/components/HomeMainClient.tsx
+++ b/apps/web/src/features/home/components/HomeMainClient.tsx
@@ -50,13 +50,16 @@ export function HomeMainClient() {
 
       {!conciergeOpen && (
         <>
-          <SectionCard title="最新の公開御朱印" description="タップで神社詳細へ">
+          <SectionCard 
+            title="みんなの御朱印" 
+            description="最近記録された御朱印をご覧いただけます"
+          >
             <HomeGoshuinFeedSection limit={12} />
           </SectionCard>
 
           <SectionCard
-            title="今いる場所の近くの神社"
-            description="位置情報をもとに、徒歩圏内の神社を優先して表示します。"
+            title="近くの神社"
+            description="現在地から近い神社をお探しします"
           >
             <HomeNearbySection />
           </SectionCard>

--- a/apps/web/src/features/home/components/HomeNearbySection.tsx
+++ b/apps/web/src/features/home/components/HomeNearbySection.tsx
@@ -6,13 +6,13 @@ import Link from "next/link";
 export function HomeNearbySection() {
   return (
     <div className="flex flex-col items-center py-4 text-center sm:py-6">
-      <p className="max-w-sm text-pretty text-sm font-normal leading-relaxed text-muted-foreground">
+      <p className="max-w-sm text-pretty text-sm leading-relaxed text-muted-foreground">
         現在地から歩いて行ける神社を地図でお探しいただけます
       </p>
 
       <Link
         href="/map"
-        className="mt-6 inline-flex items-center gap-2.5 rounded-full border border-border/50 bg-card px-6 py-3 text-sm font-normal text-foreground/70 shadow-sm transition-all duration-300 hover:border-primary/40 hover:bg-primary/5 hover:text-foreground/90 sm:mt-8"
+        className="mt-6 inline-flex items-center gap-2.5 rounded-full border border-border bg-card px-6 py-3 text-sm font-medium text-foreground/80 shadow-sm transition-all duration-300 hover:border-primary/50 hover:bg-primary/5 hover:text-foreground sm:mt-8"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -24,7 +24,7 @@ export function HomeNearbySection() {
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="text-primary/60"
+          className="text-primary"
         >
           <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
           <circle cx="12" cy="10" r="3" />

--- a/apps/web/src/features/home/components/HomeNearbySection.tsx
+++ b/apps/web/src/features/home/components/HomeNearbySection.tsx
@@ -5,20 +5,32 @@ import Link from "next/link";
 
 export function HomeNearbySection() {
   return (
-    <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-      <div className="space-y-1">
-        <p className="text-sm font-semibold text-slate-900">近くの神社を探す</p>
-        <p className="text-xs text-slate-600">地図から周辺の神社を探せます。</p>
-      </div>
+    <div className="flex flex-col items-center py-6 text-center sm:py-8">
+      <p className="max-w-xs text-pretty text-sm font-light leading-relaxed tracking-wide text-foreground/60">
+        現在地から、歩いて行ける距離の神社を地図でお探しいただけます
+      </p>
 
-      <div className="mt-3">
-        <Link
-          href="/map"
-          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-xs font-semibold text-white hover:bg-slate-800"
+      <Link
+        href="/map"
+        className="mt-8 inline-flex items-center gap-2 rounded-full border border-border/40 bg-transparent px-6 py-2.5 text-xs font-light tracking-wider text-foreground/60 transition-all duration-500 hover:border-primary/30 hover:bg-primary/5 hover:text-foreground/80"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className="opacity-60"
         >
-          地図を開く
-        </Link>
-      </div>
+          <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+          <circle cx="12" cy="10" r="3" />
+        </svg>
+        地図を開く
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/features/home/components/HomeNearbySection.tsx
+++ b/apps/web/src/features/home/components/HomeNearbySection.tsx
@@ -5,31 +5,31 @@ import Link from "next/link";
 
 export function HomeNearbySection() {
   return (
-    <div className="flex flex-col items-center py-6 text-center sm:py-8">
-      <p className="max-w-xs text-pretty text-sm font-light leading-relaxed tracking-wide text-foreground/60">
-        現在地から、歩いて行ける距離の神社を地図でお探しいただけます
+    <div className="flex flex-col items-center py-4 text-center sm:py-6">
+      <p className="max-w-sm text-pretty text-sm font-normal leading-relaxed text-muted-foreground">
+        現在地から歩いて行ける神社を地図でお探しいただけます
       </p>
 
       <Link
         href="/map"
-        className="mt-8 inline-flex items-center gap-2 rounded-full border border-border/40 bg-transparent px-6 py-2.5 text-xs font-light tracking-wider text-foreground/60 transition-all duration-500 hover:border-primary/30 hover:bg-primary/5 hover:text-foreground/80"
+        className="mt-6 inline-flex items-center gap-2.5 rounded-full border border-border/50 bg-card px-6 py-3 text-sm font-normal text-foreground/70 shadow-sm transition-all duration-300 hover:border-primary/40 hover:bg-primary/5 hover:text-foreground/90 sm:mt-8"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          width="14"
-          height="14"
+          width="16"
+          height="16"
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
-          className="opacity-60"
+          className="text-primary/60"
         >
           <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
           <circle cx="12" cy="10" r="3" />
         </svg>
-        地図を開く
+        地図から探す
       </Link>
     </div>
   );


### PR DESCRIPTION
### Branding & Visual Identity
- Renamed the platform from Jinja to KAMI MUSUBI.
- Implemented a new color palette featuring stone, soft green, and muted gold tones for a serene aesthetic.

### Homepage & Layout
- Redesigned the Hero section with editorial-style copy, increased vertical spacing, and improved CTA visibility.
- Refactored SectionCard and HomeNearbySection components to remove heavy borders and backgrounds, replacing them with subtle dividers and centered typography.
- Improved visual hierarchy by adjusting font weights, text opacity, and adding scroll hints.

### Feature Adjustments
- Hid goshuin-related feeds and public sections from the UI to streamline the core experience.
- Updated header navigation buttons to reflect the current feature set.

### Recommendation Experience
- Updated ConciergeCard, ConciergeSectionsRenderer, and DetailSection to match the "KAMI MUSUBI" theme.
- Enhanced UI contrast and typography across recommendation results for better readability.

[v0 Session](https://v0.app/chat/UDEmc0gPM9n)