### PR TITLE
feat: visit_done/reflection系Eventの必須Payloadを最小化

### DIFF
--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -701,6 +701,7 @@ export default function ShrineDetailArticle({
                     historyTheme={historyTheme}
                     threadId={tid != null ? String(tid) : null}
                     ctx={ctx}
+                    accessLevel={accessLevel}
                   />
                 ) : null}
 
@@ -726,7 +727,8 @@ export default function ShrineDetailArticle({
                           shrineId: cardProps.shrineId,
                           threadId: tid != null ? String(tid) : undefined,
                           historyTheme: historyTheme ?? undefined,
-                          ctx,
+                          accessLevel,
+                          mode: ctx === "concierge" ? "need" : undefined,
                         });
                         const now = new Date().toISOString();
                         setVisitSummary((current) => ({

--- a/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
@@ -12,12 +12,21 @@ type Props = {
   historyTheme?: string | null;
   threadId?: string | null;
   ctx?: string | null;
+  accessLevel?: "anonymous" | "free" | "premium" | null;
   onSaved?: () => void;
 };
 
 const PROMPT_TEXT = "参拝して、今どんな変化がありましたか？";
 
-export function ShrineReflectionPrompt({ shrineId, historyTheme = null, threadId = null, ctx = null, onSaved }: Props) {
+export function ShrineReflectionPrompt({
+  shrineId,
+  historyTheme = null,
+  threadId = null,
+  ctx = null,
+  accessLevel = null,
+  onSaved,
+}: Props) {
+  const mode = ctx === "concierge" ? "need" : undefined;
   const [answer, setAnswer] = useState("");
   const [moodBefore, setMoodBefore] = useState("");
   const [moodAfter, setMoodAfter] = useState("");
@@ -36,9 +45,10 @@ export function ShrineReflectionPrompt({ shrineId, historyTheme = null, threadId
       historyTheme: historyTheme ?? undefined,
       reflectionFormType: "mood_delta",
       reflectionContext: "visit_done",
-      ctx,
+      mode,
+      accessLevel,
     });
-  }, [ctx, historyTheme, shrineId, threadId]);
+  }, [accessLevel, historyTheme, mode, shrineId, threadId]);
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -65,7 +75,8 @@ export function ShrineReflectionPrompt({ shrineId, historyTheme = null, threadId
         answerLength,
         moodBefore: moodBefore || undefined,
         moodAfter: moodAfter || undefined,
-        ctx,
+        mode,
+        accessLevel,
       });
 
       setStatus("saved");

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
@@ -3,10 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const analyticsMocks = vi.hoisted(() => ({
   trackCardEvent: vi.fn(),
+  trackSearchEvent: vi.fn(),
 }));
 
 vi.mock("@/lib/analytics/cardEvents", () => ({
   trackCardEvent: analyticsMocks.trackCardEvent,
+}));
+
+vi.mock("@/lib/analytics/searchEvents", () => ({
+  trackSearchEvent: analyticsMocks.trackSearchEvent,
 }));
 
 const visitsMocks = vi.hoisted(() => ({
@@ -71,6 +76,7 @@ function SaveActionStub({ onToggleSuccess }: { onToggleSuccess?: (nextFav: boole
 describe("ShrineDetailArticle", () => {
   beforeEach(() => {
     analyticsMocks.trackCardEvent.mockClear();
+    analyticsMocks.trackSearchEvent.mockClear();
     visitsMocks.addVisit.mockReset();
     visitsMocks.getVisits.mockReset();
     visitsMocks.getVisits.mockResolvedValue([]);
@@ -454,7 +460,7 @@ describe("ShrineDetailArticle", () => {
   );
 
   describe("参拝CTA", () => {
-    function renderWithVisitCta() {
+    function renderWithVisitCta(overrides: { ctx?: string | null; historyTheme?: string | null; tid?: string | number | null } = {}) {
       return render(
         <ShrineDetailArticle
           cardProps={{
@@ -475,6 +481,9 @@ describe("ShrineDetailArticle", () => {
           sections={[]}
           recommendationMeta={null}
           saveActionNode={<SaveActionStub />}
+          ctx={overrides.ctx ?? null}
+          historyTheme={overrides.historyTheme ?? null}
+          tid={overrides.tid ?? null}
         />,
       );
     }
@@ -536,6 +545,44 @@ describe("ShrineDetailArticle", () => {
 
       expect(screen.getByText("参拝を記録しました")).toBeInTheDocument();
       expect(screen.getByText("参拝後の振り返り")).toBeInTheDocument();
+    });
+
+    it("visit_doneはsource/shrineId/historyTheme/accessLevelを送信し、ctxは含まない", async () => {
+      visitsMocks.addVisit.mockResolvedValue({});
+
+      renderWithVisitCta({ ctx: "map", historyTheme: "静寂", tid: "tid-1" });
+      fireEvent.click(screen.getByRole("button", { name: "参拝しました" }));
+
+      await waitFor(() => {
+        expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+          "visit_done",
+          expect.objectContaining({
+            source: "shrine_detail",
+            shrineId: 17,
+            threadId: "tid-1",
+            historyTheme: "静寂",
+            accessLevel: expect.any(String),
+          }),
+        );
+      });
+
+      const visitDoneCall = analyticsMocks.trackSearchEvent.mock.calls.find(([eventName]) => eventName === "visit_done");
+      expect(visitDoneCall?.[1]).not.toHaveProperty("ctx");
+      expect(visitDoneCall?.[1]?.mode).toBeUndefined();
+    });
+
+    it("ctx=concierge の場合、visit_doneはmode:needを送信する", async () => {
+      visitsMocks.addVisit.mockResolvedValue({});
+
+      renderWithVisitCta({ ctx: "concierge" });
+      fireEvent.click(screen.getByRole("button", { name: "参拝しました" }));
+
+      await waitFor(() => {
+        expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+          "visit_done",
+          expect.objectContaining({ mode: "need" }),
+        );
+      });
     });
 
     it("失敗後はエラー表示になり、再操作可能な状態に戻る", async () => {

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
@@ -23,7 +23,15 @@ describe("ShrineReflectionPrompt", () => {
   });
 
   it("表示時に reflection_prompt_view を送信する", () => {
-    render(<ShrineReflectionPrompt shrineId={17} historyTheme="静寂" threadId="tid-1" ctx="concierge" />);
+    render(
+      <ShrineReflectionPrompt
+        shrineId={17}
+        historyTheme="静寂"
+        threadId="tid-1"
+        ctx="concierge"
+        accessLevel="free"
+      />,
+    );
 
     expect(screen.getByText("参拝後の振り返り")).toBeInTheDocument();
     expect(mockedTrackSearchEvent).toHaveBeenCalledWith("reflection_prompt_view", {
@@ -33,7 +41,8 @@ describe("ShrineReflectionPrompt", () => {
       historyTheme: "静寂",
       reflectionFormType: "mood_delta",
       reflectionContext: "visit_done",
-      ctx: "concierge",
+      mode: "need",
+      accessLevel: "free",
     });
   });
 
@@ -52,7 +61,14 @@ describe("ShrineReflectionPrompt", () => {
     });
 
     render(
-      <ShrineReflectionPrompt shrineId={17} historyTheme="静寂" threadId="tid-1" ctx="concierge" onSaved={onSaved} />,
+      <ShrineReflectionPrompt
+        shrineId={17}
+        historyTheme="静寂"
+        threadId="tid-1"
+        ctx="concierge"
+        accessLevel="free"
+        onSaved={onSaved}
+      />,
     );
 
     fireEvent.change(screen.getByPlaceholderText(/少し落ち着いた/), {
@@ -87,7 +103,8 @@ describe("ShrineReflectionPrompt", () => {
       answerLength: 10,
       moodBefore: "anxious",
       moodAfter: "calm",
-      ctx: "concierge",
+      mode: "need",
+      accessLevel: "free",
     });
     expect(onSaved).toHaveBeenCalled();
   });

--- a/apps/web/src/lib/analytics/__tests__/searchEvents.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/searchEvents.test.ts
@@ -71,4 +71,44 @@ describe("searchEvents契約", () => {
       actionPromptType: "emotion",
     });
   });
+
+  it("historyThemeがnull/undefinedの場合、payloadからキー自体が省略される(空文字は送らない)", () => {
+    trackSearchEvent("visit_done", {
+      source: "shrine_detail",
+      shrineId: 1,
+      historyTheme: null,
+    });
+
+    expect(trackMock).toHaveBeenCalledTimes(1);
+    const [, payload] = trackMock.mock.calls[0] ?? [];
+    expect(payload).not.toHaveProperty("historyTheme");
+    expect(payload?.historyTheme).not.toBe("");
+  });
+
+  it("visit_doneはhistoryThemeの有無にかかわらず必ず送信される", () => {
+    trackSearchEvent("visit_done", { source: "shrine_detail", shrineId: 1 });
+    trackSearchEvent("visit_done", { source: "shrine_detail", shrineId: 2, historyTheme: "縁" });
+
+    expect(trackMock).toHaveBeenCalledTimes(2);
+    expect(trackMock).toHaveBeenNthCalledWith(1, "visit_done", expect.objectContaining({ shrineId: 1 }));
+    expect(trackMock).toHaveBeenNthCalledWith(
+      2,
+      "visit_done",
+      expect.objectContaining({ shrineId: 2, historyTheme: "縁" }),
+    );
+  });
+
+  it("modeはctx由来の値のみを受け付け、ctxというキー自体は型として存在しない", () => {
+    trackSearchEvent("visit_done", {
+      source: "shrine_detail",
+      shrineId: 1,
+      mode: "need",
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "visit_done",
+      expect.objectContaining({ mode: "need" }),
+    );
+    expect(trackMock.mock.calls[0]?.[1]).not.toHaveProperty("ctx");
+  });
 });

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -33,6 +33,11 @@ export type SearchAnalyticsPayload = {
   resultSetId?: string | null;
   shrineId?: number | string | null;
   recommendationRank?: number | null;
+  /**
+   * 遷移元URLの `ctx` クエリパラメータから導出する（`ctx === "concierge"` の場合 `"need"`）。
+   * `ctx` の値自体をpayloadへ直接送信しない。
+   */
+  mode?: "need" | "compat" | null;
   accessLevel?: "anonymous" | "free" | "premium" | null;
   shrine_data_rate?: number | null;
   consultation_reflection_rate?: number | null;

--- a/docs/product/visit-reflection-flow.md
+++ b/docs/product/visit-reflection-flow.md
@@ -98,9 +98,12 @@ type VisitDonePayload = {
   source: "concierge_result" | "shrine_detail" | "mypage";
   shrineId: number | string;
   threadId?: string | null;
+  /** Concierge結果画面など、resultSetIdを取得できる経路からのみ送信する */
   resultSetId?: string | null;
-  historyTheme: string;
+  historyTheme?: string | null;
+  /** Concierge結果画面など、recommendationRankを取得できる経路からのみ送信する */
   recommendationRank?: number | null;
+  /** 遷移元の`ctx`クエリパラメータから導出する。`ctx`自体はpayloadへ含めない */
   mode?: "need" | "compat";
   accessLevel?: "anonymous" | "free" | "premium";
   routeOpenedBefore?: boolean;
@@ -112,9 +115,8 @@ type VisitDonePayload = {
 
 - `source`
 - `shrineId`
-- `historyTheme`
 
-`historyTheme` は参拝後の分析と振り返り接続に使用する。
+`historyTheme` は参拝後の分析と振り返り接続に使用するが、値が取得できない場合はキー自体を省略してよい（空文字を送らない）。イベント自体は`historyTheme`の有無にかかわらず必ず送信する。詳細は「Analytics Contract」節の「historyTheme欠損時の扱い」を参照する。
 
 ---
 
@@ -144,11 +146,12 @@ reflection_prompt_view
 
 ```ts
 type ReflectionPromptViewPayload = {
-  source: "visit_done" | "mypage" | "night_reflection";
+  /** 画面ソース。visit_done等の「表示文脈」は`reflectionContext`が担うため、sourceはここでは混在させない */
+  source: "concierge_result" | "shrine_detail" | "map" | "shrines";
   shrineId: number | string;
   threadId?: string | null;
   resultSetId?: string | null;
-  historyTheme: string;
+  historyTheme?: string | null;
   actionTheme?: string | null;
   /** どのフォーム構造でReflectionを入力させたか */
   reflectionFormType: "one_line" | "mood_delta" | "theme_reflection";
@@ -159,6 +162,8 @@ type ReflectionPromptViewPayload = {
 ```
 
 `reflectionFormType` と `reflectionContext` は、Action Suggestion v4の `reflection_prompt.prompt_type`（`before_visit` / `after_visit` / `decision` / `emotion` / `constraint`）とは異なる語彙である。両者を混在させない。
+
+`source` は「どの画面から送信されたか」を表す全Event共通の語彙とし、`visit_done`/`mypage`/`night_reflection`のような「表示文脈」は`reflectionContext`が単独で担う。両者を混在させない。
 
 ### 質問生成
 
@@ -196,29 +201,32 @@ reflection_saved
 
 ```ts
 type ReflectionSavedPayload = {
-  source: "visit_done" | "mypage" | "night_reflection";
+  source: "concierge_result" | "shrine_detail" | "map" | "shrines";
   shrineId: number | string;
   threadId?: string | null;
   resultSetId?: string | null;
-  historyTheme: string;
+  historyTheme?: string | null;
   actionTheme?: string | null;
   reflectionFormType: "one_line" | "mood_delta" | "theme_reflection";
   reflectionContext: "visit_done" | "mypage" | "night_reflection";
   answerLength: number;
-  moodBefore?: number | null;
-  moodAfter?: number | null;
+  moodBefore?: string | null;
+  moodAfter?: string | null;
   accessLevel?: "anonymous" | "free" | "premium";
 };
 ```
+
+`moodBefore`/`moodAfter` はUI入力値をそのまま送信する文字列とする（`ShrineReflection.mood_before`/`mood_after`と同じ`CharField`型に合わせる）。
 
 ### 必須項目
 
 - `source`
 - `shrineId`
-- `historyTheme`
 - `reflectionFormType`
 - `reflectionContext`
 - `answerLength`
+
+`historyTheme`は`visit_done`と同様、値が取得できない場合はキーを省略してよい。
 
 ---
 
@@ -356,6 +364,7 @@ type ReflectionAnalyticsBasePayload = {
   threadId?: string | null;
   resultSetId?: string | null;
   historyTheme?: string | null;
+  mode?: "need" | "compat";
   accessLevel?: "anonymous" | "free" | "premium";
 };
 ```
@@ -370,9 +379,26 @@ type ReflectionAnalyticsBasePayload = {
 
 | Event | 必須項目 |
 |---|---|
-| `visit_done` | `source`, `shrineId`, `historyTheme` |
-| `reflection_prompt_view` | `source`, `shrineId`, `historyTheme`, `reflectionFormType`, `reflectionContext` |
-| `reflection_saved` | `source`, `shrineId`, `historyTheme`, `reflectionFormType`, `reflectionContext`, `answerLength` |
+| `visit_done` | `source`, `shrineId` |
+| `reflection_prompt_view` | `source`, `shrineId`, `reflectionFormType`, `reflectionContext` |
+| `reflection_saved` | `source`, `shrineId`, `reflectionFormType`, `reflectionContext`, `answerLength` |
+
+`historyTheme`はいずれのEventでも必須項目に含めない。値が取得できる場合のみpayloadへ含める任意項目として扱う（詳細は次項）。
+
+### historyTheme欠損時の扱い
+
+`Shrine.history_theme`は`blank=True, default=""`であり、本番推薦対象の神社でも値が未設定（空文字）のケースが存在しうる。また神社詳細画面へConcierge経由でなく直接アクセスした場合は、Meaning Layerの意味変換結果（`shrineMeaningPayloadV2`）自体が存在せず、`historyTheme`を取得できない。
+
+以下の方針とする。
+
+- `historyTheme`が取得できない場合でも、`visit_done` / `reflection_prompt_view` / `reflection_saved` のEvent送信自体は行う（Eventを破棄しない）。Funnelの母数（`shrine_detail_view → visit_done → ...`）を`historyTheme`の有無で歪めないことを優先する。
+- `historyTheme`の値が取得できない場合は、空文字（`""`）を送らず、payloadから`historyTheme`キー自体を省略する。
+- `historyTheme: null`を明示的に送る運用は採用しない（Analytics送信の共通シリアライズ処理が`null`/`undefined`のキーを一律で除外する実装のため、値なし状態はキー省略で統一する）。
+- `historyTheme`別の集計では、キーが存在しないレコードを「欠損」として扱う。
+
+### ctxパラメータの扱い
+
+`ctx`（`"map" | "concierge" | null`、遷移元を示すURLクエリパラメータ）は、`visit_done` / `reflection_prompt_view` / `reflection_saved` のpayloadへ直接含めない。`ctx === "concierge"`の場合のみ`mode: "need"`へ変換して送信する（他の`trackCardEvent`系イベントと同じ変換規則）。`ctx`という生のパラメータ名はAnalytics Payload契約に含めない。
 
 ### 集計指標
 


### PR DESCRIPTION
## Summary

`docs/audit/visit-reflection-implementation-consistency.md`で指摘されたPayload契約と実装の不一致を解消する（4分割の2つ目、PR1 #1990の続き）。

### 変更内容

- **必須項目からhistoryThemeを除外**: 値が取得できた場合のみpayloadへ含める任意項目とした。空文字は送らず、欠損時はキー自体を省略する。イベント送信自体はhistoryThemeの有無にかかわらず常に行う（Funnel母数を歪めないため）
- **resultSetId/recommendationRank**: 取得できる経路（Concierge結果画面等）からのみ送る任意項目と位置付けた。現状唯一の送信経路であるShrine Detail画面はConciergeの結果セットIDを保持していないため、引き続き未送信のまま
- **ctxパラメータの扱いを整理**: 未定義パラメータとして直接payloadへ送信していた`ctx`を廃止し、既存の`premium_preview_click`イベントと同じ変換規則（`ctx === "concierge" ? "need" : undefined`）で`mode`へ変換して送信
- **accessLevelを追加**: `ShrineDetailArticle`内で既に計算済みの値をそのまま利用（取得コストなし）
- **sourceのenumを統一**: `reflection_prompt_view`/`reflection_saved`が独自に持っていたsource値（`visit_done`/`mypage`/`night_reflection`）を廃止し、全Event共通の画面ソース値（`concierge_result`/`shrine_detail`/`map`/`shrines`）へ統一。旧source値はPR1で新設した`reflectionContext`と概念が重複していたため
- **moodBefore/moodAfterの型修正**: Payload型定義を`number`から実際の送信値・DB型（`ShrineReflection.mood_before`/`mood_after`のCharField）に合わせて`string`へ修正
- 新規契約テストを追加（historyTheme欠損時のキー省略、イベント送信の継続、ctx非送信を検証）
- `docs/product/visit-reflection-flow.md`へ、historyTheme欠損時の扱いとctxパラメータの扱いを明文化

### 契約判断（根拠）

- **historyTheme欠損時、イベントは送信するがキーは省略する**: `Shrine.history_theme`は`blank=True, default=""`で本番でも空文字がありうる（既存テスト`test_normalize_history_theme_returns_default_for_blank_value`でも欠損ケースが想定済み）。直接アクセス時は`shrineMeaningPayloadV2`が存在せず取得不能。欠損時にイベント自体を捨てるとFunnel母数が歪むため送信は継続する。一方、Analytics共通シリアライズ処理（`serializeSearchAnalyticsPayload`）が`null`/`undefined`を一律除外する既存実装のため、`historyTheme: null`を明示送信する意味は薄く、キー省略に統一した
- **resultSetId/recommendationRankは今回未送信のまま**: Shrine Detail画面のpropsを調査した結果、Concierge推薦結果セットのIDや順位の数値は保持されていないことを確認した（`recommendationRankExplanation`という説明テキストはあるが数値順位ではない）。取得できない値を無理に送らない
- **sourceの統一**: reflection系イベントのdocs定義における独自source値は、PR1で分離した`reflectionContext`と値域が完全一致しており、責務の重複と判断した

### 変更していないもの

- Backend Model（`Visit`/`ShrineReflection`）・Migration
- Recommendation Ranking / Score weight
- Mobile実装

### Migration有無

なし（Analytics Payload/TypeScript型のみの変更）

## Test plan

- [x] `npx tsc --noEmit`（typecheck）パス
- [x] Web全テストスイート 80 files / 446 tests パス（PR1マージ後441 + 新規5）
- [x] `git diff --check`でホワイトスペースエラーなし
- [x] pre-pushフック（OpenAPI lint / Web契約テスト）パス

## 残った判断保留

- **WebとMobileの型共有**: `packages/shared`は存在するが、Web/Mobileどちらのpackage.jsonからも依存として組み込まれておらず、共有インフラが未整備。今回新設した`SearchAnalyticsEventName`/`SearchAnalyticsPayload`型を先んじて共有パッケージへ移すと、対応するMobile実装が伴わないまま型だけ公開される状態になるため見送った。この判断はPR4（Mobile共通契約）で扱う
- PR3（保存モデル・API契約）・PR4（Mobile共通契約）は未着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)