### PR TITLE
Recommendation Reasonへ祭神・由緒・所在地の配線を接続する

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -310,6 +310,9 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
         "goriyaku": rec.get("goriyaku") or source.get("goriyaku"),
         "goriyaku_tags": rec.get("goriyaku_tags") or source.get("goriyakuTags") or breakdown.get("matched_need_tags") or [],
         "visit_style_tags": rec.get("visit_style_tags") or features.get("visit_style") or [],
+        "deity": rec.get("sajin") or source.get("sajin"),
+        "shrine_history": rec.get("description") or source.get("description"),
+        "place_context": rec.get("address") or source.get("address"),
         "place_id": rec.get("place_id"),
         "behavior_signals": rec.get("behavior_signals") if isinstance(rec.get("behavior_signals"), dict) else {},
     }

--- a/backend/temples/services/concierge_chat_candidates.py
+++ b/backend/temples/services/concierge_chat_candidates.py
@@ -126,6 +126,7 @@ def build_chat_candidates(
                 "lng": s.longitude,
                 "distance_m": dist,
                 "goriyaku": getattr(s, "goriyaku", None),
+                "sajin": getattr(s, "sajin", None),
                 "description": getattr(s, "description", None),
                 "astro_tags": getattr(s, "astro_tags", None),
                 "astro_elements": getattr(s, "astro_elements", None),

--- a/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
+++ b/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
@@ -1,0 +1,33 @@
+# backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
+
+from __future__ import annotations
+
+from temples.services.concierge_chat import _build_score_v3_candidate_profile
+
+
+def test_build_score_v3_candidate_profile_maps_deity_history_and_place_context():
+    rec = {
+        "shrine_id": 1,
+        "name": "武蔵御嶽神社",
+        "history_theme": "勝負",
+        "goriyaku": "勝負運",
+        "sajin": "櫛真智命",
+        "description": "古くから武運長久の祈願で知られる。",
+        "address": "東京都青梅市御岳山",
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "櫛真智命"
+    assert profile["shrine_history"] == "古くから武運長久の祈願で知られる。"
+    assert profile["place_context"] == "東京都青梅市御岳山"
+
+
+def test_build_score_v3_candidate_profile_handles_missing_shrine_fields():
+    rec = {"shrine_id": 1, "name": "候補神社"}
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] is None
+    assert profile["shrine_history"] is None
+    assert profile["place_context"] is None


### PR DESCRIPTION
## Summary
- `build_recommendation_reason_v4()` は `deity`/`shrine_history`/`place_context` を参照する設計だったが、呼び出し元の `_build_score_v3_candidate_profile()` がこの3キーを一切渡していなかった。神社データの有無以前に、パイプラインの配線が欠けていた構造的バグ。
- 候補データに `sajin`(祭神)を追加し、`_build_score_v3_candidate_profile()` で `sajin → deity` / `description → shrine_history` / `address → place_context` をマッピングして配線を接続した。
- これにより神社データが揃っている神社ほど、推薦理由文に神社固有情報が反映されるようになり、品質指標 `shrine_data_rate` も実態に即して機能するようになる。

## Why
Recommendation Quality（「なぜこの神社か誰が見ても納得できるか」）の現状調査で発見。理由生成ロジック自体は単体テスト済みで正しかったが、そこに正しい候補データを渡す配線関数には一切テストがなく、本番では常に空値が渡っていた。

## Test plan
- [x] `backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py`（新規、配線関数の回帰テスト）
- [x] `backend/temples/tests/services/test_recommendation_reason_v4.py`（既存、理由生成ロジック）
- [x] concierge_chat関連テスト 92件 pass
- [x] candidates/shrine_meaning/recommendation_reason関連テスト 56件 pass
- [x] pre-push: OpenAPI lint / Web契約テスト446件 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)