### PR TITLE
fix(mobile): 条件UIのご利益選択をchat payloadに反映

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -14,7 +14,7 @@ import { kamimusubiDark as theme } from "../theme";
 import { shadows } from "../design/shadow";
 import type { ConciergeContext } from "../../lib/conciergeContext";
 import { buildDerivedProfile } from "../../lib/profile";
-import { post } from "../../lib/http";
+import { get, post } from "../../lib/http";
 import { trackActionEvent, type ActionEventActionType } from "../../lib/actionEvents";
 import { useProfileStore } from "../../store/profileStore";
 
@@ -186,6 +186,35 @@ const VISIT_STYLE_OPTIONS = [
 ] as const;
 
 const GORIYAKU_OPTIONS = ["仕事運", "金運", "縁結び", "厄除け", "学業成就", "健康"] as const;
+
+type GoriyakuTagIndexEntry = { id: number; name: string };
+
+let goriyakuTagIndexPromise: Promise<GoriyakuTagIndexEntry[]> | null = null;
+
+function fetchGoriyakuTagIndex(): Promise<GoriyakuTagIndexEntry[]> {
+  if (!goriyakuTagIndexPromise) {
+    goriyakuTagIndexPromise = get<GoriyakuTagIndexEntry[]>("/goriyaku-tags/").catch((error) => {
+      goriyakuTagIndexPromise = null;
+      throw error;
+    });
+  }
+  return goriyakuTagIndexPromise;
+}
+
+async function resolveGoriyakuTagIds(label: string | undefined): Promise<number[] | undefined> {
+  if (!label) return undefined;
+
+  try {
+    const tags = await fetchGoriyakuTagIndex();
+    const matched = tags.find((tag) => tag.name === label || tag.name.startsWith(label));
+    return matched ? [matched.id] : undefined;
+  } catch {
+    if (__DEV__) {
+      console.warn("[ConciergeScreen] failed to resolve goriyaku_tag_ids", label);
+    }
+    return undefined;
+  }
+}
 
 function buildExtraCondition({
   visitStyle,
@@ -432,11 +461,13 @@ async function fetchConciergeRecommendations({
   consultation,
   extraCondition,
   birthdate,
+  goriyakuTagIds,
   profileContext,
 }: {
   consultation: string;
   extraCondition?: string;
   birthdate?: string;
+  goriyakuTagIds?: number[];
   profileContext?: ProfileContextPayload;
 }): Promise<RecommendationCard[]> {
   const normalizedBirthdate = birthdate?.trim() || undefined;
@@ -448,13 +479,13 @@ async function fetchConciergeRecommendations({
     birthdate: normalizedBirthdate,
     filters: {
       birthdate: normalizedBirthdate,
-      goriyaku_tag_ids: undefined,
+      goriyaku_tag_ids: goriyakuTagIds,
       extra_condition: normalizedExtraCondition,
       crowd: undefined,
       duration_max_min: undefined,
       free_text: normalizedExtraCondition,
     },
-    goriyaku_tag_ids: undefined,
+    goriyaku_tag_ids: goriyakuTagIds,
     extra_condition: normalizedExtraCondition,
     ...(profileContext ? { profile_context: profileContext } : {}),
   };
@@ -654,6 +685,7 @@ export default function ConciergeScreen() {
         goriyaku: selectedGoriyaku,
         supportText,
       });
+      const goriyakuTagIds = await resolveGoriyakuTagIds(selectedGoriyaku);
       const profileContext: ProfileContextPayload = {
         user_profile: {
           birthday: userProfile.birthday,
@@ -675,6 +707,7 @@ export default function ConciergeScreen() {
         consultation: queryText,
         extraCondition: extraCondition || undefined,
         birthdate,
+        goriyakuTagIds,
         profileContext,
       });
       setResults(recommendations);


### PR DESCRIPTION
## Summary

- Mobile Concierge の条件UI（誕生日・参拝スタイル・ご利益・補助条件）を chat request payload に接続。
- `goriyaku_tag_ids` が常に `undefined` 固定でハードコードされており、UIでご利益タグを選択しても backend の推薦条件に反映されないバグを修正。
- 既存の公開エンドポイント `GET /api/goriyaku-tags/`（backend変更なし）から `{id, name}` 一覧を取得し、UIの選択ラベル（例:「仕事運」）を実際の `GoriyakuTag.id` に解決してから payload の `goriyaku_tag_ids`（トップレベル・`filters` の両方）に含めるようにした。
- タグ一覧はモジュールスコープでキャッシュし、取得失敗時は `undefined` にフォールバック（既存の `extra_condition` 送信は継続されるため機能は壊れない）。
- `birthdate` / `extra_condition` / `profile_context` は元々送信済みで変更なし。`visit_style` は `extra_condition` の自由文をbackend側の辞書でキーワード一致させる既存の仕組みで、UIの選択肢が既に一致していたため変更不要。

backend / Auth Prompt / Journey Timeline は未変更。

## Test plan

- [x] `npx tsc -p tsconfig.json --noEmit`（apps/mobile）→ エラーなし
- [x] `git push` 時の pre-push フック（OpenAPI lint、Web契約テスト）→ 全通過
- [ ] 実機/エミュレータで条件UIからご利益を選択して相談を送信し、backendログで以下を確認
  - `[concierge/profile_context] received=Y`
  - `[dbg] need_tags ... has_extra=True has_goriyaku=True`
  - `[dbg] extra_tags resolved ... visit_style=[...] raw_extra=...`
  - `goriyaku_tag_ids` が選択したタグの実IDを含んでいること

🤖 Generated with [Claude Code](https://claude.com/claude-code)