### PR TITLE
本番初期データ投入を一度だけ実行するbootstrap管理を追加

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -7,17 +7,8 @@ python manage.py migrate --noinput
 echo "Repairing FeatureUsage table..."
 python manage.py repair_featureusage_table
 
-echo "Importing shrine seed data..."
-python manage.py import_shrines_seed
-
-echo "Debugging concierge candidate counts..."
-python manage.py debug_concierge_candidates
-
-echo "Backfilling concierge recommendation tags..."
-python manage.py backfill_goriyaku_tags --with-visit-style --force
-
-echo "Debugging concierge candidate counts after backfill..."
-python manage.py debug_concierge_candidates
+echo "Bootstrapping production data..."
+python manage.py bootstrap_production_data
 
 echo "Starting gunicorn on PORT=${PORT:-10000}..."
 exec gunicorn shrine_project.wsgi:application --bind 0.0.0.0:${PORT:-10000} --workers 1 --timeout 120 --access-logfile - --error-logfile - --capture-output

--- a/backend/temples/management/commands/bootstrap_production_data.py
+++ b/backend/temples/management/commands/bootstrap_production_data.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Sequence
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+from django.db import connection, transaction
+from django.db.models import Count, F
+from django.utils import timezone
+from temples.models import PlaceCache, PlacesSeed, ProductionDataBootstrapRun, Shrine
+
+
+@dataclass(frozen=True)
+class BootstrapStep:
+    step: str
+    version: str
+    command: str
+    args: tuple[str, ...] = ()
+
+
+BOOTSTRAP_STEPS: tuple[BootstrapStep, ...] = (
+    BootstrapStep(
+        step="import_shrines_seed",
+        version="2026-05-10-v1",
+        command="import_shrines_seed",
+    ),
+    BootstrapStep(
+        step="backfill_goriyaku_tags",
+        version="2026-05-10-with-visit-style-force-v1",
+        command="backfill_goriyaku_tags",
+        args=("--with-visit-style", "--force"),
+    ),
+)
+
+
+class Command(BaseCommand):
+    help = "Run one-time production data bootstrap steps that have not succeeded yet."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--skip-debug-counts",
+            action="store_true",
+            help="Do not print concierge candidate summary counts after bootstrap.",
+        )
+
+    def handle(self, *args, **options):
+        self.stdout.write("[bootstrap_production_data] start")
+
+        for step in BOOTSTRAP_STEPS:
+            self._run_step_once(step)
+
+        if not options["skip_debug_counts"]:
+            self._write_concierge_candidate_counts()
+
+        self.stdout.write(self.style.SUCCESS("[bootstrap_production_data] done"))
+
+    def _run_step_once(self, step: BootstrapStep) -> None:
+        claim_status, run = self._claim_step(step)
+        if claim_status == "success":
+            self.stdout.write(
+                f"[bootstrap_production_data] SKIP step={step.step} version={step.version} already_success"
+            )
+            return
+        if claim_status == "running":
+            self.stdout.write(
+                f"[bootstrap_production_data] SKIP step={step.step} version={step.version} "
+                f"already_running started_at={run.started_at}"
+            )
+            return
+
+        self.stdout.write(
+            f"[bootstrap_production_data] START step={step.step} version={step.version} "
+            f"attempt={run.attempts} command={step.command} args={list(step.args)}"
+        )
+
+        try:
+            call_command(step.command, *step.args)
+        except Exception as exc:
+            finished_at = timezone.now()
+            ProductionDataBootstrapRun.objects.filter(pk=run.pk).update(
+                status=ProductionDataBootstrapRun.Status.FAILED,
+                last_error=str(exc),
+                finished_at=finished_at,
+            )
+            self.stderr.write(
+                self.style.ERROR(
+                    f"[bootstrap_production_data] FAILED step={step.step} version={step.version} "
+                    f"attempt={run.attempts} error={exc}"
+                )
+            )
+            raise
+
+        finished_at = timezone.now()
+        ProductionDataBootstrapRun.objects.filter(pk=run.pk).update(
+            status=ProductionDataBootstrapRun.Status.SUCCESS,
+            last_error="",
+            finished_at=finished_at,
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"[bootstrap_production_data] SUCCESS step={step.step} version={step.version} "
+                f"attempt={run.attempts}"
+            )
+        )
+
+    def _claim_step(self, step: BootstrapStep) -> tuple[str, ProductionDataBootstrapRun]:
+        with transaction.atomic():
+            run, _created = ProductionDataBootstrapRun.objects.select_for_update().get_or_create(
+                step=step.step,
+                version=step.version,
+                defaults={
+                    "command": step.command,
+                    "args": list(step.args),
+                    "status": ProductionDataBootstrapRun.Status.RUNNING,
+                    "attempts": 0,
+                },
+            )
+            if run.status == ProductionDataBootstrapRun.Status.SUCCESS:
+                return "success", run
+
+            now = timezone.now()
+            running_started_at = run.started_at
+            running_is_recent = (
+                run.status == ProductionDataBootstrapRun.Status.RUNNING
+                and running_started_at is not None
+                and running_started_at > now - timedelta(minutes=30)
+            )
+            if running_is_recent:
+                return "running", run
+
+            run.command = step.command
+            run.args = list(step.args)
+            run.status = ProductionDataBootstrapRun.Status.RUNNING
+            run.started_at = now
+            run.finished_at = None
+            run.last_error = ""
+            run.attempts = F("attempts") + 1
+            run.save(
+                update_fields=[
+                    "command",
+                    "args",
+                    "status",
+                    "started_at",
+                    "finished_at",
+                    "last_error",
+                    "attempts",
+                    "updated_at",
+                ]
+            )
+            run.refresh_from_db(fields=["attempts"])
+            return "claimed", run
+
+    def _safe_count(self, model) -> int | str:
+        table_name = model._meta.db_table
+        if table_name not in connection.introspection.table_names():
+            return "missing_table"
+        return model.objects.count()
+
+    def _write_concierge_candidate_counts(self) -> None:
+        shrine_qs = Shrine.objects.all()
+        shrine_kind_counts: Sequence[dict[str, int | str | None]] = list(
+            shrine_qs.values("kind").annotate(total=Count("id")).order_by("kind")
+        )
+        shrine_with_location = shrine_qs.filter(
+            latitude__isnull=False,
+            longitude__isnull=False,
+        ).count()
+        shrine_with_visit_style_tags = shrine_qs.exclude(visit_style_tags=[]).count()
+        shrine_with_goriyaku_tags = shrine_qs.filter(goriyaku_tags__isnull=False).distinct().count()
+
+        self.stdout.write("[bootstrap_production_data] concierge_candidate_counts start")
+        self.stdout.write(f"[bootstrap_production_data] Shrine total: {shrine_qs.count()}")
+        for row in shrine_kind_counts:
+            self.stdout.write(
+                f"[bootstrap_production_data] Shrine kind={row['kind'] or '(blank)'} total={row['total']}"
+            )
+        self.stdout.write(
+            f"[bootstrap_production_data] Shrine with latitude/longitude: {shrine_with_location}"
+        )
+        self.stdout.write(
+            f"[bootstrap_production_data] Shrine with visit_style_tags: {shrine_with_visit_style_tags}"
+        )
+        self.stdout.write(
+            f"[bootstrap_production_data] Shrine with goriyaku_tags: {shrine_with_goriyaku_tags}"
+        )
+        self.stdout.write(f"[bootstrap_production_data] PlaceCache total: {self._safe_count(PlaceCache)}")
+        self.stdout.write(f"[bootstrap_production_data] PlacesSeed total: {self._safe_count(PlacesSeed)}")
+        self.stdout.write("[bootstrap_production_data] concierge_candidate_counts done")

--- a/backend/temples/migrations/0083_productiondatabootstraprun.py
+++ b/backend/temples/migrations/0083_productiondatabootstraprun.py
@@ -1,0 +1,67 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("temples", "0082_force_recreate_featureusage_table"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProductionDataBootstrapRun",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("step", models.CharField(max_length=100)),
+                ("version", models.CharField(max_length=100)),
+                ("command", models.CharField(max_length=100)),
+                ("args", models.JSONField(blank=True, default=list)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("running", "Running"),
+                            ("success", "Success"),
+                            ("failed", "Failed"),
+                        ],
+                        default="running",
+                        max_length=16,
+                    ),
+                ),
+                ("attempts", models.PositiveIntegerField(default=0)),
+                ("last_error", models.TextField(blank=True, default="")),
+                ("started_at", models.DateTimeField(blank=True, null=True)),
+                ("finished_at", models.DateTimeField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+        ),
+        migrations.AddConstraint(
+            model_name="productiondatabootstraprun",
+            constraint=models.UniqueConstraint(
+                fields=("step", "version"),
+                name="uniq_production_bootstrap_step_version",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="productiondatabootstraprun",
+            index=models.Index(
+                fields=["status", "updated_at"],
+                name="idx_bootstrap_status_updated",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="productiondatabootstraprun",
+            index=models.Index(
+                fields=["step", "version"],
+                name="idx_bootstrap_step_version",
+            ),
+        ),
+    ]

--- a/backend/temples/models.py
+++ b/backend/temples/models.py
@@ -77,6 +77,40 @@ class CrawlTile(models.Model):
         return f"tile({self.status}) step={self.step_km} bbox=({self.min_lat},{self.min_lng})-({self.max_lat},{self.max_lng})"
 
 
+class ProductionDataBootstrapRun(models.Model):
+    class Status(models.TextChoices):
+        RUNNING = "running", "Running"
+        SUCCESS = "success", "Success"
+        FAILED = "failed", "Failed"
+
+    step = models.CharField(max_length=100)
+    version = models.CharField(max_length=100)
+    command = models.CharField(max_length=100)
+    args = models.JSONField(default=list, blank=True)
+    status = models.CharField(max_length=16, choices=Status.choices, default=Status.RUNNING)
+    attempts = models.PositiveIntegerField(default=0)
+    last_error = models.TextField(blank=True, default="")
+    started_at = models.DateTimeField(null=True, blank=True)
+    finished_at = models.DateTimeField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["step", "version"],
+                name="uniq_production_bootstrap_step_version",
+            ),
+        ]
+        indexes = [
+            models.Index(fields=["status", "updated_at"], name="idx_bootstrap_status_updated"),
+            models.Index(fields=["step", "version"], name="idx_bootstrap_step_version"),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.step}@{self.version} ({self.status})"
+
+
 
 # 以降、この PointFieldBase を PointField として使う
 class PointField(PointFieldBase):

--- a/backend/temples/tests/test_bootstrap_production_data_command.py
+++ b/backend/temples/tests/test_bootstrap_production_data_command.py
@@ -1,0 +1,83 @@
+import json
+from io import StringIO
+
+import pytest
+from django.core.management.base import CommandError
+from django.core.management import call_command
+
+from temples.management.commands import bootstrap_production_data as bootstrap_module
+from temples.models import ProductionDataBootstrapRun, Shrine
+
+
+@pytest.mark.django_db
+def test_bootstrap_production_data_runs_unfinished_step_once(monkeypatch, tmp_path):
+    source = tmp_path / "shrines.json"
+    source.write_text(
+        json.dumps(
+            [
+                {
+                    "name_jp": "Bootstrap Test Shrine",
+                    "address": "東京都千代田区",
+                    "goriyaku": "開運",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("USE_GIS", "0")
+    monkeypatch.setattr(
+        bootstrap_module,
+        "BOOTSTRAP_STEPS",
+        (
+            bootstrap_module.BootstrapStep(
+                step="test_import_shrines_seed",
+                version="test-v1",
+                command="import_shrines_seed",
+                args=("--source", str(source)),
+            ),
+        ),
+    )
+
+    call_command("bootstrap_production_data", "--skip-debug-counts", stdout=StringIO())
+    call_command("bootstrap_production_data", "--skip-debug-counts", stdout=StringIO())
+
+    run = ProductionDataBootstrapRun.objects.get(
+        step="test_import_shrines_seed",
+        version="test-v1",
+    )
+    assert run.status == ProductionDataBootstrapRun.Status.SUCCESS
+    assert run.attempts == 1
+    assert Shrine.objects.filter(name_jp="Bootstrap Test Shrine").count() == 1
+
+
+@pytest.mark.django_db
+def test_bootstrap_production_data_records_failed_step_without_success(monkeypatch, tmp_path):
+    missing_source = tmp_path / "missing.json"
+    monkeypatch.setattr(
+        bootstrap_module,
+        "BOOTSTRAP_STEPS",
+        (
+            bootstrap_module.BootstrapStep(
+                step="test_import_shrines_seed_failure",
+                version="test-v1",
+                command="import_shrines_seed",
+                args=("--source", str(missing_source)),
+            ),
+        ),
+    )
+
+    with pytest.raises(CommandError):
+        call_command("bootstrap_production_data", "--skip-debug-counts", stdout=StringIO())
+
+    run = ProductionDataBootstrapRun.objects.get(
+        step="test_import_shrines_seed_failure",
+        version="test-v1",
+    )
+    assert run.status == ProductionDataBootstrapRun.Status.FAILED
+    assert run.attempts == 1
+    assert "source file not found" in run.last_error
+    assert not ProductionDataBootstrapRun.objects.filter(
+        step="test_import_shrines_seed_failure",
+        version="test-v1",
+        status=ProductionDataBootstrapRun.Status.SUCCESS,
+    ).exists()


### PR DESCRIPTION
## Summary
- ProductionDataBootstrapRun を追加し、本番初期データ投入の step/version/status を保存
- bootstrap_production_data コマンドを追加し、成功済みversionはskip
- start.sh を bootstrap_production_data 呼び出しに整理
- bootstrap成功/失敗記録のテストを追加

## Tests
- python manage.py check
- python manage.py makemigrations --check --dry-run
- pytest temples/tests/test_bootstrap_production_data_command.py temples/tests/test_backfill_goriyaku_tags_command.py -q