### PR TITLE
root-docs-classification-audit.mdの旧v4契約Archive移動との不整合を修正

### DIFF
--- a/docs/audit/recommendation-reason-v4-contract.md
+++ b/docs/audit/recommendation-reason-v4-contract.md
@@ -1,4 +1,11 @@
+> **Status: Archive**
+>
+> 本ドキュメントは、Recommendation Reason v4導入時点の責務、入力、出力、実装計画およびActive化条件を記録した過去設計である。
+>
+> 現行のRecommendation Reasonに関するInput / Output / 保存 / 表示 / 互換責務は、`docs/core/recommendation-reason-contract.md`を正本とする。
+
 # Recommendation Reason v4 Contract
+
 
 ## Goal
 

--- a/docs/audit/recommendation-v5-design.md
+++ b/docs/audit/recommendation-v5-design.md
@@ -4,11 +4,12 @@
 >
 > 本ドキュメントは、未実装のv5設計と次PR候補を含む将来計画である。
 >
-> 現行の推薦契約は `docs/product/recommendation-reason-v4-contract.md` を正本とする。
+> 現行のRecommendation Reason契約は `docs/core/recommendation-reason-contract.md` を正本とする。
 
 ## 目的
 
-Recommendation v5 は、推薦順位を急に変更する実装ではなく、相談解釈・意味変換・行動シグナル・振り返りシグナルを整理し、次の推薦改善に向けた設計方針を固定する。
+Recommendation
+v5 は、推薦順位を急に変更する実装ではなく、相談解釈・意味変換・行動シグナル・振り返りシグナルを整理し、次の推薦改善に向けた設計方針を固定する。
 
 現時点では Score v3 が shadow mode で評価中のため、v5では active score の変更は行わない。
 
@@ -158,13 +159,13 @@ meaning translation は以下の順に整理する。
 
 behavior を関心段階として整理する。
 
-| action | 意味 |
-| --- | --- |
-| detail_view | 興味あり |
-| route_open | 行く可能性あり |
-| save | 保留・比較・再検討 |
-| visit_done | 実行済み |
-| reflection_saved | 体験後の意味化 |
+| action           | 意味               |
+| ---------------- | ------------------ |
+| detail_view      | 興味あり           |
+| route_open       | 行く可能性あり     |
+| save             | 保留・比較・再検討 |
+| visit_done       | 実行済み           |
+| reflection_saved | 体験後の意味化     |
 
 ### 改善候補
 
@@ -200,12 +201,12 @@ behavior を関心段階として整理する。
 
 reflection は「参拝後の状態変化」として扱う。
 
-| state_change | 次回推薦方針 |
-| --- | --- |
-| improved | 少し前進するテーマを提案 |
-| unchanged | 同系統または守り・静寂を維持 |
-| worsened | 負荷を下げ、静寂・守りへ戻す |
-| unknown | 通常推薦に補助情報として扱う |
+| state_change | 次回推薦方針                 |
+| ------------ | ---------------------------- |
+| improved     | 少し前進するテーマを提案     |
+| unchanged    | 同系統または守り・静寂を維持 |
+| worsened     | 負荷を下げ、静寂・守りへ戻す |
+| unknown      | 通常推薦に補助情報として扱う |
 
 ### 改善候補
 

--- a/docs/audit/root-docs-classification-audit.md
+++ b/docs/audit/root-docs-classification-audit.md
@@ -8,6 +8,7 @@
 > - `docs/core/recommendation-reason-contract.md`
 >
 > このため、`docs/knowledge/meaning-layer-spec.md`は後続監査の判断を優先し削除した。本文中のActive・必須判定は、当時の監査結果として保持する。
+> さらに、Recommendation Reason専用正本として`docs/core/recommendation-reason-contract.md`を作成したため、旧`docs/recommendation-reason-v4-contract.md`は現行正本から外し、導入時点の設計記録として`docs/audit/recommendation-reason-v4-contract.md`へArchive移動した。
 
 # Root Documents Classification Audit
 
@@ -24,7 +25,6 @@
 - billing-paywall.md
 - premium-experience.md
 - pricing.md
-- recommendation-reason-v4-contract.md
 - recommendation-v4-interpreter-contract.md
 
 ## Reference確定
@@ -48,6 +48,7 @@
 - mobile-release-readiness-audit.md
 - premium-analytics-dashboard.md
 - premium-card-matrix.md
+- recommendation-reason-v4-contract.md
 - recommendation-score-v3-roadmap.md
 - recommendation-v4-action-suggestion-audit.md
 - recommendation-v4-active-readiness-plan.md
@@ -103,7 +104,7 @@ access-tier-copy-audit.md analytics-event-storage-audit.md concierge-ranking-obs
 | `access-tier-copy-audit.md`        | Archive       | `docs/audit/`     | 参照なし                                                      | Access Tier Copy接続時点の判断とTODOを含む                                                                                                                          |
 | `analytics-card-events.md`         | Archive       | `docs/analytics/` | `docs/analytics/save-premium-correlation.md`から参照          | Event契約、監査、移行計画、PR履歴が混在する。現行実装済みの`retentionEvents.ts`と`searchEvents.ts`をplannedと記載し、PayloadおよびEvent名にも現行実装との差異がある |
 | `analytics-event-storage-audit.md` | Archive       | `docs/audit/`     | 参照なし                                                      | Analytics保存先とProvider接続状況の時点監査                                                                                                                         |
-| `analytics-payload-audit.md`       | ActivReferenc | `docs/analytics/` | `docs/audit/cross-platform-event-contract.md`から参照         | Payloadおよび`sessionId`設計背景の補足資料。現行実装との一致確認後に確定する                                                                                        |
+| `analytics-payload-audit.md`       | Reference | `docs/analytics/` | `docs/audit/cross-platform-event-contract.md`から参照         | Payloadおよび`sessionId`設計背景の補足資料。現行実装との一致確認後に確定する                                                                                        |
 | `card-ctr-aggregation.md`          | Archive       | `docs/analytics/` | 参照なし                                                      | 集計設計と未実装Phase、次PR計画を含む                                                                                                                               |
 | `concierge-ranking-observation.md` | Archive       | `docs/audit/`     | `docs/audit/recommendation-quality-score-v3-audit.md`から参照 | Ranking WeightとCandidate Poolの観測履歴                                                                                                                            |
 | `premium-analytics-dashboard.md`   | Archive       | `docs/analytics/` | 参照なし                                                      | Dashboard・AB Test・後続実装計画の記録                                                                                                                              |
@@ -170,20 +171,23 @@ Archive化前に、現在も有効な責務定義が現行正本文書へ反映�
 | 文書                                         | Status候補    | 移動先候補        | 参照状況                      | 判断根拠                                                                                  |
 | -------------------------------------------- | ------------- | ----------------- | ----------------------------- | ----------------------------------------------------------------------------------------- |
 | `direction-ranking-design.md`                | 判断保留      | `docs/product/`   | 参照なし                      | Direction SignalとRanking Priorityを定義するが、現行Score実装との一致が未確認             |
-| `recommendation-reason-v4-contract.md`       | Active        | `docs/product/`   | Copy Guidelineから参照        | Recommendation Reason v4の責務、入力、出力、Layer Boundaryを定義する契約文書              |
-| `recommendation-score-v3-design.md`          | ActivReferenc | `docs/analytics/` | Score v3監査から参照          | Score v3のSignalと計算式の設計背景。実装Phaseとドラフトを含むため現行値は実装を正本とする |
+| `recommendation-score-v3-design.md`          | Reference | `docs/analytics/` | Score v3監査から参照          | Score v3のSignalと計算式の設計背景。実装Phaseとドラフトを含むため現行値は実装を正本とする |
 | `recommendation-score-v3-roadmap.md`         | Archive       | `docs/audit/`     | Score v3監査から参照          | Roadmap、Active化、Dashboard、観測Snapshot、TODOが混在する時点記録                        |
 | `recommendation-v4-consultation-brush-up.md` | Archive       | `docs/audit/`     | 参照なし                      | Consultation改善作業のScope・KPIを整理した短期計画                                        |
-| `recommendation-v4-copy-guideline.md`        | ActivReferenc | `docs/knowledge/` | Action Suggestion監査から参照 | v4固有のCopy Ruleを持つが、Knowledge BaseのRecommendation Copy Guideと責務が重複する      |
+| `recommendation-v4-copy-guideline.md`        | Reference | `docs/knowledge/` | Action Suggestion監査から参照 | v4固有のCopy Ruleを持つが、Knowledge BaseのRecommendation Copy Guideと責務が重複する      |
 | `recommendation-v4-interpreter-contract.md`  | Active        | `docs/product/`   | Copy Guidelineから参照        | Consultation InterpreterのField ContractとSource of Truthを定義                           |
-| `recommendation-v5-design.md`                | Archive       | `docs/audit/`     | 参照なし                      | 未実装のv5設計と次PR候補を含む将来計画                                                    |
+| `recommendation-v5-design.md`                | Archive       | `docs/audit/`     | 参照なし                      | 未実装のv5設計と次PR候補を含む将来計画                                                     |
+| `recommendation-reason-v4-contract.md`       | Archive       | `docs/audit/`     | 現行参照なし                  | Recommendation Reason v4導入時点の責務・入力・出力・実装計画・Active化条件を記録した過去設計。現行正本は`docs/core/recommendation-reason-contract.md` |
 
 ### 現行契約
 
-以下は現行実装との一致確認後、Active文書として整理する候補とする。
+Recommendation Reasonの現行正本は以下とする。
 
-- `recommendation-reason-v4-contract.md`
-- `recommendation-v4-interpreter-contract.md`
+- `docs/core/recommendation-reason-contract.md`
+- `docs/recommendation-v4-interpreter-contract.md`
+
+旧`docs/recommendation-reason-v4-contract.md`は、
+導入時点の設計記録として`docs/audit/recommendation-reason-v4-contract.md`へArchive移動した。
 
 ### Copy Guide統合候補
 
@@ -205,11 +209,11 @@ v4固有規則のうち現在も有効な内容をKnowledge Baseへ統合し、r
 | ------------------------------- | ------------- | --------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `billing-attribution-design.md` | Archive       | `docs/audit/`   | 参照なし                                            | Card AnalyticsからCheckoutまでのAttribution課題、候補案、次PR、TODOを含む時点設計    |
 | `billing-paywall.md`            | Active        | `docs/product/` | `pricing.md`、`premium-experience.md`から参照       | Billing Status、Paywall情報、Premium優先、Free制限、Server最終判定を定義する契約文書 |
-| `monetization-flow-design.md`   | ActivReferenc | `docs/product/` | Phase7関連監査・Archive文書から参照                 | Premium提示タイミング、入口、CTA、Subscription Flowを補足する収益導線設計            |
+| `monetization-flow-design.md`   | Reference | `docs/product/` | Phase7関連監査・Archive文書から参照                 | Premium提示タイミング、入口、CTA、Subscription Flowを補足する収益導線設計            |
 | `premium-card-matrix.md`        | Archive       | `docs/audit/`   | 参照なし                                            | Access Level別Card表示設計を持つが、現在地、次の一手、Payload案、実装TODOを含む      |
 | `premium-experience.md`         | Active        | `docs/product/` | Core、Meaning Layer、Pricing、Shrine Detailから参照 | Free / Premiumの体験差、表現、画面別境界を定義する現行正本候補                       |
-| `premium-plan-design.md`        | ActivReferenc | `docs/product/` | Phase7関連文書から参照                              | Reflection、Timeline、History、Memory等を含むPremium価値の包括的な構想               |
-| `premium-retention-strategy.md` | ActivReferenc | `docs/product/` | 参照なし                                            | 保存、履歴、比較を中心としたPremium継続価値とKPIの戦略補足                           |
+| `premium-plan-design.md`        | Reference | `docs/product/` | Phase7関連文書から参照                              | Reflection、Timeline、History、Memory等を含むPremium価値の包括的な構想               |
+| `premium-retention-strategy.md` | Reference | `docs/product/` | 参照なし                                            | 保存、履歴、比較を中心としたPremium継続価値とKPIの戦略補足                           |
 | `pricing.md`                    | Active        | `docs/product/` | `shrine-detail-layer.md`から参照                    | 「何に対して支払うか」、Free / Premiumの価値境界、価格表現原則を管理する             |
 
 ### 正本の責務分離
@@ -246,10 +250,10 @@ A4にはDelete候補はない。
 | ------------------------------------ | ------------- | --------------- | --------------------------------------------------- | ---------------------------------------------------------------------- |
 | `action_state_behavior_checklist.md` | Archive       | `docs/audit/`   | 参照なし                                            | 動作確認チェックリストであり、仕様契約ではない                         |
 | `journey-timeline-api-plan.md`       | Archive       | `docs/audit/`   | 参照なし                                            | Journey Timeline API のPhase計画・Backend/Mobile変更候補を含む時点設計 |
-| `journey-timeline-design.md`         | ActivReferenc | `docs/product/` | 参照なし                                            | Journey Timeline の設計思想・情報設計・Migration方針を整理した設計資料 |
+| `journey-timeline-design.md`         | Reference | `docs/product/` | 参照なし                                            | Journey Timeline の設計思想・情報設計・Migration方針を整理した設計資料 |
 | `reflection-timeline-design.md`      | Active        | `docs/product/` | Phase7関連文書から参照                              | Reflection Timeline の役割、UX、KPI、Premium接続を定義する現行設計     |
 | `shrine-detail-layer.md`             | Active        | `docs/product/` | Pricing、Premium Experience、Architecture等から参照 | 神社詳細のPublic / Context / Personal Layerと責務境界を定義            |
-| `shrine-detail-meaning-layer.md`     | ActivReferenc | `docs/product/` | 参照なし                                            | Shrine Detail のMeaning Layer設計補足ガイド                            |
+| `shrine-detail-meaning-layer.md`     | Reference | `docs/product/` | 参照なし                                            | Shrine Detail のMeaning Layer設計補足ガイド                            |
 | `shrine-detail-v3-design.md`         | Active        | `docs/product/` | Phase7 Roadmapから参照                              | Shrine Detail v3 のUX・Analytics・Premium接続を定義する正本候補        |
 | `shrine-submission-flow.md`          | Active        | `docs/product/` | Architectureから参照                                | 神社投稿、duplicate_candidate契約、推薦利用方針を定義する現行仕様      |
 
@@ -266,7 +270,7 @@ Journey、Shrine Detail、投稿フローそれぞれに固有の責務を持ち
 - `shrine-detail-v3-design.md`
 - `shrine-submission-flow.md`
 
-### ActivReferenc
+### Reference
 
 - `journey-timeline-design.md`
 - `shrine-detail-meaning-layer.md`
@@ -394,7 +398,7 @@ Layerの入出力フローを図示するが、`architecture.md`は全体レイ�
 | knowledge文書                  | 対応product文書                                                               | 関係                                                                                                                                                                                                                                            |
 | ------------------------------ | ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 旧`meaning-layer-spec.md`      | `product/meaning-translation-mapping.md` / `core/meaning-layer-connection.md` | 監査時点では抽象仕様と実装詳細の分離と評価したが、後続の本文再監査で旧文書に独自の確定仕様が存在しないことを確認した。Meaning Layerの接続責務は`core/meaning-layer-connection.md`、変換仕様は`product/meaning-translation-mapping.md`へ集約済み |
-| `recommendation-copy-guide.md` | root `recommendation-reason-v4-contract.md`（A3で移動候補）                   | knowledge側は「推薦文の文章構造原則」、root側は「fact/interpretation/actionの実装関数対応（concierge_chat_ranking.py等）」という実装トレース。抽象度は異なるが、扱う分割（3層構造）が類似しており統合または相互参照の余地がある                 |
+| `recommendation-copy-guide.md` | 監査時点のroot `recommendation-reason-v4-contract.md`（現在は`docs/audit/recommendation-reason-v4-contract.md`へArchive移動済み。現行正本は`docs/core/recommendation-reason-contract.md`）           | knowledge側は「推薦文の文章構造原則」、root側は「fact/interpretation/actionの実装関数対応（concierge_chat_ranking.py等）」という実装トレース。抽象度は異なるが、扱う分割（3層構造）が類似しており統合または相互参照の余地がある                 |
 
 #### Recommendation文書との重複確認
 
@@ -452,7 +456,7 @@ Contract）は責務が分離されている。
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | history_theme                    | `Shrine.history_theme`（`backend/temples/models.py`、CharField max_length=32、db_index）。Derivedとして事前生成値をDB保存                                                                                                | `knowledge/glossary.md`の定義（「神社の歴史や由緒から抽出した意味テーマ」）と一致。Derivedが「非保存」を意味しない点は本文からは読み取りにくく、`knowledge-base-consistency-audit.md`が既に指摘済み                                                                                                                               |
 | reason_facts                     | `backend/temples/services/concierge_chat_ranking.py`の`_build_reason_facts`、`backend/temples/services/journey_timeline.py`                                                                                              | `shrine-profile-spec.md`が「reason_factsはhistory_theme, culture_translation, user_selected_tag, need_tag, goriyaku_tag, text_hint, elementのいずれか1つでも存在すれば非空になる」と実装事実として明記。実装ファイルの存在と一致確認済み                                                                                          |
-| recommendation_reason_v4         | `backend/temples/services/recommendation_reason_v4.py`の`build_recommendation_reason_v4()`。fact/interpretation/action/used_fact/used_interpretation/used_action/qualityを生成                                           | root `recommendation-reason-v4-contract.md`の記述（fact/interpretation/actionへの分離）と実装が一致。`knowledge/recommendation-copy-guide.md`のFact→Meaning→User Connection→Recommendationという4分割とは命名が異なる（Meaningがinterpretationの一部に相当、User Connectionに明示的に対応する層がない）。**用語の不一致は要整理** |
+| recommendation_reason_v4         | `backend/temples/services/recommendation_reason_v4.py`の`build_recommendation_reason_v4()`。fact/interpretation/action/used_fact/used_interpretation/used_action/qualityを生成                                           | 監査時点のroot `recommendation-reason-v4-contract.md`の記述（fact/interpretation/actionへの分離）と実装が一致していた（同文書は現在`docs/audit/recommendation-reason-v4-contract.md`へArchive移動し、現行正本は`docs/core/recommendation-reason-contract.md`）。`knowledge/recommendation-copy-guide.md`のFact→Meaning→User Connection→Recommendationという4分割とは命名が異なる（Meaningがinterpretationの一部に相当、User Connectionに明示的に対応する層がない）。**用語の不一致は要整理** |
 | action_suggestion_v4             | `backend/temples/services/action_suggestion_builder.py`                                                                                                                                                                  | `product/action_suggestion_v4.md`のContract定義と実装ファイルが対応                                                                                                                                                                                                                                                               |
 | consultation_axis                | `backend/temples/domain/consultation_axis.py`。`ConciergeThread.recommendations_v2`内へRuntime Snapshotとして保存（`concierge_chat.py`）                                                                                 | `knowledge-base-consistency-audit.md` 7.4節で「完全対応」と確認済み。本監査でも実装ファイルの存在を確認                                                                                                                                                                                                                           |
 | matched_need_tags                | `backend/temples/services/concierge_chat_ranking.py`。`ConciergeThread.recommendations_v2`内へ保存                                                                                                                       | 同上。Runtime Snapshotとして実装済み                                                                                                                                                                                                                                                                                              |
@@ -477,11 +481,22 @@ Contract）は責務が分離されている。
 | `docs/knowledge/action-guide.md`              | 行動提案生成原則の正本                                                                                    |
 | `docs/knowledge/reflection-guide.md`          | 振り返り生成原則の正本                                                                                    |
 | `docs/knowledge/glossary.md`                  | 用語定義の正本。他文書からの参照は少ないが、README更新順序・shrine-data-guideの関連仕様節で位置付けが明確 |
+| `docs/core/recommendation-reason-contract.md` | Recommendation ReasonのInput / Output / 保存 / 表示 / 互換責務を管理する正本 |
 
-本監査時点では全12文書をActiveと判定した。
+本監査時点では、`docs/core`5文書と`docs/knowledge`8文書の合計13文書をActiveと判定した。
 
-ただし、後続の`recommendation-doc-consolidation-audit.md`により、
-`docs/knowledge/meaning-layer-spec.md`は削除へ更新された。現在のActive対象は12文書であり、本節の当初判定より1文書少ない。
+その後、`docs/knowledge/meaning-layer-spec.md`は、
+`docs/audit/recommendation-doc-consolidation-audit.md`の再監査により削除された。
+
+一方で、Recommendation Reasonの現行正本として
+`docs/core/recommendation-reason-contract.md`が新規追加された。
+
+したがって、現在のActive対象は以下の合計13文書である。
+
+- `docs/core`: 6文書
+- `docs/knowledge`: 7文書
+
+監査時点から総数は変わらないが、構成は1文書削除・1文書追加へ更新された。
 
 #### Reference確定
 
@@ -498,6 +513,7 @@ Contract）は責務が分離されている。
 - `docs/core/meaning-layer-connection.md`
 - `docs/core/narrative-guideline.md`
 - `docs/core/roadmap.md`
+- `docs/core/recommendation-reason-contract.md`
 - `docs/knowledge/README.md`
 - `docs/knowledge/shrine-profile-spec.md`
 - `docs/knowledge/shrine-data-guide.md`
@@ -522,15 +538,22 @@ Coreは「思想・責務・依存関係」の正本、Knowledgeは「知識・�
 重大な責務重複は確認されなかったが、以下の軽微な課題を確認した。
 
 1. `docs/shrine-detail-layer.md`に移動前の旧パス`docs/architecture.md`への参照切れが残っている
-2. `knowledge/recommendation-copy-guide.md`とroot
-   `recommendation-reason-v4-contract.md`の間で概念の3分割名称（Meaning/User Connection vs
-   Interpretation/Action）が不一致
+2. `docs/knowledge/recommendation-copy-guide.md`と
+   `docs/core/recommendation-reason-contract.md`の間で、
+   Meaning / User ConnectionとInterpretation / Actionの用語対応を継続して管理する必要がある
 3. `docs/knowledge`配下の個別文書（README以外）は、`docs/product/`等の実装系文書からファイルパスで直接参照されることがほぼなく、参照されているのは`docs/audit/knowledge-base-consistency-audit.md`のみ
 4. Recommendation Readiness/Coverageは文書定義のみで実装が未着手（既存監査で確認済みの結論を本監査でも再確認）
 
-これらは文書分類（Active/Reference/Archive）には影響しないため、A6の分類結果は「全12文書をActiveとする」で確定する。個別の整理は上記4点をA7以降または実装監査へ引き継ぐ。
+これらは文書分類（Active/Reference/Archive）には影響しないため、A6の分類結果は「全13文書をActiveとする」（`docs/core`6文書 + `docs/knowledge`7文書）で確定する。個別の整理は上記4点をA7以降または実装監査へ引き継ぐ。
 
 ## A7 Product
+> 後続の`docs/audit/archive-final-classification.md`において、
+> 以下2文書は独自の現行仕様を持たないDelete対象として承認され、削除済みである。
+>
+> - `docs/product/action-suggestion-layer.md`
+> - `docs/product/product-doc-consolidation.md`
+>
+> 以下のInventoryおよびArchive分類表は、A7監査時点の証跡として保持する。
 
 ### Inventory
 

--- a/docs/recommendation-v4-copy-guideline.md
+++ b/docs/recommendation-v4-copy-guideline.md
@@ -2,7 +2,8 @@
 
 ## Goal
 
-Recommendation v4 Copy Guideline は、Recommendation Reason v4 の推薦理由を、ユーザーが理解しやすく、行動につながりやすい文面に整えるためのコピー品質ルールである。
+Recommendation v4 Copy Guideline は、Recommendation Reason
+v4 の推薦理由を、ユーザーが理解しやすく、行動につながりやすい文面に整えるためのコピー品質ルールである。
 
 このガイドラインは以下を目的とする。
 
@@ -22,7 +23,7 @@ Recommendation v4 Copy Guideline は、Recommendation Reason v4 の推薦理由�
 - `fact`
 - `interpretation`
 - `action`
-- `docs/recommendation-reason-v4-contract.md`
+- `docs/core/recommendation-reason-contract.md`
 - `docs/recommendation-v4-interpreter-contract.md`
 
 ## Non Goals
@@ -70,27 +71,33 @@ Recommendation Reason v4 は「構造化データ → 自然文」の変換層�
 ### state_profile
 
 目的:
+
 - 現在状態を自然文へ変換する
 
 ルール:
+
 - 状態を断定しない
 - 「〜が含まれる相談」「〜という様子がうかがえる」程度に留める
 - 心理診断のような表現を避ける
 
 良い例:
+
 - 今回の相談には、判断に迷う様子が含まれています。
 - 少し立ち止まって整理したい文脈が見受けられます。
 
 避ける例:
+
 - あなたは迷っています。
 - あなたは疲れています。
 
 ### direction_profile
 
 目的:
+
 - 推薦方向を history_theme へ接続する
 
 ルール:
+
 - direction は直接表示しない
 - history_theme に自然変換する
 - 同じ theme を本文で繰り返さない
@@ -98,9 +105,11 @@ Recommendation Reason v4 は「構造化データ → 自然文」の変換層�
 ### emotion_profile
 
 目的:
+
 - 文体の強さを調整する
 
 ルール:
+
 - 情報は増やさない
 - 断定を弱める
 - 「考えられます」「受け取れます」「〜という文脈があります」を優先する
@@ -227,16 +236,16 @@ Action Layer は、次に取れる小さな行動を提示する。
 
 `consultation_axis` は実装上の単一フィールドではなく、Recommendation v4 で利用する相談解釈フィールド群の総称として扱う。
 
-| consultation_axis 相当 | 実装名 | 役割 | Copy Rule |
-|---|---|---|---|
-| 相談テーマ | need_profile | 何に悩んでいるか | ユーザー向けの自然語に変換する |
-| 判断文脈 | decision_context | 何を決めようとしているか | 「〜を見直したい相談」として表現する |
-| 制約 | constraint_profile | 何が制約になっているか | 「〜が気になっている文脈」と弱く表現する |
-| 着地点 | outcome_hint | どうなりたいか | 「〜したい方向」として表現する |
-| 行動意図 | action_intent | 次に何をしたいか | 小さな行動に変換する |
-| 現在状態 | state_profile | 今の心理・行動状態 | 断定せず「〜が含まれる」と表現する |
-| 推薦方向 | direction_profile | 提案する参拝体験の方向 | history_theme に接続する |
-| 感情トーン | emotion_profile | 感情の強度・傾向 | 文体の強さを調整する |
+| consultation_axis 相当 | 実装名             | 役割                     | Copy Rule                                |
+| ---------------------- | ------------------ | ------------------------ | ---------------------------------------- |
+| 相談テーマ             | need_profile       | 何に悩んでいるか         | ユーザー向けの自然語に変換する           |
+| 判断文脈               | decision_context   | 何を決めようとしているか | 「〜を見直したい相談」として表現する     |
+| 制約                   | constraint_profile | 何が制約になっているか   | 「〜が気になっている文脈」と弱く表現する |
+| 着地点                 | outcome_hint       | どうなりたいか           | 「〜したい方向」として表現する           |
+| 行動意図               | action_intent      | 次に何をしたいか         | 小さな行動に変換する                     |
+| 現在状態               | state_profile      | 今の心理・行動状態       | 断定せず「〜が含まれる」と表現する       |
+| 推薦方向               | direction_profile  | 提案する参拝体験の方向   | history_theme に接続する                 |
+| 感情トーン             | emotion_profile    | 感情の強度・傾向         | 文体の強さを調整する                     |
 
 ## Internal Key Copy Mapping
 
@@ -244,50 +253,50 @@ Action Layer は、次に取れる小さな行動を提示する。
 
 ### need_profile
 
-| key | User-facing copy |
-|---|---|
-| mental | 気持ちを落ち着け、今の状態を整理したい |
-| rest | 疲れを整え、静かに回復したい |
-| career | 仕事や働き方を見直したい |
-| money | 生活や収入の土台を整えたい |
-| love | 人との縁や関係性を見直したい |
-| study | 学びや積み重ねを続けたい |
-| courage | 次に進むための一歩を決めたい |
+| key     | User-facing copy                       |
+| ------- | -------------------------------------- |
+| mental  | 気持ちを落ち着け、今の状態を整理したい |
+| rest    | 疲れを整え、静かに回復したい           |
+| career  | 仕事や働き方を見直したい               |
+| money   | 生活や収入の土台を整えたい             |
+| love    | 人との縁や関係性を見直したい           |
+| study   | 学びや積み重ねを続けたい               |
+| courage | 次に進むための一歩を決めたい           |
 
 ### decision_context
 
-| key | User-facing copy |
-|---|---|
-| career_decision | 仕事や働き方について判断したい |
-| relationship_decision | 人との関係について見直したい |
-| money_decision | お金や生活の判断を整えたい |
-| rest_or_action | 休むか動くかを見極めたい |
+| key                   | User-facing copy               |
+| --------------------- | ------------------------------ |
+| career_decision       | 仕事や働き方について判断したい |
+| relationship_decision | 人との関係について見直したい   |
+| money_decision        | お金や生活の判断を整えたい     |
+| rest_or_action        | 休むか動くかを見極めたい       |
 
 ### constraint_profile
 
-| key | User-facing copy |
-|---|---|
-| time | 時間の余裕が少ない |
-| money | お金や収入への不安がある |
-| energy | 体力や気力が落ちている |
-| relationship | 人間関係の制約がある |
+| key          | User-facing copy         |
+| ------------ | ------------------------ |
+| time         | 時間の余裕が少ない       |
+| money        | お金や収入への不安がある |
+| energy       | 体力や気力が落ちている   |
+| relationship | 人間関係の制約がある     |
 
 ### outcome_hint
 
-| key | User-facing copy |
-|---|---|
-| decide | 判断材料を持ち帰りたい |
-| calm | 気持ちを落ち着けたい |
-| move_forward | 小さく前に進みたい |
-| clarify | 考えを整理したい |
+| key          | User-facing copy       |
+| ------------ | ---------------------- |
+| decide       | 判断材料を持ち帰りたい |
+| calm         | 気持ちを落ち着けたい   |
+| move_forward | 小さく前に進みたい     |
+| clarify      | 考えを整理したい       |
 
 ### action_intent
 
-| key | User-facing copy |
-|---|---|
-| visit | 実際に足を運んで確認したい |
-| reflect | 問いを一つに絞って整理したい |
-| save | 今回の相談を残して振り返りたい |
+| key     | User-facing copy               |
+| ------- | ------------------------------ |
+| visit   | 実際に足を運んで確認したい     |
+| reflect | 問いを一つに絞って整理したい   |
+| save    | 今回の相談を残して振り返りたい |
 
 ## recommendation_reason_v4 Copy Rule
 
@@ -470,14 +479,14 @@ Action は、小さく、実行単位で書く。
 
 Recommendation Quality Audit では、以下の観点で評価する。
 
-| Metric | Meaning | Target |
-|---|---|---|
-| reason_depth | 推薦理由の深さ | 神社事実 + 相談文脈 + 行動が入っている |
-| action_specificity | 行動提案の具体性 | 参拝前 / 中 / 後のどれかが明確 |
-| history_theme_fit | history_theme との整合 | 相談軸とテーマが矛盾しない |
-| semantic_duplication | 意味重複 | 同じ単語・同じ意味を繰り返さない |
-| shrine_specificity | 神社固有性 | 神社名 / ご利益 / history_theme のいずれかが入る |
-| consultation_fit | 相談文脈との整合 | need / decision / constraint / outcome のいずれかが反映される |
+| Metric               | Meaning                | Target                                                        |
+| -------------------- | ---------------------- | ------------------------------------------------------------- |
+| reason_depth         | 推薦理由の深さ         | 神社事実 + 相談文脈 + 行動が入っている                        |
+| action_specificity   | 行動提案の具体性       | 参拝前 / 中 / 後のどれかが明確                                |
+| history_theme_fit    | history_theme との整合 | 相談軸とテーマが矛盾しない                                    |
+| semantic_duplication | 意味重複               | 同じ単語・同じ意味を繰り返さない                              |
+| shrine_specificity   | 神社固有性             | 神社名 / ご利益 / history_theme のいずれかが入る              |
+| consultation_fit     | 相談文脈との整合       | need / decision / constraint / outcome のいずれかが反映される |
 
 ## Implementation Order
 


### PR DESCRIPTION
## Summary
- `recommendation-reason-v4-contract.md`の`docs/audit/`へのArchive移動に伴い、`docs/audit/root-docs-classification-audit.md`内に残っていた不整合を解消
- 現行正本は`docs/core/recommendation-reason-contract.md`、旧v4契約は`docs/audit/recommendation-reason-v4-contract.md`（Archive）という状態に文書内の記述を統一

## 変更内容
- `ActivReferenc`という誤字をすべて`Reference`へ置換
- 冒頭「Active確定」リストから`recommendation-reason-v4-contract.md`を削除（同時に「Archive確定」リストにも存在し矛盾していた）
- A3判定表の旧契約Active行を削除し、Archive行のみを残す
- A6「現行契約」リストに`docs/core/recommendation-reason-contract.md`を追加し、結論を「全13文書（Core6+Knowledge7）」に修正
- 旧契約を現在形で扱っていたA6の監査時点記述を、Archive移動済みである旨の履歴表現へ変更
- 破損していたテーブル行（末尾`|`欠落・trailing whitespace）を修正

## Test plan
- [x] grepで`ActivReferenc`・矛盾する`recommendation-reason-v4-contract.md`言及の残存なしを確認
- [x] `git diff --check`
- [x] push時のpre-hook（OpenAPI lint + Web契約テスト455件）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)