### PR TITLE
Design Token v1候補とPhase 6棚卸し監査記録を文書化する

### DIFF
--- a/docs/audit/design-token-phase6-audit.md
+++ b/docs/audit/design-token-phase6-audit.md
@@ -1,0 +1,287 @@
+> **Status: Reference**
+>
+> 本ドキュメントは、Design Token v1設計（`docs/design/design-token.md`）の根拠となった、Web / Mobileの現行実装棚卸し監査の記録である。
+>
+> 本文書は履歴・根拠であり、現行仕様の正本ではない。Token名・Token値の判断は`docs/design/design-token.md`を参照する。
+
+# Phase 6 Design Token 現状棚卸し監査
+
+## 目的
+
+KAMI MUSUBIのWeb（`apps/web`）とMobile（`apps/mobile`）について、Color / Typography / Radius / Shadow / Spacing / Componentの現行指定を棚卸しし、Design Token v1設計に必要な事実を収集する。
+
+## 監査対象
+
+### 正本の扱い
+
+現在の`develop`を起点とした`audit/design-token-phase6`ブランチ上の実装のみを現行正本として扱う。過去のUI案（PR #1196）・古いPR・Archive文書は現行仕様として扱わない。
+
+### Web
+
+- `apps/web/src/app/globals.css`
+- Tailwind設定（v4のCSSファースト構成、`tailwind.config.*`は非存在）
+- CSS custom properties
+- `apps/web/src/components`
+- `apps/web/src/features`
+- `apps/web/src/app`
+- inline style
+- arbitrary Tailwind values
+
+### Mobile
+
+- `apps/mobile`全体
+- theme定義（`app/theme.ts`, `app/design/*.ts`, `lib/tokens/*.ts`）
+- StyleSheet
+- inline style
+- navigation theme
+- platform別style
+
+## 調査方法
+
+Web側3系統（Color/Typography、Radius/Shadow/Spacing、Component棚卸し）とMobile側1系統（全カテゴリ）を、読み取り専用のExploreエージェントに並行して委託し、`grep`・`Read`による実コード確認結果を本文書へ統合した。コード変更・CSS変更・ファイル作成・commit・pushは一切行っていない。
+
+---
+
+## 1. Web現行Token
+
+`apps/web/tailwind.config.*`は存在しない（Tailwind v4のCSSファースト構成）。トークン定義は`apps/web/src/app/globals.css`（120行）に集約されている。
+
+| Token | 定義場所 | 値 | 採用状況（事実） |
+|---|---|---|---|
+| `--radius` | `globals.css:45` | `0.625rem` | shadcnベースコンポーネント経由の暗黙参照のみ。実コード上でこの変数がどのComponentの計算に使われているかは未確認（`@theme inline`で`--color-radius`にマッピングされている点のみ確認済み） |
+| shadcn `@theme`セマンティック色（`--background`, `--primary`, `--secondary`, `--muted`, `--accent`, `--destructive`, `--border`, `--input`, `--ring`, `--card`, `--popover`, `--sidebar-*`, `--chart-1〜5`） | `globals.css:6-42`（`@theme inline`）、`globals.css:44-111`（`:root`/`.dark`、値は`oklch(...)`関数） | shadcn/ui標準テーマ一式 | `apps/web/src/components/ui/{button,card,sheet,tabs,input}.tsx`の5ファイル＋機能コード側1箇所（`MyGoshuinTopSection.tsx:127`の`bg-muted`）のみが参照。アプリ全体ではほぼ未使用 |
+| `--font-sans`（Geist Sans） | `globals.css:9`、`layout.tsx:15-23` | `next/font/local`でローカルwoff2読込（Light/Regular/Medium/Bold各4ウェイト） | 全体の基本フォント |
+| `--font-mono`（Geist Mono） | `globals.css:10`、`layout.tsx:25-37` | 同上 | `font-mono`クラスとして18箇所（デバッグダッシュボード・コンシェルジュ画面の一部） |
+
+### 共通UIコンポーネントの採用率（事実）
+
+`apps/web/src/components/ui/`に以下が存在する: `button.tsx`（cva管理、variant: default/destructive/outline/secondary/ghost/link、size: default/sm/lg/icon）、`card.tsx`、`input.tsx`、`sheet.tsx`、`tabs.tsx`、`skeleton.tsx`、`TagList.tsx`、`SearchResultItem.tsx`。
+
+| Component | import元ファイル数 | 直接className書き下しファイル数 |
+|---|---|---|
+| Button | 1（`MyGoshuinCard.tsx`のみ） | 46（`<button`直書き） |
+| Card | 2（`ranking/page.tsx`, `RankingCard.tsx`） | 41以上（`rounded-2xl/3xl + border + bg-white`系の独自パターン） |
+| Input | 0 | 5（Textarea含む全て個別実装） |
+| Tabs | 1（`ranking/page.tsx`） | — |
+| Sheet | 1（`HamburgerMenu.tsx`） | — |
+
+---
+
+## 2. Web直接指定
+
+### Color（HEX/RGB/HSL直接指定は0件確認、全て標準Tailwindパレット名クラス経由）
+
+| 系統 | 用途 | 概算出現規模 | 代表箇所 |
+|---|---|---|---|
+| `emerald-*` | ブランド（primary action・強調テキスト） | 47ファイル、`text-emerald-700`50回、`bg-emerald-600`15回等、延べ150回超 | `GoshuinNewClient.tsx:228`, `ShrineCard.tsx:163` |
+| `slate-*` | ニュートラル（本文・境界線） | 59ファイル、`text-slate-700`89回、`text-slate-500`86回等、概算400回前後 | 全体に分散 |
+| `stone-*` | ニュートラル（slateと機能重複、透過度バリエーション多数） | 33ファイル、`text-stone-500`89回等、概算400回前後 | Home/Explore系 |
+| `gray-*` | ニュートラル（ログイン/サインアップ等の古いフォーム系） | 概算90回。`text-gray-500`20回, `bg-gray-200`12回等 | `LoginForm.tsx`, `SignupForm.tsx` |
+| `neutral-*` | ニュートラル | 概算40回 | `text-neutral-700`7回等 |
+| `amber-*` | Premium機能（バッジ・カード・CTA） | 17ファイル、`border-amber-200`15回等、概算90回 | `PremiumStateDeltaCard.tsx:60,62,68`, `ModeBadge.tsx:23` |
+| `red-*`/`rose-*` | フォームバリデーションエラー | 38ファイル、`text-red-600`13回、`text-red-700`11回等、概算80回 | `ShrineSubmissionForm.tsx`（4箇所）, `LoginForm.tsx:60` |
+| `blue-*` | ログイン/サインアップの一部ボタン | 少数ファイル、概算20回 | `LoginForm.tsx:89` |
+| `white`/`black` | 基本背景・オーバーレイ | `bg-white`122回、`text-white`53回。オーバーレイは`bg-black/50`と`bg-stone-950/35`が混在（不統一） | `layout.tsx:52`, `GoshuinDetailModal.tsx:23` |
+| ring/focus系 | フォーカスリング | 23箇所。`focus:border-emerald-300`, `focus:ring-stone-200`, `focus-visible:ring-neutral-400`が混在 | 未統一 |
+| disabled状態 | 無効化表現 | `disabled:opacity-*`33回、`disabled:text-stone-400`2回等 | 各フォーム |
+
+### Typography
+
+| 指定 | 使用箇所 | 推定用途 | 重複候補 |
+|---|---|---|---|
+| `text-sm`(325回)/`text-xs`(298回) | 全体 | 基準フォントサイズ | — |
+| `text-[11px]`(82回)/`text-[10px]`(22回) | `ConciergeFilterPanel.tsx:112,120,138,147,169`等 | 標準スケール外のarbitrary値が慣用化 | `text-xs`(12px)との差が僅少で、標準スケール未整備によりarbitrary値が乱立 |
+| `font-semibold`(219回)/`font-medium`(146回) | 全体 | 強調・見出し・ボタンテキストの主力 | `font-bold`(29回)との使い分け基準は不明（未確認） |
+| `tracking-[0.2em]`+`text-[11px]`+`font-medium`+`text-stone-500`の4値セット | `NearbySection.tsx:17`, `ExploreLayout.tsx:50`, `MapPageClient.tsx:62`, `DetailSearchAccordion.tsx:54`, `ExperienceFilterSection.tsx:17`, `NearbyShrineCardListClient.tsx:207`等、8ファイル | eyebrowラベル（NEARBY, EXPLORE等の英字ラベル） | **文字列として完全一致・重複**（コピペと推定、home/concierge/explore/map横断） |
+| `leading-6`(55)/`leading-7`(17)/`leading-5`(17) | 本文行間 | — | 数値指定とキーワード指定（`leading-relaxed`, `leading-tight`）が混在 |
+
+### Radius
+
+`rounded-2xl`(123回)最多、`rounded-full`(108回)、`rounded-xl`(103回)、`rounded-3xl`(39回)、`rounded-md`(32回)、`rounded-lg`(27回)。shadcnベース（`button.tsx`=md、`card.tsx`=xl）と機能コンポーネント側の値がしばしば不一致。同一ファイル内で4種類混在する例あり（`ConciergeClientFull.tsx`: `rounded-full`10回, `rounded-xl`7回, `rounded-3xl`7回, `rounded-lg`4回, `rounded-2xl`2回）。
+
+### Shadow
+
+`shadow-sm`(41回)最多、`shadow-xs`（Button/Input既定）、`shadow-md`（hover強調）、`shadow-lg`（Modal/Sheet）、`shadow-none`（明示的無効化）。カラー付き影（`shadow-emerald-900/5`, `shadow-stone-900/5`, `shadow-teal-900/5`等）は`HomeHeroConsultationInput.tsx`, `ConciergeTopRecommendationHero.tsx`, `ShrineSubmissionForm.tsx`の3ファイルのみに局所出現。`boxShadow`インラインstyle・CSS内`box-shadow:`・`text-shadow`・`drop-shadow`はいずれも0件（全てTailwindユーティリティクラス経由）。
+
+### Spacing
+
+Padding上位: `px-3`(121回), `p-4`(107回), `px-4`(91回), `py-2`(90回), `p-3`(53回)。Margin上位: `mt-2`(80回), `mt-1`(64回), `mt-3`(38回)。Gap上位: `gap-2`(80回), `gap-3`(28回)。space-y上位: `space-y-2`(59回), `space-y-4`(42回)。globals.cssにSpacing用CSS変数トークンは存在せず、全てハードコード運用。arbitrary spacing（`p-[3px]`）は`components/ui/tabs.tsx:29`の1件のみ。
+
+### Component棚卸し（重複実装）
+
+| Component種別 | 概算variant数 | 共通コンポーネント使用率 | 重複実装の有無 |
+|---|---|---|---|
+| Button | 24種以上の独自CTA className | 1/47 | **あり（顕著）** |
+| Card | 40件以上が独自パターン | 2/43 | **あり（顕著）** |
+| Badge/Tag | 20種以上 | 共通コンポーネント不在 | **あり（顕著）** |
+| Input/Textarea | Input 0使用、Textarea全個別 | 0/5 | **あり** |
+| Section | 2系統並存 | — | **あり** |
+| Premium CTA（amber系） | 5ファイルでほぼ同一パターン重複 | — | **あり（顕著）** |
+
+具体例（代表）:
+- 「緑背景+白文字CTA」24種の一部: `HeaderAuthButtons.tsx:24`, `ShrineDetailShell.tsx:89`, `ShrineReflectionPrompt.tsx:133`, `PublicGoshuinSection.tsx:52,73`（同一ファイル内で2バリアント）, `ConciergeEntryCard.tsx:85`, `ConciergeSectionsRenderer.tsx:641`, `ConciergeTopRecommendationHero.tsx:190`, `ShrineSubmissionForm.tsx:512`, `PlaceCardClientActions.tsx:55`
+- 「マイページ緑ピル」型CTA4〜7箇所重複: `MyPageScreen.tsx:99,178`, `GoshuinUploadForm.tsx:180`, `FavoritesSection.tsx:61`, `components/views/MyPageView.tsx:223,300,340`
+- Premium/amber系CTA5箇所重複: `ShrineDetailArticle.tsx:189,297`, `ThreadList.tsx:77`, `ConciergeSectionsRenderer.tsx:116`, `PremiumStateDeltaCard.tsx:68`
+- Section2系統: `DetailSection.tsx`（primary/secondary/tertiary、slate系、4ファイル使用）と`SectionCard.tsx`（default/subtle、stone系、`MyPageScreen.tsx`1ファイルのみ使用）
+- Badge重複例: `ShrineCardCompact.tsx:68`, `DetailDisclosureBlock.tsx:67`, `ConciergeSectionsRenderer.tsx:877`, `ModeBadge.tsx:23`, `ConciergeConsultationSummary.tsx:18,23,29`（同一ファイル内3色バリアント）
+
+---
+
+## 3. Mobile現行Token
+
+`apps/mobile`には**並行して3系統のトークン定義**が存在する。
+
+| 系統 | ファイル | 内容 | 採用状況 |
+|---|---|---|---|
+| `app/theme.ts`（41行） | `colors`（ライトテーマ、18キー）＋`kamimusubiDark`（ダークテーマ、17キー） | HEXカラー定義 | `colors`は`components/ui/Button.tsx`のみ参照（そのButton自体が未使用のため実質不使用）。`kamimusubiDark`は43ファイル横断で全画面使用 |
+| `app/design/*.ts`（radius.ts, spacing.ts, shadow.ts, cardSizes.ts, ctaSizes.ts） | Radius/Spacing/Shadowの数値トークン | 16画面・3コンポーネントから使用中。Expo Routerのファイルベースルーティング上`app/`直下に配置されているため、`_layout.tsx:106-110`で`Tabs.Screen name="design/cardSizes"`等としてルート登録されている（意図的仕様か配置ミスかは未確認） |
+| `lib/tokens/*.ts`（index.ts, radius.ts, spacing.ts, buttons.ts, cards.ts） | Radius/Spacing/Button/Cardトークン | **アプリ内のどこからもimportされていない完全なデッドコード**。値も`app/design/`系と異なる（例: `radius.sm`が`app/design`は14相当、`lib/tokens`は8） |
+
+`kamimusubiDark`主要色: `background` `#07101F`（43ファイル）、`surface` `#101827`（43箇所）、`gold`（Premium/accent）`#E0B963`（91箇所、最頻出）、`text` `#F7F0E3`（61箇所）、`muted` `#A99B80`（57箇所）、`borderGold` `#8A6C32`（37箇所）。使用が極端に少ないもの: `borderMuted`（1箇所）、`navMuted`（0箇所、定義のみ）。
+
+---
+
+## 4. Mobile直接指定
+
+- **Color**: `#FCA5A5`（`app/login.tsx:167`のエラー文字色、直書き。`theme.ts`の`error`/`errorBackground`定義は**アプリ内どこからも未参照**で孤立）。`#111`/`"white"`（`components/ui/Button.tsx:34,36`、未使用コンポーネント内）。`rgba(7, 16, 31, 0.82)`（`reflection-history/index.tsx:431`）と`rgba(7, 16, 31, 0.72)`（`AuthPrompt.tsx:54`）というオーバーレイが非統一な透過率で個別直書き。success/warning/info系のcolor tokenと使用箇所はgrep上ゼロ。
+- **Typography**: fontFamily指定は0件（システムデフォルトと推定、未確認）。fontSize(259箇所、21ファイル)/fontWeight(229箇所)/lineHeight(85箇所)/letterSpacing(63箇所)は**Typography用トークンファイル自体が存在せず**、全て各StyleSheetへの個別直書き。fontSize分布: 12(48件)/13(53件)/14(34件)/15(31件)/11(29件)/26(13件)等。fontWeight分布: "900"(62件)/"800"(57件)/"700"(55件)/"600"(51件)/"500"(4件)。"400"(normal)は未検出。
+- **Radius**: `radius.pill`(999)経由18箇所に加え、数値直書き"999"が11箇所別途存在。`radius.xl`(20)は`shrines/[id].tsx`で7箇所。直書き`24`が`goshuin/index.tsx`, `concierge/index.tsx`, `goshuin/upload.tsx`等に分散。token採用と直書きが併存し、採用率は一定でない。
+- **Shadow**: `app/design/shadow.ts`定義5パターン中、実際にコードから参照されているのは`goldCta`のみ（`app/index.tsx:338`, `app/concierge/index.tsx:1257`の2箇所）。`card`/`softCard`/`lightCard`/`skeleton`は定義済みだが使用箇所が未検出（スプレッド展開等の間接参照の可能性は排除できず、未確認）。一方`goshuin/index.tsx:170-181`と`goshuin/upload.tsx:188-199`は、token定義値に近い（一部完全一致）値を直書きで再実装している。
+- **Spacing**: `app/design/spacing.ts`（screenX16, screenXWide24, contentX20, sectionY12, sectionTop20, bottomSpace40, tightGap4, inlineGap7, smGap8, mdGap10, lgGap12, xlGap16）は16ファイル・187箇所で使用。一方`app/index.tsx`, `app/concierge/index.tsx`, `app/goshuin/index.tsx`, `app/goshuin/upload.tsx`, `app/search/index.tsx`, `app/mypage/index.tsx`の6画面はspacingトークンを一切importせず、padding/margin/gapの全てを直書き数値で記述（画面単位のトークン採用率は16/22、概算73%）。
+
+### Mobile Component棚卸し
+
+| Component種別 | 事実 |
+|---|---|
+| Button | `components/ui/Button.tsx`はアプリ内のどこからもimportされておらず未使用。全22画面が`Pressable`/`TouchableOpacity`を直接使い、`btn`系StyleSheetキーを画面ごとに個別定義 |
+| Card | 共有Cardコンポーネントなし。少なくとも15画面で「card」系StyleSheetキーが個別定義。padding/borderRadius/shadowの値も画面ごとに不統一 |
+| Badge/Tag/Pill | `concierge/index.tsx:1224-1240`と`shrines/[id].tsx:878-893`が`tagRow`/`tagPill`/`tagText`という**全く同じキー名**で別々にStyleSheetを実装（コピペと推定、未確認）。`search/index.tsx`は同一画面内に`tag`系と`miniTag`系の2種の類似Pillが並存 |
+| Input/Textarea | 共有コンポーネントなし、7箇所で個別実装 |
+| Section | `sectionTitle`/`sectionHeader`/`sectionLabel`パターンが最低7画面で個別実装 |
+| Hero | `app/index.tsx`と`app/search/index.tsx`が`hero`/`heroLead`/`heroSub`というほぼ同一キー構成で別実装 |
+| Premium | `app/premium/index.tsx`に集約。他画面からの重複実装は未確認（検出されず） |
+| Status | `statusCard`/`statusLabel`という同名キーが`birthday`と`premium`の2画面で別定義 |
+
+### Mobile補足事実
+
+- navigation theme: React Navigationの`DefaultTheme`/`DarkTheme`カスタマイズは存在しない。Expo Router `<Tabs screenOptions={{...}}>`で`tabBarActiveTintColor: theme.gold`等を直接指定する方式。
+- Platform分岐: `Platform.OS`使用は2ファイル3箇所のみ。`Platform.select`は0件。`.ios.tsx`/`.android.tsx`は存在しない。
+- `StyleSheet.create`使用: 21ファイル。`app/favorites/index.tsx`と`app/records/index.tsx`は不使用で全面インラインstyle。
+
+---
+
+## 5. Web / Mobile比較
+
+| 意味 | Web値 | Mobile値 | 一致/不一致 |
+|---|---|---|---|
+| Background | `bg-white`中心（light基調） | `#07101F`（dark基調） | **不一致（配色思想が逆）** |
+| Surface | `bg-slate-50`/`bg-stone-50`等 | `#101827`（surface）/`#0B1424`（surfaceSoft） | 不一致 |
+| Text | `text-slate-700`〜`900`（dark text on light） | `#F7F0E3`（light text on dark） | 不一致 |
+| Brand | `emerald-600`系 | `#E0B963`（gold） | **完全不一致（緑 vs 金）** |
+| Premium | `amber-*`系 | gold `#E0B963`／borderGold `#8A6C32` | 概念（黄金系）は一致、実値体系は別 |
+| Status/Error | `red-600`系（Tailwindクラス、体系化済み） | `#FCA5A5`（孤立ハードコード、token未接続） | 概念は一致、実装形態が非対称 |
+| Typography基盤 | Geist（カスタムフォント） | システムデフォルト（fontFamily指定なし） | 不一致 |
+| Radius | `rounded-full`/`2xl`/`xl`等（Tailwindスケール） | `radius.pill`(999)/`xl`(20)/`lg`(18)等 | 概念は対応、数値体系は別 |
+| Shadow | `shadow-sm`/`md`/`lg`（Tailwind定義） | `card`/`softCard`/`goldCta`（iOS shadow*+Android elevation） | 概念型は近いが値・実装方式は別 |
+| Spacing | `p-4`(16px相当)等 | `spacing.contentX20`(20)等 | 数値体系が別スケール |
+
+**最も重要な発見**: WebはEmerald（緑）ブランド＋Lightテーマ基調、MobileはGold（金）ブランド＋Darkテーマ基調という、根本的に異なるビジュアル言語で実装されている。この統一可否は本監査の範囲を超えた製品判断であり、`docs/design/design-token.md`の保留事項として記録する。
+
+---
+
+## 6. 重複・不整合
+
+### Web
+
+- ニュートラルカラー4系統重複: slate / stone / gray / neutral
+- Button共通コンポーネント使用率1/47、Card使用率2/43、Input使用率0/5
+- 「緑背景+白文字CTA」24種以上の別々のclassName文字列（角丸・padding・hover/disabled有無が全て異なる）
+- 「マイページ緑ピル」型CTAが4〜7箇所でほぼ同一パターン重複
+- Premium/amber系CTAが5箇所でほぼ同一パターン重複
+- Section役割が`DetailSection`（slate系）と`SectionCard`（stone系）の2系統で並存
+- eyebrowラベル（`text-[11px] font-medium tracking-[0.2em] text-stone-500`）が8ファイルで文字列完全一致・重複
+
+### Mobile
+
+- トークン定義3系統並存（`app/theme.ts`/`app/design/*`/`lib/tokens/*`）、うち`lib/tokens/*`は完全デッドコード
+- `components/ui/Button.tsx`は定義されているがアプリ全体で未使用
+- Card共有コンポーネントなし、15画面で個別StyleSheet実装
+- `tagRow`/`tagPill`/`tagText`が`concierge/index.tsx`と`shrines/[id].tsx`で同一キー名の別実装
+- Shadow token定義5パターン中4パターンが未使用の一方、`goshuin`配下2ファイルはtoken値に近い値を直書きで再実装（不採用状態）
+- Hero構成が`app/index.tsx`と`app/search/index.tsx`でほぼ同一キー構成の別実装
+- `statusCard`/`statusLabel`が`birthday`と`premium`の2画面で同名キーの別定義
+
+---
+
+## 7. 使用率まとめ
+
+| 対象 | 採用率（事実） |
+|---|---|
+| Web Button共通コンポーネント | 1/47ファイル |
+| Web Card共通コンポーネント | 2/43ファイル |
+| Web Input共通コンポーネント | 0/5ファイル |
+| Web shadcnセマンティック色 | 機能コード側1箇所のみ |
+| Mobile `app/design/spacing.ts` | 16/22画面（概算73%） |
+| Mobile `app/design/shadow.ts` | 定義5パターン中1パターン（`goldCta`）のみ実採用 |
+| Mobile `components/ui/Button.tsx` | 0画面（完全未使用） |
+| Mobile `app/theme.ts`の`colors`（ライトテーマ） | 実質0（未使用Buttonからの参照のみ） |
+
+---
+
+## 8. デッドコード候補
+
+以下はデッドコードの可能性が高いことを確認済みだが、本監査では削除しない。
+
+- `apps/mobile/lib/tokens/*.ts`（index.ts, radius.ts, spacing.ts, buttons.ts, cards.ts）: アプリ内のどこからもimportされていない
+- `apps/mobile/components/ui/Button.tsx`: アプリ内のどこからもimportされていない
+- `apps/mobile/app/theme.ts`の`colors`（ライトテーマ18キー）: 未使用Button経由の参照のみで実質不使用
+- `apps/mobile/app/design/shadow.ts`の`card`/`softCard`/`lightCard`/`skeleton`: 直接の参照箇所が未検出（間接参照の可能性は排除できず、断定はしない）
+- `apps/web/src/components/SampleButton.stories.tsx`: `ui/button.tsx`と無関係な独自ボタンclassNameを持つstoriesファイル（Storybook上のサンプルであり実装への組込みは未確認）
+
+---
+
+## 9. 未確認事項
+
+- Web: `--radius`変数が実際にどのComponentの計算に使われているか（shadcn/Tailwind解決の詳細は今回のgrep調査対象外）
+- Web: `text-[11px]`/`text-[10px]`という標準スケール外の値が多用されている理由が意図的仕様か
+- Web: `font-bold`と`font-semibold`の使い分け基準
+- Web: `apps/web/src/components/views/`配下（`MyPageView.tsx`等）が現行UIか旧UI残骸か（PR #1196関連の可能性があり、別途正本判定が必要）
+- Mobile: `app/design/shadow.ts`の`card`/`softCard`/`lightCard`/`skeleton`が本当に未使用か（スプレッド展開等の間接参照を全て追い切れていない）
+- Mobile: `app/design/*.ts`がExpo Routerのルートとして登録されている件（`_layout.tsx:106-110`）が意図的設計かファイル配置ミスか
+- Mobile: letterSpacing/lineHeightの用途分類は文脈からの推定であり、デザイン仕様書等との突合はしていない
+- Mobile: Spacingトークン採用率（画面単位73%）の分母定義・算出方法は厳密ではない
+- 全体: Web/Mobileのブランドカラー不一致（emerald vs gold）が意図的な差別化か、単なる実装の分岐かは本監査の範囲では判断できない
+
+---
+
+## 10. 設計判断が必要な事項
+
+以下は本監査では独断で結論を出さず、`docs/design/design-token.md`の保留事項として引き継ぐ。
+
+1. Web Emerald / Mobile Goldをブランドカラーとして統一するか、Platform別の意図的な表現差として許容するか
+2. Web Light基調 / Mobile Dark基調を統一するか（dark modeの正式対応を含む）
+3. Geist（Web）/ System Font（Mobile）のフォント統一可否
+4. Web/Mobileで完全に同じ実値（HEX等）を使うか、意味とToken名のみ共通化し実値はPlatformごとに割り当てるか
+5. Heroコンポーネントの全面共通化可否（Web/Mobileとも複数のHero実装が並存しており、役割自体は近いが画像有無等の差異がある）
+
+---
+
+## 11. 実装PR分割案
+
+Design Token v1導入時の実装PR分割は以下を想定する。詳細な目的・変更範囲・依存関係は`docs/design/design-token.md`の「Migration方針」に記載する。
+
+1. Token定義基盤（Primitive / Semantic Tokenの実装、Web CSS変数・Mobile theme拡張）
+2. Web Button / Card / Input適用
+3. Recommendation画面適用（Concierge結果画面）
+4. Shrine Detail適用
+5. Mobile Token正本整理（`app/theme.ts`/`app/design/*`の統合、`lib/tokens/*`の扱い決定）
+6. Mobile共通Component適用
+7. デッドコード整理（本監査で特定した未使用コードの削除判断、別PR）
+
+---
+
+## 品質確認
+
+- [x] 全セクションが事実（grep/Read確認済み）・未確認・保留のいずれかに明確に分類されている
+- [x] Web/Mobile比較でブランドカラー不一致という最重要事実を明記した
+- [x] `git diff --check`

--- a/docs/design/design-token.md
+++ b/docs/design/design-token.md
@@ -1,0 +1,318 @@
+> **Status: Active**
+>
+> 本ドキュメントは、KAMI MUSUBI（Web / Mobile）のDesign Token v1の正本候補である。
+>
+> 本文書はPhase 6監査（`docs/audit/design-token-phase6-audit.md`）の事実に基づくが、Token値・ブランド方針の一部は未確定である。「保留事項」節に列挙した項目は、この文書だけでは結論が出せない製品判断であり、決定後に本文書を更新する。
+>
+> 本文書は3層構造（Primitive / Semantic / Platform Theme）とカテゴリ体系を定義する。個々のToken名・実値は本文書の対象外とし、実装PRごとに別途定める。
+
+# KAMI MUSUBI Design Token v1
+
+## 目的
+
+Web（`apps/web`）とMobile（`apps/mobile`）に散在するColor / Typography / Spacing / Radius / Shadow / Componentの直接指定を、意味ベースのTokenへ段階的に置き換えるための設計方針を定める。
+
+Design Token v1は「値の統一」を最初のゴールにしない。まず「意味とToken名の共通語彙」を確立し、実値はPlatformごとの現状を尊重した形で段階移行することを目的とする。
+
+## 適用範囲
+
+- `apps/web`のColor / Typography / Spacing / Radius / Shadow / Component実装
+- `apps/mobile`のColor / Typography / Spacing / Radius / Shadow / Component実装
+- 上記を横断するSemantic Tokenの命名・分類体系
+
+## 非対象
+
+- 個々のToken実値（HEX、rem、px等の具体的な数値）の最終確定
+- Web Emerald / Mobile Goldのブランドカラー統一可否の決定
+- dark modeの正式対応（Mobileの`kamimusubiDark`は現状維持、Webへのdark mode追加は行わない）
+- Geist / System Fontの統一可否の決定
+- 既存Component実装のリファクタリング（本文書はToken設計のみを扱い、適用は別PRで行う）
+- `apps/mobile/lib/tokens/*`の削除（デッドコード候補として記録するのみ）
+
+---
+
+## 設計原則
+
+1. **Componentは原則Semantic Tokenを参照し、Primitive Tokenを直接参照しない。** Primitive Tokenへの直接参照は、Semantic Tokenで表現できない例外的なケースに限定し、その理由をコード上に残す。
+2. **WebとMobileの実値は、v1では一致を必須にしない。** 共通化するのは意味（Semantic Token名）であり、実値の割り当ては各PlatformのTheme層が担う。Web Emerald / Mobile Goldのような現行の不一致は、v1では「Platform Themeによる意図的な差」として許容する（統一するか否かは保留事項）。
+3. **既存の使用実態を無視した理想スケールを作らない。** Phase 6監査で確認した実際の値分布（例: Web `text-sm`/`text-xs`が基準、Radius `rounded-2xl`が最多）を出発点とし、乖離が大きい値は「統合候補」として明記するに留め、独断で採否を決めない。
+4. **Token名は画面名・機能名を含めない。** 「ConciergeCardColor」のような画面ベースの命名は行わず、役割ベース（例: `surface.card`, `text.primary`）で命名する。
+5. **移行は段階的に行う。** 既存実装を一括置換せず、Component単位・画面単位でPRを分割する（後述「Migration方針」）。
+
+---
+
+## 3層構造: Primitive / Semantic / Platform Theme
+
+### 1. Primitive Token
+
+素の値そのもの。色相・数値スケールなど、意味を持たない生の値の集合。
+
+- 例（構造のみ、実値は未確定）: `color.emerald.600`, `color.gold.500`, `space.4`, `space.8`, `radius.xl`
+- Primitive Tokenは複数のPlatformで共有できるが、共有を強制しない。WebとMobileで別々のPrimitive値セットを持つことを許容する（設計原則2）。
+- Componentから直接参照しない。
+
+### 2. Semantic Token
+
+役割・意味に基づくToken。Primitive Tokenを参照し、UIの「どこで何のために使うか」を表現する。
+
+- 例（構造のみ）: `color.background.surface`, `color.text.primary`, `color.action.primary`, `color.status.error`, `color.premium.accent`
+- Componentはこの層のみを参照する（設計原則1）。
+- Semantic Token名はWeb/Mobileで共通とする。実値（どのPrimitive Tokenを参照するか）はPlatform Theme層で決定する。
+
+### 3. Platform Theme
+
+Semantic Tokenに対して、各Platform（Web / Mobile、および将来的なlight/dark）ごとの実値を割り当てる層。
+
+- Web Theme: 現行のEmerald系ブランド・Light基調を出発点とする
+- Mobile Theme: 現行のGold系ブランド・Dark基調（`kamimusubiDark`）を出発点とする
+- 同一のSemantic Token（例: `color.action.primary`）が、Web Themeでは`emerald.600`相当、Mobile Themeでは`gold.500`相当を指してよい。この差を統一するかどうかは保留事項とする。
+
+```text
+Primitive Token（Platform別に別々の値集合を許容）
+        ↓ 参照
+Semantic Token（Web/Mobile共通の名前・共通の意味）
+        ↓ Platform Themeで実値を割り当て
+Web Theme / Mobile Theme（現行のEmerald/Gold、Light/Darkをそれぞれ尊重）
+        ↓ 参照
+Component（Semantic Tokenのみを参照）
+```
+
+---
+
+## Color
+
+Phase 6監査で確認した実際の用途分布に基づき、以下のカテゴリで整理する。
+
+| カテゴリ | 意味 | Web現行の対応（事実） | Mobile現行の対応（事実） |
+|---|---|---|---|
+| Background | ページ全体の背景 | `bg-white`中心 | `#07101F`（kamimusubiDark.background） |
+| Surface | Card等のコンテナ背景 | `bg-slate-50`/`bg-stone-50`等 | `#101827`（surface）/`#0B1424`（surfaceSoft） |
+| Text | 本文・見出しの文字色 | `text-slate-700`〜`900`系 | `#F7F0E3`（text）/`#A99B80`（muted） |
+| Border | 境界線 | `border-slate-200`/`border-stone-200`系 | `#384154`（border）/`#1A2336`（borderSoft） |
+| Action | ボタン等の操作要素 | `emerald-*`系 | `gold`（`#E0B963`）系 |
+| Status | success/error/warning/info | `red-*`/`rose-*`（error）が中心、success/warning/infoの体系的定義は未確認 | `error`/`errorBackground`定義はあるが未接続（`#FCA5A5`が孤立直書き）。success/warning/infoは未確認 |
+| Premium | Premium機能の強調表現 | `amber-*`系 | `gold`/`borderGold`（`#8A6C32`） |
+| Overlay | モーダル背景等の半透明オーバーレイ | `bg-black/50`と`bg-stone-950/35`が混在（不統一） | `rgba(7, 16, 31, 0.82)`と`rgba(7, 16, 31, 0.72)`が混在（不統一） |
+| Focus | フォーカスリング | `focus:border-emerald-300`, `focus:ring-stone-200`, `focus-visible:ring-neutral-400`が混在 | 明示的なfocus tokenは未確認 |
+
+**統合候補（Phase 6監査で確認した重複、方針は保留事項）**: Webのニュートラル系（slate/stone/gray/neutralの4系統）は、実装上明確な使い分け意図が確認できなかったため、Semantic Token設計時に統合可否を検討する対象とする。
+
+---
+
+## Typography
+
+| カテゴリ | 想定用途 | Web現行の近似値（事実、arbitrary値含む） | Mobile現行の近似値（事実） |
+|---|---|---|---|
+| Display | 最上位の大見出し | `text-4xl`（1件のみ確認） | fontSize 40/44/48台（数件） |
+| Heading | セクション見出し | `text-xl`(26回)/`text-2xl`(5回) | fontSize 22/26台 |
+| Body | 本文 | `text-sm`(325回)/`text-base`(17回) | fontSize 14/15台 |
+| Label | フォームラベル・補助見出し | `text-xs`(298回) | fontSize 12/13台 |
+| Caption | 補足・注記 | `text-[10px]`(22回)/`text-[9px]`(2回) | fontSize 10/11台 |
+| Eyebrow | セクション先頭の英字ラベル | `text-[11px] font-medium tracking-[0.2em]`（8ファイルで文字列完全一致、後述） | letterSpacing 0.3〜2.0の分布あり、専用カテゴリとしての明確な切り出しは未確認 |
+| Button | ボタン内テキスト | `text-sm font-semibold`が多数 | fontWeight "700"〜"900"が中心 |
+
+**Eyebrowカテゴリの根拠**: Phase 6監査で`text-[11px] font-medium tracking-[0.2em] text-stone-500`という4値セットが、home/concierge/explore/map横断で8ファイルに文字列として完全一致・重複していることを確認した。これは既に実質的な「共通パターン」として存在しており、v1で最優先にToken化する候補とする。
+
+**FontFamily**: WebはGeist（Sans/Mono）、Mobileはシステムデフォルト（fontFamily指定なし、未確認）。この差を統一するかは保留事項とする。
+
+---
+
+## Spacing
+
+4px基準のscaleを候補とする（Phase 6監査で確認したWeb/Mobile双方の値分布が4/8/12/16/20/24前後に集中しているため）。
+
+| Web現行の頻出値（事実） | Mobile現行の頻出値（事実） |
+|---|---|
+| `p-4`(107回), `px-4`(91回) ≒ 16px | `spacing.contentX20`(20) |
+| `px-3`(121回), `p-3`(53回) ≒ 12px | `spacing.smGap8`(8), `spacing.mdGap10`(10) |
+| `gap-2`(80回) ≒ 8px | `spacing.tightGap4`(4) |
+| `space-y-4`(42回) ≒ 16px | `spacing.lgGap12`(12), `spacing.xlGap16`(16) |
+
+WebとMobileの数値体系は現状別スケールであり、v1では両者を無理に一致させず、意味（Page/Section/Card/Button/Input/List/Inline）でSemantic Token名を揃えることを優先する。
+
+---
+
+## Radius
+
+役割ベースの分類を候補とする。
+
+| 役割 | Web現行の対応値（事実） | Mobile現行の対応値（事実） |
+|---|---|---|
+| Button | `rounded-md`(shadcn既定) | 個別画面ごとに14〜24が混在 |
+| Card | `rounded-xl`(103回)/`rounded-2xl`(123回、最多) | `radius.xl`(20)/`radius.lg`(18) |
+| Input | `rounded-md`(shadcn既定、ただし実採用率低い) | `radius.md`(16) |
+| Tag/Badge/Pill | `rounded-full`(108回、ほぼ全て) | `radius.pill`(999) |
+| Modal/Sheet | `rounded-xs`(sheet.tsx閉じるボタンのみ) | 個別画面ごとに分散 |
+| Image | 未確認（Card分類との重複が多い） | `radius.xs`(12)相当が一部使用 |
+
+---
+
+## Shadow / Elevation
+
+| 役割 | Web現行（Tailwindクラス） | Mobile現行（iOS shadow* + Android elevation） |
+|---|---|---|
+| elevation-0（フラット） | `shadow-none` | 未確認 |
+| elevation-1（Button/Input既定） | `shadow-xs` | 未確認 |
+| elevation-2（Card標準） | `shadow-sm`(41回、最多) | `card`（token定義済み、実採用は未検出） |
+| elevation-3（Card hover強調） | `shadow-md` | `softCard`（token定義済み、実採用は未検出） |
+| elevation-4（Modal/Sheet/強調CTA） | `shadow-lg` | `goldCta`（token定義済み、実採用2箇所で確認済み） |
+
+Mobileはプラットフォーム特性上、iOS用（`shadowColor`/`shadowOffset`/`shadowOpacity`/`shadowRadius`）とAndroid用（`elevation`）の値を1つのSemantic Tokenが両方保持する設計とする（Phase 6監査で確認した`app/design/shadow.ts`の既存パターンを踏襲）。
+
+---
+
+## Component Token
+
+Phase 6監査で確認した重複実装の規模に基づき、優先順位を以下のとおりとする。
+
+### P0（最優先）
+
+- **Button**: Web共通コンポーネント使用率1/47、Mobile共通コンポーネント使用率0/22という、両Platformで最も重複が大きい領域
+- **Card**: Web使用率2/43、Mobile少なくとも15画面で個別実装
+- **Input / Textarea**: Web使用率0/5、Mobile共有コンポーネント不在
+
+### P1
+
+- **Badge / Tag**: Web 20種以上、Mobile複数画面でキー名重複（`tagRow`/`tagPill`/`tagText`）
+- **Section**: Web 2系統並存（`DetailSection`/`SectionCard`）、Mobile 7画面以上で個別実装
+- **Premium CTA**: Web 5箇所でほぼ同一パターン重複、Mobileは`app/premium/index.tsx`に集約（他画面への重複は未確認）
+- **Status**: Web エラー表示で8種の独自実装、Mobile `statusCard`/`statusLabel`が2画面で別定義
+
+### P2
+
+- **Hero**: Web/Mobileともに複数の独立実装があるが、画像有無等の役割差があり全面共通化の可否は保留事項
+- **Modal / Sheet**: Web `sheet.tsx`（低使用率）、Mobile個別画面実装
+- **Navigation**: Mobile `_layout.tsx`のTabs設定のみ確認、Web側のNavigation Tokenは本監査範囲外
+
+各ComponentのToken（variant/size/state）の具体的な定義は、P0から着手する実装PR（後述Migration方針）の中で個別に確定する。本文書では優先順位と対象範囲のみを定める。
+
+---
+
+## 命名規則
+
+Token名は以下の階層で構成する（区切り文字・大文字小文字等の具体的なフォーマットはWeb/Mobile実装PRの中で確定し、本文書では階層構造のみを定める）。
+
+```text
+[layer].[category].[role].[variant?]
+```
+
+例（構造のみ、実際のToken名は未確定）:
+- `semantic.color.background.surface`
+- `semantic.color.action.primary`
+- `semantic.typography.eyebrow`
+- `semantic.spacing.card.padding`
+- `semantic.radius.pill`
+
+画面名・機能名（例: `concierge`, `shrineDetail`）をToken名に含めない（設計原則4）。
+
+---
+
+## Web実装形式
+
+- Primitive / Semantic Tokenは、現行の`apps/web/src/app/globals.css`の`@theme`ブロックに準ずる形式（CSS custom properties）での実装を候補とする。
+- 現行のshadcn `@theme`セマンティック層（`--background`, `--primary`等）と、v1で新設するSemantic Tokenの関係（統合するか、並存させるか）は実装PRの中で確定する。
+- Tailwindユーティリティクラスの直接使用（`bg-emerald-600`等）から、Semantic Token参照への移行は、Component単位で段階的に行う（一括置換は行わない）。
+
+## Mobile実装形式
+
+- Primitive / Semantic Tokenは、現行の`apps/mobile/app/design/*.ts`の構造（TypeScriptオブジェクトのexport）に準ずる形式を候補とする。
+- `app/theme.ts`（`colors`/`kamimusubiDark`）、`app/design/*.ts`、`lib/tokens/*.ts`という3系統の並存状態は、v1導入時に整理する（Migration方針「5. Mobile Token正本整理」を参照）。
+- `lib/tokens/*.ts`は本文書の時点ではデッドコードと確認済みだが、削除は別PR（Migration方針「7. デッドコード整理」）で判断する。
+
+## Fallback方針
+
+- Semantic Tokenが未定義のComponent・画面では、既存の直接指定（Tailwindクラス直書き、StyleSheet直書き）を維持してよい。v1は既存実装の破壊的な一括置換を前提としない。
+- 新規実装においては、可能な限りSemantic Tokenを参照する。Semantic Tokenで表現できない値が必要な場合は、Primitive Tokenへの直接参照を許容し、その理由をコード上に記録する。
+
+---
+
+## Migration方針
+
+Design Token v1の導入は、以下7段階のPRに分割する。各PRの目的・変更範囲・非対象・依存関係・Rollback方針を記録する。値・優先順位の詳細な見直しは、各PR着手時点の状況に応じて行ってよい。
+
+### 1. Token定義基盤
+
+- **目的**: Primitive / Semantic Tokenの型・値を実装し、Web（CSS custom properties）・Mobile（TypeScriptオブジェクト）双方に定義ファイルを作成する
+- **変更範囲**: 新規Token定義ファイルの追加のみ
+- **非対象**: 既存Componentの参照切り替え（このPRでは新Tokenをまだどこからも参照しない）
+- **依存関係**: なし（最初に着手する）
+- **Rollback方針**: 新規ファイルの削除のみで完全に戻せる。既存実装への影響なし
+
+### 2. Web Button / Card / Input適用
+
+- **目的**: P0 Componentのうち、Web側のButton/Card/Inputを新Semantic Tokenへ切り替える
+- **変更範囲**: `apps/web/src/components/ui/{button,card,input}.tsx`、およびこれらを参照するよう追加移行する機能コンポーネント（段階的、一括ではない）
+- **非対象**: Recommendation画面・Shrine Detail画面固有のCTA（PR 3, 4で対応）
+- **依存関係**: PR 1（Token定義基盤）
+- **Rollback方針**: 対象Component単位でrevert可能。Token定義自体（PR 1）には影響しない
+
+### 3. Recommendation画面適用
+
+- **目的**: Concierge結果画面（Hero/他候補カード等）のColor/Radius/Spacing/Shadowを新Semantic Tokenへ切り替える
+- **変更範囲**: `apps/web/src/features/concierge/**`
+- **非対象**: Backend・Analytics Event・Score/Ranking（別トラック）
+- **依存関係**: PR 1、可能であればPR 2（共通Button/Card活用のため）
+- **Rollback方針**: featureディレクトリ単位でrevert可能
+
+### 4. Shrine Detail適用
+
+- **目的**: 神社詳細画面のColor/Radius/Spacing/Shadowを新Semantic Tokenへ切り替える
+- **変更範囲**: `apps/web/src/components/shrine/**`
+- **非対象**: 神社詳細の文章・情報階層（別Epic、Phase 5監査で分離済み）
+- **依存関係**: PR 1、可能であればPR 2
+- **Rollback方針**: ディレクトリ単位でrevert可能
+
+### 5. Mobile Token正本整理
+
+- **目的**: `app/theme.ts`/`app/design/*.ts`/`lib/tokens/*.ts`の3系統並存を解消し、v1のSemantic Token構造へ統合する
+- **変更範囲**: `apps/mobile/app/theme.ts`, `apps/mobile/app/design/*.ts`
+- **非対象**: `lib/tokens/*.ts`の削除（PR 7で判断）、個別画面のStyleSheet切り替え（PR 6）
+- **依存関係**: PR 1
+- **Rollback方針**: Mobile側のtheme定義ファイルのみの変更のため、画面実装への影響を確認の上revert可能
+
+### 6. Mobile共通Component適用
+
+- **目的**: P0 Component（Button/Card/Input）のMobile版共通コンポーネント化と、主要画面への適用
+- **変更範囲**: `apps/mobile/components/ui/**`、適用対象画面（段階的）
+- **非対象**: 全22画面への一括適用（画面単位で分割する）
+- **依存関係**: PR 5
+- **Rollback方針**: 画面単位でrevert可能。共通コンポーネント自体の変更は影響範囲を確認の上判断
+
+### 7. デッドコード整理
+
+- **目的**: Phase 6監査で特定したデッドコード候補（`apps/mobile/lib/tokens/*.ts`, `apps/mobile/components/ui/Button.tsx`旧実装, `apps/web/src/components/SampleButton.stories.tsx`等）の削除判断
+- **変更範囲**: 削除対象ファイルの再確認（他PRのマージ後に参照が本当にゼロか再検索）と削除
+- **非対象**: このPR以前に判明していない新規デッドコードの調査（別途監査が必要な場合は別PR）
+- **依存関係**: PR 1〜6が完了し、旧実装への参照が完全になくなったことを確認してから着手
+- **Rollback方針**: `git revert`で削除ファイルを復元可能。削除前に対象ファイルが本当に無参照であることをPR本文に記録する
+
+---
+
+## Governance
+
+- 本文書のToken名・実値・カテゴリ構造を変更する場合は、`docs/audit/`配下に変更理由・影響範囲を記録した監査文書を作成した上で本文書を更新する。
+- Migration方針の各PRは、`docs/audit/legacy-settings-audit-update-policy.md`に準じ、共有文書（本文書・Phase 6監査文書）を並行更新しない。複数PRが同時に本文書を編集する必要がある場合は、専用の文書更新PRを別途作成する。
+- 保留事項（次節）の決定は、実装PRの中で暗黙的に行わない。決定した場合は本文書を更新し、決定の経緯を`docs/audit/`に記録する。
+
+---
+
+## 保留事項
+
+以下は本文書の時点では独断で確定しない。
+
+1. Web Emerald / Mobile Goldのブランドカラー統一可否
+2. Web Light / Mobile Darkの統一可否
+3. Geist / System Fontの統一可否
+4. dark modeの正式対応（Webへの追加を含む）
+5. Web/Mobileで完全に同じ実値を使うか、意味とToken名のみ共通化し実値はPlatform Themeに委ねるか
+6. Heroコンポーネントの全面共通化可否
+
+---
+
+## 品質確認
+
+- [x] Primitive / Semantic / Platform Themeの3層構造を、Componentからの参照方向を含めて定義した
+- [x] Token値・ブランド方針は確定させず、保留事項として明記した
+- [x] Web/Mobile差を統一しない前提を設計原則・各カテゴリ表で明記した
+- [x] 実装PR分割を7段階、各々目的/変更範囲/非対象/依存関係/Rollback方針付きで記録した
+- [x] `git diff --check`


### PR DESCRIPTION
## Summary
- Phase 6のWeb/Mobile並行監査（Color/Typography/Radius/Shadow/Spacing/Component棚卸し）の結果をもとに、Design Token v1の正本候補と監査記録を分離して文書化した
- `docs/audit/design-token-phase6-audit.md`: 監査記録（履歴・根拠、正本ではない）
- `docs/design/design-token.md`: Design Token v1正本候補

## Design Token v1の骨子
- **3層構造**: Primitive → Semantic → Platform Theme。Componentは原則Semantic Tokenのみを参照する
- **Platform差の許容**: WebとMobileの実値はv1では一致を必須にしない。共通化するのは意味とToken名のみで、実値の割り当ては各Platform Themeに委ねる（現行のWeb Emerald/Light基調とMobile Gold/Dark基調という根本的な差を、v1では「意図的な差として許容」する設計とした）
- **カテゴリ**: Color（Background/Surface/Text/Border/Action/Status/Premium/Overlay/Focus）、Typography（Display/Heading/Body/Label/Caption/Eyebrow/Button）、Spacing/Radius/Shadow、Component Token（P0: Button/Card/Input、P1: Badge・Section・Premium CTA・Status、P2: Hero・Modal・Navigation）
- **Migration方針**: 7段階のPR分割（Token定義基盤→Web Button/Card/Input→Recommendation画面→Shrine Detail→Mobile Token正本整理→Mobile共通Component→デッドコード整理）を、各々目的・変更範囲・非対象・依存関係・Rollback方針付きで記録

## 保留とした事項（独断で決定していません）
1. Web Emerald / Mobile Goldのブランドカラー統一可否
2. Web Light / Mobile Darkの統一可否
3. Geist / System Fontの統一可否
4. dark modeの正式対応
5. Web/Mobileで完全に同じ実値を使うか
6. Heroコンポーネントの全面共通化可否

## 監査で確認した主な事実
- Web: 共通Button/Card/Input使用率がそれぞれ1/47・2/43・0/5と極端に低く、同役割のCTAが24種以上の別々のclassName文字列として重複
- Mobile: トークン定義が`app/theme.ts`/`app/design/*`/`lib/tokens/*`の3系統並存し、`lib/tokens/*`と`components/ui/Button.tsx`は完全なデッドコード（本PRでは削除しない）
- Web/Mobileのブランドカラーが緑(emerald) vs 金(gold)で完全に不一致

## やらないこと
- 実装コード・CSS・StyleSheet・テストの変更
- Token値・ブランド方針の最終確定
- `apps/mobile/lib/tokens/*`の削除
- dark modeの追加

## Test plan
- [x] 作成ファイルは文書2件のみ（`docs/audit/design-token-phase6-audit.md`, `docs/design/design-token.md`）
- [x] `git diff --check` パス
- [x] pre-push hook（OpenAPI lint・Web契約テスト469件）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)