### PR TITLE
save-premium-correlation.mdを相関分析文書として修復

### DIFF
--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -13,6 +13,7 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 | ドキュメント | 責務 |
 | --- | --- |
 | `monetization-funnel.md` | Premium / Monetization FunnelのEvent名を管理する |
+| `save-premium-correlation.md` | 保存行動とPremium転換に関するEvent間の相関分析の読み方を管理する |
 
 ---
 

--- a/docs/analytics/save-premium-correlation.md
+++ b/docs/analytics/save-premium-correlation.md
@@ -1,36 +1,154 @@
-# Analytics Event Storage Audit
+> **Status: Active**
+>
+> 本ドキュメントは、保存行動とPremium転換に関するEvent間の相関分析の読み方を管理する正本文書である。
+>
+> 正確なEvent名、PayloadおよびPropertyは、`docs/analytics/monetization-funnel.md`および関連するFrontend実装コードとテストを最終的な正本とする。
+
+# Save / Premium Correlation
 
 ## 目的
 
-- event が適切に送れているか、payload が足りているかを監査する
-- 今後の改善のための課題を洗い出す
-- 次PR候補
+保存行動（Save）が、神社詳細・経路確認への行動、およびPremium転換（Preview → Checkout → Premium有効化）とどう結びついているかを分析するための、相関の読み方を定義する。
+
+本書は、Event名やPayloadを新たに定義しない。Event間の関係を分析する際の単位、欠損時の扱いおよび相関と因果を混同しない原則を管理する。
+
+---
+
+## 対象とするEvent群
+
+以下のEvent群を対象とする。正確なEvent名、PayloadおよびPropertyは、各正本を参照する。
+
+### 保存・詳細・経路確認
+
+保存意図の表明、保存の実行、神社詳細の閲覧および経路確認は、それぞれ独立したEventとして送信される。
+
+正確なEvent名およびPayloadは、関連するFrontend実装コードとテストを参照する。
+
+### Premium Preview・Checkout・Premium有効化
+
+Premium導線への関心表明から決済開始、決済成功、Premium有効化までの一連の流れを対象とする。
+
+正確なEvent名は`docs/analytics/monetization-funnel.md`を参照する。
+
+---
+
+## 保存から詳細・経路確認への行動接続
+
+保存は、それ単独で完結する行動ではなく、神社を後から見返す、または経路確認へ進むための起点として扱う。
+
+分析では、以下の順序を前提とする。
+
+```text
+保存意図の表明
+↓
+保存の実行
+↓
+神社詳細の閲覧
+↓
+経路確認
+```
+
+ただし、ユーザーは必ずしもこの順序どおりに行動しない。保存せずに経路確認へ進む、または詳細だけを確認して離脱するケースも正常な行動として扱う。
+
+保存行動には、意図の表明（保存したいという反応）と実行（保存が確定した反応）の2段階があり、この2つを混同しない。
+
+---
+
+## Premium PreviewからCheckout・Premium有効化への接続
+
+Premium導線への関心は、以下の順序で深まっていくと仮定して分析する。
+
+```text
+Premium Previewへの反応
+↓
+Checkoutの開始
+↓
+Premiumの有効化
+```
+
+この順序は仮説であり、確定した転換経路として扱わない。Premium Previewを経由せずCheckoutへ進むケースも存在しうる。
+
+Web / Mobileでは、この経路に対応するEvent名およびPayload形状が一致していない箇所がある。正確な差異は`docs/analytics/monetization-funnel.md`を参照する。
+
+Mobileは、Premiumドメイン以外のEvent送信が確認されていない。そのため、保存・詳細・経路確認とPremium転換をまたぐ相関分析は、現時点ではWebのみを対象として成立する。
+
+---
+
+## Event間の相関を読む際の分析単位
+
+相関を読む際は、以下の優先順位で分析単位を選ぶ。
+
+1. 同一セッション内の順序
+2. 安定したユーザー識別子が取得できる場合の、一定期間内（例: 7日以内）の順序
+
+初期の分析では、同一セッション内の順序のみを対象とする。
+
+匿名利用からログイン・会員登録を経て行動が継続する場合、セッションをまたいだ同一ユーザーの識別は保証されない。ユーザー単位の分析へ拡張する場合は、識別が継続している前提が成立しているかを個別に確認する。
+
+---
+
+## Event欠損時の扱い
+
+Analytics Eventは、送信失敗、通信エラーまたは計測未実装により欠損することがある。
+
+Eventが存在しないことを、その行動が発生しなかったことの証拠として扱わない。
+
+保存・詳細・経路確認の一部は、Analytics Eventとは別に、Backend側にも行動の記録が残る。Eventが欠損している場合、Backend記録の有無をあわせて確認できないか検討する。
+
+Premium・Checkoutの経路には、Analytics Event以外に行動そのものを記録する仕組みがない。Eventが欠損した場合、そのステップは確認不能として扱う。
+
+---
+
+## 同一ユーザー・同一神社・同一相談文脈を関連付ける際の注意
+
+Event同士を関連付ける際は、以下の識別子を手掛かりとする。
+
+- 神社を識別する項目
+- 相談の文脈を識別する項目
+- セッションを識別する項目
+
+これらの識別子は、Eventの種類によって送信されている場合と送信されていない場合がある。識別子が欠けているEventを、関連するEventと無理に紐付けない。
+
+同一の神社であっても、異なる相談文脈または異なるセッションから発生した行動は、同一の意思決定として扱わない。
+
+---
+
+## 相関と因果を混同しない原則
+
+あるEventの後に別のEventが多く発生していることは、前者が後者の原因であることを意味しない。
+
+例えば、Premium Previewを見たユーザーがCheckoutへ進む割合が高いことは、Premium Previewの表示がCheckoutを引き起こしたことを証明しない。両者に共通する別の要因（もともとPremiumへの関心が高いユーザー層である等）が影響している可能性を排除できない。
+
+相関分析の結果は、施策の効果を確定させる根拠としてではなく、次に検証すべき仮説を見つけるための手がかりとして扱う。
+
+---
+
+## 責務外
+
+本書では以下を管理しない。
+
+- 正確なEvent名、Payload、Property
+- KPIの具体値、成功基準
+- PostHog Dashboardの操作手順
+- API Endpoint、Model、Serializer、Component名
+- 実装コード
 
 ---
 
 ## 関連ドキュメント
 
-- `docs/analytics/save-premium-correlation.md`
-  - favorite / detail / route / premium_preview / checkout / premium_active の相関定義
-  - save_rate / detail_to_route_rate / save_to_route_rate の分析定義
-  - 「保存されるが課金されない」「詳細は見られるが参拝行動に進まない」「Premium preview は押されるが checkout に行かない」落下判定
+- `docs/analytics/README.md`
+- `docs/analytics/monetization-funnel.md`
+- `docs/analytics/analytics-payload-audit.md`
+- `docs/analytics/premium-analytics-dashboard.md`
+- `docs/product/premium-experience.md`
 
-# save / premium correlation との接続
+---
 
-`analytics-card-events.md` は event payload / provider / 保存先の監査を扱う。
+## 更新ルール
 
-一方で、`docs/analytics/save-premium-correlation.md` は、取得済み event をどう組み合わせて落下地点を判定するかを扱う。
-
-責務分離:
-
-```txt
-analytics-card-events.md
-  → event が正しく送れるか / payload が足りているか
-
-analytics/save-premium-correlation.md
-  → event を使って save / premium / checkout の相関をどう読むか
-```
-
-このため、相関分析の定義は `save-premium-correlation.md` を正本とする。
-
-# 欠損リスク
+- 本書は保存行動とPremium転換に関するEvent間の相関分析の読み方のみを管理する。
+- 分析単位、欠損時の扱いまたは相関と因果を混同しない原則が変更された場合は、本書を更新する。
+- 正確なEvent名、Payload、Property、KPIの具体値は本書で重複管理しない。
+- Web / Mobileの計測範囲が変化した場合は、対象とするEvent群の記載を見直す。
+- TODO、PR計画、実装進捗および作業履歴は本書へ記載しない。


### PR DESCRIPTION
## 変更概要

破損していた`docs/analytics/save-premium-correlation.md`を、保存行動とPremium転換の相関分析の読み方を管理するAnalytics文書として修復した。

修復前の問題:
- タイトルが`Analytics Event Storage Audit`でファイル名と不一致
- 関連ドキュメント節が自分自身（`docs/analytics/save-premium-correlation.md`）を参照
- `analytics-card-events.md`との責務説明だけで本文が終わり、相関分析の内容が一切ない
- `# 欠損リスク`見出しの後が空白のまま
- Event・Property・分析定義が実装と整合しているか未確認

修復後は、Event名・Payloadの再定義は行わず、以下の方法論のみを管理する文書へ再構成した。
- 保存から詳細・経路確認への行動接続
- Premium PreviewからCheckout・Premium有効化への接続
- Event間の相関を読む際の分析単位（session優先、user単位への拡張条件）
- Event欠損時の扱い（Backend記録の有無、Premium/Checkoutには代替記録がない事実）
- 同一ユーザー・同一神社・同一相談文脈を関連付ける際の注意
- 相関と因果を混同しない原則

（補足: 当初[PR #2058](https://github.com/etsu33/jinja_app/pull/2058)の上に積む予定でしたが、作業中に#2057・#2058がdevelopへマージされたため、baseをdevelopへ変更しています。差分には本PRのcommitのみが含まれます。）

## 確認した実装済みEvent・Property

Web・Mobile実装を直接grep確認した（本文には転記せず、正確なEvent名は実装コードへ委譲）。

| 領域 | 確認結果 |
|---|---|
| 保存 | `ShrineSaveButton.tsx`から保存意図・保存実行に相当するEventが送信されている。実行後にshrineIdを含む決定Eventも追加送信される |
| 詳細閲覧 | `ShrineDetailViewTracker.tsx`から神社詳細閲覧のEventが送信されている |
| 経路確認 | `GoogleMapRouteLink.tsx`から経路確認のEventが送信されている。同時にBackend APIへも別途書き込みが行われている（二重記録） |
| Concierge結果からの経路・保存 | `ConciergeClientFull.tsx`のaction分岐から、経路確認・保存に相当する決定Event（action値付き）が送信されている |
| Premium Preview | Concierge結果・神社詳細の両方でPremium Previewクリックに相当するEventが送信されている |
| Checkout・Premium有効化 | Web/Mobile双方でCheckout開始・Premium有効化に相当するEventが送信されている（PR #2058で確認済みのWeb/Mobile命名差が現在も残る） |
| Backend記録 | 保存・詳細閲覧・経路確認には、Analytics Eventとは別にBackend側の永続レコードが存在することを確認した（モデル名は正本文書へ列挙せず） |

## 未実装または確認できなかった項目

- 旧文書が挙げていた「保存完了」に相当する専用Eventは、Web実装を検索したが呼び出し箇所が見つからなかった（未実装と判断し、修復後の文書からは除外した）
- Concierge結果の意思決定Eventには「地図検索」に相当するaction値が集計ロジック側で参照されているが、実際にこの値を送信している呼び出し箇所は見つからなかった（発火元不明。文書には含めず、本レポートでの報告に留める）
- `docs/analytics/action-suggestion-funnel.md`（PR #2058で発見した既知の乖離）は本PRのスコープ外のため未着手

## 変更ファイル一覧

- `docs/analytics/save-premium-correlation.md`（全面修復）
- `docs/analytics/README.md`（未登録だった本書をActiveへ追加）

`docs/audit/product-document-responsibility-audit.md`と`docs/product/product-document-audit.md`は、本タスクに直接関係する記録がなかった（前者は`docs/product/`直下の文書のみを対象範囲としており、後者は変更禁止の対象）ため変更していない。

## 文書のStatus判断と根拠

**Active**とした。

理由: 本書が管理する内容（分析単位の優先順位、Event欠損時の扱い、識別子の関連付け原則、相関と因果を混同しない原則）は、実装の変更頻度に依存しない現行の分析方法論である。正確なEvent名・Payloadは実装コードと`docs/analytics/monetization-funnel.md`へ委譲することで、契約自体が実装変更のたびに陳腐化しない構成にした。また、`analytics-card-events.md`が既に本書を「相関分析の正本」として参照しており、Active相当の役割を期待されていた。

## 制約の遵守

- Product文書へAnalytics契約を戻していない（Product文書は本PRで変更していない）
- 新しいEvent名を創作していない（旧文書にあった未実装の「保存完了」相当Eventは除外した）
- KPIの具体値・成功基準は記載していない（`premium-analytics-dashboard.md`への参照に留めた）
- PostHog Dashboardの操作手順は本文へ含めていない（責務外として明記）
- API Endpoint、Model、Serializer、Component名は正本文書へ列挙していない（grep検証はしたが、文書には概念的記述のみを反映）
- `docs/product/product-document-audit.md`は変更していない
- 無関係な文書整形は行っていない（`analytics-card-events.md`など他のArchive文書の内容は触れていない）
- Status変更（無し→Active）は上記の根拠に基づいて実施した

## 実行した検証結果

```bash
# 自己参照チェック
grep -n "save-premium-correlation" docs/analytics/save-premium-correlation.md
# → 該当なし

# コードブロックの閉じ確認
grep -c '```' docs/analytics/save-premium-correlation.md docs/analytics/README.md
# → 4（偶数）、0

# Markdown参照切れ確認
grep -oE '`docs/[a-zA-Z0-9_./-]+\.md`' docs/analytics/save-premium-correlation.md | tr -d '`' | while read -r p; do
  [ -f "$p" ] || echo "MISSING: $p"
done
# → 該当なし（全参照が実在）

# Event契約との重複チェック（本文に生のEvent名が含まれていないことを確認）
grep -n "favorite_click\|save_prompt_click\|shrine_decision\|checkout_started\|premium_active\|shrine_detail_view\|route_open\|premium_preview_click\|save_success" docs/analytics/save-premium-correlation.md
# → 該当なし

git diff --check
# → エラーなし

pnpm --filter ./apps/web test:contract
# → 80 Test Files / 455 Tests 全通過
```

- `git diff --check`: エラーなし
- コードブロック: 偶数個（閉じ漏れなし）
- Markdown参照切れ: なし
- Event名の生の記載: なし（実装・monetization-funnel.mdへ委譲）
- Web契約テスト: 80ファイル455件 全通過
- pre-push hookのOpenAPI lint・Web契約テスト: 全て通過