### PR TITLE
Frontend: need_tags(入力)とmatched_need_tags(一致結果)の責務を分離

### DIFF
--- a/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.payload.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.payload.test.ts
@@ -265,6 +265,45 @@ it("place候補の詳細情報とresult_stateをpayloadへ通す", () => {
 });
 
 
+it("data._need.tags を meta.needTags へ通す（入力側need_tagsの経路）", () => {
+  const u: any = {
+    data: {
+      _need: { tags: ["career", "mental", ""] },
+      recommendations: [
+        {
+          shrine_id: 10,
+          display_name: "S1",
+          reason: "R1",
+          breakdown: { matched_need_tags: ["money"] },
+        },
+      ],
+    },
+    thread: { id: 1 },
+  };
+
+  const p = buildPayloadFromUnified(u, baseFilterState);
+  expect(p?.meta?.needTags).toEqual(["career", "mental"]);
+});
+
+it("data._need.tags が無ければ meta.needTags は空配列になる", () => {
+  const u: any = {
+    data: {
+      recommendations: [
+        {
+          shrine_id: 10,
+          display_name: "S1",
+          reason: "R1",
+          breakdown: { matched_need_tags: ["rest"] },
+        },
+      ],
+    },
+    thread: { id: 1 },
+  };
+
+  const p = buildPayloadFromUnified(u, baseFilterState);
+  expect(p?.meta?.needTags).toEqual([]);
+});
+
 it("reason_facts を reasonFacts より優先する", () => {
   const u: any = {
     data: {

--- a/apps/web/src/features/concierge/buildPayloadFromUnified.ts
+++ b/apps/web/src/features/concierge/buildPayloadFromUnified.ts
@@ -85,6 +85,15 @@ function pickConsultationAxis(...vals: unknown[]): string | null {
   return pickFirstString(...vals);
 }
 
+// ユーザー相談から抽出された入力側need_tags。breakdown.matched_need_tags（一致結果）とは責務が異なる
+function normalizeInputNeedTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .filter((t): t is string => typeof t === "string")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
 function normalizeActionSuggestions(r: any): NonNullable<NormalizedItemBase["actionSuggestions"]> {
   const raw = r?._explanation_payload?.action_suggestions;
   if (!Array.isArray(raw)) return [];
@@ -321,6 +330,8 @@ export function buildPayloadFromUnified(
     consultationAxis,
   };
 
+  const needTags = normalizeInputNeedTags((u as any)?.data?._need?.tags);
+
   const rsRaw = (u as any)?.data?._signals?.result_state ?? (u as any)?.data?._signals?.resultState ?? null;
 
   const resultState =
@@ -355,7 +366,7 @@ export function buildPayloadFromUnified(
     return {
       version: 1,
       sections,
-      meta: { mode, reply, remaining, limitReached, tid, resultState, consultationAxis },
+      meta: { mode, reply, remaining, limitReached, tid, resultState, consultationAxis, needTags },
     };
   }
 
@@ -405,7 +416,7 @@ export function buildPayloadFromUnified(
   return {
     version: 1,
     sections,
-    meta: { mode, reply, remaining, limitReached, tid, resultState, consultationAxis },
+    meta: { mode, reply, remaining, limitReached, tid, resultState, consultationAxis, needTags },
   };
 }
 

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -771,6 +771,10 @@ export default function ConciergeSectionsRenderer({
                 <div className="space-y-3">
                   {heroItem
                     ? (() => {
+                        const inputNeedTags = payload?.meta?.needTags ?? [];
+                        const matchedNeedTags = heroItem.breakdown?.matched_need_tags ?? [];
+                        const effectiveNeedTags = inputNeedTags.length > 0 ? inputNeedTags : matchedNeedTags;
+
                         const reasonVm = buildRecommendationReasonViewModel({
                           rec: {
                             id: heroItem.shrineId,
@@ -790,7 +794,7 @@ export default function ConciergeSectionsRenderer({
                           index: 0,
                           mode: normalizedMode,
                           birthdate: filterState?.birthdate ?? null,
-                          needTags: heroItem.breakdown?.matched_need_tags ?? [],
+                          needTags: effectiveNeedTags,
                         });
                         const trustMetadata = (heroItem as any).trustMetadata ?? null;
                         const trustLabels = [
@@ -833,7 +837,7 @@ export default function ConciergeSectionsRenderer({
                               primaryReason={null}
                               secondaryReason={null}
                               differenceFromOthers={null}
-                              tags={(heroItem.breakdown?.matched_need_tags ?? []).map(labelNeedDisplayTag).slice(0, 3)}
+                              tags={matchedNeedTags.map(labelNeedDisplayTag).slice(0, 3)}
                               actionSuggestions={(heroItem as any).actionSuggestions ?? []}
                               actionSuggestionV4Preview={(heroItem as any).actionSuggestionV4Preview ?? null}
                               analyticsSource="concierge_result"

--- a/apps/web/src/features/concierge/sections/types.ts
+++ b/apps/web/src/features/concierge/sections/types.ts
@@ -119,6 +119,8 @@ export type ConciergeSectionsPayload = {
     limitReached?: boolean;
     tid?: string | null;
     consultationAxis?: string | null;
+    /** ユーザー相談由来の入力側need_tags。`breakdown.matched_need_tags`（一致結果）とは責務が異なる */
+    needTags?: string[];
     resultState?: {
       matched_count?: number;
       fallback_mode?: "none" | "nearby_unfiltered" | string;

--- a/apps/web/src/lib/concierge/buildRecommendationReasonViewModel.ts
+++ b/apps/web/src/lib/concierge/buildRecommendationReasonViewModel.ts
@@ -111,6 +111,11 @@ export type BuildParams = {
   rec: RecommendationLike;
   index: number;
   mode?: "need" | "compat" | string | null;
+  /**
+   * 相談要約・Heroテーマの生成に使う有効な入力タグ（呼び出し側で解決したeffectiveNeedTags）。
+   * 入力側need_tagsを優先し、入力が無い旧Payloadに限りmatched_need_tagsをfallbackとして渡す。
+   * Backend APIのフィールド名ではない。
+   */
   needTags: string[];
   birthdate?: string | null;
   shrineBenefitLabels?: string[];

--- a/apps/web/src/viewmodels/__tests__/conciergeToShrineList.test.ts
+++ b/apps/web/src/viewmodels/__tests__/conciergeToShrineList.test.ts
@@ -316,7 +316,7 @@ it("action_suggestion_v4_preview を actionSuggestionV4Preview より優先す�
   expect(preview?.sourceKeys).toEqual(["recommendation_reason_v4"]);
 });
 
-it("matched_need_tags が空なら _need.tags を badgesOverride に使う", () => {
+it("matched_need_tags が空でも badgesOverride は matched_need_tags のみを使い、_need.tags へフォールバックしない", () => {
   const resp = {
     ok: true,
     data: {
@@ -333,7 +333,77 @@ it("matched_need_tags が空なら _need.tags を badgesOverride に使う", () 
   };
 
   const items = conciergeToShrineListItems(resp as any);
-  expect(items[0].cardProps.badgesOverride).toEqual(["金運", "休息"]);
+  // 一致チップ(badgesOverride)は一致結果(matched_need_tags)のみを使う。空なら空のまま。
+  expect(items[0].cardProps.badgesOverride).toEqual([]);
+  // Hero・相談要約は入力側need_tagsを優先するため、matched_need_tagsが空でも生成できる。
+  expect(items[0].deepReason?.shrineMeaning).toContain("金運や巡りを整えたい");
+});
+
+it("入力タグ優先: 入力側need_tagsとmatched_need_tagsが異なる場合、Hero・相談要約は入力側、一致チップ・一致理由はmatched側を使う", () => {
+  const resp = {
+    ok: true,
+    data: {
+      _need: { tags: ["career", "mental"] },
+      recommendations: [
+        {
+          name: "神社X",
+          shrine_id: 301,
+          reason: "元の理由",
+          breakdown: { matched_need_tags: ["money"] },
+        },
+      ],
+    },
+  };
+
+  const items = conciergeToShrineListItems(resp as any);
+
+  // Hero・相談要約(deepReason.shrineMeaning)は入力側タグ(career)の文脈を使う
+  expect(items[0].deepReason?.shrineMeaning).toContain("仕事や転機を見直したい");
+  // 一致チップ(badgesOverride)はmatched_need_tags(money)のみを使う
+  expect(items[0].cardProps.badgesOverride).toEqual(["金運"]);
+  // 一致理由(explanationPrimaryReason)もmatched_need_tags(money)を使う
+  expect(items[0].cardProps.explanationPrimaryReason).toBe("金運や流れを立て直す");
+});
+
+it("fallback: 入力側need_tagsが無い旧Payloadでは、matched_need_tagsでHero・相談要約を生成できる", () => {
+  const resp = {
+    ok: true,
+    data: {
+      _need: { tags: [] },
+      recommendations: [
+        {
+          name: "神社Y",
+          shrine_id: 302,
+          reason: "元の理由",
+          breakdown: { matched_need_tags: ["rest"] },
+        },
+      ],
+    },
+  };
+
+  const items = conciergeToShrineListItems(resp as any);
+
+  expect(items[0].deepReason?.shrineMeaning).toContain("静かに休みたい");
+  expect(items[0].cardProps.badgesOverride).toEqual(["休息"]);
+});
+
+it("非変更確認: breakdown.matched_need_tagsのキー・値はcardProps.breakdownにそのまま保持される", () => {
+  const resp = {
+    ok: true,
+    data: {
+      recommendations: [
+        {
+          name: "神社Z",
+          shrine_id: 303,
+          reason: "元の理由",
+          breakdown: { matched_need_tags: ["career"], score_total: 0.8 },
+        },
+      ],
+    },
+  };
+
+  const items = conciergeToShrineListItems(resp as any);
+  expect(items[0].cardProps.breakdown).toEqual({ matched_need_tags: ["career"], score_total: 0.8 });
 });
 
 it("shrine_id がない recommendation は除外される", () => {

--- a/apps/web/src/viewmodels/conciergeToShrineList.ts
+++ b/apps/web/src/viewmodels/conciergeToShrineList.ts
@@ -259,13 +259,14 @@ export function conciergeToShrineListItems(resp: ConciergeResponse): ConciergeRe
 
       const actionSuggestionV4Preview = normalizeActionSuggestionV4Preview(r.action_suggestion_v4_preview ?? r.actionSuggestionV4Preview);
 
-      const matchedTags = normalizeTagList(r.breakdown?.matched_need_tags);
-      const rawTags = matchedTags.length ? matchedTags : normalizeTagList(resp.data?._need?.tags);
-      const tags = rawTags.map(toDisplayTag).slice(0, 3);
+      const inputNeedTags = normalizeTagList(resp.data?._need?.tags);
+      const matchedNeedTags = normalizeTagList(r.breakdown?.matched_need_tags);
+      const effectiveNeedTags = inputNeedTags.length > 0 ? inputNeedTags : matchedNeedTags;
+      const tags = matchedNeedTags.map(toDisplayTag).slice(0, 3);
 
       const reasonVm = buildRecommendationReasonViewModel({
         index,
-        needTags: rawTags,
+        needTags: effectiveNeedTags,
         rec: {
           display_name: name,
           name,
@@ -292,7 +293,7 @@ export function conciergeToShrineListItems(resp: ConciergeResponse): ConciergeRe
       const primaryReasonLabel = r._explanation_payload?.primary_reason?.label?.trim() || null;
       const primaryTag = resolveListPrimaryTag({
         primaryReasonLabel,
-        fallbackTags: rawTags,
+        fallbackTags: matchedNeedTags,
       });
       const primaryMeaning =
         buildNeedPrimaryShortCopy({


### PR DESCRIPTION
## Summary
- Frontend内で、ユーザー相談由来の`need_tags`（入力）と推薦一致結果の`matched_need_tags`を明確に分離した
- 相談要約・Heroテーマは入力側タグを優先し、入力が無い旧Payloadに限り`matched_need_tags`へfallbackする
- 一致チップ・一致理由は`matched_need_tags`のみを使う（従来は逆方向の優先度で「入力」と「一致結果」が混同されていた）
- `ConciergeSectionsRenderer`（現行本線）のpayload型には入力側タグを運ぶ経路が無かったため、`consultationAxis`と同じ方式で`ConciergeSectionsPayload.meta.needTags`を追加し、`buildPayloadFromUnified.ts`で`data._need.tags`から通す
- Backend / API レスポンスキー / DB・migration / Analytics契約 / legacy UI（`ConciergeSections.tsx`, `sectionsBuilder.ts`, `sections/fromUnified.ts`, `components/legacy/`）は変更していない

## 変更ファイル
- `apps/web/src/viewmodels/conciergeToShrineList.ts`
- `apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx`
- `apps/web/src/lib/concierge/buildRecommendationReasonViewModel.ts`（`needTags`パラメータの意味をコメントで明示）
- `apps/web/src/features/concierge/sections/types.ts`（`meta.needTags`追加）
- `apps/web/src/features/concierge/buildPayloadFromUnified.ts`（`meta.needTags`の生成）
- テスト2ファイル

## レビュー時の留意点
- `ConciergeSectionsRenderer.tsx`自体のコンポーネントレンダリングテストは既存に存在しないため未追加。境界ロジックの検証は`conciergeToShrineList.ts`側のユニットテストと型チェックでカバーしている
- `matched_need_tags`が空でもチップへ`_need.tags`をfallbackしない仕様変更のため、既存テスト1件（「matched_need_tags が空なら _need.tags を badgesOverride に使う」）の期待値を新仕様に更新した

## Test plan
- [x] `npm run typecheck`
- [x] `conciergeToShrineList.test.ts`（入力タグ優先・fallback・非変更確認の3件を新規追加）
- [x] `buildRecommendationReasonViewModel.test.ts`
- [x] `buildPayloadFromUnified.payload.test.ts` / `dedupe.test.ts`（`meta.needTags`のテスト2件を追加）
- [x] `apps/web`全体のvitest（80ファイル / 455件）
- [x] `git diff --check`
- [x] push時のpre-hook（OpenAPI lint + Web契約テスト）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)