### PR TITLE
PlacesSearchResponseの未使用itemsフィールドを削除する

### DIFF
--- a/backend/temples/api/serializers/places.py
+++ b/backend/temples/api/serializers/places.py
@@ -15,9 +15,6 @@ class PlacesSearchResponse(serializers.Serializer):
     cached = serializers.BooleanField(required=False)
     provider = serializers.CharField(required=False)
 
-    # 互換が必要なら残す（不要なら消す）
-    items = PlaceItemSerializer(many=True, required=False)
-
 
 class TextSearchResponse(PlacesSearchResponse):
     pass


### PR DESCRIPTION
## 目的

`docs/audit/legacy-settings-remediation-plan.md` の候補#5（`PlacesSearchResponse.items`フィールドの削除）に対応する実装改善PR。監査文書自体は本PRでは更新しない（4つの実装PRがマージされた後の統合PRで対応）。

## `items`が未使用と判断した根拠

`backend/temples/api/serializers/places.py`の`PlacesSearchResponse.items`には「互換が必要なら残す（不要なら消す）」というコメントが付いており、開発者自身がこの時点で削除候補として認識していた。

```python
class PlacesSearchResponse(serializers.Serializer):
    results = PlaceItemSerializer(many=True, required=False)
    cached = serializers.BooleanField(required=False)
    provider = serializers.CharField(required=False)

    # 互換が必要なら残す（不要なら消す）
    items = PlaceItemSerializer(many=True, required=False)
```

## Backend・Web・Mobileで確認した範囲

- `PlacesSearchResponse` / `items` / `PlacesSearchResponse.items` / `response.items` / `data.items` / `["items"]` / `.items` / `results` / OpenAPI上のschema名を対象に、リポジトリ全域（`.git`/`.venv`/`node_modules`/`.next`/`__pycache__`/`*.pyc`除外）で検索した。
- **Backend実装**: `PlacesSearchResponse`/`TextSearchResponse`/`NearbySearchResponse`は`backend/temples/api/views/search.py`の`@extend_schema(responses={200: ...})`デコレータでのみ使用されており、これはOpenAPIドキュメント生成専用の宣言。実際のレスポンス構築（`search()`/`text_search()`/`nearby_search()`各ビュー関数）は`Response(data)`で`data`をそのまま返しており、`data`は`temples/services/google_places.py`・`temples/services/places.py`が組み立てる辞書。両サービスファイル内を検索した結果、`results`キーの設定箇所は多数あるが、`items`キーを設定する箇所は0件だった。
- **Web**: `apps/web/src/lib/api/places.ts`、`apps/web/src/app/api/places/nearby/route.ts`等のPlaces関連コードを確認したが、`.items`や`response.items`のような参照は無く、`apps/web/src/app/api/places/nearby/route.ts`はBackendレスポンスの`raw?.results`のみを読んでいる（`Array.isArray(raw?.results) ? raw.results : []`）。
- **Mobile**: `apps/mobile`配下にPlaces関連の実装自体が存在しなかった（`find`ではヒット0件）。
- 削除後に同じ検索を再実行し、監査文書内の記述以外に参照が無いことを確認済み。

## 現行レスポンスが`results`を正本としている根拠

Git履歴を確認したところ、`items`と`results`はどちらも初期実装コミット（`b2165f9e`, 2025-10-15, PR #186「Feat/favorites api」）から両方存在していたが、後続コミット（`32f57b6c`, 2026-02-21「Adjust places serializers/services for nearby response contract」）で`results`の型が実際のレスポンス構築コードに合わせて`PlaceItemSerializer(many=True)`へ調整され、`items`側には「互換が必要なら残す（不要なら消す）」というコメントが付与された。この時点で`results`が実装上の正本として扱われるようになり、`items`は宣言のみが残る状態になっていた。

## OpenAPI Schemaの変更内容

**変更なし**。理由は以下の通り。

- リポジトリで実際にCI（pre-push hook / `lint:openapi`）が検証しているのは`docs/openapi.yaml`のみであり、この文書は`PlacesSearchResponse`という名前のschemaを一切参照していない（手作業で維持されている高レベルAPI仕様であり、`items:`という記述はJSON Schemaの配列型キーワードとしての出現のみで、本フィールドとは無関係）。
- `openapi.json`（リポジトリルート）と`docs/openapi_generated.yaml`はdrf-spectacularによる自動生成ファイルとして存在するが、正式な生成コマンド（`python manage.py spectacular`）で現在のコードベースから再生成すると、本PRの変更とは無関係に**数千行規模の差分**（既存のパス欠落・順序差・version表記差など）が生じることを確認した。これは本PR以前から蓄積していた既存のドリフトであり、どのテスト・CIワークフローもこの2ファイルの鮮度を検証していないことも確認済み（`grep`で参照0件）。
- 「Schema差分が想定以上に広がった場合は、原因を調査し、対象外の差分を含めない」という制約に従い、この2ファイルは本PRの対象外として意図的に変更していない。
- 実際にCIで検証される`test_api_style.py::test_openapi_conventions`は、`/api/schema/`から**都度生成される**ライブスキーマに対して実行されるため、本フィールド削除は自動的に反映された状態でテストされている（後述）。

## 実行したテストと結果

1. Places Serializer関連テスト（`PlacesSearchResponse`を直接検証する専用テストは存在しないため、Places関連テスト全体で代替）: 28 passed
   - `test_places_find_lite.py` / `test_places_api.py` / `test_places_service_cache.py` / `test_places_view_inputs.py` / `test_places_pagetoken_retry.py` / `test_places_cache_and_throttle.py` / `services/test_places_sync.py` / `services/test_concierge_plan_places_budget.py` / `services/test_places_rank.py`
2. OpenAPI Schema契約テスト: `test_api_style.py::test_openapi_conventions` → 1 passed（`/api/schema/`から都度生成されるライブスキーマに対する検証。`items`削除後も違反なし）
3. API URL smoke test: `test_api_urls_smoke.py` → 1 passed
4. Backend Import test: `test_pkg_import_sweep.py` / `test_api_thin_modules_import.py` → 4 passed
5. `git diff --check` → 問題なし

## API Endpointや検索ロジックを変更していないこと

- 変更ファイルは`backend/temples/api/serializers/places.py`の1ファイルのみ（`git status --short`で確認済み）、差分はコメント1行+フィールド宣言2行の削除のみ
- Places検索ロジック、Places API Endpoint、`results`フィールド、Google Places API連携、Place Cache、Geocode、Route API、Web・Mobileの機能実装、Analytics Event/Payloadには一切触れていない

## 監査文書を意図的に変更していないこと

- `docs/audit/legacy-settings-final-audit.md`・`docs/audit/legacy-settings-remediation-plan.md`は本PRの対象外とし、意図的に変更していない
- 「対応済み」への更新は、P1候補#5を含む4つの実装PRがマージされた後の統合PRでまとめて行う

## 関連

- 監査元: [legacy-settings-final-audit.md](https://github.com/etsu33/jinja_app/blob/develop/docs/audit/legacy-settings-final-audit.md)（候補#5, PR #2068）
- 実施計画: [legacy-settings-remediation-plan.md](https://github.com/etsu33/jinja_app/blob/develop/docs/audit/legacy-settings-remediation-plan.md)（#5, PR #2069）
- 同系統の実装PR: #2075（`recommend_shrines()`削除、マージ済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)