### PR TITLE
P0#25: SHOW_NEW_RENDERERハードコードを解消し新レンダラーへ一本化する

### DIFF
--- a/apps/web/src/app/concierge/ConciergeClientFull.tsx
+++ b/apps/web/src/app/concierge/ConciergeClientFull.tsx
@@ -21,7 +21,6 @@ import { buildDummySections } from "@/features/concierge/sections/dummy";
 import ConciergeSectionsRenderer from "@/features/concierge/components/ConciergeSectionsRenderer";
 import ConciergeEntryCard from "@/features/concierge/components/ConciergeEntryCard";
 import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
-import { SHOW_NEW_RENDERER } from "@/features/concierge/rendererMode";
 
 import type { RendererAction, ConciergeSectionsPayload } from "@/features/concierge/sections/types";
 import { getGoriyakuTags } from "@/lib/api/tags";
@@ -1804,7 +1803,7 @@ export default function ConciergeClientFull() {
                 </div>
               ) : null}
 
-              {SHOW_NEW_RENDERER && isFilterOpen ? (
+              {isFilterOpen ? (
                 <div className="mt-3">
                   <ConciergeSectionsRenderer
                     payload={payload}
@@ -1882,67 +1881,59 @@ export default function ConciergeClientFull() {
 
       {/* ===== 通常（tidあり） ===== */}
       {hydrated && shouldShowThreadRenderer ? (
-        SHOW_NEW_RENDERER ? (
-          <div className="p-4 space-y-5">
-            {isFiltering ? (
-              <div className="rounded-3xl border border-emerald-100 bg-emerald-50/70 px-5 py-4 text-sm text-emerald-900">
-                <p className="font-semibold">条件に合わせて再提案しています</p>
-                <p className="mt-1 text-xs leading-6 text-slate-600">
-                  候補を絞り直しているため、少しだけお待ちください。
-                </p>
-              </div>
-            ) : null}
-            <ConciergeSectionsRenderer
-              payload={payload}
-              analyticsContext={modeAnalyticsPayload}
-              onAction={onRendererAction}
-              sending={sending || isFiltering}
-              threadId={thread?.id ?? activeThreadId}
-              isEntryRoute={isEntryRoute}
-              isPremiumActive={isPremiumActive}
-            />
-
-            {isLoggedIn && stateDelta && previousComparisonVisibility !== "hidden" ? (
-              <PremiumStateDeltaCard stateDelta={stateDelta} isPremium={isPremiumActive} />
-            ) : null}
-
-            <ConciergeDebugPanel unified={displayUnified} />
-
-            {!isBusy && isUiPaywall ? (
-              <div className="rounded-3xl border border-stone-200/50 bg-stone-50/70 px-5 py-4 text-sm text-stone-700">
-                <p className="font-medium text-stone-800">無料回数を使い切りました。</p>
-                <p className="mt-1 text-xs leading-6 text-stone-500">
-                  {isLoggedIn
-                    ? "続けるには有料プランへの切り替えが必要です。"
-                    : "続けるにはログイン、または有料プランへの切り替えが必要です。"}
-                </p>
-                <div className="mt-3 flex flex-col gap-2 sm:flex-row">
-                  {!isLoggedIn ? (
-                    <button
-                      type="button"
-                      className="w-full rounded-full border border-stone-200/70 bg-white/85 px-4 py-2 text-sm font-medium text-stone-700 sm:w-auto"
-                      onClick={() => redirectToAuth("login")}
-                    >
-                      ログイン
-                    </button>
-                  ) : null}
-                  <Link
-                    href="/billing/upgrade"
-                    className="w-full rounded-full border border-emerald-200/70 bg-emerald-50/90 px-4 py-2 text-center text-sm font-medium text-emerald-900 sm:w-auto"
-                  >
-                    有料プランを見る
-                  </Link>
-                </div>
-              </div>
-            ) : null}
-          </div>
-        ) : (
-          <div className="p-4">
-            <div className={`${conciergeCardClass} text-sm text-slate-600`}>
-              SHOW_NEW_RENDERER が false です（この画面は新レンダラー前提）
+        <div className="p-4 space-y-5">
+          {isFiltering ? (
+            <div className="rounded-3xl border border-emerald-100 bg-emerald-50/70 px-5 py-4 text-sm text-emerald-900">
+              <p className="font-semibold">条件に合わせて再提案しています</p>
+              <p className="mt-1 text-xs leading-6 text-slate-600">
+                候補を絞り直しているため、少しだけお待ちください。
+              </p>
             </div>
-          </div>
-        )
+          ) : null}
+          <ConciergeSectionsRenderer
+            payload={payload}
+            analyticsContext={modeAnalyticsPayload}
+            onAction={onRendererAction}
+            sending={sending || isFiltering}
+            threadId={thread?.id ?? activeThreadId}
+            isEntryRoute={isEntryRoute}
+            isPremiumActive={isPremiumActive}
+          />
+
+          {isLoggedIn && stateDelta && previousComparisonVisibility !== "hidden" ? (
+            <PremiumStateDeltaCard stateDelta={stateDelta} isPremium={isPremiumActive} />
+          ) : null}
+
+          <ConciergeDebugPanel unified={displayUnified} />
+
+          {!isBusy && isUiPaywall ? (
+            <div className="rounded-3xl border border-stone-200/50 bg-stone-50/70 px-5 py-4 text-sm text-stone-700">
+              <p className="font-medium text-stone-800">無料回数を使い切りました。</p>
+              <p className="mt-1 text-xs leading-6 text-stone-500">
+                {isLoggedIn
+                  ? "続けるには有料プランへの切り替えが必要です。"
+                  : "続けるにはログイン、または有料プランへの切り替えが必要です。"}
+              </p>
+              <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                {!isLoggedIn ? (
+                  <button
+                    type="button"
+                    className="w-full rounded-full border border-stone-200/70 bg-white/85 px-4 py-2 text-sm font-medium text-stone-700 sm:w-auto"
+                    onClick={() => redirectToAuth("login")}
+                  >
+                    ログイン
+                  </button>
+                ) : null}
+                <Link
+                  href="/billing/upgrade"
+                  className="w-full rounded-full border border-emerald-200/70 bg-emerald-50/90 px-4 py-2 text-center text-sm font-medium text-emerald-900 sm:w-auto"
+                >
+                  有料プランを見る
+                </Link>
+              </div>
+            </div>
+          ) : null}
+        </div>
       ) : null}
     </ConciergeLayout>
   );

--- a/apps/web/src/features/concierge/rendererMode.ts
+++ b/apps/web/src/features/concierge/rendererMode.ts
@@ -1,7 +1,0 @@
-// concierge/rendererMode.ts
-
-// プレゼン用の一時対応: Vercel環境変数の反映に依存せず新レンダラーを有効化する。
-// デモ完了後、NEXT_PUBLIC_CONCIERGE_RENDERER 制御へ戻す。
-export const CONCIERGE_RENDERER = "new";
-
-export const SHOW_NEW_RENDERER = true;

--- a/docs/audit/legacy-settings-final-audit.md
+++ b/docs/audit/legacy-settings-final-audit.md
@@ -161,7 +161,7 @@ KAMI MUSUBIの現行リポジトリ（Backend / `apps/web` / `apps/mobile` / `.g
 
 | 設定名 | 定義場所 | 参照場所 | 現行用途 | 分類 | 削除リスク | 必要な後続確認 | 推奨する後続PR |
 |---|---|---|---|---|---|---|---|
-| `NEXT_PUBLIC_CONCIERGE_RENDERER` / `SHOW_NEW_RENDERER` | `apps/web/src/features/concierge/rendererMode.ts` | `ConciergeClientFull.tsx`3箇所が`SHOW_NEW_RENDERER`（ハードコードされた`true`）を参照。環境変数`NEXT_PUBLIC_CONCIERGE_RENDERER`自体はコード内コメントに残るのみで、実際の分岐には使われていない | コメントに「プレゼン用の一時対応」「デモ完了後、環境変数制御へ戻す」と明記されているが、戻されていない | Deprecated | 中（環境変数制御に戻す場合、両方のレンダラーが現在も動作することを確認する必要がある） | デモが完了しているか、旧レンダラー（環境変数がfalse相当の場合の分岐）が今も必要か確認する | 環境変数制御へ戻すか、新レンダラーへの完全移行を確定して旧分岐を削除するか、いずれかを判断するPR |
+| ~~`NEXT_PUBLIC_CONCIERGE_RENDERER` / `SHOW_NEW_RENDERER`~~ | ~~`apps/web/src/features/concierge/rendererMode.ts`~~ | ~~`ConciergeClientFull.tsx`3箇所が`SHOW_NEW_RENDERER`（ハードコードされた`true`）を参照。環境変数`NEXT_PUBLIC_CONCIERGE_RENDERER`自体はコード内コメントに残るのみで、実際の分岐には使われていない~~ | ~~コメントに「プレゼン用の一時対応」「デモ完了後、環境変数制御へ戻す」と明記されているが、戻されていない~~ | Deprecated → **対応済み（削除）** | — | 調査の結果、旧レンダラー（環境変数がfalse相当の場合の分岐）の実体`ConciergeSections`は、本ハードコード導入より前のコミット`7b185e9e`（PR #847）で既に削除され、false分岐は「新レンダラー前提」というstubメッセージ、または何も表示しない空白に置き換わっていた。環境変数制御に戻しても機能する旧実装は存在しないため、母艦の判断を仰いだ上で新レンダラーへ一本化し、Flag自体（`rendererMode.ts`・`SHOW_NEW_RENDERER`・`CONCIERGE_RENDERER`）を削除した | 対応済み |
 | 互換ルート`src/app/api/shrines/[id]/route.ts`（単体GET） | `src/app/api/shrines/[id]/route.ts:1`。コメント「TODO: 互換ルート。2026-04-01 までにアクセス0なら削除」 | `apps/web`内のクライアントコードからの参照0件。期限（2026-04-01）を本監査時点（2026-07-18）で3.5ヶ月超過 | 期限切れの削除保留TODO | Deprecated | 低〜中（本番アクセスログでの実測は本監査の範囲外） | 本番アクセスログで実際のアクセス数を確認する | アクセス0を確認できたら削除するPR |
 
 ### 6.4 未使用コード（Dead）
@@ -272,7 +272,7 @@ KAMI MUSUBIの現行リポジトリ（Backend / `apps/web` / `apps/mobile` / `.g
 5. `ConciergeThread.recommendations`（v1）読み取りfallbackの削除（旧データ移行完了が前提）
 6. `apps/web`のBackendオリジンURL環境変数命名（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`の5系統併存）の1本化。影響範囲が広いため設計を先に固める
 7. `apps/web`の`src/app/api/shrines/[id]/route.ts`互換ルート削除（削除期限2026-04-01を既に超過。本番アクセスログでアクセス0を確認後）
-8. `apps/web`の`SHOW_NEW_RENDERER`ハードコード解消（デモ用の一時対応が環境変数制御へ戻されていない。`rendererMode.ts`）
+8. ~~`apps/web`の`SHOW_NEW_RENDERER`ハードコード解消（デモ用の一時対応が環境変数制御へ戻されていない。`rendererMode.ts`）~~ → 対応済み（新レンダラーへ一本化しFlagごと削除。詳細は6.3節参照）
 
 ### 追加調査が必要なもの
 

--- a/docs/audit/legacy-settings-remediation-plan.md
+++ b/docs/audit/legacy-settings-remediation-plan.md
@@ -60,7 +60,7 @@
 | 22 | `ConciergeThread.recommendations`（v1）読み取りfallbackの削除 | 互換移行 | P2 | 必要（本番DBの旧スレッド残存数） |
 | 23 | `apps/web`のBackendオリジンURL環境変数命名の1本化 | 設定統一 | P1 | 不要（ただし設計レビューは必須） |
 | 24 | `apps/web`の期限超過互換ルート（`/api/shrines/[id]`）の削除 | 削除 | **P0** | 必要（本番アクセスログ、削除実行の判断材料として） |
-| 25 | `apps/web`の`SHOW_NEW_RENDERER`ハードコード解消 | 命名修正 | **P0** | 不要 |
+| 25 | ~~`apps/web`の`SHOW_NEW_RENDERER`ハードコード解消~~ **対応済み** | 命名修正 | **P0** | 不要 |
 | 26 | ルート`.env.example`と`backend/.env.example`の統合要否判断 | 保留 | P3 | 不要（文書検索のみ） |
 | 27 | `apps/mobile`の未到達ルート6画面の実機導線確認 | 保留 | P2 | 必要（実機/シミュレータ操作） |
 | 28 | `NOMINATIM_BASE`/`NOMINATIM_EMAIL`未接続の設計意図確認 | 保留 | P3 | 必要（実装担当者への確認） |
@@ -205,22 +205,16 @@
 
 ### PR-E: 命名修正・Flag実態の是正
 
-**対象**: #15（`SCORE_V3_HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`リネーム、**対応済み**）、#25（`SHOW_NEW_RENDERER`ハードコード解消、未着手）
+**対象**: #15（`SCORE_V3_HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`リネーム、**対応済み**）、#25（`SHOW_NEW_RENDERER`ハードコード解消、**対応済み**）
 
 **#15の実施状況**: `backend/temples/services/concierge_chat_ranking.py`の`SCORE_V3_HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`を`HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`へリネームする別PRで対応済み。計算式・加算先は無変更。関連テスト（`test_score_v3_history_signal.py`）およびBackend全体テスト（745件）が通過することを確認済み。互換エイリアスは追加していない（非公開のPython定数で、参照元は定義ファイルとテストファイルの2箇所のみ、環境変数としての読み込みも無いため、旧名を残す実益がないと判断）。
 
-**変更範囲（#25、未実施）**:
-
-- `apps/web/src/features/concierge/rendererMode.ts`の`SHOW_NEW_RENDERER`ハードコードを解消し、`NEXT_PUBLIC_CONCIERGE_RENDERER`環境変数による制御へ戻す。ただし、旧レンダラー分岐（環境変数がfalse相当の場合）が現在も正しく動作するか事前に確認する。動作しない場合は、新レンダラーへの完全移行を確定した上でFlag自体を削除する（いずれの方針を採るかは母艦の判断を仰ぐ）
-
-**テスト（#25、未実施分）**:
-
-- `SHOW_NEW_RENDERER`解消PRでは、`NEXT_PUBLIC_CONCIERGE_RENDERER`を明示的に`true`/`false`双方に設定した状態で`ConciergeClientFull.tsx`のレンダリング結果を目視確認する（Web契約テストに両パターンのケースが無ければ追加する）
+**#25の実施状況**: 事前確認の結果、旧レンダラー分岐（環境変数がfalse相当の場合）は本ハードコード導入（`960dcb31`）より前のコミット`7b185e9e`（PR #847）で実体`ConciergeSections`が既に削除されており、false分岐は「新レンダラー前提」というstubメッセージ、または（`isFilterOpen`側の分岐では）何も表示しない空白になっていた。つまり環境変数制御へ単純に戻しても、ユーザーには壊れた表示しか出せない状態だった。この事実を踏まえ、別PRで新レンダラーへの完全移行を確定した上でFlag自体（`rendererMode.ts`・`SHOW_NEW_RENDERER`・`CONCIERGE_RENDERER`、および`ConciergeClientFull.tsx`側の3箇所の分岐）を削除して対応済み。Score/Recommendation/Analyticsのロジックには一切触れていない。`apps/web/.env.local`の`NEXT_PUBLIC_CONCIERGE_RENDERER`はgitignore対象のローカルファイルのため対象外。
 
 **Rollback条件**:
 
 - リネームPR（#15、対応済み）: マージ後にScore v3関連テストが失敗した場合はrevert（実施時点で745件全てパスを確認済み）
-- `SHOW_NEW_RENDERER`解消PRで、環境変数未設定時のデフォルト挙動が本番想定と異なる場合は即座にrevert（Concierge結果画面はコア体験のため、表示崩れは早急な巻き戻しが必要）
+- Flag削除PR（#25、対応済み）: マージ後にConcierge結果画面の表示崩れが確認された場合は`git revert`で即座に巻き戻す（Concierge結果画面はコア体験のため早急な対応が必要）
 
 **優先度に関する注記**: 両者ともP0だが、内容としては別領域（Backend計算ロジックの命名 / Web UIレンダリング制御）であり、依存関係が無いため同一PRにまとめる必要はない。実施順序は任意（レビューの都合で分割してもよい）。
 
@@ -301,9 +295,9 @@ Compatibility（互換目的で現役）に分類された項目について、�
 
 本監査・本計画では実施そのものを行わないが、着手する場合の目安順序を示す。
 
-1. **P0（#15, #24, #25）**: 誤解・期限超過リスクがあるため最優先。#24は事前にアクセスログ確認が必要。#15は対応済み
+1. **P0（#15, #24, #25）**: 誤解・期限超過リスクがあるため最優先。#24は事前にアクセスログ確認が必要。#15・#25は対応済み
 2. **P1のうち外部確認不要な削除（PR-A, PR-B, PR-C, PR-D）**: 参照0件を再確認した上で並行して進められる
-3. **PR-E（Feature Flag整理）**: P0の#15, #25を含むため、実質的に(1)と同時期
+3. **PR-E（Feature Flag整理）**: P0の#15, #25を含むため、実質的に(1)と同時期。両項目とも対応済み
 4. **外部環境確認（3節の8件）**: 上記と並行して進められる調査。確認が完了次第、該当するP2項目（#4, #18, #20, #22等）の実装PRへ進む
 5. **PR-F（環境変数統一の事前確認）**: 影響範囲が広いため、他の項目が落ち着いてから着手する
 6. **保留項目（9節）**: 随時、担当者の確認が取れ次第


### PR DESCRIPTION
## 目的

`docs/audit/legacy-settings-remediation-plan.md` のP0項目 #25（`apps/web`の`SHOW_NEW_RENDERER`ハードコード解消）に対応する実装改善PR。新機能追加・設計変更・仕様変更は行わない。

## 調査結果

`apps/web/src/features/concierge/rendererMode.ts`は以下のハードコードになっていた。

```ts
export const CONCIERGE_RENDERER = "new";
export const SHOW_NEW_RENDERER = true;
```

コメントには「プレゼン用の一時対応。デモ完了後、`NEXT_PUBLIC_CONCIERGE_RENDERER`制御へ戻す」とあったが、導入（`960dcb31`, 2026-05-09）から本監査時点（2026-07-18）まで約2.5ヶ月間、環境変数制御には戻されていなかった。

このハードコードを単純に元の環境変数駆動コード（`process.env.NEXT_PUBLIC_CONCIERGE_RENDERER ?? "old"`）へ復元する前に、旧レンダラー分岐（`SHOW_NEW_RENDERER`がfalseの場合）が現在も機能するかを事前確認した。

**判明した事実**: 旧レンダラーの実体`ConciergeSections`は、今回のハードコード導入よりさらに前のコミット`7b185e9e`（PR #847、マージ済み）で既に削除されており、false分岐は以下のいずれかに置き換わっていた。

- `ConciergeClientFull.tsx`のスレッド表示部分（旧1885行目付近）: 「SHOW_NEW_RENDERER が false です（この画面は新レンダラー前提）」というstubメッセージ
- フィルタ表示部分（旧1807行目付近）: 何も表示しない（`null`）

つまり、環境変数制御へ単純に復元しても、ユーザーには壊れたstubメッセージまたは空白しか表示できない状態だった。新レンダラーへの完全移行は実質的にPR #847の時点で既に確定していたが、Flag自体の削除という後始末だけが残っていた。

この状況は remediation plan 自身が明記していた分岐条件「動作しない場合は、新レンダラーへの完全移行を確定した上でFlag自体を削除する（いずれの方針を採るかは母艦の判断を仰ぐ）」に該当したため、AskUserQuestionで方針を確認し、「Flagを削除し新レンダラーへ一本化」を選択いただいた。

## 新旧設定名の対応

| 旧 | 新 |
|---|---|
| `CONCIERGE_RENDERER` / `SHOW_NEW_RENDERER`（`rendererMode.ts`） | 削除（コード自体を撤去） |
| `NEXT_PUBLIC_CONCIERGE_RENDERER`環境変数 | 未使用化（コード側の参照がゼロになったため、Vercel側に設定が残っていても効果を持たない） |

## 互換読み込みの要否と根拠

**不要と判断した**。理由は以下の通り。

- 対象は非公開の内部Flagであり、外部クライアント・外部APIとの契約ではない
- 旧レンダラー分岐は既に非機能（PR #847時点で実体が削除済み）のため、互換読み込みを用意しても復元できる挙動が存在しない
- `apps/web/.env.local`に`NEXT_PUBLIC_CONCIERGE_RENDERER=new`の記述が残っているが、このファイルはgitignore対象のローカル専用ファイルであり、リポジトリ管理外のため対象外とした

## 変更ファイル一覧

- `apps/web/src/features/concierge/rendererMode.ts` — 削除
- `apps/web/src/app/concierge/ConciergeClientFull.tsx` — `SHOW_NEW_RENDERER`のimportと3箇所の分岐（二重三項演算子・`&&`条件）を撤去し、常に新レンダラーのJSXのみを描画するよう簡素化。JSX自体の内容・propsは無変更
- `docs/audit/legacy-settings-final-audit.md` — 該当行に取り消し線と「対応済み（削除）」を追記（6.3節・後続PR候補リスト8番）
- `docs/audit/legacy-settings-remediation-plan.md` — #25の表・PR-E節・実施順序節を「対応済み」に更新

## 影響範囲

- Web (`apps/web`) の`/concierge`スレッド表示画面のみ。Backend・Mobile・Score・Recommendation・Meaning Translation・Analyticsのロジックには一切触れていない
- `SHOW_NEW_RENDERER`は導入以来ずっと`true`固定だったため、本PRによる実際のレンダリング結果の変化はない（常に真だった分岐の削除であり、挙動は保存される）

## 実行したテスト

- `npx tsc --noEmit`（`apps/web`）: エラーなし
- 関連ユニットテスト4ファイル（`conciergeToShrineList.test.ts`, `conciergeDecisionSummary.test.ts`, `ConciergeEntryCard.test.tsx`, `ConciergeTopRecommendationHero.test.tsx`）: 25件全てpass
- Web契約テストスイート全体（`pnpm --filter ./apps/web test:contract`）: 80ファイル / 455件全てpass
- ブラウザでの目視確認（`/concierge`エントリー画面 → 相談送信）: コンパイルエラー・`SHOW_NEW_RENDERER`関連の参照エラーなし。表示された「うまく取得できませんでした」はBackend未起動によるもので本変更とは無関係
- `git diff --check`: 問題なし
- `markdownlint-cli`: 新規MD060以外のエラーなし（リポジトリ全体の既知の未対応noiseのみ）
- `grep`によるリポジトリ全体の参照確認: `SHOW_NEW_RENDERER`/`CONCIERGE_RENDERER`/`rendererMode`の残存参照は監査文書内の「対応済み」注記のみ
- pre-push hook（OpenAPI lint + Web契約テスト455件）: 全て通過

## Rollback方法

`git revert`で本コミットを取り消せば、`rendererMode.ts`と3箇所の分岐が復元される。Concierge結果画面の表示崩れが確認された場合は即座にrevertする。

## 関連

- 監査元: [legacy-settings-final-audit.md](https://github.com/etsu33/jinja_app/blob/develop/docs/audit/legacy-settings-final-audit.md) (PR #2068)
- 実施計画: [legacy-settings-remediation-plan.md](https://github.com/etsu33/jinja_app/blob/develop/docs/audit/legacy-settings-remediation-plan.md) (PR #2069)
- P0命名整合の先行PR: #2070（マージ済み）
- P0互換ルート削除PR: #2071（別テーマのため本PRには含めず）

🤖 Generated with [Claude Code](https://claude.com/claude-code)