### PR TITLE
action-suggestion-funnel.mdを現行実装と一致させる

### DIFF
--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -12,6 +12,7 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 
 | ドキュメント | 責務 |
 | --- | --- |
+| `action-suggestion-funnel.md` | Action SuggestionのEvent名を管理する |
 | `monetization-funnel.md` | Premium / Monetization FunnelのEvent名を管理する |
 | `save-premium-correlation.md` | 保存行動とPremium転換に関するEvent間の相関分析の読み方を管理する |
 

--- a/docs/analytics/action-suggestion-funnel.md
+++ b/docs/analytics/action-suggestion-funnel.md
@@ -1,209 +1,104 @@
-
+> **Status: Active**
+>
+> 本ドキュメントは、Action SuggestionのEvent名を管理する正本文書である。
+>
+> 正確なPayload、Propertyおよび実装状況は、関連するFrontend・Backend実装コードおよびテストを最終的な正本とする。
 
 # Action Suggestion Funnel
 
-## イベント一覧
+## 目的
 
-### action_suggestion_view
-
-行動提案カードが表示された時に送信。
-
-発火箇所:
-- ConciergeTopRecommendationHero.tsx
-- useEffect 内
-
-目的:
-- 行動提案が何回ユーザーに露出したか確認する
-- action_suggestion_click / action_done の母数を作る
+Action Suggestionカードの表示から行動着手・完了までを観測するため、送信されているEvent名を一意に整理する。
 
 ---
 
-### action_suggestion_click
+## Web
 
-「試してみる」ボタン押下時に送信。
+Action Suggestionカードが表示されたとき、以下の2つのEventが同時に送信される。
 
-発火箇所:
-- ConciergeTopRecommendationHero.tsx
+| Event | 意味 |
+|---|---|
+| `action_suggestion_preview_view` | Action Suggestionカード（primary / secondary行動、振り返り観点のプレビューを含む）が表示された |
+| `action_suggestion_reflection_preview_view` | Action Suggestion内の振り返り観点のプレビューが表示された |
 
-目的:
-- 行動提案に興味を持った割合を確認する
+`action_suggestion_reflection_preview_view`は、実際のReflection入力UIが表示されたことを意味しない。実際のReflection入力UI表示は別のEventで計測しており、混同しない。正確な区別は`docs/product/visit-reflection-flow.md`および`docs/analytics/reflection-funnel-dashboard.md`を参照する。
 
----
+Webでは、Primary / Secondary行動へのクリック、または行動の着手・完了を計測するEventは現時点で存在しない。
 
-### action_done
-
-「完了」ボタン押下時に送信。
-
-発火箇所:
-- ConciergeTopRecommendationHero.tsx
-
-目的:
-- ユーザー自己申告ベースの行動完了率を確認する
-
-注意:
-- 現在はDB保存されない
-- PostHogイベントのみ
-- 再訪時に状態は保持されない
-
----
-
-## Payload一覧
-
-全イベント共通で以下を送信。
+### action_suggestion_preview_view Payload
 
 | 項目 | 内容 |
-|--------|--------|
-| source | イベント発生元 |
+|---|---|
+| source | Eventが発生した画面・導線 |
 | threadId | 相談セッションID |
-| resultSetId | レコメンド結果ID |
+| resultSetId | 推薦結果セットID |
 | shrineId | 神社ID |
 | recommendationRank | 推薦順位 |
 | position | 表示位置 |
 | historyTheme | 履歴テーマ |
-| actionSuggestionId | 行動提案ID |
-| actionCategory | 行動カテゴリ |
-| actionTheme | 行動テーマ |
-| actionPosition | 表示順 |
+| actionSuggestionVersion | Action Suggestionのバージョン |
+| primaryActionType | primary行動の種別 |
+| secondaryActionType | secondary行動の種別 |
+| actionPromptType | 振り返り観点の種別 |
+| actionSource | 行動提案の根拠 |
+| sourceKeys | 行動提案の根拠キー |
+| summaryLine | 要約文 |
+
+### action_suggestion_reflection_preview_view Payload
+
+上記のPayloadに加えて、以下を送信する。
+
+| 項目 | 内容 |
+|---|---|
+| reflectionPromptSourceSeed | 振り返り観点生成の元になった手掛かり |
 
 ---
 
-## PostHogで見るファネル
+## Mobile
 
-### 基本ファネル
+Mobileでは、Action Suggestionカードの表示を計測するEventは存在しない。
 
-action_suggestion_view
-↓
-action_suggestion_click
-↓
-action_done
+Primary / Secondary行動をタップした場合、着手・完了に相当する記録がBackendへ送信される。これはPostHog Eventではなく、Backend側に永続化される記録である。
 
-確認したい指標:
-
-- View → Click CVR
-- Click → Done CVR
-- View → Done CVR
+正確な送信内容、永続化条件および実装状況は、関連するMobile・Backend実装とテストを参照する。
 
 ---
 
-### テーマ別分析
+## Web / Mobileの計測範囲の違い
 
-比較対象:
+| 観点 | Web | Mobile |
+|---|---|---|
+| カード表示の計測 | あり（PostHog Event） | なし |
+| 行動の着手・完了の計測 | なし | あり（Backend永続化、PostHog Eventではない） |
 
-- historyTheme別
-- actionCategory別
-- actionSuggestionId別
-
-確認したいこと:
-
-- どのテーマが行動されやすいか
-- どのカテゴリが完了率高いか
+WebとMobileでは、計測の対象および方式（PostHog Event / Backend永続化）がともに異なる。同一の指標として比較しない。
 
 ---
 
-### 推薦順位分析
+## 責務外
 
-比較対象:
+本書では以下を管理しない。
 
-- recommendationRank
-
-確認したいこと:
-
-- 上位推薦ほど行動率が高いか
+- KPIの具体値、成功基準
+- Backend永続化の実装詳細
+- 実装コード、テストケース
 
 ---
 
-## 現状の制約
+## 関連ドキュメント
 
-### 1. action_done が永続化されない
-
-現在は PostHog のみ。
-
-そのため:
-
-- 行動履歴に残らない
-- パーソナライズに利用できない
-- 再訪時に状態が消える
+- `docs/analytics/README.md`
+- `docs/product/action_suggestion_v4.md`
+- `docs/product/visit-reflection-flow.md`
+- `docs/analytics/reflection-funnel-dashboard.md`
+- `docs/audit/cross-platform-event-contract.md`
 
 ---
 
-### 2. 実行日時が存在しない
+## 更新ルール
 
-現在取得しているのは:
-
-- ボタンを押した
-
-のみ。
-
-実際に行動したかは保証できない。
-
----
-
-### 3. 行動後体験が存在しない
-
-action_done 後に:
-
-- 振り返り
-- メモ
-- 継続記録
-
-などの導線がない。
-
----
-
-## 次の設計TODO
-
-- [ ] action_done 後のUI状態設計
-- [ ] action_done 永続化要否判断
-- [ ] reflection連携設計
-
----
-
-## 次PR候補
-
-### PR1
-
-action_done UI状態追加
-
-候補:
-
-- 完了済み表示
-- チェックマーク表示
-- ボタン無効化
-
----
-
-### PR2
-
-action_done 永続化
-
-候補:
-
-- ActionCompletion モデル
-- ユーザー紐付け
-- 実行日時保存
-
----
-
-### PR3
-
-行動履歴分析
-
-追加イベント候補:
-
-- action_reflection_view
-- action_reflection_saved
-- action_repeat
-
----
-
-### PR4
-
-Recommendation Score v2連携
-
-行動シグナルとして活用候補:
-
-- action_suggestion_click
-- action_done
-- reflection_saved
-
-行動実績を推薦ロジックへ反映する。
+- 本書はAction SuggestionのEvent名およびWeb側Payloadのみを管理する。
+- Event名が追加・変更・削除された場合は、実装確認のうえ本書を更新する。
+- KPIの具体値、成功基準およびBackend永続化の実装詳細は本書で重複管理しない。
+- Web / Mobileの計測範囲が変化した場合は、本書の記載を実態に合わせて更新する。
+- TODO、PR計画、実装進捗および作業履歴は本書へ記載しない。

--- a/docs/audit/cross-platform-event-contract.md
+++ b/docs/audit/cross-platform-event-contract.md
@@ -54,7 +54,7 @@ Current State以外(Issues以降)はすべて「事実」ではなく「提案�
 
 うち `card_view`/`card_cta_click`/`card_partial_view`/`card_teaser_view`/`save_prompt_view`/`save_prompt_click` は`cardEvents.ts`の`trackCardEvent()`経由(consultation/recommendation両ドメインに跨って`ConciergeSectionsRenderer.tsx`・`ConciergeClientFull.tsx`から多数呼び出し、約19箇所)。
 
-**未使用(dead)として確認された宣言済みイベント名**: `shrine_search` / `map_search` / `action_suggestion_view` / `action_suggestion_click` / `primary_action_click` / `secondary_action_click`(`searchEvents.ts`の型union上に存在するが呼び出し元0件)。
+**未使用(dead)として確認された宣言済みイベント名**: `shrine_search` / `map_search` / `action_suggestion_view` / `action_suggestion_click` / `action_started` / `action_completed` / `action_done` / `primary_action_click` / `secondary_action_click`(`searchEvents.ts`の型union上に存在するが呼び出し元0件)。うち`action_started`/`action_completed`はPostHog経路(`trackSearchEvent`)としては未使用だが、同名の`action_type`値がBackend `ActionEvent`モデル経由でMobile Conciergeから`POST /api/action-events/`へ送信・DB永続化されている、PostHogとは無関係の別系統として存在する(詳細: `docs/analytics/action-suggestion-funnel.md`)。
 
 ### recommendation
 
@@ -237,7 +237,7 @@ premiumドメインを軸にした、フィールド単位の対応表(事実)�
 | `shrine_detail_view`の二重記録 | Web: PostHogへの`track()`呼び出しと、Backend `shrine-interactions/`への`trackShrineInteraction()`POSTが同一クリックに対して両方発生(`ShrineDetailViewTracker.tsx:22,28`) |
 | `route_open`の二重記録 | 同様にPostHog `track()` + Backend `shrine-interactions/`への二重POST(`GoogleMapRouteLink.tsx:32,43`) |
 | `checkout_success`と`premium_active`の重複 | Webの`app/billing/success/page.tsx`内で、73行目と83行目が実質同一payload(checkoutSessionId/source/funnelStep/cardId/historyTheme)を持つ2つの別イベント名として発火している |
-| Web宣言済みだが未使用のイベント名(10件) | `shrine_search`, `map_search`, `action_suggestion_view`, `action_suggestion_click`, `primary_action_click`, `secondary_action_click`, `premium_preview_view`, `next_session`, `next_thread`, `comparison_preview` — 型定義上は存在するが呼び出し元0件 |
+| Web宣言済みだが未使用のイベント名(13件) | `shrine_search`, `map_search`, `action_suggestion_view`, `action_suggestion_click`, `action_started`, `action_completed`, `action_done`, `primary_action_click`, `secondary_action_click`, `premium_preview_view`, `next_session`, `next_thread`, `comparison_preview` — 型定義上は存在するが呼び出し元0件。うち`action_started`/`action_completed`はPostHog経路としては未使用(Backend `ActionEvent`モデルの`action_type`値としては使用中、Web側からの送信元は0件) |
 | 発火元不明の参照イベント名(3件) | `conciergeDecisionSummary.ts`が`concierge_return_after_detail`/`concierge_result_click`/`concierge_premium_click`を参照しているが、これらを発火するコードが見当たらない(集計ロジックが常にゼロを返している可能性) |
 
 ---

--- a/docs/audit/cross-platform-event-contract.md
+++ b/docs/audit/cross-platform-event-contract.md
@@ -45,8 +45,8 @@ Current State以外(Issues以降)はすべて「事実」ではなく「提案�
 | `consultation_completed` | `ConciergeClientFull.tsx:1198` | threadId, mode, flow, hasBirthdate, recommendationCount, historyTheme, consultationAxis?, source |
 | `filter_result` | `ConciergeClientFull.tsx:1211` | source, threadId, mode, recommendation_count(snake_case混在), is_zero_result, hasFilter |
 | `consultation_theme_click` | `ConciergeClientFull.tsx:1486` | label, text(相談テーマの定型文コピー), source |
-| `action_suggestion_preview_view` | `ConciergeTopRecommendationHero.tsx:120` | source, threadId, resultSetId, shrineId, recommendationRank, position, historyTheme, actionSuggestionVersion, primaryActionType, secondaryActionType, promptType, actionSource, sourceKeys, summaryLine |
-| `reflection_prompt_view`(concierge文脈) | `ConciergeTopRecommendationHero.tsx:121` | 上記 + reflectionPromptSourceSeed |
+| `action_suggestion_preview_view` | `ConciergeTopRecommendationHero.tsx:120` | source, threadId, resultSetId, shrineId, recommendationRank, position, historyTheme, actionSuggestionVersion, primaryActionType, secondaryActionType, actionPromptType, actionSource, sourceKeys, summaryLine |
+| `action_suggestion_reflection_preview_view` | `ConciergeTopRecommendationHero.tsx:123`（訂正: 初回監査時は`reflection_prompt_view`(concierge文脈)として誤記録していたが、実際のイベント名は別物） | 上記 + reflectionPromptSourceSeed |
 | `concierge_result_impression` | `ConciergeSectionsRenderer.tsx:358` | source, threadId, resultSetId, shrineId, position, recommendationRank, mode, historyTheme, consultationAxis? |
 | `shrine_detail_transition` | `ConciergeSectionsRenderer.tsx:847,983` | source, threadId, resultSetId, position, recommendationRank, shrineId, mode, flow, hasBirthdate, recommendationCount, historyTheme, consultationAxis?, firstClick |
 | `recommendation_quality` | `features/concierge/hooks.ts:140` | source, threadId, shrineId, recommendationRank, accessLevel, shrine_data_rate等snake_caseメトリクス群 |


### PR DESCRIPTION
## 変更概要

`docs/analytics/action-suggestion-funnel.md`を、現在のWeb・Mobile・Backend実装と一致するAnalytics正本文書へ更新した。旧文書の内容は推測が混じった企画メモに近く、実際に送信されているEvent名と一致していなかった。

## 確認した実装済みEvent・Property

Web・Mobile・Backendの実装コードとテストを直接確認した（本文には転記せず、正確なEvent名・Payloadは実装コードへ委譲）。

| Event | 実装状況 | 確認方法 |
|---|---|---|
| `action_suggestion_preview_view` | Web: 実装済み・テスト済み | `ConciergeTopRecommendationHero.tsx`のuseEffect内、同名のテストで送信payloadを検証済み |
| `action_suggestion_reflection_preview_view` | Web: 実装済み・テスト済み | 同上。ソースコード中のコメントで「実際のReflection入力UI表示ではないため専用Eventで計測する」意図が明記されている |
| `action_started` / `action_completed` | Mobile: 実装済み（Backend永続化、PostHog Eventではない）、Backend: テスト済み | Mobile Concierge画面のPrimary/Secondary行動タップ時に、Backend APIへ記録を送信する専用モジュールから確認。Web側にも同名の型・関数が定義されているが呼び出し箇所はゼロ（デッドコード） |
| `action_suggestion_view` | 未実装（デッドコード） | 型定義に存在するが呼び出し箇所ゼロ |
| `action_suggestion_click` | 未実装（デッドコード） | 呼び出し箇所ゼロ |
| `action_done` | 未実装（デッドコード） | 呼び出し箇所ゼロ |
| `primary_action_click` / `secondary_action_click` | 未実装（デッドコード） | 型定義に存在するが呼び出し箇所ゼロ |
| `action_suggestion_reflection_preview_click` | 未実装 | Web・Mobile全体で該当する文字列自体が存在しない |

## Payload・Property確認結果

Web側の2つのEventについて、実際に送信されているpayloadフィールドをソースコードから直接確認し、文書へ反映した。旧文書にあった`actionSuggestionId` / `actionCategory` / `actionTheme` / `actionPosition`はいずれもWebのPostHog Payloadには含まれておらず（`actionSuggestionId`・`actionCategory`はMobileのBackend永続化フローでのみ使用）、削除した。

## Web / Mobile差分

- Web: カード表示（プレビュー）のみPostHog Eventとして計測。Primary/Secondary行動のクリック・完了は現時点で計測なし
- Mobile: カード表示の計測はなし。Primary/Secondary行動のタップ時にBackendへ着手・完了を永続化する仕組みがあるが、これはPostHog Eventではない

両者は計測の対象・方式ともに異なるため、同一指標として比較しないことを文書に明記した。

## 変更ファイル一覧

- `docs/analytics/action-suggestion-funnel.md`（全面更新）
- `docs/analytics/README.md`（未登録だった本書をActiveへ追加）
- `docs/audit/cross-platform-event-contract.md`（誤記録の訂正、詳細は下記）

`docs/product/action_suggestion_v4.md`はすでに`docs/analytics/`配下への一般委譲のみで完結しており（Event名を保持していない）、Product文書側の変更は不要だった。

## cross-platform-event-contract.mdの訂正について

consultation domainの表で、`ConciergeTopRecommendationHero.tsx`の3つ目のtrackSearchEvent呼び出しが`reflection_prompt_view`(concierge文脈)として記録されていたが、実際のイベント名は`action_suggestion_reflection_preview_view`であることをソースコードで確認した。行番号も121ではなく123だった。該当行のみを訂正し、他の内容には触れていない。

## 制約の遵守

- Eventを創作していない（実装で確認できたもののみ記載し、旧文書にあった未実装Eventはすべて削除した）
- KPIを書き足していない（旧文書のFunnel/KPI/次PR候補セクションは全て削除し、責務外として明記した）
- Product文書は変更していない
- Backendコードは貼っていない（Mobileの永続化フローは仕組みの存在と概念のみを記述し、API・Model・Serializerの詳細は実装への参照に留めた）
- `docs/product/product-document-audit.md`は変更していない

## 実行した確認コマンド

```bash
# Web: 各Eventの呼び出し箇所を直接確認
grep -rn '"<event名>"' apps/web/src apps/mobile | grep -v "__tests__\|\.test\.\|searchEvents.ts"

# Backend永続化フローの存在確認（コード内容は読むが文書へは転記しない）
grep -rln "action-events\|action_events\|ActionEvent" backend/temples/

# コードブロックの閉じ確認
grep -c '```' docs/analytics/action-suggestion-funnel.md docs/analytics/README.md docs/audit/cross-platform-event-contract.md

# Markdown参照切れ確認
grep -oE '`docs/[a-zA-Z0-9_./-]+\.md`' docs/analytics/action-suggestion-funnel.md | tr -d '`' | while read -r p; do
  [ -f "$p" ] || echo "MISSING: $p"
done

# 削除対象イベントが再混入していないことの確認
grep -n "action_done\|action_suggestion_view\b\|action_suggestion_click\b\|primary_action_click\|secondary_action_click\|action_suggestion_reflection_preview_click" docs/analytics/action-suggestion-funnel.md

git diff --check
pnpm --filter ./apps/web test:contract
```

## テスト・Markdown確認結果

- `git diff --check`: エラーなし
- コードブロック: 全ファイル偶数個（`action-suggestion-funnel.md`は0個で正常）
- Markdown参照切れ: なし（全リンク先が実在）
- 削除対象イベントの再混入チェック: なし
- Web契約テスト: 80ファイル455件 全通過
- pre-push hookのOpenAPI lint・Web契約テスト: 全て通過