### PR TITLE
トップ入力からコンシェルジュ結果へ直結

### DIFF
--- a/apps/web/src/app/concierge/ConciergeClientFull.tsx
+++ b/apps/web/src/app/concierge/ConciergeClientFull.tsx
@@ -498,11 +498,15 @@ export default function ConciergeClientFull() {
   const [entrySubmitting, setEntrySubmitting] = useState(false);
   const [needText, setNeedText] = useState("");
   const [entryValidationError, setEntryValidationError] = useState<string | null>(null);
+  const autoSubmitThemeRef = useRef<string | null>(null);
+  const autoSubmitConsumedThemeRef = useRef<string | null>(null);
 
   useEffect(() => {
     const theme = (sp.get("theme") ?? "").trim();
     if (!theme) return;
+    if (autoSubmitConsumedThemeRef.current === theme) return;
 
+    autoSubmitThemeRef.current = theme;
     setNeedText((current) => (current.trim() ? current : theme));
   }, [sp]);
 
@@ -1363,6 +1367,22 @@ export default function ConciergeClientFull() {
     },
     [canSend, sending, entrySubmitting, send, isEntryRoute, buildConciergePayload],
   );
+
+  useEffect(() => {
+    const theme = autoSubmitThemeRef.current;
+    if (!theme) return;
+    if (!hydrated) return;
+    if (!isEntryRoute) return;
+    if (!canSend) return;
+    if (sending) return;
+    if (entrySubmitting) return;
+
+    autoSubmitThemeRef.current = null;
+    autoSubmitConsumedThemeRef.current = theme;
+    setNeedText(theme);
+    setEntryValidationError(null);
+    void safeSend(theme, { kind: "home_theme_submit", textLen: theme.length });
+  }, [canSend, entrySubmitting, hydrated, isEntryRoute, safeSend, sending]);
 
   /* ----------------------------------------
    * UI表示の判定


### PR DESCRIPTION
## 概要
- /concierge?theme=... で遷移した場合に自動送信するよう変更
- トップ入力後に再入力が必要になる体験を解消
- /concierge 直接アクセス時の自由入力導線は維持
- 二重送信防止用の ref を追加

