### PR TITLE
Consultation Interpreter契約を意味責務中心に整理

### DIFF
--- a/docs/product/recommendation-v4-interpreter-contract.md
+++ b/docs/product/recommendation-v4-interpreter-contract.md
@@ -1,270 +1,337 @@
 > **Status: Active**
 >
-> 本ドキュメントは、対象機能の現行仕様を管理する正本文書である。
+> 本ドキュメントは、KAMI MUSUBIにおけるConsultation Interpreterの解釈フィールドと意味責務を管理する正本文書である。
 >
-> 正確な物理実装と挙動は、関連する実装コードおよびテストを最終的な正本とする。
+> 正確な生成処理、出力構造、キー、分類ロジックおよび利用条件は、関連するCore文書、Backend実装およびテストを最終的な正本とする。
+
 # Recommendation v4 / Consultation Interpreter Contract
 
-## Goal
+## 目的
 
-相談文を推薦ロジック・意味変換・推薦理由生成で再利用できる構造に分解する。
+ユーザーの相談文を、Meaning Translation、Recommendation、Recommendation ReasonおよびAction Suggestionで再利用できる意味要素へ整理する。
 
-このcontractは、Recommendation v4で `consultation_interpreter.py` が返すべき出力責務を固定する。
+Consultation Interpreterは、ユーザーの性格、心理状態、将来または正解を断定するものではない。
 
-## Current Output
-
-`interpret_consultation()` は以下の構造を返す。
-
-- raw_query
-- state_profile
-- need_profile
-- direction_profile
-- emotion_profile
-- action_intent
-- decision_context
-- constraint_profile
-- outcome_hint
-
-これらは Recommendation v4 における consultation_axis 相当の入力として利用される。
-
-各フィールドの責務は以下の通り。
-
-| Field | Responsibility | Used By |
-|-------|----------------|---------|
-| raw_query | 正規化済み相談文 | recommendation reason / debug |
-| state_profile | 現在状態 | direction / meaning translation |
-| need_profile | 相談テーマ・ご利益 | scoring / shrine matching |
-| direction_profile | 推薦方向 | history_theme |
-| emotion_profile | 感情トーン | recommendation reason / action suggestion |
-| action_intent | 行動意図 | action suggestion / CTA |
-| decision_context | 判断したい内容 | meaning translation / recommendation reason |
-| constraint_profile | 制約条件 | meaning translation / recommendation reason |
-| outcome_hint | 望む着地点 | meaning translation / recommendation reason |
-
-## Field Contract
-
-### raw_query
-
-#### Goal
-ユーザーが入力した相談文の正規化済み原文を保持する。
-
-#### Responsibility
-- strip済みの文字列を返す
-- 推薦理由生成時の原文参照に使う
-- 意味変換層で文脈を再確認するために使う
-
-#### Out of Scope
-- 要約しない
-- 解釈を混ぜない
+相談文に含まれる状態、目的、感情、制約および行動意図を、後続レイヤーが参照できる文脈として整理する。
 
 ---
 
-### state_profile
+## 基本原則
 
-#### Goal
-ユーザーの現在状態を表す。
-
-#### Responsibility
-- 疲れている
-- 不安
-- 迷い
-- 停滞
-- 変化準備
-
-など、現在の心理・行動状態を抽出する。
-
-#### Expected Keys
-- primary_state
-- secondary_states
-- state_hits
-- confidence
-
-#### Used By
-- direction_profile
-- recommendation reason
-- action_suggestion
+- ユーザーの相談原文を解釈結果と混同しない
+- 一つの入力から一つの心理状態を断定しない
+- 解釈結果は推薦順位を単独で決定しない
+- 相談テーマ、ご利益、誕生日、相性および方位は補助情報として扱う
+- 医療、心理、宗教または人生上の結果を判定しない
+- Frontendで相談解釈ロジックを重複実装しない
+- 正確な出力Schemaおよび生成処理はBackend実装とテストを正本とする
 
 ---
 
-### need_profile
+## 解釈フィールド
 
-#### Goal
-ユーザーが求めているテーマ・ご利益・目的を表す。
+Consultation Interpreterは、相談内容を以下の意味要素へ整理する。
 
-#### Responsibility
-- need_tags を統合する
-- query由来の need を抽出する
-- selected_goriyaku_tag_ids を保持する
+| フィールド | 意味責務 | 主な接続先 |
+|---|---|---|
+| `raw_query` | ユーザーが入力した相談原文 | Meaning Translation、Recommendation Reason |
+| `state_profile` | 相談文から読み取れる現在状態の候補 | Meaning Translation、Recommendation Reason |
+| `need_profile` | 求めている目的、願いまたは支援テーマ | Recommendation、Meaning Translation |
+| `direction_profile` | どの方向の体験へ接続するかという候補 | Meaning Translation、Action Suggestion |
+| `emotion_profile` | 相談文に表れている感情トーンと強さ | Recommendation Reason、Action Suggestion |
+| `action_intent` | 次に取りたい行動の候補 | Action Suggestion、CTA |
+| `decision_context` | ユーザーが整理または判断したい対象 | Meaning Translation、Recommendation Reason |
+| `constraint_profile` | 行動や判断に影響する制約 | Recommendation Reason、Action Suggestion |
+| `outcome_hint` | ユーザーが望んでいる着地点の候補 | Recommendation Reason、Action Suggestion |
 
-#### Expected Keys
-- need_tags
-- need_hits
-- primary_need_tag
-- selected_goriyaku_tag_ids
-
-
-#### Used By
-- recommendation scoring
-- shrine matching
-- recommendation reason
-
-#### Source of Truth
-
-`need_tags.py` is the canonical source of need classification.
-
-Responsibilities:
-
-- Define the 15 need tag taxonomy.
-- Manage keyword and regex matching.
-- Resolve boundary cases between tags.
-- Provide stable `need_tags` for downstream consumers.
-
-`consultation_interpreter.py` must not define an independent taxonomy.
-Its `NEED_KEYWORDS` exist only as a lightweight interpretation aid for building `need_profile` and must remain aligned with `need_tags.py`.
-
-Any addition, deletion, or rename of a need tag must be performed in `need_tags.py` first and then synchronized to `consultation_interpreter.py`.
+各フィールドの正確なキー、型、必須条件、fallbackおよび生成順序は、関連するBackend実装とテストを正本とする。
 
 ---
 
-### direction_profile
+## raw_query
 
-#### Goal
-ユーザーに対して、どの方向の参拝体験を提案するかを表す。
+### 意味責務
 
-#### Responsibility
-- rest
-- stabilize
-- review
-- reset
-- challenge
+`raw_query`は、ユーザーが入力した相談内容の原文を保持する。
 
-など、推薦の方向性を示す。
+後続レイヤーが、構造化された解釈だけでは失われる文脈を確認するために利用できる。
 
-#### Expected Keys
-- direction
-- themes
-- source_state
+### 原則
 
-#### Used By
-- history_theme selection
-- meaning_translation
-- recommendation reason
+- ユーザーの表現を解釈結果へ置き換えない
+- 要約結果を原文として扱わない
+- 推薦理由へ相談原文をそのまま露出させることを前提にしない
+- Debug用途や物理的な正規化処理は本書では管理しない
 
 ---
 
-### emotion_profile
+## state_profile
 
-#### Goal
-相談文から読み取れる感情トーンと強度を表す。
+### 意味責務
 
-#### Responsibility
-- tone を返す
-- intensity を返す
-- 感情シグナルを保持する
+`state_profile`は、相談文から読み取れる現在状態の候補を整理する。
 
-#### Expected Keys
-- tone
-- intensity
-- signals
+対象には、疲労、不安、迷い、停滞または変化への準備などが含まれうる。
 
-#### Used By
-- recommendation reason tone
-- action_suggestion tone
-- reflection question seed
+### 原則
+
+- 心理診断として扱わない
+- 一つの状態へ固定しない
+- ユーザー本人が明示していない状態を断定しない
+- Meaning TranslationやRecommendation Reasonの補助文脈として利用する
 
 ---
 
-### action_intent
+## need_profile
 
-#### Goal
-ユーザーが次に取りたい行動意図を表す。
+### 意味責務
 
-#### Responsibility
-- 参拝したい
-- 整理したい
-- 保存したい
+`need_profile`は、ユーザーが求めている目的、願い、支援テーマまたは関心を整理する。
 
-などの行動意図を抽出する。
+相談テーマや明示されたご利益は、自由入力を補助する情報として利用できる。
 
-#### Expected Keys
-- intent
-- strength
-- candidates
-- intent_hits
+### 原則
 
-#### Used By
-- action_suggestion
-- route_open CTA
-- reflection flow
+- 自由入力を優先する
+- 相談テーマだけで目的を確定しない
+- ご利益だけで推薦結果を決定しない
+- 正確な`need_tags`の分類、抽出、優先順位および同期手順はBackend実装とテストを正本とする
 
-## Additional Interpretation Fields
+---
 
-以下のフィールドは Recommendation v4 で利用する追加解釈情報である。
+## direction_profile
 
-### decision_context
+### 意味責務
 
-ユーザーが何を決めようとしているか。
+`direction_profile`は、相談内容をどの方向の参拝体験や行動文脈へ接続するかを整理する。
+
+例として、休息、安定、見直し、切り替えまたは挑戦などの方向性を扱いうる。
+
+### 原則
+
+- 推薦順位そのものを表さない
+- 方角または吉方位と同一視しない
+- `history_theme`を単独で確定しない
+- Meaning TranslationとAction Suggestionの補助文脈として利用する
+
+---
+
+## emotion_profile
+
+### 意味責務
+
+`emotion_profile`は、相談文に表れている感情トーンおよび強度の候補を整理する。
+
+Recommendation ReasonやAction Suggestionの表現負荷を調整するために利用できる。
+
+### 原則
+
+- 感情を診断しない
+- 本人が明示していない感情を断定しない
+- 強い不安や疲労を課金または行動促進に利用しない
+- 表示文言はKnowledgeのコピー原則に従う
+
+---
+
+## action_intent
+
+### 意味責務
+
+`action_intent`は、ユーザーが次に取りたい行動の候補を整理する。
+
+例として、詳細を知る、保存する、経路を確認する、参拝する、振り返るまたは一度立ち止まるなどを扱いうる。
+
+### 原則
+
+- 行動を強制しない
+- 行動しない選択を異常として扱わない
+- Action SuggestionやCTAの補助文脈として利用する
+- 正確なCTA判定や画面遷移は各Product文書と実装を正本とする
+
+---
+
+## decision_context
+
+### 意味責務
+
+`decision_context`は、ユーザーが何について整理または判断しようとしているかを表す。
 
 例:
 
-- 転職するか
+- 働き方を変えるか
 - 関係を続けるか
-- 休むか動くか
-- お金を使うか守るか
+- 休むか行動するか
+- 支出するか守るか
 
-### constraint_profile
+判断の正解や結論は生成しない。
 
-ユーザーの制約条件。
+---
 
-例:
+## constraint_profile
 
-- 時間がない
-- お金が不安
-- 体力が落ちている
-- 人間関係の制約がある
+### 意味責務
 
-### outcome_hint
-
-ユーザーが望む着地点。
+`constraint_profile`は、行動や判断に影響する現実的な制約を整理する。
 
 例:
 
-- 決めたい
-- 落ち着きたい
-- 背中を押されたい
-- 整理したい
+- 時間
+- 費用
+- 移動
+- 体力
+- 人間関係
+- 利用可能な選択肢
 
-## Non Goals
+制約は、ユーザーの行動を否定するためではなく、無理のない提案へ調整するために利用する。
 
-- ranking logicを変更しない
-- Score v3 weightを変更しない
-- 神社DB構造を変更しない
-- UIを変更しない
+---
 
-## KPI
+## outcome_hint
 
-このcontract改善により、以下の改善を狙う。
+### 意味責務
 
-- detail_open_rate
-- save_rate
-- route_open_rate
-- reflection_saved_rate
+`outcome_hint`は、ユーザーが相談を通して望んでいる着地点の候補を整理する。
 
-## Recommendation Reason v4 Integration
+例:
 
-The interpretation layer prepares structured inputs for `recommendation_reason_v4`; it does not generate recommendation copy directly.
+- 判断材料を得たい
+- 気持ちを整理したい
+- 少し落ち着きたい
+- 次の一歩を考えたい
 
-Expected mapping:
+結果の実現や効果を保証しない。
 
-| Interpreter Field | recommendation_reason_v4 usage |
-|-------------------|--------------------------------|
-| state_profile | Describe the user's current situation. |
-| need_profile | Explain why the shrine matches the user's needs. |
-| direction_profile | Determine the recommended direction or theme. |
-| emotion_profile | Adjust tone and wording. |
-| decision_context | Reflect the decision the user is trying to make. |
-| constraint_profile | Mention practical constraints when appropriate. |
-| outcome_hint | Connect the recommendation to the desired outcome. |
-| action_intent | Generate action suggestions and CTA. |
+---
 
-Recommendation copy should be generated from the structured interpretation rather than directly from the raw query whenever possible.
+## 後続レイヤーとの接続
+
+### Meaning Translation
+
+Consultation Interpreterで整理した状態、目的、方向、感情、判断対象および制約を、神社文脈、`history_theme`、ActionおよびReflectionへ接続する。
+
+変換関係は`docs/product/meaning-translation-mapping.md`を参照する。
+
+### Recommendation
+
+Consultation Interpreterは、推薦候補の抽出や順位決定に利用できる文脈を提供する。
+
+Score、Weight、Ranking、fallbackおよび一致判定の物理ロジックは、Backend実装とテストを正本とする。
+
+### Recommendation Reason
+
+Recommendation Reasonは、構造化された解釈結果と神社情報を利用し、「なぜこの提案なのか」を説明する。
+
+Consultation Interpreter自体は推薦コピーを生成しない。
+
+### Action Suggestion
+
+Action Suggestionは、行動意図、判断対象、制約および望む着地点を参照し、次に取りやすい小さな行動へ接続する。
+
+出力契約は`docs/product/action_suggestion_v4.md`を参照する。
+
+---
+
+## 責務境界
+
+### Product
+
+Productでは以下を管理する。
+
+- 解釈フィールドの意味
+- 各フィールドの体験上の役割
+- 後続レイヤーとの接続
+- 断定を避ける原則
+- 行動負荷を上げない原則
+
+### Core
+
+以下は`docs/core/`配下の正本文書を参照する。
+
+- Consultation InterpretationとMeaning Translationの構造的な接続
+- Recommendation全体のデータフロー
+- Frontend、BFFおよびBackendの技術責務
+- Source of Truth
+- 推薦時点の文脈保持
+
+### Backend・実装
+
+以下は関連するBackend実装とテストを正本とする。
+
+- 実装ファイル名
+- 関数名
+- 正確な出力Schema
+- Fieldのキーと型
+- 必須・任意条件
+- 分類語彙
+- keywordおよびregex判定
+- fallback
+- ScoreおよびRankingへの反映
+- 保存処理
+
+### Analytics
+
+以下は`docs/analytics/`配下の正本文書を参照する。
+
+- Event名
+- Payload
+- Property
+- Funnel
+- KPI
+- 集計方法
+- Recommendation品質の評価方法
+
+### Knowledge
+
+以下は`docs/knowledge/`配下の正本文書を参照する。
+
+- 推薦理由の表現原則
+- 感情や状態を断定しないコピー
+- ActionおよびReflectionの表現ガイド
+- 神社FactとMeaningの扱い
+
+---
+
+## 責務外
+
+本書では以下を管理しない。
+
+- 推薦順位
+- Score Weight
+- 神社DB構造
+- API Endpoint
+- UIレイアウト
+- Component構造
+- Analytics KPIの具体値
+- 実装手順
+- テストケース一覧
+- PR計画
+- 作業履歴
+
+---
+
+## 関連ドキュメント
+
+- `docs/product/README.md`
+- `docs/product/concierge-first-final-spec.md`
+- `docs/product/consultation-theme-taxonomy.md`
+- `docs/product/meaning-translation-mapping.md`
+- `docs/product/action_suggestion_v4.md`
+- `docs/core/architecture.md`
+- `docs/core/meaning-layer.md`
+- `docs/core/meaning-layer-connection.md`
+- `docs/core/recommendation-reason-contract.md`
+- `docs/knowledge/recommendation-copy-guide.md`
+- `docs/knowledge/action-guide.md`
+- `docs/knowledge/reflection-guide.md`
+
+---
+
+## 更新ルール
+
+- 本書はConsultation Interpreterの解釈フィールドと意味責務を管理する。
+- 正確なキー、型、Schema、生成処理およびfallbackは本書で重複管理しない。
+- Score、Weight、RankingまたはAPI仕様は本書へ記載しない。
+- KPI、Event、PayloadおよびFunnelはAnalytics文書で管理する。
+- 解釈フィールドの追加、削除または意味変更がある場合のみ本書を更新する。
+- 物理実装のみを変更した場合は、本書の意味契約へ影響があるかを確認する。
+- TODO、PR計画、実装進捗、テスト手順および作業履歴は本書へ記載しない。


### PR DESCRIPTION
## 変更概要

Consultation Interpreter文書を、物理実装中心の記述から解釈フィールドの意味責務を管理するProduct契約へ整理しました。

## 主な変更

- 9つの解釈フィールドの意味責務を明文化
- 実装ファイル名、関数名、Expected KeysをBackend実装・テストへ委譲
- Score、Weight、RankingをBackend責務へ委譲
- Event、Payload、KPI、FunnelをAnalytics責務へ委譲
- Meaning Translation、Recommendation Reason、Action Suggestionとの接続を整理
- Product、Core、Backend、Analytics、Knowledgeの責務境界を追加
- 更新ルールを追加

## 確認

- 実装固有語彙の残存確認済み
- Markdown参照切れなし
- コードブロック正常
- `git diff --check`成功