### PR TITLE
Web共通Component(Button/Card/Input)へDesign Token v1を適用する

### DIFF
--- a/apps/web/src/components/ui/__tests__/button.test.tsx
+++ b/apps/web/src/components/ui/__tests__/button.test.tsx
@@ -65,4 +65,59 @@ describe("Button", () => {
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "/mypage");
   });
+
+  it("追加のclassNameがButtonへ維持される", () => {
+    render(<Button className="custom-extra-class">追加class</Button>);
+    expect(screen.getByRole("button", { name: "追加class" })).toHaveClass("custom-extra-class");
+  });
+
+  it("disabledのとき操作不能になる", () => {
+    const onClick = vi.fn();
+    render(
+      <Button disabled onClick={onClick}>
+        無効
+      </Button>,
+    );
+    const btn = screen.getByRole("button", { name: "無効" });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("baseクラスがradius Semantic Tokenを参照する", () => {
+      render(<Button>Base</Button>);
+      expect(screen.getByRole("button", { name: "Base" }).className).toContain(
+        "rounded-[var(--kt-radius-control)]",
+      );
+    });
+
+    it("default variantがshadow Semantic Tokenを参照する", () => {
+      render(<Button variant="default">Default</Button>);
+      expect(screen.getByRole("button", { name: "Default" }).className).toContain(
+        "shadow-[var(--kt-shadow-low)]",
+      );
+    });
+
+    it("destructive variantがstatus-error Semantic Tokenを参照する", () => {
+      render(<Button variant="destructive">Destructive</Button>);
+      const className = screen.getByRole("button", { name: "Destructive" }).className;
+      expect(className).toContain("bg-[var(--kt-color-status-error)]");
+      expect(className).toContain("shadow-[var(--kt-shadow-low)]");
+    });
+
+    it("outline variantがsurface-default Semantic Tokenを参照する", () => {
+      render(<Button variant="outline">Outline</Button>);
+      const className = screen.getByRole("button", { name: "Outline" }).className;
+      expect(className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(className).toContain("shadow-[var(--kt-shadow-low)]");
+    });
+
+    it("secondary variantがshadow Semantic Tokenを参照する", () => {
+      render(<Button variant="secondary">Secondary</Button>);
+      expect(screen.getByRole("button", { name: "Secondary" }).className).toContain(
+        "shadow-[var(--kt-shadow-low)]",
+      );
+    });
+  });
 });

--- a/apps/web/src/components/ui/__tests__/card.test.tsx
+++ b/apps/web/src/components/ui/__tests__/card.test.tsx
@@ -4,6 +4,7 @@ import {
   CardContent,
   CardHeader,
   CardTitle,
+  CardDescription,
   CardFooter,
   CardAction,
 } from "../card"; // ← CardActionを追加
@@ -31,5 +32,38 @@ describe("Card", () => {
       </Card>
     );
     expect(screen.getByText("Click me")).toBeInTheDocument();
+  });
+
+  it("renders description", () => {
+    render(
+      <Card>
+        <CardDescription>説明文</CardDescription>
+      </Card>,
+    );
+    expect(screen.getByText("説明文")).toBeInTheDocument();
+  });
+
+  it("追加のclassNameがCardへ維持される", () => {
+    const { container } = render(<Card className="custom-extra-class">本文</Card>);
+    expect(container.querySelector('[data-slot="card"]')).toHaveClass("custom-extra-class");
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("Cardがsurface-default / shadow-medium Semantic Tokenを参照する", () => {
+      const { container } = render(<Card>本文</Card>);
+      const className = container.querySelector('[data-slot="card"]')?.className ?? "";
+      expect(className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(className).toContain("shadow-[var(--kt-shadow-medium)]");
+    });
+
+    it("CardDescriptionがtext-muted Semantic Tokenを参照する", () => {
+      const { container } = render(
+        <Card>
+          <CardDescription>説明</CardDescription>
+        </Card>,
+      );
+      const className = container.querySelector('[data-slot="card-description"]')?.className ?? "";
+      expect(className).toContain("text-[var(--kt-color-text-muted)]");
+    });
   });
 });

--- a/apps/web/src/components/ui/__tests__/input.test.tsx
+++ b/apps/web/src/components/ui/__tests__/input.test.tsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { Input } from "../input";
+
+describe("Input", () => {
+  it("入力欄として描画される", () => {
+    render(<Input placeholder="例: なまえ" />);
+    expect(screen.getByPlaceholderText("例: なまえ")).toBeInTheDocument();
+  });
+
+  it("value/onChangeが機能する", () => {
+    const onChange = vi.fn();
+    render(<Input value="初期値" onChange={onChange} readOnly={false} />);
+    const input = screen.getByDisplayValue("初期値");
+    fireEvent.change(input, { target: { value: "変更後" } });
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it("disabledのとき操作不能になる", () => {
+    render(<Input disabled placeholder="無効" />);
+    expect(screen.getByPlaceholderText("無効")).toBeDisabled();
+  });
+
+  it("追加のclassNameが維持される", () => {
+    render(<Input className="custom-extra-class" placeholder="test" />);
+    expect(screen.getByPlaceholderText("test")).toHaveClass("custom-extra-class");
+  });
+
+  it("aria-invalidを受け取れる", () => {
+    render(<Input aria-invalid="true" placeholder="不正値" />);
+    expect(screen.getByPlaceholderText("不正値")).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("refで実DOM要素を参照できる", () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(<Input ref={ref} placeholder="ref確認" />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it("type='file'を指定できる(file input互換)", () => {
+    const { container } = render(<Input type="file" />);
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("border-default / shadow-low / radius-control / text-muted / status-errorを参照する", () => {
+      render(<Input placeholder="token" />);
+      const className = screen.getByPlaceholderText("token").className;
+      expect(className).toContain("border-[var(--kt-color-border-default)]");
+      expect(className).toContain("shadow-[var(--kt-shadow-low)]");
+      expect(className).toContain("rounded-[var(--kt-radius-control)]");
+      expect(className).toContain("placeholder:text-[var(--kt-color-text-muted)]");
+      expect(className).toContain("aria-invalid:border-[var(--kt-color-status-error)]");
+    });
+  });
+});

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -5,18 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--kt-radius-control)] text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-[var(--kt-shadow-low)] hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+          "bg-[var(--kt-color-status-error)] text-white shadow-[var(--kt-shadow-low)] hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
         outline:
-          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+          "border bg-[var(--kt-color-surface-default)] shadow-[var(--kt-shadow-low)] hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+          "bg-secondary text-secondary-foreground shadow-[var(--kt-shadow-low)] hover:bg-secondary/80",
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-[var(--kt-color-surface-default)] text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-[var(--kt-shadow-medium)]",
         className
       )}
       {...props}
@@ -42,7 +42,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-[var(--kt-color-text-muted)] text-sm", className)}
       {...props}
     />
   )

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -8,9 +8,9 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-[var(--kt-color-text-muted)] selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-[var(--kt-color-border-default)] flex h-9 w-full min-w-0 rounded-[var(--kt-radius-control)] border bg-transparent px-3 py-1 text-base shadow-[var(--kt-shadow-low)] transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+        "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-[var(--kt-color-status-error)]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
`docs/design/design-token.md`に基づき、Web共通UI Component（Button/Card/Input）へDesign Token v1のSemantic Tokenを接続した。既存の見た目・公開API・利用方法は維持し、既存shadcn Token値と`--kt-*`のoklch値を厳密に照合して**完全一致する箇所のみ**を置換した。

## 重要な発見
shadcnのデフォルトテーマは、実際にはTailwind標準パレットの値をそのままoklch形式でコピーして使っている（例: `--border`=`slate-200`、`--primary`=`slate-900`、`--foreground`=`slate-950`、`--destructive`=`red-600`と完全一致）。これにより、多くの値を「見た目を変えずに」Semantic Tokenへ置換できることが判明した。

## 置換した箇所（値が完全一致することを確認済み）
- **Button**: base `rounded-md`→`--kt-radius-control`、各variantの`shadow-xs`→`--kt-shadow-low`、destructive `bg-destructive`(red-600)→`--kt-color-status-error`、outline `bg-background`(white)→`--kt-color-surface-default`
- **Card**: `bg-card`(white)→`--kt-color-surface-default`、`shadow-sm`→`--kt-shadow-medium`、CardDescription `text-muted-foreground`(slate-500)→`--kt-color-text-muted`
- **Input**: `border-input`(slate-200)→`--kt-color-border-default`、`shadow-xs`→`--kt-shadow-low`、`rounded-md`→`--kt-radius-control`、placeholder(slate-500)→`--kt-color-text-muted`、`aria-invalid:border-destructive`(red-600)→`--kt-color-status-error`

## 除外した箇所（見た目が変わるため）
- Button `bg-primary`(slate-900)・focus-visible ring(slate-400系): 対応するSemantic Tokenが別の色（emerald系）を指すため除外。**ユーザー提示の想定Token一覧に`--kt-color-border-focus`が含まれていたが、見た目維持を優先し今回は適用していない**（別PR候補）
- Card `rounded-xl`(0.75rem)・`text-card-foreground`(slate-950): Semantic Tokenの値（`--kt-radius-card`=1rem／`--kt-color-text-primary`=slate-900）と厳密に不一致のため除外
- Button `bg-secondary`(slate-100): 対応するSemantic Tokenなし

## 利用箇所への影響
実際の利用は`Button`が`MyGoshuinCard.tsx`（`variant="secondary"`、className完全上書き）のみ、`Card`が`RankingCard.tsx`/`app/ranking/page.tsx`（className上書きで背景色等を制御）のみ、`Input`は0箇所。いずれもclassName上書きにより既存の見た目が維持されることを実ブラウザで確認した。利用側ファイルは一切変更していない。

## Test plan
- [x] 既存テスト（クラス文字列を検証していないことを確認済み）は無修正で全パス
- [x] Token参照を検証する新規テスト19件追加（Button 7件、Card 4件、Input 8件）、CSS文字列全体比較は行わずToken参照の存在のみ確認
- [x] Web全テスト496件パス（既存477+新規19）
- [x] `npx tsc --noEmit` / `npx eslint .` パス
- [x] `pnpm --filter ./apps/web test:contract` パス
- [x] `git diff --check` パス
- [x] 実ブラウザ: `--tw-shadow`/背景色/radiusの計算値がToken値と完全一致することを確認。ランキング画面（Card実利用箇所）を375px/390px/430pxで確認、横スクロール・コンソールエラーなし、既存の見た目（黄色/グレー背景の上書き）が維持されていることを確認

## やらないこと
- Recommendation画面・Shrine Detailへの直接適用
- Mobile変更
- Brand色変更・Emerald/Gold統一・dark mode追加
- Typography Token適用
- Component API変更・全画面のclassName置換
- Button/Card/Input以外の共通Component変更
- Analytics・Backend/API変更
- focus-visible ring色の変更（別PR候補として報告）

🤖 Generated with [Claude Code](https://claude.com/claude-code)