### PR TITLE
Analytics基盤とPremium画面のイベント計測を追加

### DIFF
--- a/apps/mobile/app/premium/index.tsx
+++ b/apps/mobile/app/premium/index.tsx
@@ -10,6 +10,7 @@ import {
   type BillingStatus,
 } from "../../lib/billing";
 import { isUnauthenticatedError } from "../../lib/http";
+import { track } from "../../lib/analytics";
 import { StateCard } from "../../components/common/StateCard";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 import { kamimusubiDark as theme } from "../theme";
@@ -62,12 +63,22 @@ function describeStatus(status: BillingStatus): { label: string; helper: string 
   };
 }
 
+type CheckoutFailureReason = "unauthenticated" | "invalid_response" | "unknown";
+
 export default function PremiumScreen() {
   const router = useRouter();
   const [state, setState] = React.useState<StatusState>({ kind: "loading" });
   const [checkoutLoading, setCheckoutLoading] = React.useState(false);
   const [checkoutError, setCheckoutError] = React.useState<string | null>(null);
   const checkoutInFlightRef = React.useRef(false);
+  const hasTrackedScreenViewRef = React.useRef(false);
+
+  // premium_screen_view: 画面表示は1回だけ計測する(二重計測防止)
+  React.useEffect(() => {
+    if (hasTrackedScreenViewRef.current) return;
+    hasTrackedScreenViewRef.current = true;
+    track("premium_screen_view");
+  }, []);
 
   const loadStatus = React.useCallback(async () => {
     setState({ kind: "loading" });
@@ -75,7 +86,12 @@ export default function PremiumScreen() {
 
     try {
       const status = await getAuthenticatedBillingStatus();
-      setState(status ? { kind: "ready", status } : { kind: "error" });
+      if (status) {
+        setState({ kind: "ready", status });
+        track("premium_status_view", { plan: status.plan, is_active: status.is_active });
+      } else {
+        setState({ kind: "error" });
+      }
     } catch (error) {
       if (isUnauthenticatedError(error)) {
         setState({ kind: "unauthenticated" });
@@ -94,25 +110,34 @@ export default function PremiumScreen() {
 
   const onStartCheckout = React.useCallback(async () => {
     // Checkout開始中の二重送信防止: refで即時ガードし、setState反映前の連打も弾く
+    // このガードを通過した1回分だけ upgrade_click / checkout_started を計測する(二重計測防止)
     if (checkoutInFlightRef.current) return;
     checkoutInFlightRef.current = true;
     setCheckoutLoading(true);
     setCheckoutError(null);
+    track("premium_upgrade_click");
 
     try {
+      track("premium_checkout_started");
+      // checkout session ID はここで取得できるが、analyticsのpayloadには含めない
       const session = await createBillingCheckoutSession({
         successUrl: CHECKOUT_SUCCESS_URL,
         cancelUrl: CHECKOUT_CANCEL_URL,
       });
       await Linking.openURL(session.checkout_url);
     } catch (error) {
+      let reason: CheckoutFailureReason = "unknown";
+
       if (isUnauthenticatedError(error)) {
+        reason = "unauthenticated";
         setState({ kind: "unauthenticated" });
       } else if (error instanceof InvalidCheckoutResponseError) {
+        reason = "invalid_response";
         setCheckoutError("お支払いページの準備に失敗しました。しばらくしてからもう一度お試しください。");
       } else {
         setCheckoutError("お支払いページを開けませんでした。通信状況を確認してもう一度お試しください。");
       }
+      track("premium_checkout_failed", { reason });
       if (__DEV__) {
         console.warn("[PremiumScreen] checkout failed", error);
       }

--- a/apps/mobile/lib/__tests__/analytics.test.ts
+++ b/apps/mobile/lib/__tests__/analytics.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// __DEV__ は Metro/React Native が注入するグローバルで、vitest実行環境には存在しないため定義する。
+(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+
+import {
+  ConsoleAnalyticsProvider,
+  getAnalyticsProvider,
+  serializeAnalyticsPayload,
+  setAnalyticsProvider,
+  track,
+  type AnalyticsProvider,
+} from "../analytics";
+
+describe("serializeAnalyticsPayload", () => {
+  it("null / undefined / object / array / session_id / sessionId / NaNを除外し、プリミティブ値のみを残す", () => {
+    expect(
+      serializeAnalyticsPayload({
+        source: "mypage",
+        session_id: "session-secret",
+        sessionId: "session-secret-legacy",
+        nested: { value: 1 },
+        list: ["a"],
+        invalidNumber: Number.NaN,
+      }),
+    ).toEqual({
+      source: "mypage",
+    });
+  });
+
+  it("string/number/booleanのプリミティブ値をそのまま残す", () => {
+    expect(
+      serializeAnalyticsPayload({
+        name: "premium_screen_view",
+        count: 3,
+        active: true,
+      }),
+    ).toEqual({
+      name: "premium_screen_view",
+      count: 3,
+      active: true,
+    });
+  });
+
+  it("nullとundefinedのフィールドを除外する", () => {
+    expect(serializeAnalyticsPayload({ a: null, b: undefined, c: "ok" })).toEqual({ c: "ok" });
+  });
+
+  it("Infinity / -Infinityを除外する", () => {
+    expect(serializeAnalyticsPayload({ a: Infinity, b: -Infinity, c: 1 })).toEqual({ c: 1 });
+  });
+
+  it("payloadがnull/undefinedでも例外を投げず空オブジェクトを返す", () => {
+    expect(serializeAnalyticsPayload(null)).toEqual({});
+    expect(serializeAnalyticsPayload(undefined)).toEqual({});
+  });
+
+  it("空オブジェクトを渡すと空オブジェクトを返す", () => {
+    expect(serializeAnalyticsPayload({})).toEqual({});
+  });
+});
+
+describe("track / provider差し替え", () => {
+  afterEach(() => {
+    setAnalyticsProvider(null);
+  });
+
+  it("既定はConsoleAnalyticsProviderを使う", () => {
+    expect(getAnalyticsProvider()).toBeInstanceOf(ConsoleAnalyticsProvider);
+  });
+
+  it("setAnalyticsProviderで差し替えたproviderのtrackが呼ばれる", () => {
+    const trackSpy = vi.fn();
+    const customProvider: AnalyticsProvider = { track: trackSpy };
+    setAnalyticsProvider(customProvider);
+
+    track("premium_screen_view", { plan: "free" });
+
+    expect(trackSpy).toHaveBeenCalledWith("premium_screen_view", { plan: "free" });
+  });
+
+  it("setAnalyticsProvider(null)で既定のConsoleAnalyticsProviderへ戻る", () => {
+    setAnalyticsProvider({ track: vi.fn() });
+    setAnalyticsProvider(null);
+
+    expect(getAnalyticsProvider()).toBeInstanceOf(ConsoleAnalyticsProvider);
+  });
+
+  it("track経由でもsession_id/sessionIdはproviderに渡す前に除外される", () => {
+    const trackSpy = vi.fn();
+    setAnalyticsProvider({ track: trackSpy });
+
+    track("premium_checkout_started", { session_id: "secret", sessionId: "secret2", plan: "free" });
+
+    expect(trackSpy).toHaveBeenCalledWith("premium_checkout_started", { plan: "free" });
+  });
+
+  it("provider.trackが例外を投げても握り潰し、呼び出し元に伝播しない", () => {
+    setAnalyticsProvider({
+      track: () => {
+        throw new Error("boom");
+      },
+    });
+
+    expect(() => track("premium_checkout_failed", { reason: "unknown" })).not.toThrow();
+  });
+
+  it("eventNameが空文字/空白のみの場合は送信しない", () => {
+    const trackSpy = vi.fn();
+    setAnalyticsProvider({ track: trackSpy });
+
+    track("");
+    track("   ");
+
+    expect(trackSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/analytics.ts
+++ b/apps/mobile/lib/analytics.ts
@@ -1,0 +1,70 @@
+// Analytics payloadのプリミティブ型
+// 送信先(Console/将来の外部プロバイダ)に渡せる値だけを許容する。
+export type AnalyticsPayload = Record<string, string | number | boolean>;
+
+// provider interface
+// 実際の送信手段(Console/PostHog等)はこのinterfaceの実装差し替えで切り替える。
+export interface AnalyticsProvider {
+  track(eventName: string, payload: AnalyticsPayload): void;
+}
+
+function isPrimitiveValue(value: unknown): value is string | number | boolean {
+  if (typeof value === "string" || typeof value === "boolean") return true;
+  if (typeof value === "number") return Number.isFinite(value);
+  return false;
+}
+
+// serializer
+// object/array/null/undefined/NaN等の非プリミティブ値は破棄し、
+// プリミティブ型のフィールドだけを残す(送信先の型崩れを防ぐため)。
+export function serializeAnalyticsPayload(payload: Record<string, unknown> | null | undefined): AnalyticsPayload {
+  const source = payload && typeof payload === "object" ? payload : {};
+  const result: AnalyticsPayload = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (key === "session_id" || key === "sessionId") continue;
+
+    if (isPrimitiveValue(value)) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+// Console provider
+// 既定のprovider。開発時のみ出力し、本番ビルドでは何もしない。
+export class ConsoleAnalyticsProvider implements AnalyticsProvider {
+  track(eventName: string, payload: AnalyticsPayload): void {
+    if (__DEV__) {
+      console.info("[analytics]", eventName, payload);
+    }
+  }
+}
+
+const defaultAnalyticsProvider = new ConsoleAnalyticsProvider();
+let analyticsProvider: AnalyticsProvider = defaultAnalyticsProvider;
+
+// provider差し替え
+// null を渡すと既定のConsoleAnalyticsProviderへ戻す。
+export function setAnalyticsProvider(provider: AnalyticsProvider | null): void {
+  analyticsProvider = provider ?? defaultAnalyticsProvider;
+}
+
+export function getAnalyticsProvider(): AnalyticsProvider {
+  return analyticsProvider;
+}
+
+// 送信本体。送信失敗はアプリ本体の動作を止めないよう握り潰す。
+export function track(eventName: string, payload: Record<string, unknown> = {}): void {
+  const trimmedName = eventName.trim();
+  if (!trimmedName) return;
+
+  try {
+    getAnalyticsProvider().track(trimmedName, serializeAnalyticsPayload(payload));
+  } catch (error) {
+    if (__DEV__) {
+      console.warn("[track] failed", error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `apps/mobile/lib/analytics.ts`: Web版(`apps/web/src/lib/analytics/track.ts`/`providers.ts`)の`AnalyticsProvider`パターンに揃えたAnalytics Contractを新規実装。
  - `AnalyticsPayload = Record<string, string | number | boolean>`(プリミティブ型のみ)
  - `serializeAnalyticsPayload()`: null/undefined/object/array/NaN/Infinityおよび`session_id`/`sessionId`キーを除外
  - `AnalyticsProvider` interface、既定の`ConsoleAnalyticsProvider`(`__DEV__`時のみ出力)
  - `setAnalyticsProvider`/`getAnalyticsProvider`によるprovider差し替え
  - `track()`: provider呼び出しを`try/catch`で握り潰し、送信失敗でアプリを止めない
- `apps/mobile/lib/__tests__/analytics.test.ts`: serializerの正常系/除外系(session_id/sessionId/NaN/Infinity/null/undefined/object/array)、provider差し替え、送信失敗の握り潰しを検証(12ケース)
- `apps/mobile/app/premium/index.tsx`: Premium画面にイベント計測を追加
  - `premium_screen_view`: マウント時に1回のみ(refガードで二重計測防止)
  - `premium_status_view`: 登録状況取得成功時に`{ plan, is_active }`
  - `premium_upgrade_click` / `premium_checkout_started`: 既存の`checkoutInFlightRef`二重送信防止ガードを通過した1回分だけ発火(同じガードを流用するため二重計測されない)
  - `premium_checkout_failed`: `{ reason: "unauthenticated" | "invalid_response" | "unknown" }` — checkout session IDはpayloadに含めない(serializerでも念のため除外される二段構え)

## Verification
- `tsc -p tsconfig.json --noEmit`: 新規エラーなし(既存の`vitest`型未導入エラーのみ、無関係)
- `vitest run`: 25 passed(既存13 + analytics新規12)
- Expo Web + 実Backend(stub premium)で`/premium`表示時に`[analytics] premium_screen_view` / `[analytics] premium_status_view`がconsoleへ出力されることを実機確認
- pre-pushのOpenAPI lint・Web契約テスト(438件)通過

## Test plan
- [x] typecheck
- [x] Premium表示時のイベント確認(実機、console出力で確認)
- [x] serializerユニットテスト(session_id/sessionId除外、Analytics失敗握り潰し含む)
- [ ] Free表示時のイベント確認、Checkout成功/失敗時のイベント確認は、検証中にローカルのExpo Webプレビュー環境が不安定になり実機確認を完了できませんでした。二重送信防止ガード(`checkoutInFlightRef`)は前回のPR(#1966)で5連打→実API呼び出し1回のみであることを実機確認済みで、今回のイベント計測もその同じガードの内側に配置しているため、構造的に同様の担保があります。念のため別途実機での追加確認を推奨します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)