### PR TITLE
Product文書からAnalytics契約をdocs/analytics配下へ委譲・統合

### DIFF
--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -8,12 +8,21 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 
 ---
 
+## Active
+
+| ドキュメント | 責務 |
+| --- | --- |
+| `monetization-funnel.md` | Premium / Monetization FunnelのEvent名を管理する |
+
+---
+
 ## Reference
 
 | ドキュメント | 責務 |
 | --- | --- |
 | `analytics-payload-audit.md` | Analytics Payload、Session IDおよび計測設計の背景を補足する |
 | `recommendation-score-v3-design.md` | Recommendation Score v3のSignal、Weightおよび評価設計を補足する |
+| `reflection-funnel-dashboard.md` | Reflection FunnelのKPI・PostHogダッシュボード設計を補足する |
 
 ---
 

--- a/docs/analytics/monetization-funnel.md
+++ b/docs/analytics/monetization-funnel.md
@@ -1,0 +1,90 @@
+> **Status: Active**
+>
+> 本ドキュメントは、Premium / Monetization FunnelのEvent名を管理する正本文書である。
+>
+> 正確なPayload、Web / Mobileの送信差異の検証結果は`docs/audit/cross-platform-event-contract.md`、実装状況は関連するBackend・Frontend実装コードおよびテストを最終的な正本とする。
+
+# Monetization Funnel Events
+
+## 目的
+
+Premiumへの転換Funnelにおいて、どのEventが送信されているかを一意に整理する。
+
+---
+
+## Web
+
+| Event | 意味 |
+|---|---|
+| `comparison_preview` | 前回比較のプレビューを表示した |
+| `upgrade_click` | アップグレード導線を押した |
+| `checkout_started` | 決済を開始した |
+| `checkout_success` | 決済が成功した |
+| `premium_active` | Premiumが有効化された |
+
+---
+
+## Mobile
+
+| Event | 意味 |
+|---|---|
+| `premium_screen_view` | Premium画面を表示した |
+| `premium_status_view` | 現在のBilling状態を表示した |
+| `premium_upgrade_click` | アップグレード導線を押した |
+| `premium_checkout_started` | 決済を開始した |
+| `premium_checkout_failed` | 決済起動に失敗した |
+| `premium_checkout_returned` | 外部ブラウザ決済から復帰した |
+| `premium_active` | Premiumが有効化された |
+
+---
+
+## Web / Mobileの既知の不整合
+
+以下は`docs/audit/cross-platform-event-contract.md`で確認済みの未解消事項である。
+
+- アップグレード導線: `upgrade_click`（Web）/ `premium_upgrade_click`（Mobile）で名称が異なる
+- 決済開始: `checkout_started`（Web）/ `premium_checkout_started`（Mobile）で名称が異なる
+- 決済成功・復帰: Webの`checkout_success`は決済成功シグナルだが、Mobileの`premium_checkout_returned`は外部ブラウザからの復帰検知であり、意味が非対称
+- `premium_active`はWeb / Mobileでイベント名が一致しているが、Payload形状が異なる
+
+これらの解消方針は本書では決定しない。詳細は`docs/audit/cross-platform-event-contract.md`を参照する。
+
+---
+
+## Funnel / KPI設計の背景
+
+Card可視化からCheckout、Premium化までの詳細なFunnel定義、CTR計算式およびRetention KPIは`docs/analytics/premium-analytics-dashboard.md`（Archive）に設計背景として記録されている。
+
+Archive文書のため、現行実装との整合はイベント名単位でのみ確認済みであり、KPI・Dashboard構成自体の実装状況は未確認である。
+
+---
+
+## 責務外
+
+本書では以下を管理しない。
+
+- Card CTR、Card Visibility Eventの契約
+- 正確なPayload、Property
+- Dashboard実装
+- 実装コード、テストケース
+
+---
+
+## 関連ドキュメント
+
+- `docs/analytics/README.md`
+- `docs/analytics/premium-analytics-dashboard.md`
+- `docs/audit/cross-platform-event-contract.md`
+- `docs/product/monetization-flow-design.md`
+- `docs/product/premium-experience.md`
+- `docs/product/billing-paywall.md`
+
+---
+
+## 更新ルール
+
+- 本書はPremium / Monetization FunnelのEvent一覧のみを管理する。
+- Web / Mobileで新しいEventが追加または名称変更された場合は、本書を更新する。
+- 正確なPayload、Property、KPI計算式および実装状況は本書で重複管理しない。
+- Web / Mobileの命名統一方針が確定した場合は、本書の記載を実態に合わせて更新する。
+- TODO、PR計画、実装進捗および作業履歴は本書へ記載しない。

--- a/docs/analytics/reflection-funnel-dashboard.md
+++ b/docs/analytics/reflection-funnel-dashboard.md
@@ -1,8 +1,8 @@
 > **Status: Reference**
 >
-> 本ドキュメントは、参拝後振り返り導線のFunnel KPI・PostHogダッシュボード設計を補足するReference文書である。
+> 本ドキュメントは、`visit_done` / `reflection_prompt_view` / `reflection_saved`によるFunnel、KPIおよびPostHogダッシュボード設計を管理するReference文書である。
 >
-> Visit / Reflectionのイベント・保存責務は `docs/product/visit-reflection-flow.md` を正本とする。
+> Visit / Reflectionの体験・保存責務は`docs/product/visit-reflection-flow.md`を正本とする。正確なEvent送信条件、Payloadおよび実装状況は、関連するBackend・Frontend実装コードおよびテストを最終的な正本とする。
 
 # Reflection Funnel Dashboard
 
@@ -152,16 +152,18 @@ Breakdown: shrineId
 
 ## 関連ドキュメント
 
-- `docs/product/README.md`
+- `docs/analytics/README.md`
 - `docs/product/visit-reflection-flow.md`
 - `docs/product/history-theme-taxonomy.md`
+- `docs/audit/cross-platform-event-contract.md`
 
 ---
 
 ## 更新ルール
 
 - 本書はReflection Funnelのダッシュボード設計・KPI定義のみを管理する。
-- Visit / ReflectionのEvent名・Payload契約は本書で重複管理しない。
+- Visit / Reflectionの体験責務は本書で重複管理せず、`docs/product/visit-reflection-flow.md`を参照する。
+- 正確なEvent送信条件、Payloadおよび実装状況は本書で重複管理せず、関連するBackend・Frontend実装コードおよびテストを参照する。
 - historyThemeのカテゴリ名称は `docs/product/history-theme-taxonomy.md` の定義に従う。
 - ダッシュボード構成またはKPI定義が変更された場合のみ更新する。
 - 実装進捗、作業履歴は本書へ記載しない。

--- a/docs/audit/product-document-responsibility-audit.md
+++ b/docs/audit/product-document-responsibility-audit.md
@@ -247,7 +247,8 @@ Product文書は、体験、機能目的、入力・出力の意味および責�
 | `visit-reflection-flow.md` | Active | Active維持・体験責務への整理完了 | 参拝完了からReflection保存、次回相談までを接続する体験とVisit / Reflectionの意味責務 | Event名、TypeScript Payload型、Django Model全文、Index、採用Field、Mobile送信状況、PostHog集計、実装ファイル名が混在していた | 体験フロー、Visit / Reflectionの意味責務、Free / Premium境界を残す。Event・Payload・FunnelはAnalytics、Model・Field・Index・APIは実装とテストへ委譲 |
 | `reflection-timeline-design.md` | Reference | Reference | 写真、御朱印、検索、比較、感情推移など、長期的な振り返り体験の構想 | 写真、御朱印、検索、感情推移、行動記録、Premium分析、KPIなど未実装または将来構想が現行仕様として混在していた。現行のTimeline体験責務はJourney Timelineへ統合済み | 現行のTimeline体験責務はJourney Timeline正本へ統合完了。本書は長期構想・設計思想を扱うReferenceとして維持する |
 | `journey-timeline-design.md` | Active | Active正本 | 相談・提案・参拝・振り返りを「ご縁の歩み」として時系列で接続する現行体験設計 | 従来は内容が簡略でReflection Timelineと責務が重複していたが、Event・State分離とVisit / Reflection接続方針を整理し、正本として統合完了 | Journey Timelineの現行体験仕様を管理する正本として維持する。正確なEvent構造・API・Serializer・表示処理はBackend・Mobile実装とテストを正本とする |
-| `reflection-funnel-dashboard.md` | Reference | Analytics移管候補・Reference維持 | VisitからReflection保存までのFunnel、KPIおよびPostHog Dashboard設計 | 内容の中心がEvent、KPI、Breakdown、Dashboard、観測期間およびSuccess Criteriaであり、ProductよりAnalytics責務に属する | `docs/analytics/`へ移管または同等文書へ統合する。移管完了まではReferenceとして維持し、Product README上の分類を後続PRで更新する |
+
+`reflection-funnel-dashboard.md`は`docs/analytics/reflection-funnel-dashboard.md`へ移管が完了したため、本表から除外した（対象範囲はdocs/product/直下の文書のため）。移管の詳細は9節を参照する。
 
 ### Premium・Billing
 
@@ -373,7 +374,6 @@ Product文書は、体験、機能目的、入力・出力の意味および責�
 - `monetization-flow-design.md`
 - `need-mode-ui-flow.md`
 - `product-document-audit.md`
-- `reflection-funnel-dashboard.md`
 - `reflection-timeline-design.md`
 - `shrine-detail-meaning-layer.md`
 - `visit-style-taxonomy.md`
@@ -393,10 +393,10 @@ Product文書は、体験、機能目的、入力・出力の意味および責�
   - `premium-experience.md`への独自原則統合後、Reference化候補
 - `history-theme-taxonomy.md`
   - Knowledge移管候補（責務境界整理は完了、移管判断は保留継続）
-- `reflection-funnel-dashboard.md`
-  - Analytics移管候補
 
 Timeline正本名称は「Journey Timeline」で確定した。`journey-timeline-design.md`をJourney Timelineの現行体験仕様の正本（Active）とし、`reflection-timeline-design.md`は長期構想・設計思想を扱うReferenceへ変更した。統合候補としての判断保留は解除済みである。
+
+`reflection-funnel-dashboard.md`のAnalytics移管は完了した。`docs/analytics/reflection-funnel-dashboard.md`へ移動し、Product文書（35件）の対象から除外した。以後のProduct文書総数は34件として扱う。
 
 ### Delete候補
 
@@ -475,14 +475,14 @@ Event、Payload、KPI、Funnelおよび実装状況をAnalytics文書へ委譲�
 
 Product直下のMarkdown文書35件について、現行分類、主責務、重複、委譲先および後続対応を確認した。
 
-監査時点の最終分類は以下である。
+監査時点の最終分類は以下である（`reflection-funnel-dashboard.md`の`docs/analytics/`への移管完了後の件数）。
 
 | 分類 | 件数 |
 |---|---:|
 | Active | 17 |
-| Reference | 16 |
+| Reference | 15 |
 | Archive | 2 |
-| 合計 | 35 |
+| 合計 | 34 |
 
 監査により、Product文書には以下の責務混在が存在することを確認した。
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -112,7 +112,6 @@ billing-paywall.md
 | `need-mode-ui-flow.md`               | Need Mode UI導線                                                   |
 | `compat-mode-ui-flow.md`             | Compat Mode UI導線                                                 |
 | `visit-style-taxonomy.md`            | 参拝スタイル分類                                                   |
-| `reflection-funnel-dashboard.md`     | Reflection KPI・分析設計                                           |
 | `explore-integration-design.md`      | Explore体験設計                                                    |
 | `product-document-audit.md`          | Product文書の監査・分類管理                                        |
 | `card-visibility-renderer-split.md`  | Card表示可否とRenderer責務の設計補足                               |

--- a/docs/product/monetization-flow-design.md
+++ b/docs/product/monetization-flow-design.md
@@ -2,7 +2,7 @@
 >
 > 本ドキュメントは、Premium提示タイミング、CTA方針および収益導線の設計背景を記録した参照資料である。
 >
-> Free / Premiumの提供価値境界は`docs/product/premium-experience.md`、価格表現は`docs/product/pricing.md`、Billing / Paywallの判定原則は`docs/product/billing-paywall.md`を正本とする。正確なEvent、Payload、FunnelおよびKPIは`docs/analytics/`配下の正本文書、現行仕様は実装コードおよびテストを最終的な正本とする。
+> Free / Premiumの提供価値境界は`docs/product/premium-experience.md`、価格表現は`docs/product/pricing.md`、Billing / Paywallの判定原則は`docs/product/billing-paywall.md`を正本とする。正確なEvent名は`docs/analytics/monetization-funnel.md`、Payload・FunnelおよびKPIは`docs/analytics/`配下の正本文書、現行仕様は実装コードおよびテストを最終的な正本とする。
 
 # Monetization Flow Design
 
@@ -362,7 +362,7 @@ Monetization Flowでは、収益導線のどの段階でユーザーが離脱ま
 - Premium化後に機能が利用されているか
 - 解約導線が使われたか
 
-正確なEvent名、Payload、Property、Funnel、Context情報およびKPI（Revenue・Retention・Engagementを含む）は、`docs/analytics/`配下の正本文書を参照する。
+正確なEvent名は`docs/analytics/monetization-funnel.md`を参照する。Payload、Property、Funnel、Context情報およびKPI（Revenue・Retention・Engagementを含む）は、`docs/analytics/`配下の正本文書を参照する。
 
 計測は、決済の成否だけでなく、Premium化後にReflection・Timeline・月次レビューなどの体験が実際に使われているかを確認する目的で設計する。Premiumの成果は購入時点だけで判断せず、その後の継続行動まで含めて評価する方針とする。
 
@@ -412,3 +412,4 @@ Premium は、神社情報を閉じるためのものではない。
 - `docs/product/premium-experience.md`
 - `docs/product/pricing.md`
 - `docs/product/billing-paywall.md`
+- `docs/analytics/monetization-funnel.md`

--- a/docs/product/premium-experience.md
+++ b/docs/product/premium-experience.md
@@ -162,7 +162,7 @@ Billing状態の判定原則、Paywall表示の判定原則および利用制限
 
 Premium提示タイミング、CTA方針および収益導線の設計背景は、`docs/product/monetization-flow-design.md`を参照する。
 
-正確なEvent、Payload、FunnelおよびKPIは、`docs/analytics/`配下の正本文書を参照する。
+正確なEvent名は`docs/analytics/monetization-funnel.md`、PayloadおよびKPIは`docs/analytics/`配下の正本文書を参照する。
 
 ---
 

--- a/docs/product/visit-reflection-flow.md
+++ b/docs/product/visit-reflection-flow.md
@@ -338,6 +338,8 @@ Productでは、VisitおよびReflection体験について、以下を観測す�
 - 集計方法
 - Dashboard構成
 
+参拝から振り返りまでのFunnel、KPIおよびPostHog Dashboard構成は、`docs/analytics/reflection-funnel-dashboard.md`を参照する。
+
 Analyticsは体験改善の観測に使用する。
 
 個別ユーザーの心理状態、宗教的効果、信仰の程度または人生上の成果を判定するためには使用しない。
@@ -550,7 +552,7 @@ Reflectionでは以下を扱わない。
 - `docs/product/journey-timeline-design.md`
 - `docs/analytics/reflection-next-recommendation-design.md`
 - `docs/analytics/history-theme-dashboard.md`
-- `docs/product/reflection-funnel-dashboard.md`
+- `docs/analytics/reflection-funnel-dashboard.md`
 - `docs/core/architecture.md`
 - `docs/core/meaning-layer-connection.md`
 - `docs/core/recommendation-readiness.md`


### PR DESCRIPTION
## Summary

Productが「何を観測するか」だけを管理し、正確なEvent名・Payload・Property・Funnel・KPIをAnalytics正本へ集約する目的で、docs/analytics配下を監査し、Product文書からの委譲先を確定した。

- **reflection-funnel-dashboard.mdを移管**: `docs/product/` → `docs/analytics/`。`visit_done` / `reflection_prompt_view` / `reflection_saved`のFunnel・KPI・PostHog Dashboard設計の正本として位置付け直した
- **monetization-funnel.mdを新設**: Premium / Monetization Funnelに既存の正本がなかったため、Web/Mobileの現行実装で確認できたEvent名（後述）を登録。Web/Mobile間の命名不整合を既知の未解消事項として明記した
- **Product文書を観測目的＋参照のみへ整理**: monetization-flow-design.md、premium-experience.md、visit-reflection-flow.mdのAnalytics委譲箇所を、汎用的な`docs/analytics/`配下から具体的な文書名へ更新
- **README.md・監査文書を現行分類へ整合**: reflection-funnel-dashboard.mdの移管に伴い、Product文書総数を35→34件へ更新

このPRは[PR #2057](https://github.com/etsu33/jinja_app/pull/2057)（Premium / Billing文書の体験責務と物理責務を分離）の上に積んでおり、baseは`docs/premium-billing-responsibility-alignment`。#2057マージ後、GitHubが自動的にbaseをdevelopへ retarget する想定。

## 変更ファイル一覧

- `docs/analytics/reflection-funnel-dashboard.md`（新規、`docs/product/`からrename）
- `docs/analytics/monetization-funnel.md`（新規作成）
- `docs/analytics/README.md`
- `docs/product/README.md`
- `docs/product/monetization-flow-design.md`
- `docs/product/premium-experience.md`
- `docs/product/visit-reflection-flow.md`
- `docs/audit/product-document-responsibility-audit.md`

## 1. docs/analytics配下の監査結果

- Status表記があるのは30ファイル中5ファイルのみ（Archive 4、Reference 1）。大半がStatusなしで、`docs/product/`や`docs/core/`ほど正本管理が徹底されていない
- `docs/analytics/action-suggestion-funnel.md`はAction Suggestion関連の唯一の正本候補だが、実装と乖離している（後述、対応は本PR範囲外）
- `docs/analytics/premium-analytics-dashboard.md`はArchiveだが、Event名・Funnel定義の多くは現行実装と一致することを確認した（設計背景として引き続き参照可能）
- `docs/analytics/save-premium-correlation.md`は内容が壊れている（タイトルが"Analytics Event Storage Audit"で、ファイル名と不一致。自己参照的な記述があり、本文が完成していない）。**別途修正が必要な既存の問題として発見**、本PRでは触れていない
- `docs/audit/cross-platform-event-contract.md`という非常に詳細なWeb/Mobile横断Event監査が既に存在し、file:line付きで現行実装を検証していた。今回の新規Analytics文書はこの監査結果を根拠として作成した

## 2. 既存正本の確認結果

| 契約 | 既存正本 | 判断 |
|---|---|---|
| `visit_done` / `reflection_prompt_view` / `reflection_saved` | `docs/product/reflection-funnel-dashboard.md`（Funnel・KPI・Dashboard定義は既にあったが配置場所が誤り） | **移管**（新規文書は作らず） |
| `action_suggestion_reflection_preview_view` | なし（`action-suggestion-funnel.md`は存在するが本イベント未収録、かつ他のイベント名も実装と乖離） | 既存正本の修正は本PR範囲外。Product側は既に一般委譲のみで正しく完結しているため実害なし |
| Premium / MonetizationのEvent・Funnel・KPI | なし（`premium-analytics-dashboard.md`はArchive、`save-premium-correlation.md`は壊れている） | **新規作成**（`monetization-funnel.md`） |

## 3. action_suggestion_reflection_preview_viewについて

`apps/web/src/lib/analytics/searchEvents.ts`と`ConciergeTopRecommendationHero.tsx:123`で実際に送信されているLive Eventであることを確認した。`docs/analytics/action-suggestion-funnel.md`は`action_suggestion_view`/`action_suggestion_click`という実装上デッドになった名前を使っており、本イベントを含んでいない。この文書の正確性改善（実装との突き合わせ、TODO/次PR候補の整理）は、不明な契約を推測で新設しないという制約から本PRでは行わず、別タスクとしてフラグする。

## 4. reflection-funnel-dashboard.mdの移動判断

- 独自情報（Funnel定義、3つのKPI計算式、historyTheme/shrine別Breakdown、PostHog Dashboard Widget構成、Observation Period、Success Criteria）はAnalytics責務そのものであり、統合先となる既存文書がなかったため**移動（Move）**を選択
- Status:Referenceは維持（Dashboard実装状況が未確認のため、Activeへの格上げは行わなかった）

## 5. Product文書の整理結果

- `visit-reflection-flow.md`: `docs/analytics/`配下への一般委譲は既存のまま維持しつつ、Funnel/KPI/Dashboardの具体的な参照先を`docs/analytics/reflection-funnel-dashboard.md`に明記。移動に伴う参照切れも修正
- `monetization-flow-design.md`: Event名の参照先を`docs/analytics/monetization-funnel.md`に明記（Payload/Property/Funnel/KPIは引き続き`docs/analytics/`配下への一般委譲）
- `premium-experience.md`: Monetization委譲節のEvent名参照を同様に更新
- `action_suggestion_v4.md`: 確認のみ実施。既に意味責務のみを管理し、Analytics委譲は一般参照で完結していたため変更不要だった

## 6. README.md・監査文書の整合

- `docs/product/README.md`: Referenceテーブルから`reflection-funnel-dashboard.md`を削除
- `docs/analytics/README.md`: 新設の`## Active`セクションに`monetization-funnel.md`、`## Reference`セクションに`reflection-funnel-dashboard.md`を追加
- `docs/audit/product-document-responsibility-audit.md`: `reflection-funnel-dashboard.md`の行をProduct文書の表から除外（移管完了の注記付き）、最終分類のReferenceリストから削除、統合候補リストから解消済みとして除去、結論の件数をActive17/Reference15/Archive2/合計34へ更新

## 制約の遵守

- Event名・PayloadをProduct文書へ戻していない
- Backend/Frontend実装コード（TypeScript型定義や関数本体）はAnalytics文書へ貼り付けていない。`monetization-funnel.md`のEvent名・Payloadフィールド名は`grep`による直接確認と`docs/audit/cross-platform-event-contract.md`の検証結果に基づく事実の記載であり、コード片の転記は行っていない
- PostHog上の現行送信状況は実装（`apps/web/src/lib/analytics/billing.ts`、`apps/mobile/lib/premiumAnalytics.ts`等）とテストで確認した
- 不明な契約（`action_suggestion_reflection_preview_view`の正確なPayload等）は推測で新設せず、既知のギャップとして報告するに留めた
- `docs/product/product-document-audit.md`は変更していない（この作業ツリーに以前から存在する無関係な未コミット差分も、本PRには含めていない）

## 実行した確認コマンド

```bash
# コードブロックの閉じ確認（フェンス数が偶数であること）
grep -c '```' docs/analytics/reflection-funnel-dashboard.md docs/analytics/monetization-funnel.md \
  docs/analytics/README.md docs/product/monetization-flow-design.md docs/product/premium-experience.md \
  docs/product/visit-reflection-flow.md docs/product/README.md docs/audit/product-document-responsibility-audit.md

# Markdown参照切れ確認
grep -oE '`docs/[a-zA-Z0-9_./-]+\.md`' <file> | tr -d '`' | while read -r p; do
  [ -f "$p" ] || echo "MISSING: $p"
done

# 空白関連のdiffエラー確認
git diff --check
git diff --cached --check

# Webの実装確認（イベント名の裏取り）
grep -n "checkout_started\|premium_active\|comparison_preview\|upgrade_click" apps/web/src/lib/analytics/billing.ts
cat apps/mobile/lib/premiumAnalytics.ts
grep -rn "action_suggestion_reflection_preview_view" apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx

# Web契約テスト
pnpm --filter ./apps/web test:contract
```

## テスト・Markdown確認結果

- `git diff --check` / `git diff --cached --check`: エラーなし
- 対象8ファイルのコードブロック: すべて偶数個（閉じ漏れなし）
- 全ファイルの`docs/*.md`参照リンク: すべて実在するファイルを指している（参照切れなし）
- `pnpm --filter ./apps/web test:contract`: 80 Test Files / 455 Tests 全通過
- pre-push hookのOpenAPI lint・Web契約テスト: 全て通過