### PR TITLE
他候補カードに開閉UIと最小限の理由・住所表示を追加する

### DIFF
--- a/apps/web/src/components/shrines/ShrineCardCompact.tsx
+++ b/apps/web/src/components/shrines/ShrineCardCompact.tsx
@@ -33,7 +33,7 @@ export default function ShrineCardCompact({
   imageUrl = null,
   address = null,
   summary: _summary = null,
-  primaryReason: _primaryReason = null,
+  primaryReason = null,
   trustMetadata = null,
   tags: _tags = [],
   distanceM = null,
@@ -73,6 +73,9 @@ export default function ShrineCardCompact({
               </div>
             ) : null}
             {originSummary ? <p className="line-clamp-1 text-xs leading-5 text-slate-500">{originSummary}</p> : null}
+            {!originSummary && primaryReason ? (
+              <p className="line-clamp-1 text-xs leading-5 text-slate-500">{primaryReason}</p>
+            ) : null}
           </div>
 
           {address || distText || href ? (
@@ -85,7 +88,7 @@ export default function ShrineCardCompact({
                 <Link
                   href={href}
                   onClick={onDetailClick}
-                  className="ml-auto inline-flex items-center text-[11px] font-normal text-slate-400 transition hover:text-slate-600"
+                  className="-m-3 ml-auto inline-flex items-center p-3 text-[11px] font-normal text-slate-400 transition hover:text-slate-600"
                 >
                   詳細だけ見る
                 </Link>

--- a/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
+++ b/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineCardCompact from "../ShrineCardCompact";
+
+describe("ShrineCardCompact", () => {
+  it("shows address when address is present", () => {
+    render(
+      <ShrineCardCompact
+        name="検証神社"
+        href="/shrines/1?ctx=concierge"
+        address="東京都千代田区1-1-1"
+        distanceM={500}
+      />,
+    );
+
+    expect(screen.getByText("東京都千代田区1-1-1")).toBeInTheDocument();
+    expect(screen.queryByText("500m")).not.toBeInTheDocument();
+  });
+
+  it("falls back to distance when address is missing", () => {
+    render(<ShrineCardCompact name="検証神社" href="/shrines/1?ctx=concierge" address={null} distanceM={500} />);
+
+    expect(screen.getByText("500m")).toBeInTheDocument();
+  });
+
+  it("shows no supplementary line when both address and distance are missing", () => {
+    render(<ShrineCardCompact name="検証神社" address={null} distanceM={null} />);
+
+    expect(screen.queryByText(/m$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/km$/)).not.toBeInTheDocument();
+  });
+
+  it("renders primaryReason as the single reason block, but not summary or tags", () => {
+    render(
+      <ShrineCardCompact
+        name="検証神社"
+        href="/shrines/1?ctx=concierge"
+        summary="長いMeaning文のサマリー"
+        primaryReason="短い理由"
+        tags={["mental", "rest"]}
+      />,
+    );
+
+    expect(screen.getByText("短い理由")).toBeInTheDocument();
+    expect(screen.queryByText("長いMeaning文のサマリー")).not.toBeInTheDocument();
+    expect(screen.queryByText("mental")).not.toBeInTheDocument();
+  });
+
+  it("does not render primaryReason when it is null", () => {
+    const { container } = render(
+      <ShrineCardCompact name="検証神社" href="/shrines/1?ctx=concierge" primaryReason={null} />,
+    );
+
+    expect(container.querySelectorAll("p")).toHaveLength(0);
+  });
+});

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import DetailSection from "@/components/shrine/DetailSection";
 import PlaceShrineCard from "@/components/shrine/PlaceShrineCard";
@@ -236,6 +236,7 @@ export default function ConciergeSectionsRenderer({
   const trackedImpressionKeysRef = useRef<Set<string>>(new Set());
   const trackedCardEventKeysRef = useRef<Set<string>>(new Set());
   const [showOtherRecommendations, setShowOtherRecommendations] = useState(false);
+  const otherRecommendationsId = useId();
 
   const { isLoggedIn, loading: authLoading } = useAuth();
   const isGuestUser = !authLoading && !isLoggedIn;
@@ -957,30 +958,56 @@ export default function ConciergeSectionsRenderer({
 
                   {otherRegisteredItems.length > 0 ? (
                     <div className="pt-8">
-                      {!showOtherRecommendations ? (
-                        <button
-                          type="button"
-                          className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs font-semibold text-slate-500 transition hover:bg-slate-50 hover:text-slate-700"
-                          onClick={() => setShowOtherRecommendations(true)}
-                        >
-                          迷った時だけ、ほかの神社を見る
-                        </button>
-                      ) : (
-                        <div>
-                          <div className="mb-2 text-xs font-semibold tracking-[0.16em] text-slate-500">ほかの神社</div>
+                      <button
+                        type="button"
+                        className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs font-semibold text-slate-500 transition hover:bg-slate-50 hover:text-slate-700"
+                        aria-expanded={showOtherRecommendations}
+                        aria-controls={otherRecommendationsId}
+                        onClick={() => setShowOtherRecommendations((prev) => !prev)}
+                      >
+                        {showOtherRecommendations ? "ほかの神社を閉じる" : "迷った時だけ、ほかの神社を見る"}
+                      </button>
+
+                      {showOtherRecommendations ? (
+                        <div id={otherRecommendationsId}>
+                          <div className="mb-2 mt-3 text-xs font-semibold tracking-[0.16em] text-slate-500">
+                            ほかの神社
+                          </div>
                           <p className="mb-3 text-xs leading-5 text-slate-500">迷った時の参考です。</p>
 
                           <div className="space-y-3">
                             {otherRegisteredItems.map((item: RegisteredShrineItem, compactIdx: number) => {
+                              const compactReasonVm = buildRecommendationReasonViewModel({
+                                rec: {
+                                  id: item.shrineId,
+                                  display_name: item.title,
+                                  name: item.title,
+                                  breakdown: item.breakdown ?? null,
+                                  breakdown_detail: (item as any).breakdown_detail ?? null,
+                                  reason: item.description ?? null,
+                                  fallback_mode: payload?.meta?.resultState?.fallback_mode ?? null,
+                                  distance_m: (item as any).distance_m ?? null,
+                                  popular_score: (item as any).popular_score ?? null,
+                                  astro_elements: (item as any).astro_elements ?? null,
+                                  astro_priority: (item as any).astro_priority ?? null,
+                                  explanation: (item as any).explanation ?? null,
+                                  reason_facts: (item as any).reasonFacts ?? null,
+                                },
+                                index: compactIdx + 1,
+                                mode: normalizedMode,
+                                birthdate: filterState?.birthdate ?? null,
+                                needTags: item.breakdown?.matched_need_tags ?? [],
+                              });
+
                               return (
                                 <div key={`rec-${i}-compact-${item.shrineId}`} className="space-y-2">
                                   <ShrineCardCompact
                                     name={item.title}
                                     href={item.detailHref}
                                     imageUrl={item.imageUrl}
-                                    address={null}
+                                    address={item.address ?? null}
                                     summary={null}
-                                    primaryReason={null}
+                                    primaryReason={compactReasonVm.list.primaryPhrase}
                                     tags={[]}
                                     distanceM={(item as any).distance_m ?? null}
                                     onDetailClick={() =>
@@ -1013,7 +1040,7 @@ export default function ConciergeSectionsRenderer({
                             })}
                           </div>
                         </div>
-                      )}
+                      ) : null}
                     </div>
                   ) : null}
 

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.otherRecommendations.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.otherRecommendations.test.tsx
@@ -1,0 +1,199 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const analyticsMocks = vi.hoisted(() => ({
+  trackSearchEvent: vi.fn(),
+  trackCardEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/searchEvents", () => ({
+  trackSearchEvent: analyticsMocks.trackSearchEvent,
+}));
+
+vi.mock("@/lib/analytics/cardEvents", () => ({
+  trackCardEvent: analyticsMocks.trackCardEvent,
+}));
+
+const authMock = vi.hoisted(() => ({
+  useAuth: vi.fn(() => ({ isLoggedIn: false, loading: false })),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: authMock.useAuth,
+}));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[]) {
+  const u: any = {
+    data: { recommendations },
+    thread: { id: 768 },
+  };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+const heroRec = {
+  shrine_id: 1,
+  display_name: "第一候補神社",
+  reason: "第一候補の理由文です。",
+  address: "東京都千代田区1-1-1",
+};
+
+const otherRecWithAddress = {
+  shrine_id: 2,
+  display_name: "他候補神社A",
+  reason:
+    "この長い理由文は44文字を大きく超える想定で書かれており、compactTextによって句点や記号の位置で自然に切り詰められることを検証するためのテキストです。",
+  address: "東京都中央区2-2-2",
+};
+
+const otherRecWithoutAddress = {
+  shrine_id: 3,
+  display_name: "他候補神社B",
+  reason: "他候補神社Bの短い理由。",
+};
+
+describe("ConciergeSectionsRenderer - 他候補の開閉UI", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    authMock.useAuth.mockReturnValue({ isLoggedIn: false, loading: false });
+    window.localStorage.clear();
+  });
+
+  it("他候補一覧は初期状態で非表示である", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    expect(screen.getByText("迷った時だけ、ほかの神社を見る")).toBeInTheDocument();
+    expect(screen.queryByText("他候補神社A")).not.toBeInTheDocument();
+  });
+
+  it("ワンタップで展開し、再度クリックすると折りたたまれ、もう一度開ける", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    const toggle = screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" });
+    fireEvent.click(toggle);
+
+    expect(screen.getByText("他候補神社A")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "ほかの神社を閉じる" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "ほかの神社を閉じる" }));
+    expect(screen.queryByText("他候補神社A")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+    expect(screen.getByText("他候補神社A")).toBeInTheDocument();
+  });
+
+  it("aria-expandedが開閉stateと同期し、aria-controlsがContainerのidと一致する", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    const toggle = screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggle);
+
+    const opened = screen.getByRole("button", { name: "ほかの神社を閉じる" });
+    expect(opened).toHaveAttribute("aria-expanded", "true");
+
+    const controlsId = opened.getAttribute("aria-controls");
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).not.toBeNull();
+    expect(document.getElementById(controlsId as string)?.textContent).toContain("ほかの神社");
+  });
+
+  it("開閉後もトリガーボタンにフォーカスが残る", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    const toggle = screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" });
+    toggle.focus();
+    fireEvent.click(toggle);
+
+    const opened = screen.getByRole("button", { name: "ほかの神社を閉じる" });
+    expect(document.activeElement).toBe(opened);
+
+    fireEvent.click(opened);
+    const closed = screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" });
+    expect(document.activeElement).toBe(closed);
+  });
+
+  it("他候補カードにaddressが表示される", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+
+    expect(screen.getByText("東京都中央区2-2-2")).toBeInTheDocument();
+  });
+
+  it("他候補カードの理由は44字以内に圧縮された1ブロックのみ表示され、summary・tagsは表示されない", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+
+    // primaryPhraseはreason_facts/breakdown由来のテンプレート文であり、
+    // 元のreasonテキストをそのまま切り詰めたものではないため、
+    // 「1ブロックのみ・44字以内」という配線・表示制約のみを検証する。
+    const compactCard = screen.getByText("他候補神社A").closest("article");
+    expect(compactCard).not.toBeNull();
+
+    const reasonParagraphs = Array.from(compactCard?.querySelectorAll("p") ?? []);
+    expect(reasonParagraphs).toHaveLength(1);
+    expect((reasonParagraphs[0].textContent ?? "").length).toBeGreaterThan(0);
+    expect((reasonParagraphs[0].textContent ?? "").length).toBeLessThanOrEqual(44);
+  });
+
+  it("addressがない他候補カードでもエラーにならず表示される", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithoutAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+    expect(screen.getByText("他候補神社B")).toBeInTheDocument();
+  });
+
+  it("Heroの表示・詳細リンクに変更がない", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    expect(screen.getByText("第一候補神社")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "神社の詳細を見る" })).toBeInTheDocument();
+  });
+
+  it("他候補の詳細クリックで既存のshrine_detail_transitionイベントが従来どおり発火する", () => {
+    const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+    fireEvent.click(screen.getByText("詳細だけ見る"));
+
+    expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+      "shrine_detail_transition",
+      expect.objectContaining({
+        source: "concierge_result",
+        position: "compact",
+        shrineId: 2,
+        recommendationRank: 2,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Concierge結果画面「迷った時だけ、ほかの神社を見る」を、開閉両対応のトグルにする（従来は開くのみで閉じる手段がなかった）
- トグルボタンに`aria-expanded`/`aria-controls`を付与し、`useId()`で生成した一意なidを他候補リストContainerへ付与
- 各他候補カードに`address`（欠損時は既存のdistanceフォールバック）と、`reasonVm.list.primaryPhrase`（44字以内に圧縮済み）による理由ブロックを1つだけ表示
- `ShrineCardCompact`の`primaryReason` propが実際には描画されない死んだpropsだったため、表示ロジックを追加
- 「詳細だけ見る」リンクのタップ領域を、視覚サイズを変えない負マージン+padding手法で拡大（32.5px→40.5px、実ブラウザで測定済み）

## Why
Phase 1〜5の監査で、他候補カードの`address`/`summary`/`primaryReason`がPR #1142（2位以下候補カードの表示量を抑制）で意図的にnull固定されたまま、開いた一覧を閉じる手段自体が存在しないことが判明した。第一候補を主役として維持しつつ、最低限の比較材料と開閉の自由度をユーザーに戻す。

## やらないこと（明示的にスコープ外）
- Hero（第一候補）・Backend・Score/Ranking・API Response Schema
- 神社詳細画面（文章重複整理は別Epic）
- 新規Analytics Event追加・既存Event名/payload変更
- タグ・summary表示の追加、新規汎用Disclosureコンポーネント作成
- Color Token

## 事前確認
- `recommendations`セクションは型定義上は複数を許容するが、唯一のpayload生成元(`buildPayloadFromUnified.ts`)は常に1個だけ生成し、全テストも`.find()`（単数）のみを使用していることを確認。既存`showOtherRecommendations: boolean`をそのまま利用した
- PR #1283（他候補カードのanalytics view eventを追加、MERGED済み）により、`showOtherRecommendations`がtrueになった瞬間に発火する`card_view`イベント（`cardId: "other_shrines"`/`"shrine_compact"`）が既に存在することを確認。今回のuseEffect依存配列・発火条件は変更していない

## Test plan
- [x] `ShrineCardCompact.test.tsx`（新規、5件）: address表示/distance fallback/両方欠損/primaryReason1ブロック表示/primaryReason null時非表示
- [x] `ConciergeSectionsRenderer.otherRecommendations.test.tsx`（新規、9件）: 初期非表示/開閉/再展開/aria-expanded同期/aria-controls一致/フォーカス維持/address表示/理由1ブロック44字以内/addressなし他候補の表示/Hero非変更/shrine_detail_transition回帰
- [x] 合計14件
- [x] `npx tsc --noEmit` / `npx eslint .` パス
- [x] `pnpm --filter ./apps/web test:contract` 460件パス（既存446件+新規14件）
- [x] `git diff --check` パス
- [x] 実ブラウザ（375px/390px/430px）で開閉・aria属性・フォーカス保持・横スクロールなしを確認

### Coverage補足

全460テストは成功したが、`ConciergeSectionsRenderer`を初めてテスト対象としてimportしたことで、同ファイル内の既存未テスト領域がグローバルCoverageの分母に追加され、Coverage閾値を下回った。

今回変更した開閉UI・aria属性・理由表示の変更箇所は、Coverage上すべて実行済みである。

Coverage回帰は、閾値変更や除外設定ではなく、`ConciergeSectionsRenderer`の既存未テスト経路を補う専用PRで対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
