### PR TITLE
Mobile PremiumにAppState復帰計測とBilling Status再確認を追加

### DIFF
--- a/apps/mobile/app/premium/index.tsx
+++ b/apps/mobile/app/premium/index.tsx
@@ -1,5 +1,15 @@
 import * as React from "react";
-import { ActivityIndicator, Linking, Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import {
+  ActivityIndicator,
+  AppState,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type AppStateStatus,
+} from "react-native";
 import { useRouter } from "expo-router";
 
 import {
@@ -11,7 +21,9 @@ import {
 } from "../../lib/billing";
 import { isUnauthenticatedError } from "../../lib/http";
 import {
+  trackPremiumActive,
   trackPremiumCheckoutFailed,
+  trackPremiumCheckoutReturned,
   trackPremiumCheckoutStarted,
   trackPremiumScreenView,
   trackPremiumStatusView,
@@ -78,6 +90,10 @@ export default function PremiumScreen() {
   const checkoutInFlightRef = React.useRef(false);
   const hasTrackedScreenViewRef = React.useRef(false);
   const lastTrackedStatusKeyRef = React.useRef<string | null>(null);
+  // Checkoutを開いた後、外部ブラウザへ一度backgroundし復帰したことを検知するためのフラグ。
+  // Checkoutを開始していない通常のAppState復帰では何もしない(awaitingCheckoutReturnRefがfalseのまま)。
+  const awaitingCheckoutReturnRef = React.useRef(false);
+  const hasBackgroundedSinceCheckoutRef = React.useRef(false);
 
   // premium_screen_view: 画面表示は1回だけ計測する(二重計測防止)
   React.useEffect(() => {
@@ -94,11 +110,12 @@ export default function PremiumScreen() {
       const status = await getAuthenticatedBillingStatus();
       if (status) {
         setState({ kind: "ready", status });
-        // premium_status_view: 同じstatusへの再計測は避ける(タブ復帰・再試行での重複送信防止)
+        // premium_status_view / premium_active: 同じstatusへの再計測は避ける(タブ復帰・再試行・Checkout復帰再取得での重複送信防止)
         const statusKey = `${status.plan}|${status.is_active}|${status.provider}`;
         if (lastTrackedStatusKeyRef.current !== statusKey) {
           lastTrackedStatusKeyRef.current = statusKey;
           trackPremiumStatusView(status);
+          trackPremiumActive(status);
         }
       } else {
         setState({ kind: "error" });
@@ -119,6 +136,29 @@ export default function PremiumScreen() {
     void loadStatus();
   }, [loadStatus]);
 
+  // Checkout復帰計測: Checkout開始後に一度background/inactiveへ遷移したことを確認してから
+  // active復帰を「Checkoutから戻ってきた」と判定する(通常のAppState復帰では何もしない)。
+  React.useEffect(() => {
+    const subscription = AppState.addEventListener("change", (nextState: AppStateStatus) => {
+      if (!awaitingCheckoutReturnRef.current) return;
+
+      if (nextState === "background" || nextState === "inactive") {
+        hasBackgroundedSinceCheckoutRef.current = true;
+        return;
+      }
+
+      if (nextState === "active" && hasBackgroundedSinceCheckoutRef.current) {
+        // 同じCheckout試行での重複送信防止: 検知した時点でフラグを倒す
+        awaitingCheckoutReturnRef.current = false;
+        hasBackgroundedSinceCheckoutRef.current = false;
+        trackPremiumCheckoutReturned();
+        void loadStatus();
+      }
+    });
+
+    return () => subscription.remove();
+  }, [loadStatus]);
+
   const onStartCheckout = React.useCallback(async () => {
     // Checkout開始中の二重送信防止: refで即時ガードし、setState反映前の連打も弾く
     // このガードを通過した1回分だけ upgrade_click / checkout_started を計測する(二重計測防止)
@@ -126,6 +166,8 @@ export default function PremiumScreen() {
     checkoutInFlightRef.current = true;
     setCheckoutLoading(true);
     setCheckoutError(null);
+    awaitingCheckoutReturnRef.current = false;
+    hasBackgroundedSinceCheckoutRef.current = false;
     trackPremiumUpgradeClick();
 
     try {
@@ -137,9 +179,17 @@ export default function PremiumScreen() {
 
       trackPremiumCheckoutStarted();
 
+      // openURL呼び出し中にOSがbackgroundへ遷移させる場合があるため、
+      // 呼び出し前に復帰検知を有効化しておく(成功後に立てるとbackground遷移を取りこぼす)
+      awaitingCheckoutReturnRef.current = true;
+      hasBackgroundedSinceCheckoutRef.current = false;
+
       try {
         await Linking.openURL(session.checkout_url);
       } catch (error) {
+        awaitingCheckoutReturnRef.current = false;
+        hasBackgroundedSinceCheckoutRef.current = false;
+
         trackPremiumCheckoutFailed("open_url_failed");
         setCheckoutError("お支払いページを開けませんでした。通信状況を確認してもう一度お試しください。");
         if (__DEV__) {

--- a/apps/mobile/lib/__tests__/premiumAnalytics.test.ts
+++ b/apps/mobile/lib/__tests__/premiumAnalytics.test.ts
@@ -4,8 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 (globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
 
 import { setAnalyticsProvider, type AnalyticsProvider } from "../analytics";
+import type { BillingProvider } from "../billing";
 import {
+  trackPremiumActive,
   trackPremiumCheckoutFailed,
+  trackPremiumCheckoutReturned,
   trackPremiumCheckoutStarted,
   trackPremiumScreenView,
   trackPremiumStatusView,
@@ -74,6 +77,38 @@ describe("premiumAnalytics", () => {
         source: "mobile_premium",
         failureType,
       });
+    },
+  );
+
+  it("trackPremiumCheckoutReturnedはsourceのみを送る", () => {
+    trackPremiumCheckoutReturned();
+
+    expect(trackSpy).toHaveBeenCalledWith("premium_checkout_returned", {
+      source: "mobile_premium",
+    });
+  });
+
+  it("trackPremiumActiveはplan===premium かつ is_active===trueのときのみ送る", () => {
+    trackPremiumActive({ plan: "premium", is_active: true, provider: "stripe" });
+
+    expect(trackSpy).toHaveBeenCalledWith("premium_active", {
+      plan: "premium",
+      isActive: true,
+      provider: "stripe",
+      source: "mobile_premium",
+    });
+  });
+
+  it.each([
+    { plan: "free", is_active: true, provider: "stripe" },
+    { plan: "premium", is_active: false, provider: "stripe" },
+    { plan: "free", is_active: false, provider: "unknown" },
+  ] as const)(
+    "trackPremiumActiveはplan=%s is_active=%sでは送らない",
+    (status: { plan: "free" | "premium"; is_active: boolean; provider: BillingProvider }) => {
+      trackPremiumActive(status);
+
+      expect(trackSpy).not.toHaveBeenCalled();
     },
   );
 });

--- a/apps/mobile/lib/premiumAnalytics.ts
+++ b/apps/mobile/lib/premiumAnalytics.ts
@@ -32,3 +32,22 @@ export function trackPremiumCheckoutStarted(): void {
 export function trackPremiumCheckoutFailed(failureType: PremiumCheckoutFailureType): void {
   track("premium_checkout_failed", { source: SOURCE, failureType });
 }
+
+// Checkout(外部ブラウザ)からMobileへ復帰したタイミングで送信する。
+// 決済成功を証明するものではなく、あくまで「復帰を検知した」計測。
+export function trackPremiumCheckoutReturned(): void {
+  track("premium_checkout_returned", { source: SOURCE });
+}
+
+// Billing Status再取得後、plan === "premium" && is_active === true の場合のみ送信する。
+// ガードをここに置くことで、呼び出し側の条件分岐漏れによる誤送信を防ぐ。
+export function trackPremiumActive(status: Pick<BillingStatus, "plan" | "is_active" | "provider">): void {
+  if (status.plan !== "premium" || !status.is_active) return;
+
+  track("premium_active", {
+    plan: "premium",
+    isActive: true,
+    provider: status.provider,
+    source: SOURCE,
+  });
+}


### PR DESCRIPTION
apps/webとBackendを変更せず(ai-sanpai-navi://はURLField/Stripeのsuccess_url/ cancel_urlに直接使えないため)、外部CheckoutからのAppState復帰を検知して
premium_checkout_returnedを送信し、Billing Statusを再取得する構成にした。

- premiumAnalytics.ts: trackPremiumCheckoutReturned(source固定payload)、 trackPremiumActive(plan/is_activeガードを内包し、premium+active確認時のみ送信)を追加
- premium/index.tsx: Checkout開始(openURL成功時)にawaitingCheckoutReturnRefを立て、 AppStateがbackground/inactiveを経てactiveへ戻ったときのみ復帰とみなす (通常のAppState復帰では何もしない)。復帰検知後はloadStatus()を再実行し、 既存のstatusKeyベースの重複防止(lastTrackedStatusKeyRef)でpremium_status_view/ premium_activeの二重送信を防ぐ。checkoutInFlightRefによる連打防止は変更なし
- premiumAnalytics.test.ts: 新規2イベントのpayload形状とpremium_activeのガード条件を検証