### PR TITLE
Backendオリジン環境変数統一の監査・移行設計を記録する

### DIFF
--- a/docs/audit/backend-origin-env-migration-design.md
+++ b/docs/audit/backend-origin-env-migration-design.md
@@ -1,0 +1,227 @@
+> **Status: Reference**
+>
+> 本ドキュメントは、`docs/audit/legacy-settings-remediation-plan.md`候補#23（`apps/web`のBackendオリジンURL環境変数命名の1本化）に対応する監査・移行設計である。
+>
+> 本文書は監査と設計のみを目的とし、実装コード・環境変数のいずれも変更していない。実施は本文書のPhase 1〜4を前提に、母艦の承認を得た上で別PRで行う。
+
+# Backend Origin環境変数 移行設計
+
+## 目的
+
+`apps/web`がDjango Backendの接続先URLを解決する際に使用している環境変数名が複数系統に分裂している状態を監査し、統一後の名称・共通ヘルパーの責務・移行順序・Rollback条件を設計する。
+
+本監査は、`docs/audit/legacy-settings-remediation-plan.md`「7. 環境変数統一PRの事前確認項目確定」（PR-F）が定義した4つの事前確認項目に対応する。
+
+---
+
+## 1. Backendオリジン関連の環境変数名の全域検索結果
+
+`apps/web`全域（`.ts`/`.tsx`/`.env*`/`README.md`/`playwright.config.ts`/`vitest.config.ts`）と、`.github/workflows/`・`docs/`を対象に、Backendオリジン解決に関わる環境変数名を検索した。
+
+### 1.1 発見した環境変数名（7系統）
+
+監査時点（`docs/audit/legacy-settings-final-audit.md`§6.1）では5〜6系統として記録されていたが、本監査で再検索した結果、**`NEXT_PUBLIC_API_BASE_URL`（`_URL`サフィックス付き。既知の`NEXT_PUBLIC_API_BASE`とは別名）が追加で見つかり、合計7系統**であることを確認した。
+
+| # | 環境変数名 | 用途の実態 | 定義箇所（`.env`/`.env.local`） |
+|---:|---|---|---|
+| 1 | `DJANGO_ORIGIN` | Backendオリジン解決（サーバー側） | `apps/web/.env`に空文字列で存在（値未設定） |
+| 2 | `BACKEND_ORIGIN` | 同上 | `apps/web/.env`に空文字列で存在（値未設定） |
+| 3 | `DJANGO_API_BASE_URL` | 同上（別系統） | 定義箇所なし |
+| 4 | `BACKEND_URL` | 同上（別系統） | 定義箇所なし |
+| 5 | `BACKEND_BASE_URL` | 同上（別系統） | 定義箇所なし |
+| 6 | `NEXT_PUBLIC_API_BASE_URL` | 同上（別系統。クライアント公開prefixだがサーバー側でも読まれる） | 定義箇所なし（`playwright.config.ts`がE2E実行時にのみ動的設定） |
+| 7 | `NEXT_PUBLIC_API_BASE` | クライアント側APIベースURL（**Backendオリジンとは別concern**。Next.js自身の`/api/*`への相対パス解決用） | `apps/web/.env:2`に`http://127.0.0.1:8000/api`として設定済み |
+
+**#7（`NEXT_PUBLIC_API_BASE`）はBackendオリジン統一の対象外とする**。クライアント側コード（`src/lib/api.ts`・`src/lib/api/http.ts`）が使用し、デフォルト値`/api`（Next.js自身のBFF Routeへの相対パス）で正しく機能している。既存監査（`legacy-settings-final-audit.md`149行目）でも「Active」と分類済みで、Compatibility問題を抱えていない。
+
+### 1.2 apps/web内の環境変数サンプル・READMEの確認結果
+
+- `apps/web/.env.example`は**存在しない**（`ls`で確認、Git管理下にも無し）
+- ルート`.env.example`にもBackendオリジン関連の記載は無い
+- `apps/web/README.md`にBackendオリジン関連環境変数の説明は**一切無い**
+- `docs/infra/env_policy.md`は「`backend/.env.example`を正本とする」と明記しており、`apps/web`固有の環境変数一覧は本書のスコープ外と明言している（64行目「本書が扱わないもの：個別の環境変数一覧」）
+
+**結論**: `apps/web`のBackendオリジン関連環境変数は、テンプレート・ドキュメントいずれにも存在せず、開発者は実装コードのフォールバック順序を読むことでしか正しい設定方法を知る手段がない。
+
+---
+
+## 2. 各参照ファイルのフォールバック優先順位一覧
+
+Backendオリジンを解決している実装は、独立した4つの解決ロジックに分かれている。
+
+| ファイル | 関数/変数 | フォールバック優先順位 | 最終フォールバック | 呼び出し元 |
+|---|---|---|---|---|
+| `apps/web/src/lib/server/backend.ts` | `getDjangoOrigin()` | `DJANGO_ORIGIN` → `BACKEND_ORIGIN` | `http://127.0.0.1:8000` | `djFetch()`経由で**19ファイル**が使用（`apps/web/src/app/api/**`の大半のBFF Route） |
+| `apps/web/src/app/api/auth/login/route.ts` | 66行目（ログ出力専用） | `DJANGO_ORIGIN` → `BACKEND_ORIGIN` | `http://127.0.0.1:8000` | ログ出力のみ。実際のfetchは`djFetch()`（=`backend.ts`のロジック）に委譲しており、この行自体は挙動に影響しない重複コード |
+| `apps/web/src/app/api/auth/register/route.ts` | `BACKEND_BASE_URL`（モジュール定数） | `DJANGO_API_BASE_URL` → `BACKEND_ORIGIN` → `BACKEND_BASE_URL` | `http://127.0.0.1:8000` | このファイル単体。`djFetch()`を使わず`fetch()`を直接呼んでおり、Cookie/Authorization転送ロジックを経由しない |
+| `apps/web/src/lib/api/shrines.server.ts` | `resolveBackendPublicBaseUrl()` | `DJANGO_API_BASE_URL` → `BACKEND_URL` → `NEXT_PUBLIC_API_BASE_URL` | 全て未設定なら`resolveServerBaseUrl()`（**Web自身のorigin**。Backendオリジンとは別concern）にフォールバック | `getShrinePublicServer()` |
+| `apps/web/src/lib/api/shrineMeaning.server.ts` | `resolveBackendPublicBaseUrl()`（`shrines.server.ts`と同一ロジックが重複定義） | 同上 | 同上 | `fetchShrineMeaningPayloadV2Server()` |
+
+### 2.1 重要な発見: `resolveServerBaseUrl()`への隠れた依存
+
+`shrines.server.ts`・`shrineMeaning.server.ts`は、Backendオリジン関連の3環境変数が全て未設定の場合、`apps/web/src/lib/server/resolveServerBaseUrl.ts`の`resolveServerBaseUrl()`を最終フォールバックとして呼び出している。この関数は**Web（Next.js）自身のoriginを解決する関数**であり、Backend（Django）のoriginとは全く別の責務を持つ（`WEB_BASE_URL`/`PLAYWRIGHT_BASE_URL`/リクエストの`host`ヘッダ/Vercelの`VERCEL_URL`系変数を参照）。
+
+`playwright.config.ts`はE2E実行時に`NEXT_PUBLIC_API_BASE_URL`をWebサーバー自身のURL（`baseURL`）に設定しており（コメント「E2E は Next(3000)で自己完結」）、これは意図的な設計（E2E時はNext.jsの`/api/public/shrines/...`が自己完結的にBackend役を代行する）である。しかし、本番環境で万が一`NEXT_PUBLIC_API_BASE_URL`が未設定かつ`DJANGO_API_BASE_URL`/`BACKEND_URL`も未設定だった場合、`resolveServerBaseUrl()`が呼ばれ、**「BackendオリジンのつもりでWeb自身のURLを返す」**という意図しない状態になり得る。これは本番運用リスクとして扱うべき発見であり、統一設計で解消する。
+
+### 2.2 テストファイルにおける無効な環境変数設定
+
+`apps/web/src/app/api/public/goshuins/route.test.ts`・`apps/web/src/app/api/public/goshuins/feed/route.test.ts`は、テスト内で`process.env.DJANGO_API_BASE_URL`を設定しているが、対象の`route.ts`は`djFetch()`（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`のみを参照）を使用しており、この環境変数設定はテストの実際の挙動に影響しない無効な記述である。テストファイル自体の修正は本監査の対象外（実装コード変更禁止）とする。
+
+---
+
+## 3. 既存アーキテクチャ文書との整合性確認
+
+`docs/core/authentication-flow.md`「禁止事項」（267〜276行目）は以下を明記している。
+
+> - Frontend Route内でBackend URLを直接組み立てる
+> - Frontend ComponentからBackend Originを直接呼び出す
+> - 認証付きRouteで`NEXT_PUBLIC_API_BASE`や`API_BASE_URL`を直接参照する
+
+この既存の禁止事項は、本監査が発見した状況の一部（`register/route.ts`・`shrines.server.ts`・`shrineMeaning.server.ts`が`process.env`を直接参照し、独自のフォールバック連鎖を組み立てている状態）と整合しない。特に`shrines.server.ts`/`shrineMeaning.server.ts`が`NEXT_PUBLIC_API_BASE_URL`（クライアント公開prefixを持つ変数）をサーバー側フォールバックとして参照している点は、「認証付きRouteで`NEXT_PUBLIC_API_BASE`や`API_BASE_URL`を直接参照する」という禁止事項の趣旨（クライアント公開設定をサーバー側の権威ある設定源として使わない）に抵触する可能性がある。
+
+この既存文書は、共通ヘルパー経由での一本化が本来の設計方針であったことを裏付ける根拠として扱う。
+
+---
+
+## 4. Vercel確認が必要な項目（分離）
+
+以下は本監査の範囲では確認できず、Vercel管理画面（Production/Preview環境変数設定）へのアクセスを持つ担当者による確認が必要。
+
+| # | 確認項目 | 確認目的 |
+|---:|---|---|
+| 1 | Production環境で`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`/`NEXT_PUBLIC_API_BASE_URL`のうちどれが実際に設定されているか、およびその値 | 現在本番でどの名称が実効しているかを特定する。統一後の値を決める根拠になる |
+| 2 | Preview環境で同上 | Production/Previewで設定が食い違っていないか確認する |
+| 3 | Production/Previewで`NEXT_PUBLIC_API_BASE`の実際の値 | クライアント側設定が意図通り`/api`相対パスのままか、誤って絶対URLが設定されていないか確認する |
+| 4 | CI（GitHub Actions）でE2E（Playwright）が実行される設定になっているか | `.github/workflows/`を検索した限りE2E実行ジョブは見つからなかったが、Vercel側のプレビューデプロイ後フックなどで別途実行されていないか確認する |
+
+本監査ではVercelダッシュボードへの参照を行っておらず（ローカル`apps/web/.env`/`.env.local`はGit管理外・開発者個人設定のため参考情報に留める）、上記4項目は実装着手前に別途確認が必要な外部確認事項として分離する。
+
+参考情報として、ローカル開発環境（Git管理外の`apps/web/.env`）では`NEXT_PUBLIC_API_BASE=http://127.0.0.1:8000/api`のみが値を持ち、`DJANGO_ORIGIN`/`BACKEND_ORIGIN`は空文字列（未設定同然）だった。これは1開発者のローカル設定であり、Production/Previewの実態を代表しない。
+
+---
+
+## 5. 統一後の正式な環境変数名候補
+
+### 5.1 候補の比較
+
+| 候補 | 根拠 | 懸念 |
+|---|---|---|
+| `BACKEND_ORIGIN`（推奨） | 現行の最優先解決パス（`getDjangoOrigin()`）で第2優先。`docs/core/architecture.md`・`authentication-flow.md`が一貫して「Backend」という役割名を使用しており、実装フレームワーク名（Django）に依存しない。将来Backendの実装が変わっても名称変更が不要 | 移行期間中は`DJANGO_ORIGIN`が最優先のままのため、優先順位の入れ替えが必要 |
+| `DJANGO_ORIGIN` | 現行の最優先解決パスで第1優先。変更コストが最小 | フレームワーク名に依存した命名であり、将来性に欠ける。既存文書（`architecture.md`等）が一貫して「Backend」を使っているため、他の用語と不整合 |
+
+**結論**: `BACKEND_ORIGIN`を統一後の正式名称として採用する。既存の`legacy-settings-remediation-plan.md`「3. PR-F事前確認項目」3番目の項目が挙げていた候補（「例: `BACKEND_ORIGIN`への一本化」）とも一致する。
+
+### 5.2 統一後に廃止する名称（移行完了後）
+
+`DJANGO_ORIGIN`、`DJANGO_API_BASE_URL`、`BACKEND_URL`、`BACKEND_BASE_URL`、`NEXT_PUBLIC_API_BASE_URL`の5つ。
+
+`NEXT_PUBLIC_API_BASE`（プレフィックスなし版）は統一対象外（クライアント側の別concern、変更しない）。
+
+---
+
+## 6. 共通Backendオリジン解決ヘルパーの責務設計
+
+### 6.1 配置
+
+既存の`apps/web/src/lib/server/backend.ts`の`getDjangoOrigin()`を拡張する形で統一する。新規ファイルは作らず、既存の最多利用箇所（19ファイルが`djFetch`経由で依存）を土台とする。
+
+`legacy-settings-remediation-plan.md`が提案していた新規ファイル`src/lib/server/resolveBackendOrigin.ts`は、既存の`backend.ts`と責務が重複するため採用しない。既存ファイル内の関数名を将来的に`resolveBackendOrigin()`へリネームするかは、影響範囲（19ファイル全ての`import`更新）を考慮し、名称統一の効果に対して変更コストが見合うかを実装フェーズで判断する。
+
+### 6.2 責務範囲（このヘルパーが担うもの）
+
+- Django Backendの origin（プロトコル＋ホスト、末尾スラッシュなし）を1箇所で解決する
+- 移行期間中は新旧環境変数名を優先順位付きで読み、非推奨名が使われた場合はログへ記録する（後述6.4）
+- ローカル開発時の安全なデフォルト値（`http://127.0.0.1:8000`）を提供する
+
+### 6.3 責務範囲外（このヘルパーが担わないもの）
+
+- Web自身のoriginの解決（`resolveServerBaseUrl()`の責務のまま。統合しない。目的が異なるため誤って一本化すると6.1節の隠れた依存問題を悪化させる）
+- クライアント側APIベースパスの解決（`NEXT_PUBLIC_API_BASE`のまま。`api.ts`/`http.ts`は変更しない）
+- 認証ヘッダ・Cookieの転送（`djFetch()`の既存責務のまま）
+- Authorizationやcredentialsの付与判断
+
+### 6.4 移行期間中のフォールバック優先順位（設計案）
+
+```text
+1. BACKEND_ORIGIN        （新名・最優先）
+2. DJANGO_ORIGIN         （旧名・現行最優先。非推奨警告をconsole.warnへ出力）
+3. DJANGO_API_BASE_URL   （旧名・register/shrines系。非推奨警告）
+4. BACKEND_URL           （旧名・shrines系。非推奨警告）
+5. BACKEND_BASE_URL      （旧名・register系。非推奨警告）
+6. NEXT_PUBLIC_API_BASE_URL（旧名・shrines系。非推奨警告。※NEXT_PUBLIC_API_BASEとは別物）
+7. http://127.0.0.1:8000 （最終フォールバック、ローカル開発用）
+```
+
+`NEXT_PUBLIC_API_BASE_URL`のみ、E2E実行時にWeb自身のURLを意図的に指す特殊ケース（2.1節参照）があるため、統一後もこの用途を壊さないよう、E2E実行時の設定方法自体を`playwright.config.ts`側で`BACKEND_ORIGIN`直接指定に置き換える設計とする（実装フェーズの変更範囲に含む）。
+
+非推奨名が実際に使われて解決した場合は、`console.warn("[BACKEND_ORIGIN_DEPRECATED] <name> was used to resolve backend origin. Set BACKEND_ORIGIN instead.")`のような形で記録し、Vercel Runtime Logsから移行完了状況を追跡できるようにする（Vercel Hobbyプランはログ保持期間が1時間のため、移行期間中はこまめな確認が必要になる点に留意する）。
+
+---
+
+## 7. 新旧環境変数の移行順序（Phase設計）
+
+### Phase 0（本監査・本設計。完了）
+
+- 環境変数名の全域検索、フォールバック優先順位の一覧化、Vercel確認項目の分離、統一後の名称候補整理、共通ヘルパーの責務設計、移行順序設計、Rollback条件の定義
+- 実装コード・環境変数のいずれも変更しない
+
+### Phase 1（Vercel環境変数の追加。外部確認完了後、コード変更なし）
+
+- 4節の確認結果を踏まえ、Production/Preview両方に`BACKEND_ORIGIN`を追加する（既存の実効値と同じ値を設定する）
+- 既存の`DJANGO_ORIGIN`等はこの時点では削除しない（並行稼働）
+- コード変更は行わない。この時点では新環境変数は誰にも参照されていない
+
+### Phase 2（共通ヘルパーへの集約。コード変更・後方互換維持）
+
+- `backend.ts`の`getDjangoOrigin()`を6.4節のフォールバック優先順位へ拡張する
+- `register/route.ts`・`shrines.server.ts`・`shrineMeaning.server.ts`・`login/route.ts`のログ行を、共通ヘルパー呼び出しへ置き換える
+- `register/route.ts`が`fetch()`を直接呼んでいる点は、Cookie/Authorization転送が元々不要な処理（新規登録は未認証状態で呼ばれるため）であることを確認した上で、`djFetch()`への置き換えは本移行の必須要件とはしない（別途判断）
+- `playwright.config.ts`のE2E設定を`NEXT_PUBLIC_API_BASE_URL`から`BACKEND_ORIGIN`への直接指定へ変更する
+- 全ての既存フォールバック名は維持するため、この時点でVercel側の設定変更は不要（Phase 1の追加のみで動作する）
+- Web Typecheck・Lint・契約テスト全件・E2E（可能な範囲）で回帰が無いことを確認する
+
+### Phase 3（非推奨環境変数の解消状況モニタリング）
+
+- Phase 2デプロイ後、Vercel Runtime Logsで`BACKEND_ORIGIN_DEPRECATED`警告の有無を確認する（Hobbyプランのログ保持制約を踏まえ、複数回・時間を空けて確認する）
+- 警告が一定期間出ていないことを確認できたら、Vercel側の旧環境変数（`DJANGO_ORIGIN`等）を削除してよいと判断する
+
+### Phase 4（旧名の削除・文書整備）
+
+- Vercel Production/PreviewからPhase 3で安全と判断した旧環境変数を削除する
+- 共通ヘルパーから旧名フォールバックとdeprecated警告ロジックを削除し、`BACKEND_ORIGIN`のみを参照する形へ簡略化する
+- `apps/web/.env.example`を新規作成し、`BACKEND_ORIGIN`を含む実際に使用される環境変数を記載する
+- `docs/core/authentication-flow.md`の禁止事項、または新規に`apps/web`向けのenv文書を作成し、`BACKEND_ORIGIN`が正本であることを明記する
+
+---
+
+## 8. Rollback条件
+
+| Phase | Rollback条件 | Rollback方法 |
+|---|---|---|
+| Phase 1 | Vercel環境変数追加後、既存デプロイに影響が出た場合（通常は影響しないはずだが、Vercelの環境変数反映タイミングでビルドキャッシュ等に不整合が出た場合） | 追加した`BACKEND_ORIGIN`をVercelダッシュボードから削除する（コードは変更していないため即座に旧状態へ戻る） |
+| Phase 2 | デプロイ後、Backend疎通失敗（502・タイムアウト）がRuntime Logsで検出された場合。またはWeb契約テスト・E2Eが失敗した場合 | `git revert`でPhase 2のコミットを取り消す。Vercel側の`BACKEND_ORIGIN`はPhase 1で追加済みのまま残してよい（未参照になるだけで実害なし） |
+| Phase 3（モニタリングのみ） | 該当なし（コード・設定変更を伴わない） | — |
+| Phase 4 | 旧環境変数削除後、想定外の消費者（本監査で捕捉できなかった参照箇所、または外部連携）がBackend疎通に失敗した場合 | 削除した旧環境変数をVercelダッシュボードで即座に復元する（設定変更のみで復旧、コードデプロイ不要） |
+
+Phase 2・4のいずれも、コード変更を伴う場合は本番デプロイ後にRuntime Logsでのエラー監視を必須とし、異常検知後は上記の方法で速やかに`revert`する。
+
+---
+
+## 9. 品質確認
+
+- [x] Markdownコードブロックの閉じ確認（コードフェンス数は偶数）
+- [x] Markdownテーブルの列数確認
+- [x] `git diff --check`
+
+---
+
+## 10. 実装コード・環境変数への変更が無いこと
+
+本文書の作成にあたり、以下は一切変更していない。
+
+- `apps/web/src/lib/server/backend.ts`・`apps/web/src/app/api/auth/login/route.ts`・`apps/web/src/app/api/auth/register/route.ts`・`apps/web/src/lib/api/shrines.server.ts`・`apps/web/src/lib/api/shrineMeaning.server.ts`・`apps/web/src/lib/server/resolveServerBaseUrl.ts`・`apps/web/src/lib/api.ts`・`apps/web/src/lib/api/http.ts`・`apps/web/playwright.config.ts`
+- Vercel環境変数（Production/Preview）
+- ローカル`.env`/`.env.local`（Git管理外のため本文書の対象外）
+- `docs/core/authentication-flow.md`等の既存アーキテクチャ文書
+
+7節のPhase 1〜4は、本文書の承認後に別PRで着手する実施計画であり、本PRでは実施していない。

--- a/docs/audit/legacy-settings-final-audit.md
+++ b/docs/audit/legacy-settings-final-audit.md
@@ -144,8 +144,8 @@ KAMI MUSUBIの現行リポジトリ（Backend / `apps/web` / `apps/mobile` / `.g
 
 | 設定名 | 定義場所 | 参照場所 | 現行用途 | 分類 | 削除リスク | 必要な後続確認 | 推奨する後続PR |
 |---|---|---|---|---|---|---|---|
-| `DJANGO_ORIGIN` / `BACKEND_ORIGIN` | `apps/web/.env:21-22` | `src/lib/server/backend.ts:6`、`src/app/api/auth/login/route.ts:66`が論理OR演算子によるフォールバックで解決 | Backendオリジンの解決 | Compatibility（新旧2キー併存） | 中 | どちらが正式名か、コミット履歴で経緯を確認する | 1つの名前へ統一するPR |
-| `DJANGO_API_BASE_URL` / `BACKEND_URL` / `BACKEND_BASE_URL` | 定義箇所なし（`.env`/`.env.local`/`.env.example`いずれにも無し） | `src/lib/api/shrines.server.ts:13-15`、`shrineMeaning.server.ts:13-15`、`api/auth/register/route.ts:5-7`が独自の論理OR演算子によるフォールバック連鎖を持つ | 上記と別系統の、ファイルごとに異なるBackendオリジン解決ロジック | Uncertain（命名がさらに分岐しており実態把握が必要） | 中〜高（5系統の命名が並立しており、どれか1つを削除すると他のフォールバックに依存しているファイルが影響を受ける可能性） | `DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`/`NEXT_PUBLIC_API_BASE`の6命名を1箇所（例: `src/lib/server/backend.ts`）に集約できるか設計を検討する | Backendオリジン解決ロジックを共通ヘルパーへ集約し、環境変数名を1つに統一するPR（影響範囲が広いため慎重な設計が必要） |
+| `DJANGO_ORIGIN` / `BACKEND_ORIGIN` | `apps/web/.env:21-22` | `src/lib/server/backend.ts:6`、`src/app/api/auth/login/route.ts:66`が論理OR演算子によるフォールバックで解決 | Backendオリジンの解決 | Compatibility（新旧2キー併存） → **監査・移行設計完了（未実施）** | 中 | どちらが正式名か、コミット履歴で経緯を確認する | 監査・移行設計を`docs/audit/backend-origin-env-migration-design.md`へ記録済み。統一後は`BACKEND_ORIGIN`を採用する設計とした。実際の移行（Vercel環境変数変更・コード変更）は別PR |
+| `DJANGO_API_BASE_URL` / `BACKEND_URL` / `BACKEND_BASE_URL` / `NEXT_PUBLIC_API_BASE_URL`（**監査により新たに`NEXT_PUBLIC_API_BASE_URL`を追加確認**） | 定義箇所なし（`.env`/`.env.local`/`.env.example`いずれにも無し。`NEXT_PUBLIC_API_BASE_URL`のみ`playwright.config.ts`がE2E実行時に動的設定） | `src/lib/api/shrines.server.ts:13-15`、`shrineMeaning.server.ts:13-15`、`api/auth/register/route.ts:5-7`が独自の論理OR演算子によるフォールバック連鎖を持つ。加えて`shrines.server.ts`/`shrineMeaning.server.ts`は全て未設定の場合`resolveServerBaseUrl()`（Web自身のorigin解決関数、Backendオリジンとは別concern）へフォールバックする隠れた依存を持つことを新たに確認した | 上記と別系統の、ファイルごとに異なるBackendオリジン解決ロジック | Uncertain（命名がさらに分岐しており実態把握が必要） → **監査・移行設計完了（未実施）** | 中〜高（5〜7系統の命名が並立しており、どれか1つを削除すると他のフォールバックに依存しているファイルが影響を受ける可能性） | `docs/audit/backend-origin-env-migration-design.md`で全7系統のフォールバック優先順位を一覧化済み。統一後は`BACKEND_ORIGIN`へ集約し、既存`backend.ts`の`getDjangoOrigin()`を拡張する設計とした | Backendオリジン解決ロジックを共通ヘルパーへ集約し、環境変数名を1つに統一するPR（影響範囲が広いためPhase 1〜4に分割する設計とした。詳細は移行設計文書を参照） |
 | `NEXT_PUBLIC_API_BASE` | `apps/web/.env:2` | `src/lib/api.ts:2`、`src/lib/api/http.ts:60` | クライアント側APIベースURL | Active | なし | なし | なし |
 
 ### 6.2 `apps/web/.env`内のDjangoバックエンド設定の混入
@@ -270,7 +270,7 @@ KAMI MUSUBIの現行リポジトリ（Backend / `apps/web` / `apps/mobile` / `.g
 3. `BillingStatusLegacyView`（単数形`billing/status/`）の削除（本番アクセスログ確認が前提）
 4. `temples/api/serializers/concierge.py`のCOMPAT LAYER解消（新モジュールへの統合完了が前提）
 5. `ConciergeThread.recommendations`（v1）読み取りfallbackの削除（旧データ移行完了が前提）
-6. `apps/web`のBackendオリジンURL環境変数命名（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`の5系統併存）の1本化。影響範囲が広いため設計を先に固める
+6. `apps/web`のBackendオリジンURL環境変数命名（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`/`NEXT_PUBLIC_API_BASE_URL`の7系統併存。監査により`NEXT_PUBLIC_API_BASE_URL`を追加確認）の1本化。**監査・移行設計は`docs/audit/backend-origin-env-migration-design.md`で完了**。実際の移行（Vercel環境変数変更・コード変更）はVercel確認完了後の別PRで実施
 7. `apps/web`の`src/app/api/shrines/[id]/route.ts`互換ルート削除（削除期限2026-04-01を既に超過。本番アクセスログでアクセス0を確認後）
 8. ~~`apps/web`の`SHOW_NEW_RENDERER`ハードコード解消（デモ用の一時対応が環境変数制御へ戻されていない。`rendererMode.ts`）~~ → 対応済み（新レンダラーへ一本化しFlagごと削除。詳細は6.3節参照）
 
@@ -378,3 +378,13 @@ KAMI MUSUBIの現行リポジトリ（Backend / `apps/web` / `apps/mobile` / `.g
 - `package.json`・lockfile・設定ファイルは変更していない
 
 以上により、候補#6は「対応済み」へ更新した。これにより、2026-07-18時点で残っていたP1未対応3件（#6, #10, #23）のうち#6が解消された。
+
+### 候補#23の監査・移行設計完了
+
+候補#6（PR #2081）までの完了により、P1のうち「削除フェーズ」の対象は全て解消された。残る候補#23（Backendオリジン環境変数命名統一）は、単純な未参照コード削除ではなく設計判断・外部環境確認を要するため、「削除フェーズ」とは別の「環境変数移行フェーズ」として扱う。
+
+`apps/web`のBackendオリジン関連環境変数を全域検索した結果、6.1節が記録していた5系統に加えて`NEXT_PUBLIC_API_BASE_URL`（`shrines.server.ts`/`shrineMeaning.server.ts`が参照。既知の`NEXT_PUBLIC_API_BASE`とは別名）が新たに見つかり、**合計7系統**であることを確認した。5ファイルのフォールバック優先順位を一覧化し、`shrines.server.ts`/`shrineMeaning.server.ts`が最終的にWeb自身のorigin解決関数（`resolveServerBaseUrl()`）へフォールバックする隠れた依存を新たに発見した。`apps/web/.env.example`が存在しないこと、`docs/core/authentication-flow.md`の既存禁止事項との不整合も確認した。
+
+統一後の名称候補として`BACKEND_ORIGIN`を選定し、既存の`backend.ts`の`getDjangoOrigin()`を拡張する共通ヘルパー設計、Phase 1〜4の移行順序、各Phaseに対応するRollback条件を設計した。詳細は`docs/audit/backend-origin-env-migration-design.md`を正本とする。
+
+実装コード・Vercel環境変数・既存アーキテクチャ文書はいずれも変更していない。候補#23は「対応済み」ではなく「監査・移行設計完了、実施は別トラック（Vercel確認完了後の別PR）」として記録する。

--- a/docs/audit/legacy-settings-remediation-plan.md
+++ b/docs/audit/legacy-settings-remediation-plan.md
@@ -45,7 +45,7 @@
 | 7 | ~~`apps/mobile`の`nativewind`/`tailwindcss`関連一式の削除~~ **対応済み**（PR #2078） | 削除 | P1 | 不要 |
 | 8 | Score v3の到達不能axisキー4件（28エントリ）の削除、またはエイリアス追加による復活 | 保留 | P2 | 必要（Product判断：4 axis正式導入の計画有無） |
 | 9 | ~~`BillingState`/`plan_from_profile()`の削除~~ **対応済み** | 削除 | P1 | 不要 |
-| 10 | `apps/web/src/lib/auth/token.ts`の削除 | 削除 | P1 | 不要（**未対応**。PR-Bグルーピングでは#2/#11/#12/#13/#14と同一PR対象として計画されていたが、実施されたPR #2077の範囲には含まれておらず、`develop`上に現存することを2026-07-18時点で確認済み） |
+| 10 | ~~`apps/web/src/lib/auth/token.ts`の削除~~ **対応済み**（PR #2080） | 削除 | P1 | 不要 |
 | 11 | ~~Web Analytics dead event（`premium_preview_view`/`next_session`/`next_thread`）の型定義削除~~ **対応済み**（PR #2077） | 削除 | P1 | 不要 |
 | 12 | ~~`RecommendationReasonViewModel.why`/`.interpretation`の削除~~ **対応済み**（PR #2077） | 削除 | P1 | 不要 |
 | 13 | ~~`useMyGoshuin.ts`・`MapCardListClient.tsx`の削除~~ **対応済み**（PR #2077） | 削除 | P1 | 不要 |
@@ -58,7 +58,7 @@
 | 20 | `BillingStatusLegacyView`（単数形`billing/status/`）の削除 | 削除 | P2 | 必要（本番アクセスログ） |
 | 21 | `temples/api/serializers/concierge.py`のCOMPAT LAYER解消 | 互換移行 | P3 | 不要（ロードマップ確認のみ） |
 | 22 | `ConciergeThread.recommendations`（v1）読み取りfallbackの削除 | 互換移行 | P2 | 必要（本番DBの旧スレッド残存数） |
-| 23 | `apps/web`のBackendオリジンURL環境変数命名の1本化 | 設定統一 | P1 | 不要（ただし設計レビューは必須） |
+| 23 | `apps/web`のBackendオリジンURL環境変数命名の1本化（**監査・移行設計は完了**。`docs/audit/backend-origin-env-migration-design.md`参照。実際の移行実施はVercel確認後の別PR） | 設定統一 | P1 | 不要（ただし設計レビューは必須） |
 | 24 | `apps/web`の期限超過互換ルート（`/api/shrines/[id]`）の削除 | 削除 | **P0** | 必要（本番アクセスログ、削除実行の判断材料として） |
 | 25 | ~~`apps/web`の`SHOW_NEW_RENDERER`ハードコード解消~~ **対応済み** | 命名修正 | **P0** | 不要 |
 | 26 | ルート`.env.example`と`backend/.env.example`の統合要否判断 | 保留 | P3 | 不要（文書検索のみ） |
@@ -134,7 +134,7 @@
 
 ### PR-B: Web Dead Code削除
 
-**対象**: #2（`legacy/`+`ConciergeSections.tsx`、**対応済み**）、#10（`src/lib/auth/token.ts`、**未対応**）、#11（Analytics dead event型定義、**対応済み**）、#12（`RecommendationReasonViewModel.why`/`.interpretation`、**対応済み**）、#13（`useMyGoshuin.ts`・`MapCardListClient.tsx`、**対応済み**）、#14（`@heroicons/react`、**対応済み**）
+**対象**: #2（`legacy/`+`ConciergeSections.tsx`、**対応済み**）、#10（`src/lib/auth/token.ts`、**対応済み**。ただしPR-Bグルーピング内ではなく単独PR #2080で実施）、#11（Analytics dead event型定義、**対応済み**）、#12（`RecommendationReasonViewModel.why`/`.interpretation`、**対応済み**）、#13（`useMyGoshuin.ts`・`MapCardListClient.tsx`、**対応済み**）、#14（`@heroicons/react`、**対応済み**）
 
 **変更範囲**:
 
@@ -159,7 +159,7 @@
 
 **実施状況（PR #2077）**: 上記対象のうち#2・#11・#12・#13・#14の5件を実施した。`concierge/components/legacy/`＋`ConciergeSections.tsx`を削除、`cardEvents.ts`の`premium_preview_view`と`retentionEvents.ts`の`next_session`/`next_thread`を型定義から削除、`buildRecommendationReasonViewModel.ts`から`.why`/`.interpretation`を削除（テストの`.why.*`アサーションは値が同一の`.list.*`/`.debug.reasonKeys.*`へ整合、snapshotも再生成）、`useMyGoshuin.ts`と専用テストを削除、`MapCardListClient.tsx`を削除、`package.json`から`@heroicons/react`を`pnpm remove`で削除した。Web Typecheck・Lintともにエラーなし、Web契約テスト446件pass、関連Unit Test 88件pass、`next build`成功を確認済み。
 
-**#10が未実施であることについて**: `src/lib/auth/token.ts`はPR #2077の変更ファイル一覧に含まれておらず、`develop`上に現存することを確認した（2026-07-18時点）。本PRグルーピングの計画時点では#2/#11/#12/#13/#14と同一PR対象として整理していたが、実際の実装PRのスコープには含まれなかった。改めて#10単独、または他のP1項目とまとめた削除PRを起票する必要がある。
+**#10の実施状況（PR #2080）**: `src/lib/auth/token.ts`はPR #2077の変更ファイル一覧に含まれておらず、`develop`上に現存することを2026-07-18時点で確認していた（計画時点では#2/#11/#12/#13/#14と同一PR対象として整理していたが、実際の実装PRのスコープには含まれなかった）。この漏れに対応するため、`token.ts`単独の削除PR（PR #2080）を起票した。import元・`ACCESS_KEY`/`REFRESH_KEY`/`tokens`各exportの参照元をリポジトリ全域で再検索し0件であることを確認、現行の認証はhttpOnly Cookie（`access_token`/`refresh_token`、`middleware.ts`と`login/route.ts`が使用）に一本化されていることを確認した上で`token.ts`を削除した。Web Typecheck・Lint・契約テスト446件が通過することを確認済み。
 
 ### PR-C: Backend API Serializer軽微削除
 
@@ -238,16 +238,16 @@
 
 ### PR-F: `apps/web` Backendオリジン環境変数の統一（設計フェーズ先行）
 
-**対象**: #23（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`の5系統併存）
+**対象**: #23（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`の5系統併存。**監査の結果、`NEXT_PUBLIC_API_BASE_URL`を加えた7系統であることが判明**）
 
 このPRは影響範囲が広いため、実装PRの前に以下の**事前確認**を完了する。
 
-**事前確認項目**:
+**事前確認項目の実施状況**: 4項目中2・3を完了し、詳細な監査・移行設計を`docs/audit/backend-origin-env-migration-design.md`へ記録した（削除フェーズではなく、監査・設計のみを行うPRとして実施。実装コード・環境変数は変更していない）。1・4は引き続きVercelダッシュボードへのアクセスが必要なため未着手。
 
-1. 5つの環境変数名それぞれについて、`apps/web/.env`・`apps/web/.env.local`・Vercelの環境変数設定（本番/Preview）に実際にどの名前が設定されているかを確認する（Vercel側の確認はダッシュボードで行い、本監査の範囲外）
-2. `src/lib/server/backend.ts`、`src/app/api/auth/login/route.ts`、`src/app/api/auth/register/route.ts`、`src/lib/api/shrines.server.ts`、`src/lib/api/shrineMeaning.server.ts`の5ファイルそれぞれで、現在どの優先順位でフォールバックしているかを一覧化する（本監査で確認済みの情報を土台に、さらに他の参照箇所が無いか`grep -rn "DJANGO_ORIGIN\|BACKEND_ORIGIN\|DJANGO_API_BASE_URL\|BACKEND_URL\|BACKEND_BASE_URL"`で再確認する）
-3. 統一後の単一名称candidate（例: `BACKEND_ORIGIN`への一本化）を決め、共通ヘルパー関数（例: `src/lib/server/resolveBackendOrigin.ts`）への集約設計を先にレビューする
-4. Vercel環境変数の切り替えタイミングとコードデプロイのタイミングをどう同期するか（新旧両対応の移行期間を設けるか）を決める
+1. ~~5つの環境変数名それぞれについて...~~ **未着手（Vercel確認が必要）**。同文書「4. Vercel確認が必要な項目」に4項目の確認リストを整理済み
+2. ~~5ファイルそれぞれで、現在どの優先順位でフォールバックしているかを一覧化する~~ **完了**。同文書「2. 各参照ファイルのフォールバック優先順位一覧」で5ファイル（うち1ファイルはログ出力専用の重複コードと判明）を一覧化し、加えて`resolveServerBaseUrl()`への隠れたフォールバック依存という新たなリスクを発見した
+3. ~~統一後の単一名称candidateを決め、共通ヘルパー関数への集約設計をレビューする~~ **完了**。同文書「5. 統一後の正式な環境変数名候補」で`BACKEND_ORIGIN`を採用候補として整理し、「6. 共通Backendオリジン解決ヘルパーの責務設計」で既存`backend.ts`の`getDjangoOrigin()`を拡張する設計を整理した（新規ファイル`resolveBackendOrigin.ts`は既存実装との責務重複のため採用しない方針とした）
+4. Vercel環境変数の切り替えタイミングとコードデプロイのタイミングをどう同期するか **設計は完了**（同文書「7. 新旧環境変数の移行順序」Phase 1〜4）が、実際の切り替え実施はVercel確認（項目1）の完了後
 
 **変更範囲（事前確認完了後）**:
 
@@ -366,18 +366,54 @@ Compatibility（互換目的で現役）に分類された項目について、�
 
 ---
 
-## 13. #6の追加対応（PR #2081）
+## 13. #10の追加対応（PR #2080）
 
-上記12節は2026-07-18時点のスナップショットとして保持する。その後、#6（`apps/mobile/components/home/`配下未使用コンポーネント群と関連ファイル）を対象とした単独の削除PR（PR #2081）を実施したため、本節で追加対応の内容と更新後の集計を記録する。
+> **注記（2026-07-18・本節の復元について）**: 本節はPR #2080で一度追加されたが、PR #2081が並行して同一ファイルの末尾へ別セクションを追加した際、squash mergeの結果としてPR #2080側の追記（本節と、1節の#10行・4節PR-B「対象」行・「#10の実施状況」段落・10節item 2の該当箇所）が`develop`上で失われていたことを、本PR（#23監査着手時のdevelop最新化確認）で発見した。該当箇所は全て本PRで復元済みである。PR #2080のコード変更自体（`token.ts`削除）はGit履歴・現行`develop`上に正しく反映されており、影響を受けたのはこの監査文書の記述のみである。
 
-**#6の実施内容**: 対象10ファイル（`components/PopularSection.tsx`、`components/PopularShrineCard.tsx`、`components/Skeletons.tsx`、`hooks/usePopularShrines.ts`、`components/home/NearbyShrines.tsx`、`components/home/RankingCarousel.tsx`、`components/home/SearchChips.tsx`、`components/home/MyPageCard.tsx`、`components/home/RecentViewed.tsx`、`components/ui/Layout.tsx`）のimport・JSX・router参照をリポジトリ全域で再検索し、定義箇所自身を除き参照0件であることを確認した上で削除した。Git履歴を確認し、対象ファイルはいずれも初期MVP実装（2025年9〜10月）に由来する旧Home画面のコンポーネント群であり、現行のHome画面（`app/index.tsx`、2026-06-18の全面刷新以降）は`ConditionFieldsCard`のみに依存する別実装であることを確認した。Mobile Typecheck（削除対象由来の新規エラー0件）・Unit Test 57件pass・Expo起動確認（Metro Bundler起動・config解決成功）を確認済み。`package.json`・lockfile・設定ファイルは変更していない。
+上記12節は2026-07-18時点のスナップショットとして保持する。その後、#10（`apps/web/src/lib/auth/token.ts`）を対象とした単独の削除PR（PR #2080）を実施したため、本節で追加対応の内容と更新後の集計を記録する。
 
-**更新後のP1集計**（本節時点。PR #2080による#10の対応は別途反映される）:
+**#10の実施内容**: `apps/web/src/lib/auth/token.ts`のimport元・`ACCESS_KEY`/`REFRESH_KEY`/`tokens`各exportの参照元をリポジトリ全域（`.ts`/`.tsx`）で再検索し、定義箇所自身を除き0件であることを確認した。localStorageベースの認証（`tokens.access`/`tokens.refresh`）が現行コードで使われていないこと、現行の認証はhttpOnly Cookie（`access_token`/`refresh_token`、`middleware.ts`と`login/route.ts`が使用）に一本化されていることを確認した上で削除した。Git履歴から、`token.ts`は2025-10-05に`authToken`として導入され、2025-10-30に`tokens`（`access`/`refresh`両対応）へ拡張されたのを最後に一度も参照されないまま放置されていたことを確認した。Web Typecheck・Lintともにエラーなし、Web契約テスト446件が通過することを確認済み。
+
+**更新後のP1集計（PR #2080時点）**:
 
 - P1合計: 13件
-- 対応済み: **11件**（#1, #2, #3, #5, #6, #7, #9, #11, #12, #13, #14）
-- 未対応: **2件**（#10, #23）
+- 対応済み: **11件**（#1, #2, #3, #5, #7, #9, #10, #11, #12, #13, #14）
+- 未対応: **2件**（#6, #23）
 - 外部環境確認が必要: 0件
 - 保留: 0件
 
-残る未対応のうち#10（`apps/web/src/lib/auth/token.ts`）はPR #2080で別途対応済み（マージ状況は当該PRを参照）。#23（Backendオリジン環境変数命名統一）は「削除フェーズ」ではなく「環境変数移行フェーズ」として、削除系のP1項目とは別枠で扱う。5系統の環境変数名（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`）の統一は、単純な未参照コード削除とは異なり、Vercel本番/Preview環境変数の実際の設定値確認、共通ヘルパーへの設計集約、新旧切替タイミングの調整（7節のPR-F事前確認項目）を要するため、削除系のP1消化とは別のトラックとして計画する。
+残る未対応2件（#6: `apps/mobile/components/home/`配下未使用コンポーネント群、#23: Backendオリジン環境変数命名統一）は、引き続き個別PRの起票が必要である。
+
+---
+
+## 14. #6の追加対応（PR #2081）
+
+その後、#6（`apps/mobile/components/home/`配下未使用コンポーネント群と関連ファイル）を対象とした単独の削除PR（PR #2081）を実施したため、本節で追加対応の内容と更新後の集計を記録する。
+
+**#6の実施内容**: 対象10ファイル（`components/PopularSection.tsx`、`components/PopularShrineCard.tsx`、`components/Skeletons.tsx`、`hooks/usePopularShrines.ts`、`components/home/NearbyShrines.tsx`、`components/home/RankingCarousel.tsx`、`components/home/SearchChips.tsx`、`components/home/MyPageCard.tsx`、`components/home/RecentViewed.tsx`、`components/ui/Layout.tsx`）のimport・JSX・router参照をリポジトリ全域で再検索し、定義箇所自身を除き参照0件であることを確認した上で削除した。Git履歴を確認し、対象ファイルはいずれも初期MVP実装（2025年9〜10月）に由来する旧Home画面のコンポーネント群であり、現行のHome画面（`app/index.tsx`、2026-06-18の全面刷新以降）は`ConditionFieldsCard`のみに依存する別実装であることを確認した。Mobile Typecheck（削除対象由来の新規エラー0件）・Unit Test 57件pass・Expo起動確認（Metro Bundler起動・config解決成功）を確認済み。`package.json`・lockfile・設定ファイルは変更していない。
+
+**更新後のP1集計（PR #2081時点）**:
+
+- P1合計: 13件
+- 対応済み: **12件**（#1, #2, #3, #5, #6, #7, #9, #10, #11, #12, #13, #14）
+- 未対応: **1件**（#23）
+- 外部環境確認が必要: 0件
+- 保留: 0件
+
+残る未対応1件（#23: Backendオリジン環境変数命名統一）は、「削除フェーズ」ではなく「環境変数移行フェーズ」として、削除系のP1項目とは別枠で扱う。5系統の環境変数名（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`）の統一は、単純な未参照コード削除とは異なり、Vercel本番/Preview環境変数の実際の設定値確認、共通ヘルパーへの設計集約、新旧切替タイミングの調整（7節のPR-F事前確認項目）を要するため、削除系のP1消化とは別のトラックとして計画する。
+
+---
+
+## 15. #23: 環境変数移行フェーズの監査・設計完了（現ドキュメント作成PR）
+
+候補#6（PR #2081）までの完了により、削除系のP1未対応項目は0件となった。残る候補#23は「削除フェーズ」の対象ではなく、独立した「環境変数移行フェーズ」として扱う。
+
+**#23の監査・設計内容**: `apps/web`のBackendオリジン関連環境変数を全域検索した結果、監査時点の5系統（`DJANGO_ORIGIN`/`BACKEND_ORIGIN`/`DJANGO_API_BASE_URL`/`BACKEND_URL`/`BACKEND_BASE_URL`）に加えて、`NEXT_PUBLIC_API_BASE_URL`（`shrines.server.ts`/`shrineMeaning.server.ts`が参照。既知の`NEXT_PUBLIC_API_BASE`とは別名）が新たに見つかり、**合計7系統**であることを確認した。5ファイルのフォールバック優先順位を一覧化し、うち1ファイル（`login/route.ts`）はログ出力専用の重複コードであること、`shrines.server.ts`/`shrineMeaning.server.ts`が最終的にWeb自身のorigin解決関数（`resolveServerBaseUrl()`）へフォールバックする隠れた依存を持つことを新たに発見した。`apps/web/.env.example`が存在せずREADMEにも記載が無いこと、`docs/core/authentication-flow.md`の既存禁止事項と現状の乖離も確認した。
+
+統一後の名称候補として`BACKEND_ORIGIN`を選定し、既存の`backend.ts`の`getDjangoOrigin()`を拡張する形での共通ヘルパー設計、Phase 1〜4の移行順序（Vercel環境変数追加→共通ヘルパーへの集約→非推奨警告によるモニタリング→旧名削除・文書整備）、各Phaseに対応するRollback条件を設計した。
+
+詳細は`docs/audit/backend-origin-env-migration-design.md`を正本とする。
+
+**実施していないこと**: 実装コード（`backend.ts`・`register/route.ts`・`shrines.server.ts`・`shrineMeaning.server.ts`・`resolveServerBaseUrl.ts`・`api.ts`・`http.ts`・`playwright.config.ts`）、Vercel環境変数、`docs/core/authentication-flow.md`等の既存アーキテクチャ文書は一切変更していない。Phase 1〜4は本設計の承認後、別PRで着手する。
+
+**#23の位置づけ**: 「削除フェーズ」のP1項目（#1〜#14のうち削除系11件）とは異なり、#23は「環境変数移行フェーズ」の1件目として扱う。監査・設計は完了したが、Phase 1（Vercel環境変数追加）以降は4節に整理したVercel確認項目の完了を前提とするため、本節時点では「対応済み」ではなく「監査・設計完了、実施は別トラック」として記録する。


### PR DESCRIPTION
## 目的

`docs/audit/legacy-settings-remediation-plan.md`候補#23（`apps/web`のBackendオリジンURL環境変数命名の1本化、PR-F事前確認項目）に対応する監査・設計PR。実装コード・環境変数は一切変更せず、監査結果と移行設計のみをdocs/auditへ記録する。

## 前提確認

- PR #2080（`token.ts`削除）はMERGED、`develop`に反映済み
- PR #2081（Mobile Home Component群削除）はMERGED、`develop`に反映済み
- **重要な発見と復元**: PR #2080とPR #2081が同一ファイル（`legacy-settings-remediation-plan.md`）の末尾へ並行してセクションを追加した際、後にマージされたPR #2081のsquash mergeがPR #2080側の追記（#10行・PR-B「対象」行・「#10の実施状況」段落・「実施順序」該当箇所・独自の「## 13」セクション全体）を`develop`上で消失させていたことを、本PRの`develop`最新化確認で発見した。PR #2080のコード変更自体（`token.ts`削除）は正しく反映されているが、監査文書の記述のみ失われていたため、本PRで復元した（該当箇所に復元の経緯を明記）。

## Backendオリジン関連の環境変数名の全域検索結果

`apps/web`全域（`.ts`/`.tsx`/`.env*`/`README.md`/`playwright.config.ts`/CI設定）を検索した結果、監査時点の5系統に加えて**`NEXT_PUBLIC_API_BASE_URL`（既知の`NEXT_PUBLIC_API_BASE`とは別名）を新たに発見し、合計7系統**であることを確認した。

## 各参照ファイルのフォールバック優先順位

5ファイル（`backend.ts`／`login/route.ts`／`register/route.ts`／`shrines.server.ts`／`shrineMeaning.server.ts`）それぞれのフォールバック優先順位を一覧化した。うち`login/route.ts`はログ出力専用の重複コード、`shrines.server.ts`/`shrineMeaning.server.ts`は最終的にWeb自身のorigin解決関数`resolveServerBaseUrl()`へフォールバックする隠れた依存があることを新たに発見した。`register/route.ts`は`djFetch()`を使わず素の`fetch()`を直接呼んでいることも確認した。

## apps/web内の環境変数サンプル・README確認結果

`apps/web/.env.example`は存在せず、READMEにもBackendオリジン関連の記載は無いことを確認した。`docs/infra/env_policy.md`もWeb固有の環境変数一覧は対象外と明言している。

## Vercel確認が必要な項目の分離

Production/Preview環境変数の実際の設定値確認など4項目を、実装着手前の外部確認事項として分離した（本PRでは未実施）。

## 統一後の正式な環境変数名候補

`BACKEND_ORIGIN`を採用候補とした（現行最多利用パスの第2優先、フレームワーク非依存の命名、既存アーキテクチャ文書との用語整合）。

## 共通Backendオリジン解決ヘルパーの責務設計

既存の`apps/web/src/lib/server/backend.ts`の`getDjangoOrigin()`（19ファイルが`djFetch`経由で依存する最多利用パス）を拡張する設計とし、新規ファイル作成は責務重複のため不採用とした。Web自身のorigin解決・クライアント側APIベースパス・認証ヘッダ転送とは責務を分離する設計とした。

## 新旧環境変数の移行順序

Phase 1（Vercel環境変数追加）→ Phase 2（共通ヘルパーへの集約・後方互換維持）→ Phase 3（非推奨警告によるモニタリング）→ Phase 4（旧名削除・文書整備）の4段階で設計した。

## Rollback条件

Phaseごとに、Vercel環境変数の即時復元（設定変更のみ）または`git revert`（コード変更を伴う場合）によるRollback条件を定義した。

## docs/auditへの記録

新規: [`docs/audit/backend-origin-env-migration-design.md`](docs/audit/backend-origin-env-migration-design.md)（全10節、上記の監査・設計内容を記録）

更新:
- `docs/audit/legacy-settings-final-audit.md`: §6.1の該当2行を更新し、監査・移行設計完了である旨と新設計文書への参照を追記。「9. 推奨する後続PR一覧」の該当項目も更新。「11. 後続対応状況」に新セクション「候補#23の監査・移行設計完了」を追加
- `docs/audit/legacy-settings-remediation-plan.md`: PR-F節（7節）の事前確認項目1〜4の実施状況を更新（2・3は完了、1・4はVercel確認待ち）。1節の#23行を更新。**PR #2080由来の失われていた内容を復元**（「## 13. #10の追加対応（PR #2080）」を復元、既存の「## 13. #6の追加対応」は「## 14」へ繰り下げ）。新セクション「## 15. #23: 環境変数移行フェーズの監査・設計完了」を追加

## 実装コードと環境変数は変更していないこと

- `backend.ts`・`login/route.ts`・`register/route.ts`・`shrines.server.ts`・`shrineMeaning.server.ts`・`resolveServerBaseUrl.ts`・`api.ts`・`http.ts`・`playwright.config.ts`は一切変更していない
- Vercel環境変数（Production/Preview）は変更していない（そもそも本PRからは変更不可能な外部設定）
- `docs/core/authentication-flow.md`等の既存アーキテクチャ文書も変更していない
- 変更ファイルは新規1件＋既存2件のdocs/auditのみ（`git status --short`で確認済み）

## Markdown・git diff確認結果

- `markdownlint-cli`: 新規追加した1件のMD018（見出し誤認識）は修正済み。既知の未対応MD060（リポジトリ全体の既存noise）とMD012（本PRのdiff範囲外の既存問題、`legacy-settings-final-audit.md:293`）以外のエラーなし
- `git diff --check`: 問題なし

## 今後のP1状況

削除フェーズのP1は#1〜#14のうち削除系11件全て対応済みとなった。残る#23は「環境変数移行フェーズ」の1件目として、本PRで監査・設計を完了した。実際のPhase 1〜4の実施は、Vercel確認完了後に別PRで着手する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)