### PR TITLE
Recommendation画面へDesign Tokenを適用

### DIFF
--- a/apps/web/src/components/shrines/ShrineCardCompact.tsx
+++ b/apps/web/src/components/shrines/ShrineCardCompact.tsx
@@ -49,9 +49,9 @@ export default function ShrineCardCompact({
   const originSummary = trustMetadata?.originSummary?.trim() || null;
 
   return (
-    <article className="rounded-2xl border border-slate-100 bg-white/90 p-3">
+    <article className="rounded-[var(--kt-radius-card)] border border-slate-100 bg-white/90 p-3">
       <div className="flex gap-3">
-        <div className="h-14 w-16 shrink-0 overflow-hidden rounded-xl bg-slate-100">
+        <div className="h-14 w-16 shrink-0 overflow-hidden rounded-[var(--kt-radius-image)] bg-slate-100">
           {imageUrl ? (
             <Image src={imageUrl} alt={name} width={64} height={56} className="h-full w-full object-cover" />
           ) : null}
@@ -59,7 +59,7 @@ export default function ShrineCardCompact({
 
         <div className="min-w-0 flex-1">
           <div className="space-y-1.5">
-            <h3 className="truncate text-sm font-semibold text-slate-900">{name}</h3>
+            <h3 className="truncate text-sm font-semibold text-[var(--kt-color-text-primary)]">{name}</h3>
             {visibleTrustLabels.length > 0 ? (
               <div className="flex flex-wrap gap-1">
                 {visibleTrustLabels.map((label) => (
@@ -72,17 +72,17 @@ export default function ShrineCardCompact({
                 ))}
               </div>
             ) : null}
-            {originSummary ? <p className="line-clamp-1 text-xs leading-5 text-slate-500">{originSummary}</p> : null}
+            {originSummary ? <p className="line-clamp-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{originSummary}</p> : null}
             {!originSummary && primaryReason ? (
-              <p className="line-clamp-1 text-xs leading-5 text-slate-500">{primaryReason}</p>
+              <p className="line-clamp-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{primaryReason}</p>
             ) : null}
           </div>
 
           {address || distText || href ? (
             <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
-              {address ? <span className="truncate text-xs text-slate-500">{address}</span> : null}
+              {address ? <span className="truncate text-xs text-[var(--kt-color-text-muted)]">{address}</span> : null}
 
-              {!address && distText ? <span className="text-xs text-slate-500">{distText}</span> : null}
+              {!address && distText ? <span className="text-xs text-[var(--kt-color-text-muted)]">{distText}</span> : null}
 
               {href ? (
                 <Link

--- a/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
+++ b/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
@@ -54,4 +54,27 @@ describe("ShrineCardCompact", () => {
 
     expect(container.querySelectorAll("p")).toHaveLength(0);
   });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("radius-card / radius-image / text-primary / text-mutedを参照する", () => {
+      const { container } = render(
+        <ShrineCardCompact
+          name="検証神社"
+          href="/shrines/1?ctx=concierge"
+          address="東京都千代田区1-1-1"
+          primaryReason="短い理由"
+        />,
+      );
+
+      const article = container.querySelector("article");
+      expect(article?.className).toContain("rounded-[var(--kt-radius-card)]");
+
+      const imageWrap = container.querySelector("article > div > div");
+      expect(imageWrap?.className).toContain("rounded-[var(--kt-radius-image)]");
+
+      expect(screen.getByText("検証神社").className).toContain("text-[var(--kt-color-text-primary)]");
+      expect(screen.getByText("東京都千代田区1-1-1").className).toContain("text-[var(--kt-color-text-muted)]");
+      expect(screen.getByText("短い理由").className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+  });
 });

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -37,9 +37,15 @@ type AnalyticsContext = Pick<
   "mode" | "flow" | "hasBirthdate" | "recommendationCount" | "historyTheme" | "consultationAxis"
 >;
 
-const conciergeSoftCardClass = "rounded-2xl border border-slate-200 bg-slate-50 shadow-sm p-4";
-const conciergeNoticeCardClass = "rounded-2xl border border-amber-200 bg-amber-50 shadow-sm p-4";
-const conciergePremiumCardClass = "rounded-2xl border border-amber-200 bg-amber-50/80 shadow-sm p-4";
+// Design Token v1: 実値が完全一致する箇所のみ --kt-* 参照へ置換 (docs/design/design-token.md)
+const conciergeSoftCardClass =
+  "rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] shadow-[var(--kt-shadow-medium)] p-4";
+// border-amber-200 / bg-amber-50 は値としてはPremium Tokenと一致するが、
+// 本カードの意味は「Notice(警告・注意喚起)」でありPremiumではないため、
+// 意味の異なるTokenを流用しないよう非適用とする(radius/shadowのみ置換)。
+const conciergeNoticeCardClass = "rounded-[var(--kt-radius-card)] border border-amber-200 bg-amber-50 shadow-[var(--kt-shadow-medium)] p-4";
+const conciergePremiumCardClass =
+  "rounded-[var(--kt-radius-card)] border border-[var(--kt-color-premium-border)] bg-amber-50/80 shadow-[var(--kt-shadow-medium)] p-4";
 
 /**
  * Conciergeではfavorite操作を提供しない。
@@ -113,7 +119,7 @@ function ConciergePremiumEntryCard(props: {
         <p className="text-xs leading-6 text-slate-600">相談内容に基づく状態整理、選んだ理由、行動の意味を記録として残せます。</p>
         <a
           href={href}
-          className="inline-flex items-center rounded-xl bg-amber-700 px-3 py-2 text-xs font-semibold text-white hover:bg-amber-800"
+          className="inline-flex items-center rounded-[var(--kt-radius-panel)] bg-[var(--kt-color-premium-accent)] px-3 py-2 text-xs font-semibold text-[var(--kt-color-text-inverse)] hover:bg-amber-800"
           onClick={() => {
             trackCardEvent({
               event: "premium_preview_click",
@@ -892,10 +898,10 @@ export default function ConciergeSectionsRenderer({
                             {shrineMeaningVisibility !== "hidden" ? (
                               <section className={conciergeSoftCardClass}>
                                 <div className="space-y-2">
-                                  <p className="text-xs font-semibold tracking-[0.12em] text-slate-500">
+                                  <p className="text-xs font-semibold tracking-[0.12em] text-[var(--kt-color-text-muted)]">
                                     相談から見た意味
                                   </p>
-                                  <p className="text-sm leading-7 text-slate-700">{reasonVm.detail.shrineMeaning}</p>
+                                  <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">{reasonVm.detail.shrineMeaning}</p>
                                 </div>
                               </section>
                             ) : null}
@@ -903,11 +909,11 @@ export default function ConciergeSectionsRenderer({
                             {historyThemeDisplay ? (
                               <section className={conciergeSoftCardClass}>
                                 <div className="space-y-2">
-                                  <p className="text-xs font-semibold tracking-[0.12em] text-slate-500">
+                                  <p className="text-xs font-semibold tracking-[0.12em] text-[var(--kt-color-text-muted)]">
                                     この神社が持つ文脈
                                   </p>
-                                  
-                                  <p className="text-sm leading-7 text-slate-700">{historyThemeDisplay.body}</p>
+
+                                  <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">{historyThemeDisplay.body}</p>
                                 </div>
                               </section>
                             ) : null}
@@ -915,10 +921,10 @@ export default function ConciergeSectionsRenderer({
                             {actionMeaningVisibility !== "hidden" ? (
                               <section className={conciergeSoftCardClass}>
                                 <div className="space-y-2">
-                                  <p className="text-xs font-semibold tracking-[0.12em] text-slate-500">
+                                  <p className="text-xs font-semibold tracking-[0.12em] text-[var(--kt-color-text-muted)]">
                                     今の自分への問い
                                   </p>
-                                  <p className="text-sm leading-7 text-slate-700">
+                                  <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">
                                     {actionMeaningVisibility === "teaser"
                                       ? "この結果を保存すると、今の状態や選んだ理由をあとから見返せます。"
                                       : (reasonVm.detail.actionMeaning ?? reasonVm.detail.shrineMeaning)}
@@ -960,7 +966,7 @@ export default function ConciergeSectionsRenderer({
                     <div className="pt-8">
                       <button
                         type="button"
-                        className="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-xs font-semibold text-slate-500 transition hover:bg-slate-50 hover:text-slate-700"
+                        className="w-full rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] px-4 py-3 text-xs font-semibold text-[var(--kt-color-text-muted)] transition hover:bg-[var(--kt-color-background-subtle)] hover:text-[var(--kt-color-text-secondary)]"
                         aria-expanded={showOtherRecommendations}
                         aria-controls={otherRecommendationsId}
                         onClick={() => setShowOtherRecommendations((prev) => !prev)}
@@ -970,10 +976,10 @@ export default function ConciergeSectionsRenderer({
 
                       {showOtherRecommendations ? (
                         <div id={otherRecommendationsId}>
-                          <div className="mb-2 mt-3 text-xs font-semibold tracking-[0.16em] text-slate-500">
+                          <div className="mb-2 mt-3 text-xs font-semibold tracking-[0.16em] text-[var(--kt-color-text-muted)]">
                             ほかの神社
                           </div>
-                          <p className="mb-3 text-xs leading-5 text-slate-500">迷った時の参考です。</p>
+                          <p className="mb-3 text-xs leading-5 text-[var(--kt-color-text-muted)]">迷った時の参考です。</p>
 
                           <div className="space-y-3">
                             {otherRegisteredItems.map((item: RegisteredShrineItem, compactIdx: number) => {

--- a/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
@@ -159,26 +159,26 @@ export default function ConciergeTopRecommendationHero({
               </div>
             ) : null}
 
-            {originSummary ? <p className="text-sm leading-7 text-slate-700">{originSummary}</p> : null}
-            {address ? <div className="text-xs leading-5 text-slate-500">{address}</div> : null}
+            {originSummary ? <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">{originSummary}</p> : null}
+            {address ? <div className="text-xs leading-5 text-[var(--kt-color-text-muted)]">{address}</div> : null}
           </div>
         </div>
 
-        <div className="rounded-2xl border border-emerald-100 bg-white/70 px-4 py-3 shadow-sm shadow-emerald-900/5">
+        <div className="rounded-[var(--kt-radius-card)] border border-emerald-100 bg-white/70 px-4 py-3 shadow-sm shadow-emerald-900/5">
           <div className="space-y-1.5">
             <p className="text-[11px] font-semibold tracking-[0.14em] text-emerald-700">今回の入口</p>
             <p className="text-sm font-semibold leading-6 text-slate-800">{entranceCopy}</p>
-            {topReasonLabel ? <p className="text-xs leading-5 text-slate-500">{topReasonLabel}</p> : null}
+            {topReasonLabel ? <p className="text-xs leading-5 text-[var(--kt-color-text-muted)]">{topReasonLabel}</p> : null}
           </div>
         </div>
 
         {actionSuggestionV4Summary ? (
           <div
-            className="rounded-2xl border border-teal-100 bg-teal-50/70 px-4 py-3 shadow-sm shadow-teal-900/5"
+            className="rounded-[var(--kt-radius-card)] border border-teal-100 bg-teal-50/70 px-4 py-3 shadow-sm shadow-teal-900/5"
             data-testid="hero-action-suggestion-v4-preview"
           >
             <p className="text-[11px] font-semibold tracking-[0.14em] text-teal-700">次の一歩</p>
-            <p className="mt-1 truncate text-sm leading-6 text-slate-700">{actionSuggestionV4Summary}</p>
+            <p className="mt-1 truncate text-sm leading-6 text-[var(--kt-color-text-secondary)]">{actionSuggestionV4Summary}</p>
           </div>
         ) : null}
 
@@ -187,7 +187,7 @@ export default function ConciergeTopRecommendationHero({
             <Link
               href={href}
               onClick={onDetailClick}
-              className="inline-flex w-full items-center justify-center rounded-2xl bg-emerald-600 px-5 py-3.5 text-sm font-bold text-white shadow-md shadow-emerald-900/20 transition hover:bg-emerald-700"
+              className="inline-flex w-full items-center justify-center rounded-[var(--kt-radius-card)] bg-[var(--kt-color-action-primary)] px-5 py-3.5 text-sm font-bold text-[var(--kt-color-action-primary-text)] shadow-md shadow-emerald-900/20 transition hover:bg-[var(--kt-color-action-primary-hover)]"
             >
               {routeLabel}
             </Link>

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.otherRecommendations.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.otherRecommendations.test.tsx
@@ -196,4 +196,19 @@ describe("ConciergeSectionsRenderer - 他候補の開閉UI", () => {
       }),
     );
   });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("開閉トリガーボタンがradius-card / border-default / surface-default / text-mutedを参照する", () => {
+      const payload = buildTestPayload([heroRec, otherRecWithAddress]);
+      render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+      const toggle = screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" });
+      expect(toggle.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(toggle.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(toggle.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(toggle.className).toContain("text-[var(--kt-color-text-muted)]");
+      expect(toggle.className).toContain("hover:bg-[var(--kt-color-background-subtle)]");
+      expect(toggle.className).toContain("hover:text-[var(--kt-color-text-secondary)]");
+    });
+  });
 });

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
@@ -185,4 +185,41 @@ describe("ConciergeTopRecommendationHero", () => {
     fireEvent.click(screen.getByRole("link", { name: "神社の詳細を見る" }));
     expect(onDetailClick).toHaveBeenCalledTimes(1);
   });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("CTAリンクがaction-primary系Tokenを参照する", () => {
+      render(
+        <ConciergeTopRecommendationHero
+          name="検証神社"
+          href="/shrines/17?ctx=concierge"
+          catchCopy="今の相談に合う候補です。"
+          routeLabel="詳しく見る"
+        />,
+      );
+
+      const cta = screen.getByRole("link", { name: "詳しく見る" });
+      expect(cta.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(cta.className).toContain("bg-[var(--kt-color-action-primary)]");
+      expect(cta.className).toContain("text-[var(--kt-color-action-primary-text)]");
+      expect(cta.className).toContain("hover:bg-[var(--kt-color-action-primary-hover)]");
+    });
+
+    it("originSummary / address / topReasonLabelがtext-secondary / text-mutedを参照する", () => {
+      render(
+        <ConciergeTopRecommendationHero
+          name="検証神社"
+          href="/shrines/17?ctx=concierge"
+          catchCopy="今の相談に合う候補です。"
+          originSummary="由緒の要約"
+          address="東京都千代田区1-1-1"
+          topReasonLabel="選ばれた理由"
+          routeLabel="詳しく見る"
+        />,
+      );
+
+      expect(screen.getByText("由緒の要約").className).toContain("text-[var(--kt-color-text-secondary)]");
+      expect(screen.getByText("東京都千代田区1-1-1").className).toContain("text-[var(--kt-color-text-muted)]");
+      expect(screen.getByText("選ばれた理由").className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+  });
 });


### PR DESCRIPTION
- Recommendation画面のColor / Radius / Shadow指定をSemantic Token参照へ変更

- 現行値とToken値が完全一致する箇所だけを置換

- Hero・意味カード・Premium導線・他候補UIの見た目と挙動を維持

## Scope

- ConciergeTopRecommendationHero

- ConciergeSectionsRendererのRecommendation表示範囲

- ShrineCardCompact

- 関連テスト

## Design decisions

- SpacingとTypographyは今回の対象外

- Emerald / Tealの半透明Surfaceとブランド色付きShadowは対応Tokenと実値が一致しないため未適用

- NoticeカードはPremiumと責務が異なるためPremium Tokenを流用しない

- PR #2086で追加した他候補の開閉・ARIA・理由・住所・Analytics契約は変更しない

## Non-goals

- Recommendation Reason文言変更

- 情報階層変更

- 他候補UI仕様変更

- Premium境界変更

- Analytics変更

- Backend / API変更

- 神社詳細画面変更

## Test

- [x] 対象テスト22件成功

- [x] Web全500テスト成功

- [x] TypeScript成功

- [x] ESLint成功

- [x] Contract test成功

- [x] git diff --check成功

- [x] 375px / 390px / 430pxで表示確認

- [x] CSS変数の解決を確認

- [x] コンソールエラーなし"