### PR TITLE
Recommendation Funnel定義を整理

### DIFF
--- a/docs/analytics/recommendation-funnel-analysis.md
+++ b/docs/analytics/recommendation-funnel-analysis.md
@@ -118,6 +118,95 @@ apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
 - route_to_save_cvr を backend 集計へ追加するか
 ```
 
+## Recommendation Funnel Definition
+
+### recommendation_view の正本
+
+暫定正本: PostHog `concierge_result_impression`
+
+理由:
+
+- 現時点で backend `behavior_funnel.py` には `recommendation_view_count` がない
+- frontend の `ConciergeSectionsRenderer.tsx` から `concierge_result_impression` が送信されている
+- 推薦表示はユーザー行動ではなく表示イベントなので、まずはPostHog観測で十分
+
+将来:
+
+- DB正本化する場合は `ConciergeRecommendationLog` を `recommendation_view_count` として扱うか検討する
+
+### recommendation_click の正本
+
+暫定正本: PostHog `shrine_detail_transition`
+
+理由:
+
+- ユーザーが推薦結果から詳細に進んだ行動を表す
+- backend の `ConciergeRecommendationClickLog` は存在するが、現行ファネルでは未反映
+- 初期分析では `concierge_result_impression → shrine_detail_transition` を見る
+
+将来:
+
+- DB正本化する場合は `ConciergeRecommendationClickLog` と `ShrineInteractionLog.detail_view` の関係を整理する
+
+### recommendation_to_detail_cvr
+
+```text
+recommendation_to_detail_cvr =
+  shrine_detail_transition / concierge_result_impression
+```
+
+暫定正本: PostHog
+
+理由:
+
+- 推薦表示から詳細遷移までの入口ファネルは、現時点ではDB正本が弱い
+- `concierge_result_impression` と `shrine_detail_transition` はPostHog上で同一文脈として観測しやすい
+- Recommendation Score v2 の重み変更前に、まず入口CVRとして確認する
+
+### detail_to_route_cvr
+
+```text
+detail_to_route_cvr =
+  route_open_count / detail_view_count
+```
+
+正本: backend DB
+
+理由:
+
+- `detail_view_count` と `route_open_count` は `behavior_funnel.py` で集計済み
+- 詳細閲覧から経路表示への遷移は、神社提案が行動意図につながったかを見る指標として扱える
+
+### route_to_save_cvr
+
+```text
+route_to_save_cvr =
+  save_count / route_open_count
+```
+
+正本: backend DB
+
+理由:
+
+- `route_open_count` と `save_count` は `behavior_funnel.py` で集計済み
+- 経路表示後に保存する流れは、参拝検討の継続意図として扱える
+- ただし保存は route_open より前に発生する場合もあるため、初期分析では補助指標として扱う
+
+## Recommendation Score v2への反映方針
+
+- `recommendation_view` は重みに使わない
+- `recommendation_click` は当面重みに使わない
+- `shrine_card_click` は当面重みに使わない
+- Recommendation Score v2 は実行シグナル優先を維持する
+- 重み調整は `detail_view` / `route_open` / `save` / `visit_done` / `reflection_saved` を中心に行う
+
+理由:
+
+- `recommendation_view` は表示イベントであり、ユーザーの意思決定とは限らない
+- `recommendation_click` / `shrine_card_click` は興味シグナルだが、実行意図としては弱い
+- 神社_APP の価値は、クリックよりも「実際に向かう・保存する・振り返る」行動にある
+- 初期の重み調整では、実行シグナルを優先した方がRecommendation Score v2の目的と一致する
+
 ## 次PR候補
 
 ```markdown
@@ -133,11 +222,11 @@ apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
 ### Recommendation Funnel
 
 ```markdown
-- [ ] recommendation_view の正本を決める
-- [ ] recommendation_click の正本を決める
-- [ ] recommendation_to_detail_cvr の定義を決める
-- [ ] detail_to_route_cvr の定義を決める
-- [ ] route_to_save_cvr の定義を決める
+- [x] recommendation_view の正本を決める
+- [x] recommendation_click の正本を決める
+- [x] recommendation_to_detail_cvr の定義を決める
+- [x] detail_to_route_cvr の定義を決める
+- [x] route_to_save_cvr の定義を決める
 ```
 
 ### PostHog監査
@@ -153,8 +242,8 @@ apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
 ### Recommendation Score v2
 
 ```markdown
-- [ ] recommendation_view を重みに使うか判断
-- [ ] recommendation_click を重みに使うか判断
-- [ ] shrine_card_click を重みに使うか判断
-- [ ] 実行シグナル優先方針を維持するか確認
+- [x] recommendation_view を重みに使うか判断
+- [x] recommendation_click を重みに使うか判断
+- [x] shrine_card_click を重みに使うか判断
+- [x] 実行シグナル優先方針を維持するか確認
 ```


### PR DESCRIPTION
## 概要
- recommendation_view / recommendation_click の暫定正本を定義
- recommendation_to_detail_cvr / detail_to_route_cvr / route_to_save_cvr を定義
- Recommendation Score v2 では実行シグナル優先を維持する方針を追記

