### PR TITLE
Mobile版Premium案内ページとBilling APIクライアントを追加

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -81,6 +81,7 @@ export default function Root() {
         }}
       />
       <Tabs.Screen name="journey/index" options={{ href: null }} />
+      <Tabs.Screen name="premium/index" options={{ href: null }} />
       <Tabs.Screen name="favorites/index" options={{ href: null }} />
       <Tabs.Screen name="goshuin/index" options={{ href: null }} />
       <Tabs.Screen name="goshuin/upload" options={{ href: null }} />

--- a/apps/mobile/app/mypage/index.tsx
+++ b/apps/mobile/app/mypage/index.tsx
@@ -4,6 +4,22 @@ import { useRouter } from "expo-router";
 import { kamimusubiDark as theme } from "../theme";
 import { getFavoriteShrines, getRecentViewed } from "../../lib/shrineStorage";
 import { getCounts } from "../../lib/storage";
+import { getAuthenticatedBillingStatus, isPremiumStatus, type BillingStatus } from "../../lib/billing";
+import { isUnauthenticatedError } from "../../lib/http";
+
+type PremiumMetaState =
+  | { kind: "loading" }
+  | { kind: "unauthenticated" }
+  | { kind: "error" }
+  | { kind: "ready"; status: BillingStatus };
+
+// billing.ts の isPremiumStatus をそのまま利用し、Free/Premium判定ロジックはここで持たない。
+function describePremiumMeta(state: PremiumMetaState): string {
+  if (state.kind === "loading") return "確認中...";
+  if (state.kind === "unauthenticated") return "ログインすると確認できます";
+  if (state.kind === "error") return "登録状況を確認できませんでした";
+  return isPremiumStatus(state.status) ? "Premium登録済み" : "現在はFreeプラン";
+}
 
 type MyPageCardProps = {
   title: string;
@@ -60,6 +76,25 @@ export default function MyPageScreen() {
   const [favoriteCount, setFavoriteCount] = React.useState<number | null>(null);
   const [recentCount, setRecentCount] = React.useState<number | null>(null);
   const [visitCount, setVisitCount] = React.useState<number | null>(null);
+  const [premiumMeta, setPremiumMeta] = React.useState<PremiumMetaState>({ kind: "loading" });
+
+  React.useEffect(() => {
+    let mounted = true;
+
+    getAuthenticatedBillingStatus()
+      .then((status) => {
+        if (!mounted) return;
+        setPremiumMeta(status ? { kind: "ready", status } : { kind: "error" });
+      })
+      .catch((error) => {
+        if (!mounted) return;
+        setPremiumMeta(isUnauthenticatedError(error) ? { kind: "unauthenticated" } : { kind: "error" });
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   React.useEffect(() => {
     let mounted = true;
@@ -157,9 +192,10 @@ export default function MyPageScreen() {
         <MyPageCard
           title="Premium"
           description="前回比較、深い振り返り、保存した相談の整理を使えるようにします。"
-          meta="現在はFreeプラン"
+          meta={describePremiumMeta(premiumMeta)}
           iconText="P"
           actionLabel="確認"
+          onPress={() => router.push("/premium")}
         />
       </View>
 

--- a/apps/mobile/app/premium/index.tsx
+++ b/apps/mobile/app/premium/index.tsx
@@ -1,0 +1,301 @@
+import * as React from "react";
+import { ActivityIndicator, Linking, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useRouter } from "expo-router";
+
+import {
+  InvalidCheckoutResponseError,
+  createBillingCheckoutSession,
+  getAuthenticatedBillingStatus,
+  isPremiumStatus,
+  type BillingStatus,
+} from "../../lib/billing";
+import { isUnauthenticatedError } from "../../lib/http";
+import { StateCard } from "../../components/common/StateCard";
+import { AuthPrompt } from "../../components/common/AuthPrompt";
+import { kamimusubiDark as theme } from "../theme";
+import { spacing } from "../design/spacing";
+import { cardSizes } from "../design/cardSizes";
+import { radius } from "../design/radius";
+import { ctaSizes } from "../design/ctaSizes";
+
+// Stripe Checkout はhttp(s)のリダイレクト先を要求するため、Web版の /billing/success, /billing/cancel を再利用する。
+// API サーバーのオリジンを流用した暫定値。Webアプリの配信ドメインが確定したら差し替える。
+function resolveCheckoutOrigin(): string {
+  const apiBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL ?? "http://localhost:8000/api";
+  try {
+    return new URL(apiBaseUrl).origin;
+  } catch {
+    return "http://localhost:8000";
+  }
+}
+
+const CHECKOUT_ORIGIN = resolveCheckoutOrigin();
+const CHECKOUT_SUCCESS_URL = `${CHECKOUT_ORIGIN}/billing/success`;
+const CHECKOUT_CANCEL_URL = `${CHECKOUT_ORIGIN}/billing/cancel`;
+
+type StatusState =
+  | { kind: "loading" }
+  | { kind: "unauthenticated" }
+  | { kind: "error" }
+  | { kind: "ready"; status: BillingStatus };
+
+function formatDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("ja-JP", { year: "numeric", month: "long", day: "numeric" });
+}
+
+function describeStatus(status: BillingStatus): { label: string; helper: string } {
+  if (isPremiumStatus(status)) {
+    const periodEnd = status.current_period_end ? formatDate(status.current_period_end) : "";
+    return {
+      label: "Premium登録済み",
+      helper: periodEnd
+        ? `次回更新日: ${periodEnd}${status.cancel_at_period_end ? "（更新停止予定）" : ""}`
+        : "Premiumの機能をすべて利用できます。",
+    };
+  }
+
+  return {
+    label: "現在はFreeプラン",
+    helper: "前回比較、深い振り返り、保存した相談の整理などのPremium機能を利用できます。",
+  };
+}
+
+export default function PremiumScreen() {
+  const router = useRouter();
+  const [state, setState] = React.useState<StatusState>({ kind: "loading" });
+  const [checkoutLoading, setCheckoutLoading] = React.useState(false);
+  const [checkoutError, setCheckoutError] = React.useState<string | null>(null);
+  const checkoutInFlightRef = React.useRef(false);
+
+  const loadStatus = React.useCallback(async () => {
+    setState({ kind: "loading" });
+    setCheckoutError(null);
+
+    try {
+      const status = await getAuthenticatedBillingStatus();
+      setState(status ? { kind: "ready", status } : { kind: "error" });
+    } catch (error) {
+      if (isUnauthenticatedError(error)) {
+        setState({ kind: "unauthenticated" });
+      } else {
+        if (__DEV__) {
+          console.warn("[PremiumScreen] failed to load billing status", error);
+        }
+        setState({ kind: "error" });
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void loadStatus();
+  }, [loadStatus]);
+
+  const onStartCheckout = React.useCallback(async () => {
+    // Checkout開始中の二重送信防止: refで即時ガードし、setState反映前の連打も弾く
+    if (checkoutInFlightRef.current) return;
+    checkoutInFlightRef.current = true;
+    setCheckoutLoading(true);
+    setCheckoutError(null);
+
+    try {
+      const session = await createBillingCheckoutSession({
+        successUrl: CHECKOUT_SUCCESS_URL,
+        cancelUrl: CHECKOUT_CANCEL_URL,
+      });
+      await Linking.openURL(session.checkout_url);
+    } catch (error) {
+      if (isUnauthenticatedError(error)) {
+        setState({ kind: "unauthenticated" });
+      } else if (error instanceof InvalidCheckoutResponseError) {
+        setCheckoutError("お支払いページの準備に失敗しました。しばらくしてからもう一度お試しください。");
+      } else {
+        setCheckoutError("お支払いページを開けませんでした。通信状況を確認してもう一度お試しください。");
+      }
+      if (__DEV__) {
+        console.warn("[PremiumScreen] checkout failed", error);
+      }
+    } finally {
+      checkoutInFlightRef.current = false;
+      setCheckoutLoading(false);
+    }
+  }, []);
+
+  return (
+    <>
+      <ScrollView
+        style={styles.screen}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.header}>
+          <Pressable onPress={() => router.replace("/mypage")} style={styles.backButton}>
+            <Text style={styles.backText}>← マイページへ戻る</Text>
+          </Pressable>
+          <Text style={styles.title}>Premium</Text>
+          <Text style={styles.subtitle}>
+            前回比較、深い振り返り、保存した相談の整理などをPremiumで利用できます。
+          </Text>
+        </View>
+
+        {state.kind === "loading" ? (
+          <StateCard title="読み込み中" description="Premiumの登録状況を確認しています。" />
+        ) : null}
+
+        {state.kind === "error" ? (
+          <View style={styles.errorBlock}>
+            <StateCard
+              title="登録状況を確認できませんでした"
+              description="通信状況を確認して、もう一度お試しください。"
+            />
+            <Pressable onPress={() => void loadStatus()} style={styles.retryButton} accessibilityRole="button">
+              <Text style={styles.retryButtonText}>再試行</Text>
+            </Pressable>
+          </View>
+        ) : null}
+
+        {state.kind === "unauthenticated" ? (
+          <StateCard
+            title="ログインが必要です"
+            description="Premiumの登録状況を見るには、ログインしてください。"
+          />
+        ) : null}
+
+        {state.kind === "ready" ? (
+          <View style={styles.statusCard}>
+            <Text style={styles.statusLabel}>{describeStatus(state.status).label}</Text>
+            <Text style={styles.statusHelper}>{describeStatus(state.status).helper}</Text>
+
+            {isPremiumStatus(state.status) ? null : (
+              <View style={styles.checkoutSection}>
+                <Pressable
+                  onPress={() => void onStartCheckout()}
+                  disabled={checkoutLoading}
+                  style={({ pressed }) => [
+                    styles.checkoutButton,
+                    checkoutLoading && styles.checkoutButtonDisabled,
+                    pressed && !checkoutLoading && styles.checkoutButtonPressed,
+                  ]}
+                  accessibilityRole="button"
+                >
+                  {checkoutLoading ? (
+                    <ActivityIndicator color={theme.background} />
+                  ) : (
+                    <Text style={styles.checkoutButtonText}>Premiumに登録する</Text>
+                  )}
+                </Pressable>
+
+                {checkoutError ? <Text style={styles.checkoutErrorText}>{checkoutError}</Text> : null}
+              </View>
+            )}
+          </View>
+        ) : null}
+      </ScrollView>
+
+      <AuthPrompt
+        visible={state.kind === "unauthenticated"}
+        onClose={() => router.replace("/mypage")}
+        description="Premiumの登録状況を見るには、ログインが必要です。"
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: theme.background,
+  },
+  content: {
+    padding: spacing.screenXWide,
+    paddingBottom: spacing.bottomSpace,
+    gap: spacing.lgGap,
+  },
+  header: {
+    gap: spacing.mdGap,
+  },
+  backButton: {
+    alignSelf: "flex-start",
+    marginBottom: spacing.smGap,
+  },
+  backText: {
+    color: theme.gold,
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  title: {
+    color: theme.gold,
+    fontSize: 26,
+    fontWeight: "900",
+  },
+  subtitle: {
+    color: theme.text,
+    fontSize: 15,
+    lineHeight: 23,
+    fontWeight: "600",
+  },
+  errorBlock: {
+    gap: spacing.smGap,
+  },
+  retryButton: {
+    alignSelf: "flex-start",
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderGold,
+    borderRadius: radius.pill,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  retryButtonText: {
+    color: theme.gold,
+    fontSize: 13,
+    fontWeight: "800",
+  },
+  statusCard: {
+    backgroundColor: theme.surface,
+    borderColor: theme.borderHeader,
+    borderRadius: radius.lg,
+    borderWidth: cardSizes.borderWidth,
+    padding: cardSizes.cardPaddingLg,
+    gap: spacing.smGap,
+  },
+  statusLabel: {
+    color: theme.gold,
+    fontSize: 18,
+    fontWeight: "900",
+  },
+  statusHelper: {
+    color: theme.mutedSoft,
+    fontSize: 13,
+    lineHeight: 20,
+    fontWeight: "600",
+  },
+  checkoutSection: {
+    marginTop: spacing.smGap,
+    gap: spacing.smGap,
+  },
+  checkoutButton: {
+    minHeight: ctaSizes.mediumHeight,
+    borderRadius: radius.md,
+    backgroundColor: theme.gold,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  checkoutButtonDisabled: {
+    opacity: 0.6,
+  },
+  checkoutButtonPressed: {
+    opacity: 0.85,
+  },
+  checkoutButtonText: {
+    color: theme.background,
+    fontSize: 15,
+    fontWeight: "800",
+  },
+  checkoutErrorText: {
+    color: theme.gold,
+    fontSize: 12,
+    lineHeight: 18,
+    fontWeight: "700",
+  },
+});

--- a/apps/mobile/lib/billing.ts
+++ b/apps/mobile/lib/billing.ts
@@ -1,0 +1,160 @@
+import { get, getAuth, isUnauthenticatedError, postAuth } from "./http";
+
+export type BillingPlan = "free" | "premium";
+export type BillingProvider = "stub" | "stripe" | "revenuecat" | "unknown";
+
+export type BillingStatus = {
+  plan: BillingPlan;
+  is_active: boolean;
+  provider: BillingProvider;
+  current_period_end: string | null;
+  trial_ends_at: string | null;
+  cancel_at_period_end: boolean;
+};
+
+export type BillingCheckoutSession = {
+  session_id: string;
+  checkout_url: string;
+};
+
+export type CreateBillingCheckoutSessionParams = {
+  successUrl: string;
+  cancelUrl: string;
+};
+
+export class InvalidCheckoutResponseError extends Error {
+  constructor(message = "Checkout response is invalid") {
+    super(message);
+    this.name = "InvalidCheckoutResponseError";
+  }
+}
+
+const BILLING_PLAN_VALUES: readonly BillingPlan[] = ["free", "premium"];
+const BILLING_PROVIDER_VALUES: readonly BillingProvider[] = ["stub", "stripe", "revenuecat", "unknown"];
+
+const DEFAULT_BILLING_STATUS: BillingStatus = {
+  plan: "free",
+  is_active: false,
+  provider: "unknown",
+  current_period_end: null,
+  trial_ends_at: null,
+  cancel_at_period_end: false,
+};
+
+// --- APIレスポンスの防御的な型変換 ---
+// backend/temples/api/views/billing.py の BillingStatusSerializer / CheckoutResponseSerializer に対応する。
+// 想定外の型・欠損値が来ても例外を投げず、安全な既定値にフォールバックする。
+
+function asPlan(value: unknown): BillingPlan {
+  return typeof value === "string" && (BILLING_PLAN_VALUES as string[]).includes(value)
+    ? (value as BillingPlan)
+    : "free";
+}
+
+function asProvider(value: unknown): BillingProvider {
+  return typeof value === "string" && (BILLING_PROVIDER_VALUES as string[]).includes(value)
+    ? (value as BillingProvider)
+    : "unknown";
+}
+
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function asNullableIsoString(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  return Number.isNaN(new Date(value).getTime()) ? null : value;
+}
+
+function parseBillingStatus(value: unknown): BillingStatus {
+  const record = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+
+  return {
+    plan: asPlan(record.plan),
+    is_active: asBoolean(record.is_active, false),
+    provider: asProvider(record.provider),
+    current_period_end: asNullableIsoString(record.current_period_end),
+    trial_ends_at: asNullableIsoString(record.trial_ends_at),
+    cancel_at_period_end: asBoolean(record.cancel_at_period_end, false),
+  };
+}
+
+function isValidHttpUrl(value: unknown): value is string {
+  if (typeof value !== "string" || !value.trim()) return false;
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// --- 不正なCheckoutレスポンスのエラー処理 ---
+// session_id / checkout_url が欠損・不正な場合は InvalidCheckoutResponseError を投げる。
+// Checkoutはユーザー操作の結果なので、ここでは失敗を握りつぶさず呼び出し元に伝播させる。
+function parseCheckoutSession(value: unknown): BillingCheckoutSession {
+  const record = value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+  const sessionId = typeof record.session_id === "string" ? record.session_id.trim() : "";
+
+  if (!sessionId) {
+    throw new InvalidCheckoutResponseError("Checkout response is missing session_id");
+  }
+  if (!isValidHttpUrl(record.checkout_url)) {
+    throw new InvalidCheckoutResponseError("Checkout response is missing a valid checkout_url");
+  }
+
+  return { session_id: sessionId, checkout_url: record.checkout_url as string };
+}
+
+// --- Billing Status取得 (未認証可、AllowAny) ---
+// 未ログイン時はstub/既定の課金状態を返すエンドポイントのため、通信失敗時もfreeの既定値にフォールバックする。
+export async function getBillingStatus(): Promise<BillingStatus> {
+  try {
+    const data = await get<unknown>("/billings/status/");
+    return parseBillingStatus(data);
+  } catch (error) {
+    if (__DEV__) {
+      console.warn("[getBillingStatus] failed", error);
+    }
+    return { ...DEFAULT_BILLING_STATUS };
+  }
+}
+
+// --- 認証付きBilling Status取得 ---
+// ログインユーザー自身の正確な課金状態を取得する。未認証エラーは呼び出し元に伝播させる。
+export async function getAuthenticatedBillingStatus(): Promise<BillingStatus | null> {
+  try {
+    const data = await getAuth<unknown>("/billings/status/");
+    return parseBillingStatus(data);
+  } catch (error) {
+    if (isUnauthenticatedError(error)) throw error;
+    if (__DEV__) {
+      console.warn("[getAuthenticatedBillingStatus] failed", error);
+    }
+    return null;
+  }
+}
+
+// --- Checkout Session作成 ---
+// 認証必須。success_url / cancel_url は呼び出し元(画面)が組み立てて渡す。
+export async function createBillingCheckoutSession({
+  successUrl,
+  cancelUrl,
+}: CreateBillingCheckoutSessionParams): Promise<BillingCheckoutSession> {
+  const data = await postAuth<unknown>("/billings/checkout/", {
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+  });
+
+  return parseCheckoutSession(data);
+}
+
+// --- Free / Premium判定 ---
+// backend の is_premium_for_user と同じ条件(plan === "premium" かつ is_active)で判定する。
+export function isPremiumStatus(status: BillingStatus | null | undefined): boolean {
+  return status?.plan === "premium" && status.is_active === true;
+}
+
+export function isFreeStatus(status: BillingStatus | null | undefined): boolean {
+  return !isPremiumStatus(status);
+}


### PR DESCRIPTION
## Summary
- `apps/mobile/lib/billing.ts`: 既存Backend課金API(`GET /billings/status/`, `POST /billings/checkout/`)を呼び出すモバイルクライアントを新規実装。APIレスポンスの防御的な型変換、Free/Premium判定ヘルパー(`isPremiumStatus`)、不正なCheckoutレスポンス用の`InvalidCheckoutResponseError`を提供。
- `apps/mobile/app/premium/index.tsx`: Premium案内画面を新規作成。`getAuthenticatedBillingStatus`で登録状況を取得し、loading/free/premium/status API errorを表示。Freeの場合のみCheckout開始ボタンを表示し、`createBillingCheckoutSession`の戻り値の`checkout_url`のみを`Linking.openURL`で開く。refによる二重送信防止、`InvalidCheckoutResponseError`と汎用エラーをそれぞれ利用者向け文言に変換。
- `apps/mobile/app/mypage/index.tsx`: 既存のPremiumカードに`onPress`(`/premium`へ遷移)を追加し、静的だった`meta`をAPI結果(`describePremiumMeta`、判定ロジックは`billing.ts`の`isPremiumStatus`をそのまま利用し重複実装なし)に置き換え。API失敗時も`onPress`は常に有効なままカードを操作可能に維持。
- `apps/mobile/app/_layout.tsx`: `premium/index`がタブバーに誤って表示されないよう`href: null`で登録(新規ルート追加に伴う必須の追従修正)。

## Verification
- `tsc -p tsconfig.json --noEmit`: 新規エラーなし(既存の`vitest`型未導入エラー1件のみ、無関係・変更前から存在)
- Expo Web + 実Backend(stub課金)で全表示状態を実機確認:
  - mypage: Premiumカードのmeta表示(loading/free/premium/error全パターン)、API失敗時もカード操作可能
  - `/premium`: loading → free(Checkout開始ボタン表示)/ premium(登録済み表示、Checkoutボタン非表示、更新日表示) / status API error(再試行ボタンで再試行可能、クラッシュなし)
  - Checkout: 実backend(stubプロバイダ)で`checkout_url`をそのまま`Linking.openURL`が開くことを確認、不正レスポンス(`session_id`/`checkout_url`空)時に利用者向けエラー文言を表示、5連打しても実APIコールは1回のみ(二重送信防止、`ActivityIndicator`表示)であることをDOM計測で確認

## Test plan
- [x] typecheck (`tsc --noEmit`)
- [x] Free状態表示確認(実backend, stubプロバイダ)
- [x] Premium状態表示確認(実backend, stubプロバイダ)
- [x] API失敗時の表示・再試行確認(接続不可の一時backendで確認)
- [x] Checkout不正レスポンス時の表示確認(fetchモックで検証)
- [x] Checkout二重送信防止確認(5連打→実APIコール1回)

🤖 Generated with [Claude Code](https://claude.com/claude-code)