### PR TITLE
feat: MobileにVisit/Reflection Analytics契約を実装(PR4)

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -15,6 +15,7 @@ import { ctaSizes } from "../design/ctaSizes";
 import { createFavoriteByShrineId } from "../../lib/favorites";
 import { createVisitByShrineId } from "../../lib/visits";
 import { createShrineReflection } from "../../lib/reflections";
+import { trackVisitDone, trackReflectionPromptView, trackReflectionSaved } from "../../lib/visitReflectionAnalytics";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 
 type RecommendationReasonFactAxis =
@@ -468,12 +469,29 @@ export default function ShrineDetail() {
     try {
       await createVisitByShrineId(targetShrineId);
       setVisited(true);
+      trackVisitDone({
+        shrineId: targetShrineId,
+        historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+      });
     } catch (error) {
       if (isUnauthenticatedError(error)) {
         setAuthPromptVisible(true);
       }
     }
-  }, [apiShrineId, shrineId]);
+  }, [apiShrineId, contextReasonFacts, shrine, shrineId]);
+
+  React.useEffect(() => {
+    const targetShrineId = apiShrineId ?? shrineId;
+    if (!visited || !targetShrineId) return;
+
+    trackReflectionPromptView({
+      shrineId: targetShrineId,
+      historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+      reflectionFormType: "one_line",
+      reflectionContext: "visit_done",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visited]);
 
   const onSaveReflection = React.useCallback(async () => {
     const targetShrineId = apiShrineId ?? shrineId;
@@ -493,6 +511,13 @@ export default function ShrineDetail() {
 
       if (saved) {
         setReflectionSaved(true);
+        trackReflectionSaved({
+          shrineId: targetShrineId,
+          historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+          reflectionFormType: "one_line",
+          reflectionContext: "visit_done",
+          answerLength: answer.length,
+        });
       }
     } catch (error) {
       if (isUnauthenticatedError(error)) {

--- a/apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts
+++ b/apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// __DEV__ は Metro/React Native が注入するグローバルで、vitest実行環境には存在しないため定義する。
+(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+
+import { setAnalyticsProvider, type AnalyticsProvider } from "../analytics";
+import { trackReflectionPromptView, trackReflectionSaved, trackVisitDone } from "../visitReflectionAnalytics";
+
+describe("visitReflectionAnalytics", () => {
+  const trackSpy = vi.fn();
+
+  beforeEach(() => {
+    const customProvider: AnalyticsProvider = { track: trackSpy };
+    setAnalyticsProvider(customProvider);
+  });
+
+  afterEach(() => {
+    trackSpy.mockClear();
+    setAnalyticsProvider(null);
+  });
+
+  it("trackVisitDoneはsource/platform/shrineId/historyThemeを送る", () => {
+    trackVisitDone({ shrineId: 17, historyTheme: "静寂" });
+
+    expect(trackSpy).toHaveBeenCalledWith("visit_done", {
+      source: "shrine_detail",
+      platform: "mobile",
+      shrineId: 17,
+      historyTheme: "静寂",
+    });
+  });
+
+  it("trackVisitDoneはhistoryTheme/threadIdが未取得の場合キー自体を送らない", () => {
+    trackVisitDone({ shrineId: 17, historyTheme: "" });
+
+    expect(trackSpy).toHaveBeenCalledWith("visit_done", {
+      source: "shrine_detail",
+      platform: "mobile",
+      shrineId: 17,
+    });
+  });
+
+  it("trackReflectionPromptViewはreflectionFormType/reflectionContextを送る", () => {
+    trackReflectionPromptView({
+      shrineId: 17,
+      historyTheme: "静寂",
+      reflectionFormType: "one_line",
+      reflectionContext: "visit_done",
+    });
+
+    expect(trackSpy).toHaveBeenCalledWith("reflection_prompt_view", {
+      source: "shrine_detail",
+      platform: "mobile",
+      shrineId: 17,
+      historyTheme: "静寂",
+      reflectionFormType: "one_line",
+      reflectionContext: "visit_done",
+    });
+  });
+
+  it("trackReflectionSavedはanswerLengthを送り、moodBefore/moodAfterが空なら送らない", () => {
+    trackReflectionSaved({
+      shrineId: 17,
+      historyTheme: "静寂",
+      reflectionFormType: "one_line",
+      reflectionContext: "visit_done",
+      answerLength: 12,
+      moodBefore: "",
+      moodAfter: "",
+    });
+
+    expect(trackSpy).toHaveBeenCalledWith("reflection_saved", {
+      source: "shrine_detail",
+      platform: "mobile",
+      shrineId: 17,
+      historyTheme: "静寂",
+      reflectionFormType: "one_line",
+      reflectionContext: "visit_done",
+      answerLength: 12,
+    });
+  });
+
+  it("threadIdが取得できた場合はpayloadに含める", () => {
+    trackVisitDone({ shrineId: 17, threadId: 42, historyTheme: "静寂" });
+
+    expect(trackSpy).toHaveBeenCalledWith("visit_done", {
+      source: "shrine_detail",
+      platform: "mobile",
+      shrineId: 17,
+      threadId: 42,
+      historyTheme: "静寂",
+    });
+  });
+});

--- a/apps/mobile/lib/visitReflectionAnalytics.ts
+++ b/apps/mobile/lib/visitReflectionAnalytics.ts
@@ -1,0 +1,63 @@
+// Visit/Reflection Analyticsイベント契約
+// apps/web/src/lib/analytics/searchEvents.ts のイベント名・フィールド名の意味に合わせる。
+// packages/sharedはpnpm-workspaceからapps/mobileが除外されており(pnpm-workspace.yaml参照)、
+// 型そのものをWeb/Mobileで共有する基盤がまだ無いため、契約(イベント名・フィールドの意味)のみを揃え、
+// 型定義はこのファイルに個別で持つ。
+import { track } from "./analytics";
+
+const SOURCE = "shrine_detail";
+
+export type VisitReflectionFormType = "one_line" | "mood_delta" | "theme_reflection";
+export type VisitReflectionContext = "visit_done" | "mypage" | "night_reflection";
+
+type BasePayloadParams = {
+  shrineId: number | string;
+  threadId?: number | string | null;
+  historyTheme?: string | null;
+};
+
+function buildBasePayload({ shrineId, threadId, historyTheme }: BasePayloadParams): Record<string, unknown> {
+  return {
+    source: SOURCE,
+    platform: "mobile",
+    shrineId,
+    threadId: threadId || undefined,
+    historyTheme: historyTheme || undefined,
+  };
+}
+
+export function trackVisitDone(params: BasePayloadParams): void {
+  track("visit_done", buildBasePayload(params));
+}
+
+export type ReflectionPromptViewParams = BasePayloadParams & {
+  reflectionFormType: VisitReflectionFormType;
+  reflectionContext: VisitReflectionContext;
+};
+
+export function trackReflectionPromptView(params: ReflectionPromptViewParams): void {
+  track("reflection_prompt_view", {
+    ...buildBasePayload(params),
+    reflectionFormType: params.reflectionFormType,
+    reflectionContext: params.reflectionContext,
+  });
+}
+
+export type ReflectionSavedParams = BasePayloadParams & {
+  reflectionFormType: VisitReflectionFormType;
+  reflectionContext: VisitReflectionContext;
+  answerLength: number;
+  moodBefore?: string | null;
+  moodAfter?: string | null;
+};
+
+export function trackReflectionSaved(params: ReflectionSavedParams): void {
+  track("reflection_saved", {
+    ...buildBasePayload(params),
+    reflectionFormType: params.reflectionFormType,
+    reflectionContext: params.reflectionContext,
+    answerLength: params.answerLength,
+    moodBefore: params.moodBefore || undefined,
+    moodAfter: params.moodAfter || undefined,
+  });
+}

--- a/docs/product/visit-reflection-flow.md
+++ b/docs/product/visit-reflection-flow.md
@@ -438,6 +438,21 @@ type ReflectionAnalyticsBasePayload = {
 
 `ctx`（`"map" | "concierge" | null`、遷移元を示すURLクエリパラメータ）は、`visit_done` / `reflection_prompt_view` / `reflection_saved` のpayloadへ直接含めない。`ctx === "concierge"`の場合のみ`mode: "need"`へ変換して送信する（他の`trackCardEvent`系イベントと同じ変換規則）。`ctx`という生のパラメータ名はAnalytics Payload契約に含めない。
 
+### Mobile送信状況
+
+Mobile（`apps/mobile`）は神社詳細画面（`app/shrines/[id].tsx`）に参拝記録・振り返り保存の実UIを持ち、`visit_done` / `reflection_prompt_view` / `reflection_saved` を同一イベント名・同一フィールド意味でPostHogへ送信する（`apps/mobile/lib/visitReflectionAnalytics.ts`）。Web/MobileのイベントはPostHog上の同一プロジェクトに集約される。
+
+Mobileでは以下の項目を送信しない。理由は「取得できない値を無理に埋めない」という方針（前項「historyTheme欠損時の扱い」と同じ考え方）に基づく。
+
+| 項目 | 扱い |
+|---|---|
+| `threadId` | Mobileの神社詳細画面はConcierge相談スレッドからの遷移パラメータを受け取っていないため、常に未送信。導線を追加する場合は本項を更新する |
+| `mode` / `ctx` / `accessLevel` | Mobileの神社詳細画面にConcierge文脈・Free/Premium文脈を渡す導線が現時点で存在しないため未送信 |
+| `resultSetId` | Backendに対応する概念がなく、Web側でもDB保存とは接続しない値のため、Mobileでも送信しない |
+| `moodBefore` / `moodAfter` | Mobileの振り返り入力UIは自由記述の一言のみで、気分の前後入力欄を持たない（`reflectionFormType: "one_line"`固定）。常に空のため送信しない |
+
+Web/Mobile間で型定義そのものを共有する基盤（`packages/shared`）は未整備であり（`pnpm-workspace.yaml`で`apps/mobile`がworkspace対象から除外されている）、契約（イベント名・フィールドの意味）のみを揃え、型定義は各アプリ側で個別に持つ。
+
 ### 集計指標
 
 - `route_open → visit_done` CVR


### PR DESCRIPTION
## 変更概要

Visit / Reflection Contract整合実装のPR4。事前調査の結果、Mobile（`apps/mobile`）の神社詳細画面には参拝記録・振り返り保存の**実UIと実API呼び出しが既に存在する**ことを確認した（`createVisitByShrineId`/`createShrineReflection`、`app/shrines/[id].tsx`）。ブリーフ想定の「Mobile側にUI未実装」という前提は現状と異なっていたため、「UIが実在する以上フェイクではない」との判断で、Webと同一のイベント名・フィールド意味を持つAnalytics計測を実装した。

## 変更ファイル

- `apps/mobile/lib/visitReflectionAnalytics.ts`（新規） — `visit_done`/`reflection_prompt_view`/`reflection_saved`をWebと同一イベント名・フィールド意味で送信する関数群。既存の`lib/premiumAnalytics.ts`と同じ「`track()`薄いラッパー」パターンに従う
- `apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts`（新規） — 既存の`premiumAnalytics.test.ts`と同スタイルのテスト（実行不可、理由は下記テスト結果参照）
- `apps/mobile/app/shrines/[id].tsx` — `onVisitDone`/`onSaveReflection`への計測呼び出し追加、`visited`が`true`になったタイミングで`reflection_prompt_view`を送る`useEffect`を追加
- `docs/product/visit-reflection-flow.md` — Analytics Contract配下に「Mobile送信状況」節を追加し、Mobileが送る/送らないフィールドと理由を明記

## 契約判断

- **イベント名・フィールド意味はWebと同一とする**: `source: "shrine_detail"`、`historyTheme`欠損時はキー省略（`docs/product/visit-reflection-flow.md`の既存方針と同じ）
- **`platform: "mobile"`を付与**: 既存の`premiumAnalytics.ts`と同じ慣習（Web/MobileのイベントはPostHog上で同一プロジェクトに集約されるため、プラットフォーム別集計に必要）
- **`threadId`/`mode`/`ctx`/`accessLevel`は送信しない**: Mobileの神社詳細画面はConcierge相談スレッドや`ctx`/Free-Premium文脈を受け取る導線を持たないため、値を偽装しない（未取得のままキー省略）
- **`resultSetId`は送信しない**: Backendに対応する概念がなく、Web側でもDB保存とは接続しない値のため、Mobileでも追加しない
- **`reflectionFormType`は`"one_line"`固定**: Mobileの振り返り入力UIは自由記述の一言のみで、気分の前後入力欄を持たないため。Web側で既に定義済みの`"one_line" | "mood_delta" | "theme_reflection"`のうち`"one_line"`をそのまま利用し、Enum自体の変更はしていない
- **`packages/shared`での型共有は行わない**: `pnpm-workspace.yaml`で`apps/mobile`がworkspace対象から明示的に除外されており（`!apps/mobile`）、型定義を跨いで共有する基盤が存在しない。契約（イベント名・フィールドの意味）のみをdocsで揃え、型定義は各アプリ側で個別に持つ方針とした。ビルド設定を変更してworkspace統合すること自体は本PRのスコープを超える大きな変更のため着手していない（判断保留として下記に記載）

## Migration有無

なし。Analyticsイベントのみの変更で、Backend/DBへの変更は含まない。

## テスト結果

- Frontend(Web): `vitest run` — 450 passed（既存分、Mobile変更の影響なし）
- Backend: 変更なし、未実行（Mobile Analyticsのみのスコープのため対象外）
- **Mobile: `npx tsc -p tsconfig.json --noEmit`** — 新規追加したファイルによるエラーは0件。ただし`lib/__tests__/`配下の既存4ファイル（`analytics.test.ts`等、本PR以前から存在）が`Cannot find module 'vitest'`エラーを出しており、これは本PR着手前のdevelop時点で既に発生していた既存の問題であることを確認済み（本PRが原因ではない）
- **Mobile: `apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts`は実行できていない**: `apps/mobile/package.json`に`test`スクリプトが無く、`vitest`もmobile側の依存関係にインストールされていないため、リポジトリ内のどのコマンドでも実行不可能な状態（既存の`premiumAnalytics.test.ts`等も同様に未実行）。テストコードは`track()`のシリアライズ仕様（`serializeAnalyticsPayload`がnull/undefined/空文字由来のundefinedを除外する挙動）を手動でトレースして作成しており、ロジック自体は`premiumAnalytics.ts`で実証済みの同一パターンを踏襲しているが、**実行による検証はできていない**

## 残った判断保留

- Mobileのテスト実行基盤（`vitest`のインストール・設定）が存在しない。これは本PR以前からの既存課題であり、`visitReflectionAnalytics.test.ts`を含む`lib/__tests__/`配下のテストを実際に動かすには別途インフラ整備が必要
- `packages/shared`をMobileへ組み込みWeb/Mobile間で型定義自体を共有する基盤整備は、pnpm-workspace設定・Metro bundler設定にまたがる大きな変更になるため本PRでは着手していない
- Mobileの神社詳細画面にConcierge相談スレッドの遷移パラメータ（`threadId`）や`ctx`/Free-Premium文脈を渡す導線を追加するかどうかは、Concierge→神社詳細のナビゲーション設計に関わる別課題として扱う

## PR URL

作成中（このPR自体）