### PR TITLE
Design Token正本への文書導線とStatus表現を整備

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # docs/（設計・運用ドキュメント）
 
-このディレクトリは **AI参拝ナビの設計・運用・実装判断の根拠**を集約します。  
+このディレクトリは **AI参拝ナビの設計・運用・実装判断の根拠**を集約します。
 「どこに何が書いてあるか」を最短で辿れることを目的にしています。
 
 ---
@@ -151,6 +151,22 @@ WebはFrontendからBackend APIを直接呼び出さず、Next.js の `/api` Rou
 
 - `product/recommendation-v4-interpreter-contract.md`
   - Consultation InterpreterのInput / Output契約
+
+## 🎨 Design・UI基盤
+
+Web / Mobile共通のDesign Token、UI基盤および視覚言語に関する正本文書は以下を参照する。
+
+- `design/design-token.md`
+  - Primitive / Semantic / Platform Themeの3層構造
+  - Semantic Tokenの責務と参照原則
+  - Web / MobileのPlatform Theme差分方針
+  - Component Tokenの優先順位
+  - 段階的な移行順序とGovernance
+
+監査時点の現行値、重複実装およびWeb / Mobile比較の根拠は以下を参照する。
+
+- `audit/design-token-phase6-audit.md`
+  - Design Token Phase 6の棚卸し・比較・不整合記録
 
 ---
 

--- a/docs/design/design-token.md
+++ b/docs/design/design-token.md
@@ -1,6 +1,6 @@
 > **Status: Active**
 >
-> 本ドキュメントは、KAMI MUSUBI（Web / Mobile）のDesign Token v1の正本候補である。
+> 本ドキュメントは、KAMI MUSUBI（Web / Mobile）のDesign Token構造・責務・移行原則に関する現行正本である。
 >
 > 本文書はPhase 6監査（`docs/audit/design-token-phase6-audit.md`）の事実に基づくが、Token値・ブランド方針の一部は未確定である。「保留事項」節に列挙した項目は、この文書だけでは結論が出せない製品判断であり、決定後に本文書を更新する。
 >


### PR DESCRIPTION
- docs/README.mdにDesign・UI基盤の正本導線を追加

- Design Token正本をプロダクト・体験設計の直後へ配置

- design-token.mdのStatus: Activeと正本表現を整合

- 確定済みの構造・責務と未確定のToken値・ブランド方針を明確化

## Scope

- docs/README.md

- docs/design/design-token.md

## Test

- [x] Design・UI基盤の見出しが1件のみ

- [x] git diff --check

## Non-goals

- Token設計の変更

- Token値の決定

- CSS / TypeScript / Mobile StyleSheetの変更"