### PR TITLE
feat: reflection_prompt_viewの意味をReflection入力UI表示のみへ限定

### DIFF
--- a/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
@@ -34,7 +34,8 @@ export function ShrineReflectionPrompt({ shrineId, historyTheme = null, threadId
       shrineId,
       threadId: threadId ?? undefined,
       historyTheme: historyTheme ?? undefined,
-      promptType: "visit_done_reflection",
+      reflectionFormType: "mood_delta",
+      reflectionContext: "visit_done",
       ctx,
     });
   }, [ctx, historyTheme, shrineId, threadId]);
@@ -59,7 +60,8 @@ export function ShrineReflectionPrompt({ shrineId, historyTheme = null, threadId
         shrineId,
         threadId: threadId ?? undefined,
         historyTheme: historyTheme ?? undefined,
-        promptType: "visit_done_reflection",
+        reflectionFormType: "mood_delta",
+        reflectionContext: "visit_done",
         answerLength,
         moodBefore: moodBefore || undefined,
         moodAfter: moodAfter || undefined,

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
@@ -31,7 +31,8 @@ describe("ShrineReflectionPrompt", () => {
       shrineId: 17,
       threadId: "tid-1",
       historyTheme: "静寂",
-      promptType: "visit_done_reflection",
+      reflectionFormType: "mood_delta",
+      reflectionContext: "visit_done",
       ctx: "concierge",
     });
   });
@@ -81,7 +82,8 @@ describe("ShrineReflectionPrompt", () => {
       shrineId: 17,
       threadId: "tid-1",
       historyTheme: "静寂",
-      promptType: "visit_done_reflection",
+      reflectionFormType: "mood_delta",
+      reflectionContext: "visit_done",
       answerLength: 10,
       moodBefore: "anxious",
       moodAfter: "calm",

--- a/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
@@ -111,14 +111,16 @@ export default function ConciergeTopRecommendationHero({
       actionSuggestionVersion: visibleActionSuggestionV4Preview.version,
       primaryActionType: visibleActionSuggestionV4Preview.primaryAction.actionType,
       secondaryActionType: visibleActionSuggestionV4Preview.secondaryAction.actionType,
-      promptType: visibleActionSuggestionV4Preview.reflectionPrompt.promptType,
+      actionPromptType: visibleActionSuggestionV4Preview.reflectionPrompt.promptType,
       actionSource: visibleActionSuggestionV4Preview.actionSource.source,
       sourceKeys: visibleActionSuggestionV4Preview.sourceKeys.join(","),
       summaryLine: actionSuggestionV4Summary,
     };
 
     trackSearchEvent("action_suggestion_preview_view", basePayload);
-    trackSearchEvent("reflection_prompt_view", {
+    // Action Suggestionのreflection promptは「実際にReflection入力UIが表示された」ことを意味しないため、
+    // reflection_prompt_view ではなく専用イベントで計測する。
+    trackSearchEvent("action_suggestion_reflection_preview_view", {
       ...basePayload,
       reflectionPromptSourceSeed: visibleActionSuggestionV4Preview.reflectionPrompt.sourceSeed,
     });

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
@@ -145,7 +145,7 @@ describe("ConciergeTopRecommendationHero", () => {
           actionSuggestionVersion: "v4",
           primaryActionType: "detail_open",
           secondaryActionType: "save",
-          promptType: "before_visit",
+          actionPromptType: "before_visit",
           actionSource: "fallback",
           sourceKeys: "meaning_translation",
           summaryLine: "まず詳細を見て、行く理由を確認する",
@@ -154,11 +154,15 @@ describe("ConciergeTopRecommendationHero", () => {
     });
 
     expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
-      "reflection_prompt_view",
+      "action_suggestion_reflection_preview_view",
       expect.objectContaining({
-        promptType: "before_visit",
+        actionPromptType: "before_visit",
         reflectionPromptSourceSeed: "fallback",
       }),
+    );
+    expect(analyticsMocks.trackSearchEvent).not.toHaveBeenCalledWith(
+      "reflection_prompt_view",
+      expect.anything(),
     );
   });
   it("calls the detail click handler and renders secondary action slot", () => {

--- a/apps/web/src/lib/analytics/__tests__/searchEvents.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/searchEvents.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAnalyticsProvider } from "@/lib/analytics/providers";
+import {
+  serializeSearchAnalyticsPayload,
+  trackSearchEvent,
+} from "@/lib/analytics/searchEvents";
+
+vi.mock("@/lib/analytics/providers", () => ({
+  getAnalyticsProvider: vi.fn(),
+}));
+
+const mockedGetAnalyticsProvider = vi.mocked(getAnalyticsProvider);
+
+describe("searchEvents契約", () => {
+  const trackMock = vi.fn();
+
+  beforeEach(() => {
+    trackMock.mockReset();
+    mockedGetAnalyticsProvider.mockReturnValue({ track: trackMock });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reflection_prompt_view / reflection_saved は reflectionFormType と reflectionContext を運ぶ", () => {
+    trackSearchEvent("reflection_prompt_view", {
+      source: "shrine_detail",
+      shrineId: 1,
+      historyTheme: "静寂",
+      reflectionFormType: "mood_delta",
+      reflectionContext: "visit_done",
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "reflection_prompt_view",
+      expect.objectContaining({
+        reflectionFormType: "mood_delta",
+        reflectionContext: "visit_done",
+      }),
+    );
+    expect(trackMock.mock.calls[0]?.[1]).not.toHaveProperty("promptType");
+  });
+
+  it("action_suggestion_reflection_preview_view は actionPromptType を運び、reflectionFormType を持たない", () => {
+    trackSearchEvent("action_suggestion_reflection_preview_view", {
+      source: "concierge_result",
+      shrineId: 1,
+      actionPromptType: "before_visit",
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "action_suggestion_reflection_preview_view",
+      expect.objectContaining({ actionPromptType: "before_visit" }),
+    );
+    expect(trackMock.mock.calls[0]?.[1]).not.toHaveProperty("reflectionFormType");
+    expect(trackMock.mock.calls[0]?.[1]).not.toHaveProperty("promptType");
+  });
+
+  it("serializeSearchAnalyticsPayloadはreflectionFormType/reflectionContext/actionPromptTypeを保持する", () => {
+    const serialized = serializeSearchAnalyticsPayload({
+      reflectionFormType: "mood_delta",
+      reflectionContext: "visit_done",
+      actionPromptType: "emotion",
+    });
+
+    expect(serialized).toEqual({
+      reflectionFormType: "mood_delta",
+      reflectionContext: "visit_done",
+      actionPromptType: "emotion",
+    });
+  });
+});

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -12,6 +12,7 @@ export type SearchAnalyticsEventName =
   | "recommendation_quality"
   | "action_suggestion_view"
   | "action_suggestion_click"
+  | "action_suggestion_reflection_preview_view"
   | "action_started"
   | "action_completed"
   | "action_done"
@@ -47,7 +48,21 @@ export type SearchAnalyticsPayload = {
   historyTheme?: string | null;
   consultationAxis?: string | null;
   actionTheme?: string | null;
-  promptType?: string | null;
+  /**
+   * 実際のReflection入力UI（reflection_prompt_view / reflection_saved）でのみ使用する。
+   * どのフォーム構造で入力させたかを表す。
+   */
+  reflectionFormType?: "one_line" | "mood_delta" | "theme_reflection" | null;
+  /**
+   * 実際のReflection入力UI（reflection_prompt_view / reflection_saved）でのみ使用する。
+   * Reflectionがどの文脈で表示されたかを表す。
+   */
+  reflectionContext?: "visit_done" | "mypage" | "night_reflection" | null;
+  /**
+   * Action Suggestion v4のreflection_prompt.prompt_typeをそのまま転記する。
+   * action_suggestion_preview_view / action_suggestion_reflection_preview_viewでのみ使用する。
+   */
+  actionPromptType?: "before_visit" | "after_visit" | "decision" | "emotion" | "constraint" | null;
   answerLength?: number | null;
   moodBefore?: string | null;
   moodAfter?: string | null;

--- a/docs/product/action_suggestion_v4.md
+++ b/docs/product/action_suggestion_v4.md
@@ -133,6 +133,18 @@ primary_action を補完する行動。
 - 宗教的な正解を示さない
 - 行動前後の整理を支援する
 
+### Analytics Event
+
+`reflection_prompt` はConcierge結果画面で回答不可のプレビューとして表示されることがある。この表示は、ユーザーが実際に回答できるReflection入力UIの表示ではないため、`docs/product/visit-reflection-flow.md` が定義する `reflection_prompt_view` には含めない。
+
+プレビュー表示の計測には以下の専用イベントを使用する。
+
+```text
+action_suggestion_reflection_preview_view
+```
+
+Payloadには `prompt_type`（`before_visit | after_visit | decision | emotion | constraint`）を `actionPromptType` として渡す。`visit-reflection-flow.md` が定義する `reflectionFormType` / `reflectionContext` とは別の語彙であり、混在させない。
+
 ---
 
 ## action_source

--- a/docs/product/visit-reflection-flow.md
+++ b/docs/product/visit-reflection-flow.md
@@ -63,9 +63,11 @@ next_consultation_started
 |---|---|
 | `route_open` | 現地への移動検討を記録する |
 | `visit_done` | 参拝・訪問完了を記録する |
-| `reflection_prompt_view` | 振り返り入力の表示を記録する |
+| `reflection_prompt_view` | 実際のReflection入力UIが表示されたことだけを記録する |
 | `reflection_saved` | 振り返り保存を記録する |
 | `next_consultation_started` | 次回相談への再接続を記録する |
+
+`reflection_prompt_view` は、ユーザーが回答できるReflection入力UIの表示のみを対象とする。Concierge結果画面でAction Suggestionの振り返り質問プレビューを表示した場合は、`reflection_prompt_view` ではなく `docs/product/action_suggestion_v4.md` が定義する別イベントを使用する（詳細は本書「reflection_prompt_view」節を参照）。
 
 ---
 
@@ -120,9 +122,11 @@ type VisitDonePayload = {
 
 ### 責務
 
-振り返り入力UIが表示された事実を記録する。
+ユーザーが回答できるReflection入力UIが実際に表示された事実を記録する。
 
 表示されたことだけを扱い、回答や保存完了は扱わない。
+
+`reflection_prompt_view` は、ユーザーが実際に回答可能なReflection入力フォームの表示にのみ使用する。Action Suggestionの振り返り質問プレビュー（Concierge結果画面で表示される、回答不可のプレビューテキスト）はこのイベントに含めない。プレビュー表示の計測は `docs/product/action_suggestion_v4.md` が定義する `action_suggestion_reflection_preview_view` を使用する。
 
 ### 発火条件
 
@@ -146,10 +150,15 @@ type ReflectionPromptViewPayload = {
   resultSetId?: string | null;
   historyTheme: string;
   actionTheme?: string | null;
-  promptType: "one_line" | "mood_delta" | "theme_reflection";
+  /** どのフォーム構造でReflectionを入力させたか */
+  reflectionFormType: "one_line" | "mood_delta" | "theme_reflection";
+  /** Reflectionがどの文脈で表示されたか */
+  reflectionContext: "visit_done" | "mypage" | "night_reflection";
   accessLevel?: "anonymous" | "free" | "premium";
 };
 ```
+
+`reflectionFormType` と `reflectionContext` は、Action Suggestion v4の `reflection_prompt.prompt_type`（`before_visit` / `after_visit` / `decision` / `emotion` / `constraint`）とは異なる語彙である。両者を混在させない。
 
 ### 質問生成
 
@@ -193,7 +202,8 @@ type ReflectionSavedPayload = {
   resultSetId?: string | null;
   historyTheme: string;
   actionTheme?: string | null;
-  promptType: "one_line" | "mood_delta" | "theme_reflection";
+  reflectionFormType: "one_line" | "mood_delta" | "theme_reflection";
+  reflectionContext: "visit_done" | "mypage" | "night_reflection";
   answerLength: number;
   moodBefore?: number | null;
   moodAfter?: number | null;
@@ -206,7 +216,8 @@ type ReflectionSavedPayload = {
 - `source`
 - `shrineId`
 - `historyTheme`
-- `promptType`
+- `reflectionFormType`
+- `reflectionContext`
 - `answerLength`
 
 ---
@@ -360,8 +371,8 @@ type ReflectionAnalyticsBasePayload = {
 | Event | 必須項目 |
 |---|---|
 | `visit_done` | `source`, `shrineId`, `historyTheme` |
-| `reflection_prompt_view` | `source`, `shrineId`, `historyTheme`, `promptType` |
-| `reflection_saved` | `source`, `shrineId`, `historyTheme`, `answerLength` |
+| `reflection_prompt_view` | `source`, `shrineId`, `historyTheme`, `reflectionFormType`, `reflectionContext` |
+| `reflection_saved` | `source`, `shrineId`, `historyTheme`, `reflectionFormType`, `reflectionContext`, `answerLength` |
 
 ### 集計指標
 


### PR DESCRIPTION
## Summary

`docs/audit/visit-reflection-implementation-consistency.md`で指摘された問題のうち、以下2点をPR1として解消する（4分割の1つ目）。

1. `reflection_prompt_view`が「実際のReflection入力UI表示」と「Concierge結果画面でのAction Suggestion振り返りプレビュー表示（回答不可）」という異なる意味で同一イベント名から送信されていた
2. `promptType`が`one_line/mood_delta/theme_reflection`・`visit_done_reflection`固定・`before_visit/after_visit/decision/emotion/constraint`の3系統で混在していた

### 変更内容

- **`ConciergeTopRecommendationHero.tsx`**: Action Suggestionプレビュー表示時に送信していた`reflection_prompt_view`を`action_suggestion_reflection_preview_view`へ改名。このタイミングでは既に`action_suggestion_preview_view`が同一payloadで送信済みだったため、実質的には重複計装のイベント名修正（payload構造は維持）
- **Promptの責務分離**:
  - `reflectionFormType`（`one_line | mood_delta | theme_reflection`）・`reflectionContext`（`visit_done | mypage | night_reflection`）: 実際のReflection入力UI（`ShrineReflectionPrompt.tsx`）専用。現行UIは自由記述＋参拝前後mood入力の単一フォームのため、`reflectionFormType="mood_delta"`・`reflectionContext="visit_done"`を採用（判断根拠は下記参照）
  - `actionPromptType`: Action Suggestion v4の`prompt_type`をそのまま転記する用途に限定
- `SearchAnalyticsPayload`型から`promptType`を削除し、上記3フィールドをリテラルユニオン型として追加
- 新規契約テスト`searchEvents.test.ts`を追加。`reflection_prompt_view`/`reflection_saved`が`promptType`を含まないこと、新イベントが`actionPromptType`のみを運ぶことを検証
- `docs/product/visit-reflection-flow.md`・`docs/product/action_suggestion_v4.md`を実装に合わせて更新

### 契約判断（根拠）

- **`reflectionFormType: "mood_delta"`を採用した理由**: 現行の`ShrineReflectionPrompt.tsx`は自由記述の`answer`に加え、`moodBefore`/`moodAfter`を任意入力として受け付ける唯一のフォーム構造。3候補（`one_line`/`mood_delta`/`theme_reflection`）のうち、mood before/afterの捕捉というフォームの特徴に最も一致するのは`mood_delta`と判断した。他の2値は将来別フォームが実装された場合の予約値として型に残す
- **`reflectionContext: "visit_done"`を採用した理由**: `ShrineReflectionPrompt`は`ShrineDetailArticle.tsx`内で`hasVisitHistory`（Visit記録済み）の場合にのみ表示される。マイページ・夜間通知経由の表示は未実装のため、現状唯一の文脈として`visit_done`を採用

### 変更していないもの

- Backend Model（`Visit`/`ShrineReflection`）・Migration
- Recommendation Ranking / Score weight
- Mobile実装
- Reflection保存API

### Migration有無

なし（Analytics Event/TypeScript型のみの変更）

## Test plan

- [x] `npx tsc --noEmit`（typecheck）パス
- [x] Web全テストスイート 80 files / 441 tests パス（既存438 + 新規3）
- [x] `git diff --check`でホワイトスペースエラーなし
- [x] pre-pushフック（OpenAPI lint / Web契約テスト）パス

## 残った判断保留

- `docs/audit/visit-reflection-implementation-consistency.md`への追記: このブランチは`develop`から作成しており、当該監査文書はまだ未マージのPR #1989のブランチにのみ存在するため、今回は追記していない。PR #1989マージ後に別途追記が必要
- PR2（Payload契約）・PR3（保存モデル・API契約）・PR4（Mobile共通契約）は未着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)