### PR TITLE
神社詳細画面へDesign Tokenを適用

### DIFF
--- a/apps/web/src/components/shrine/DetailDisclosureBlock.tsx
+++ b/apps/web/src/components/shrine/DetailDisclosureBlock.tsx
@@ -40,7 +40,7 @@ export default function DetailDisclosureBlock({
   const lv = levelLabel(level);
 
   return (
-    <div className="overflow-hidden rounded-2xl border bg-white">
+    <div className="overflow-hidden rounded-[var(--kt-radius-card)] border bg-[var(--kt-color-surface-default)]">
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
@@ -48,9 +48,9 @@ export default function DetailDisclosureBlock({
         aria-expanded={open}
       >
         {materials.length ? (
-          <div className="shrink-0 rounded-xl border bg-white p-3">
-            <div className="text-xs font-semibold text-slate-700">材料</div>
-            <ul className="mt-2 space-y-1 text-xs text-slate-700">
+          <div className="shrink-0 rounded-[var(--kt-radius-panel)] border bg-[var(--kt-color-surface-default)] p-3">
+            <div className="text-xs font-semibold text-[var(--kt-color-text-secondary)]">材料</div>
+            <ul className="mt-2 space-y-1 text-xs text-[var(--kt-color-text-secondary)]">
               {materials.map((m) => (
                 <li key={m.label}>
                   {m.label}：{m.value}
@@ -62,9 +62,9 @@ export default function DetailDisclosureBlock({
 
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <div className="truncate text-sm font-semibold text-slate-900">{title}</div>
+            <div className="truncate text-sm font-semibold text-[var(--kt-color-text-primary)]">{title}</div>
             {lv ? (
-              <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-700">
+              <span className="shrink-0 rounded-[var(--kt-radius-pill)] bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-[var(--kt-color-text-secondary)]">
                 {lv}
               </span>
             ) : null}
@@ -81,8 +81,8 @@ export default function DetailDisclosureBlock({
       </button>
 
       {open ? (
-        <div className="border-t bg-white px-4 pb-4 pt-3">
-          {hint ? <div className="mb-3 text-xs text-slate-500">{hint}</div> : null}
+        <div className="border-t bg-[var(--kt-color-surface-default)] px-4 pb-4 pt-3">
+          {hint ? <div className="mb-3 text-xs text-[var(--kt-color-text-muted)]">{hint}</div> : null}
           {children}
         </div>
       ) : null}

--- a/apps/web/src/components/shrine/ShrineDetailShell.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailShell.tsx
@@ -65,8 +65,8 @@ export default function ShrineDetailShell({
         </div>
 
         <div className="min-w-0 flex-1 px-2 text-center">
-          <div className="truncate text-sm font-semibold text-slate-900">{title}</div>
-          {subtitle ? <div className="truncate text-[11px] text-slate-500">{subtitle}</div> : null}
+          <div className="truncate text-sm font-semibold text-[var(--kt-color-text-primary)]">{title}</div>
+          {subtitle ? <div className="truncate text-[11px] text-[var(--kt-color-text-muted)]">{subtitle}</div> : null}
         </div>
 
         {/* 右側はレイアウト固定のため空 */}
@@ -86,7 +86,7 @@ export default function ShrineDetailShell({
                 ctx={ctx}
                 tid={tid}
                 historyTheme={historyTheme}
-                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-xl bg-slate-900 px-4 py-3 text-sm font-semibold text-white hover:bg-slate-800"
+                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] bg-slate-900 px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-inverse)] hover:bg-slate-800"
               />
             ) : null}
 
@@ -97,7 +97,7 @@ export default function ShrineDetailShell({
             {addGoshuinHref ? (
               <Link
                 href={addGoshuinHref}
-                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-xl border bg-white px-4 py-3 text-sm font-semibold text-slate-900 hover:bg-slate-50"
+                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] border bg-[var(--kt-color-surface-default)] px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-primary)] hover:bg-slate-50"
               >
                 {LABELS.addGoshuin}
               </Link>

--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -84,18 +84,18 @@ export default function ShrineSaveButton({
 
   const buttonClass =
     variant === "subtle"
-      ? `inline-flex w-full items-center justify-center rounded-xl border px-4 py-2.5 text-xs font-semibold transition
+      ? `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-2.5 text-xs font-semibold transition
           ${
             fav
               ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-              : "border-slate-200 bg-white text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+              : "border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-muted)] hover:bg-slate-50 hover:text-slate-700"
           }
           disabled:opacity-60`
-      : `inline-flex w-full items-center justify-center rounded-xl border px-4 py-3 text-sm font-semibold transition
+      : `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold transition
           ${
             fav
               ? "border-emerald-300 bg-emerald-50 text-emerald-700"
-              : "border-slate-300 bg-white text-slate-900 hover:bg-slate-50"
+              : "border-[var(--kt-color-border-strong)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-primary)] hover:bg-slate-50"
           }
           disabled:opacity-60`;
 
@@ -111,7 +111,7 @@ export default function ShrineSaveButton({
               : "あとで見返すために保存"}
       </button>
 
-      {err ? <p className="text-xs text-red-600">{err}</p> : null}
+      {err ? <p className="text-xs text-[var(--kt-color-status-error)]">{err}</p> : null}
     </div>
   );
 }

--- a/apps/web/src/components/shrine/__tests__/DetailDisclosureBlock.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/DetailDisclosureBlock.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import DetailDisclosureBlock from "../DetailDisclosureBlock";
+
+describe("DetailDisclosureBlock", () => {
+  it("初期状態では閉じており、aria-expandedはfalseでchildrenは表示されない", () => {
+    render(
+      <DetailDisclosureBlock title="ご利益" summary="要約テキスト">
+        <p>詳細本文</p>
+      </DetailDisclosureBlock>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /ご利益/ });
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("詳細本文")).not.toBeInTheDocument();
+  });
+
+  it("クリックすると開き、aria-expandedがtrueになりchildrenが表示される", () => {
+    render(
+      <DetailDisclosureBlock title="ご利益" summary="要約テキスト">
+        <p>詳細本文</p>
+      </DetailDisclosureBlock>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /ご利益/ }));
+
+    const trigger = screen.getByRole("button", { name: /ご利益/ });
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("詳細本文")).toBeInTheDocument();
+  });
+
+  it("再度クリックすると閉じ、childrenが非表示になる", () => {
+    render(
+      <DetailDisclosureBlock title="ご利益" summary="要約テキスト">
+        <p>詳細本文</p>
+      </DetailDisclosureBlock>,
+    );
+
+    const trigger = screen.getByRole("button", { name: /ご利益/ });
+    fireEvent.click(trigger);
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("詳細本文")).not.toBeInTheDocument();
+  });
+
+  it("defaultOpenがtrueの場合、初期状態から開いて表示する", () => {
+    render(
+      <DetailDisclosureBlock title="ご利益" summary="要約テキスト" defaultOpen>
+        <p>詳細本文</p>
+      </DetailDisclosureBlock>,
+    );
+
+    expect(screen.getByRole("button", { name: /ご利益/ })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("詳細本文")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("外枠がradius-card / surface-defaultを参照する", () => {
+      const { container } = render(
+        <DetailDisclosureBlock title="ご利益" summary="要約テキスト">
+          <p>詳細本文</p>
+        </DetailDisclosureBlock>,
+      );
+
+      const wrapper = container.firstElementChild;
+      expect(wrapper?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(wrapper?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+
+    it("titleがtext-primaryを、開閉パネルがsurface-defaultを参照する", () => {
+      render(
+        <DetailDisclosureBlock title="ご利益" summary="要約テキスト" hint="補足ヒント">
+          <p>詳細本文</p>
+        </DetailDisclosureBlock>,
+      );
+
+      expect(screen.getByText("ご利益").className).toContain("text-[var(--kt-color-text-primary)]");
+
+      fireEvent.click(screen.getByRole("button", { name: /ご利益/ }));
+
+      expect(screen.getByText("補足ヒント").className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+
+    it("levelバッジがradius-pillを参照する", () => {
+      render(
+        <DetailDisclosureBlock title="ご利益" summary="要約テキスト" level="strong">
+          <p>詳細本文</p>
+        </DetailDisclosureBlock>,
+      );
+
+      expect(screen.getByText("高").className).toContain("rounded-[var(--kt-radius-pill)]");
+    });
+
+    it("materialsがある場合、材料ブロックがradius-panel / surface-defaultを参照する", () => {
+      render(
+        <DetailDisclosureBlock
+          title="ご利益"
+          summary="要約テキスト"
+          materials={[{ label: "五行", value: "木" }]}
+        >
+          <p>詳細本文</p>
+        </DetailDisclosureBlock>,
+      );
+
+      const materialsHeading = screen.getByText("材料");
+      const materialsBlock = materialsHeading.parentElement;
+      expect(materialsBlock?.className).toContain("rounded-[var(--kt-radius-panel)]");
+      expect(materialsBlock?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/__tests__/ShrineDetailShell.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/ShrineDetailShell.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineDetailShell from "../ShrineDetailShell";
+
+describe("ShrineDetailShell", () => {
+  it("titleとsubtitleを表示する", () => {
+    render(
+      <ShrineDetailShell title="乃木神社" subtitle="東京都港区赤坂" close={{ kind: "back", label: "戻る" }} />,
+    );
+
+    expect(screen.getByText("乃木神社")).toBeInTheDocument();
+    expect(screen.getByText("東京都港区赤坂")).toBeInTheDocument();
+  });
+
+  it("操作対象がない場合は操作sectionを表示しない", () => {
+    render(<ShrineDetailShell title="乃木神社" close={{ kind: "back", label: "戻る" }} />);
+
+    expect(screen.queryByText("操作")).not.toBeInTheDocument();
+  });
+
+  it("hideActionsがtrueの場合、CTAがあっても操作sectionを表示しない", () => {
+    render(
+      <ShrineDetailShell
+        title="乃木神社"
+        close={{ kind: "back", label: "戻る" }}
+        googleDirHref="https://maps.google.com/?q=1,1"
+        hideActions
+      />,
+    );
+
+    expect(screen.queryByText("操作")).not.toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("titleがtext-primaryを、subtitleがtext-mutedを参照する", () => {
+      render(
+        <ShrineDetailShell title="乃木神社" subtitle="東京都港区赤坂" close={{ kind: "back", label: "戻る" }} />,
+      );
+
+      expect(screen.getByText("乃木神社").className).toContain("text-[var(--kt-color-text-primary)]");
+      expect(screen.getByText("東京都港区赤坂").className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+
+    it("経路案内CTAがradius-panel / text-inverseを参照する", () => {
+      render(
+        <ShrineDetailShell
+          title="乃木神社"
+          close={{ kind: "back", label: "戻る" }}
+          googleDirHref="https://maps.google.com/?q=1,1"
+        />,
+      );
+
+      const cta = screen.getByRole("link", { name: "Googleマップで経路案内" });
+      expect(cta.className).toContain("rounded-[var(--kt-radius-panel)]");
+      expect(cta.className).toContain("text-[var(--kt-color-text-inverse)]");
+    });
+
+    it("御朱印追加CTAがradius-panel / surface-default / text-primaryを参照する", () => {
+      render(
+        <ShrineDetailShell
+          title="乃木神社"
+          close={{ kind: "back", label: "戻る" }}
+          addGoshuinHref="/shrines/17/goshuins/new"
+        />,
+      );
+
+      const cta = screen.getByRole("link", { name: "御朱印を追加" });
+      expect(cta.className).toContain("rounded-[var(--kt-radius-panel)]");
+      expect(cta.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(cta.className).toContain("text-[var(--kt-color-text-primary)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/__tests__/ShrineSaveButton.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/ShrineSaveButton.test.tsx
@@ -125,4 +125,44 @@ describe("ShrineSaveButton", () => {
     expect(pushMock).not.toHaveBeenCalled();
     expect(trackMock).not.toHaveBeenCalled();
   });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("未保存時、defaultバリアントがradius-panel / border-strong / surface-default / text-primaryを参照する", () => {
+      useFavoriteMock.mockImplementation(() => ({
+        fav: false,
+        busy: false,
+        toggle: vi.fn(),
+      }));
+
+      render(<ShrineSaveButton shrineId={17} nextPath="/shrines/17" guestMode={false} />);
+
+      const button = screen.getByRole("button", { name: "あとで見返すために保存" });
+      expect(button.className).toContain("rounded-[var(--kt-radius-panel)]");
+      expect(button.className).toContain("border-[var(--kt-color-border-strong)]");
+      expect(button.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(button.className).toContain("text-[var(--kt-color-text-primary)]");
+    });
+
+    it("エラー表示がstatus-errorを参照する", async () => {
+      useFavoriteMock.mockImplementation(() => ({
+        fav: true,
+        busy: false,
+        toggle: vi.fn().mockRejectedValue(new Error("failed")),
+      }));
+
+      render(
+        <ShrineSaveButton
+          shrineId={17}
+          nextPath="/shrines/17"
+          guestMode={false}
+          initial={{ fav: true, favorite_id: 1 }}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "保存しました" }));
+
+      const errorText = await screen.findByText("保存の更新に失敗しました");
+      expect(errorText.className).toContain("text-[var(--kt-color-status-error)]");
+    });
+  });
 });

--- a/apps/web/src/components/shrine/detail/ShrineActionSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineActionSection.tsx
@@ -9,7 +9,7 @@ function ActionItems({ items }: { items: DetailMeaningItem[] }) {
   return (
     <div className="space-y-3">
       {items.map((item) => (
-        <div key={item.key} className="rounded-2xl border border-amber-200 bg-amber-50 p-4 shadow-sm">
+        <div key={item.key} className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-premium-border)] bg-[var(--kt-color-premium-surface)] p-4 shadow-[var(--kt-shadow-medium)]">
           <h3 className="text-sm font-semibold text-amber-950">{item.title}</h3>
           <p className="mt-2 text-[15px] leading-7 text-amber-950">{item.body}</p>
         </div>
@@ -20,8 +20,8 @@ function ActionItems({ items }: { items: DetailMeaningItem[] }) {
 
 export default function ShrineActionSection({ section }: Props) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4">
-      <h2 className="text-base font-semibold text-slate-900">{section.heading}</h2>
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">{section.heading}</h2>
 
       <div className="mt-4">
         <ActionItems items={section.items} />

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -176,7 +176,7 @@ function PremiumUpgradePrompt({
   const ctaLabel = isGuestUser ? "ログインして意味を深掘りする" : "この神社を選ぶ意味を深掘りする";
 
   return (
-    <section className="rounded-2xl border border-amber-100 bg-amber-50/70 p-4">
+    <section className="rounded-[var(--kt-radius-card)] border border-amber-100 bg-amber-50/70 p-4">
       <div className="space-y-2">
         <p className="text-sm font-semibold leading-6 text-amber-950">
           {isGuestUser
@@ -186,7 +186,7 @@ function PremiumUpgradePrompt({
         <p className="text-xs leading-6 text-slate-600">相談内容に基づく状態整理、相性、行動の意味づけを表示します。</p>
         <Link
           href={href}
-          className="inline-flex items-center rounded-xl bg-amber-700 px-3 py-2 text-xs font-semibold text-white hover:bg-amber-800"
+          className="inline-flex items-center rounded-[var(--kt-radius-panel)] bg-[var(--kt-color-premium-accent)] px-3 py-2 text-xs font-semibold text-[var(--kt-color-text-inverse)] hover:bg-amber-800"
           onClick={() =>
             trackCardEvent({
               event: "premium_preview_click",
@@ -213,11 +213,11 @@ function ShrineDetailHeroHeader(props: { title: string; heroMeaningCopy?: string
   const resolvedHeroMeaningCopy = props.heroMeaningCopy?.trim() || "今のあなたと静かに重なる神社です。";
 
   return (
-    <section className="rounded-2xl border bg-white p-5 shadow-sm">
+    <section className="rounded-[var(--kt-radius-card)] border bg-[var(--kt-color-surface-default)] p-5 shadow-[var(--kt-shadow-medium)]">
       <div className="space-y-2">
-        <h1 className="text-xl font-semibold tracking-tight text-slate-900">{props.title}</h1>
+        <h1 className="text-xl font-semibold tracking-tight text-[var(--kt-color-text-primary)]">{props.title}</h1>
 
-        <p className="text-[11px] font-semibold tracking-[0.08em] text-slate-500">この神社の意味</p>
+        <p className="text-[11px] font-semibold tracking-[0.08em] text-[var(--kt-color-text-muted)]">この神社の意味</p>
 
         <p className="text-[15px] leading-7 text-slate-800">{resolvedHeroMeaningCopy}</p>
 
@@ -289,12 +289,12 @@ function ShrineDetailStateDeltaSection({
 
   if (!isPremiumActive) {
     return (
-      <section className="rounded-2xl border border-amber-200 bg-amber-50/80 p-4">
+      <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-premium-border)] bg-amber-50/80 p-4">
         <div className="space-y-2">
-          <p className="text-xs font-semibold tracking-[0.08em] text-amber-700">前回との違い</p>
+          <p className="text-xs font-semibold tracking-[0.08em] text-[var(--kt-color-premium-accent)]">前回との違い</p>
           <p className="text-sm font-semibold leading-6 text-amber-950">Premiumでは、前回からの変化をこの神社選びとあわせて確認できます。</p>
           <p className="text-xs leading-6 text-slate-600">今回強く出たテーマや、変わらず残っているテーマを見返せます。</p>
-          <Link href="/billing/upgrade?source=shrine_detail_state_delta&funnelStep=comparison_preview" className="inline-flex rounded-2xl bg-amber-700 px-4 py-2 text-sm font-semibold text-white hover:bg-amber-800">
+          <Link href="/billing/upgrade?source=shrine_detail_state_delta&funnelStep=comparison_preview" className="inline-flex rounded-[var(--kt-radius-card)] bg-[var(--kt-color-premium-accent)] px-4 py-2 text-sm font-semibold text-[var(--kt-color-text-inverse)] hover:bg-amber-800">
             前回との違いを見る
           </Link>
         </div>
@@ -303,32 +303,32 @@ function ShrineDetailStateDeltaSection({
   }
 
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4 shadow-[var(--kt-shadow-medium)]">
       <div className="space-y-4">
         <div>
           <p className="text-xs font-semibold tracking-[0.08em] text-slate-400">前回との違い</p>
-          <p className="mt-2 text-sm leading-6 text-slate-700">
+          <p className="mt-2 text-sm leading-6 text-[var(--kt-color-text-secondary)]">
             {stateDelta.summary ??
               "今回の相談内容から、前回との違いを整理しています。相談を重ねるほど、変化の見え方が安定します。"}
           </p>
         </div>
 
         {stateDelta.transitionNarrative?.summary ? (
-          <div className="rounded-2xl bg-emerald-50/60 p-3">
+          <div className="rounded-[var(--kt-radius-card)] bg-emerald-50/60 p-3">
             <p className="text-xs font-semibold text-emerald-700">前回から変わったこと</p>
             <p className="mt-1 text-sm font-semibold leading-6 text-slate-800">
               {stateDelta.transitionNarrative.title}
             </p>
-            <p className="mt-2 text-sm leading-6 text-slate-700">{stateDelta.transitionNarrative.summary}</p>
+            <p className="mt-2 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{stateDelta.transitionNarrative.summary}</p>
           </div>
         ) : null}
 
         {stateDelta.actionReflection ? (
-          <div className="rounded-2xl bg-amber-50/70 p-3">
-            <p className="text-xs font-semibold text-amber-700">前回の行動</p>
+          <div className="rounded-[var(--kt-radius-card)] bg-amber-50/70 p-3">
+            <p className="text-xs font-semibold text-[var(--kt-color-premium-accent)]">前回の行動</p>
             <p className="mt-1 text-sm font-semibold leading-6 text-slate-800">{stateDelta.actionReflection.title}</p>
-            <p className="mt-2 text-sm leading-6 text-slate-700">{stateDelta.actionReflection.summary}</p>
-            <p className="mt-2 text-xs font-semibold text-amber-700">{stateDelta.actionReflection.nextActionLabel}</p>
+            <p className="mt-2 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{stateDelta.actionReflection.summary}</p>
+            <p className="mt-2 text-xs font-semibold text-[var(--kt-color-premium-accent)]">{stateDelta.actionReflection.nextActionLabel}</p>
           </div>
         ) : null}
 
@@ -338,9 +338,9 @@ function ShrineDetailStateDeltaSection({
           defaultOpen={false}
         >
           <div className="space-y-3">
-            <div className="rounded-2xl bg-slate-50 p-3">
-              <p className="text-xs font-semibold text-slate-500">今優先したいこと</p>
-              <p className="mt-2 text-sm leading-6 text-slate-700">
+            <div className="rounded-[var(--kt-radius-card)] bg-[var(--kt-color-background-subtle)] p-3">
+              <p className="text-xs font-semibold text-[var(--kt-color-text-muted)]">今優先したいこと</p>
+              <p className="mt-2 text-sm leading-6 text-[var(--kt-color-text-secondary)]">
                 {renderStateDeltaTagSentence(
                   changedNeedTags,
                   "今回は新しく強まったテーマを断定するより、今見えている流れを優先して整理しています。",
@@ -348,9 +348,9 @@ function ShrineDetailStateDeltaSection({
               </p>
             </div>
 
-            <div className="rounded-2xl bg-slate-50 p-3">
-              <p className="text-xs font-semibold text-slate-500">変わらず残っていること</p>
-              <p className="mt-2 text-sm leading-6 text-slate-700">
+            <div className="rounded-[var(--kt-radius-card)] bg-[var(--kt-color-background-subtle)] p-3">
+              <p className="text-xs font-semibold text-[var(--kt-color-text-muted)]">変わらず残っていること</p>
+              <p className="mt-2 text-sm leading-6 text-[var(--kt-color-text-secondary)]">
                 {renderStateDeltaTagSentence(
                   continuedNeedTags,
                   "今回は前回と同じテーマが中心に続くというより、別の方向に意識が向き始めています。",
@@ -632,8 +632,8 @@ export default function ShrineDetailArticle({
         />
         <ShrineDetailHeroCard title={cardProps.title} imageUrl={heroImageUrl} />
         {directionSupportCopy ? (
-          <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-            <p className="text-xs leading-5 text-slate-500">{directionSupportCopy}</p>
+          <div className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] px-4 py-3">
+            <p className="text-xs leading-5 text-[var(--kt-color-text-muted)]">{directionSupportCopy}</p>
           </div>
         ) : null}
         {showStateDeltaSection ? (
@@ -641,7 +641,7 @@ export default function ShrineDetailArticle({
         ) : null}
         {/* 参拝後文言 (after-visit copy) */}
         {showAfterVisitCopy ? (
-          <div className="rounded-2xl border border-emerald-200 bg-white p-3 mt-2">
+          <div className="rounded-[var(--kt-radius-card)] border border-emerald-200 bg-[var(--kt-color-surface-default)] p-3 mt-2">
             <p className="text-sm font-semibold text-emerald-700">参拝お疲れさまでした</p>
             <p className="mt-1 text-xs text-slate-600">
               あなたの参拝が記録されました。次回の相談で前回の行動として振り返ることができます。
@@ -664,7 +664,7 @@ export default function ShrineDetailArticle({
 
       {resolvedSaveActionNode ? (
         <section className="pt-4">
-          <div className="overflow-hidden rounded-2xl border border-emerald-200 bg-white">
+          <div className="overflow-hidden rounded-[var(--kt-radius-card)] border border-emerald-200 bg-[var(--kt-color-surface-default)]">
             <div className="space-y-2 p-4">
               {resolvedSaveActionNode}
               <p className="text-xs leading-5 text-slate-600">あとで記録から見返せます</p>
@@ -684,15 +684,15 @@ export default function ShrineDetailArticle({
               ) : null}
             </div>
 
-            <div className="border-t border-slate-200 p-4">
+            <div className="border-t border-[var(--kt-color-border-default)] p-4">
               <div className="space-y-2">
                 {hasVisitHistory ? (
-                  <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 p-3">
+                  <div className="rounded-[var(--kt-radius-panel)] border border-emerald-200 bg-emerald-50/70 p-3">
                     <p className="text-sm font-semibold text-emerald-700">参拝を記録しました</p>
                     <p className="mt-1 text-xs text-slate-600">次回の相談で、前回の行動として振り返れます。</p>
                   </div>
                 ) : (
-                  <p className="text-xs leading-5 text-slate-500">参拝後に記録できます</p>
+                  <p className="text-xs leading-5 text-[var(--kt-color-text-muted)]">参拝後に記録できます</p>
                 )}
 
                 {hasVisitHistory ? (
@@ -706,7 +706,7 @@ export default function ShrineDetailArticle({
                 ) : null}
 
                 {visitError ? (
-                  <div className="rounded-xl border border-rose-200 bg-white p-3">
+                  <div className="rounded-[var(--kt-radius-panel)] border border-rose-200 bg-[var(--kt-color-surface-default)] p-3">
                     <p className="text-sm font-semibold text-rose-700">参拝記録に失敗しました</p>
                   </div>
                 ) : null}
@@ -742,7 +742,7 @@ export default function ShrineDetailArticle({
                         setVisitSubmitting(false);
                       }
                     }}
-                    className="w-full rounded-2xl border border-emerald-200 bg-white px-4 py-2 text-sm font-semibold text-emerald-800 hover:bg-emerald-50 disabled:opacity-60"
+                    className="w-full rounded-[var(--kt-radius-card)] border border-emerald-200 bg-[var(--kt-color-surface-default)] px-4 py-2 text-sm font-semibold text-emerald-800 hover:bg-emerald-50 disabled:opacity-60"
                   >
                     {visitSubmitting ? "記録中..." : "参拝しました"}
                   </button>
@@ -774,7 +774,7 @@ export default function ShrineDetailArticle({
                 {benefitTagObjs.map((t) => (
                   <span
                     key={t.id}
-                    className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
+                    className="inline-flex items-center rounded-[var(--kt-radius-pill)] bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
                   >
                     {t.label}
                   </span>
@@ -785,7 +785,7 @@ export default function ShrineDetailArticle({
                 {benefitLabels.map((label) => (
                   <span
                     key={label}
-                    className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
+                    className="inline-flex items-center rounded-[var(--kt-radius-pill)] bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
                   >
                     {label}
                   </span>

--- a/apps/web/src/components/shrine/detail/ShrineDetailHeroCard.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailHeroCard.tsx
@@ -13,7 +13,7 @@ type Props = {
 export default function ShrineDetailHeroCard({ title, imageUrl = null }: Props) {
   return (
     <section className="pt-1">
-      <article className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <article className="overflow-hidden rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] shadow-[var(--kt-shadow-medium)]">
         <div className="relative h-32 w-full bg-slate-100">
           {imageUrl ? (
             <Image src={imageUrl} alt={title} fill className="object-cover" sizes="(max-width: 768px) 100vw, 448px" />
@@ -21,7 +21,7 @@ export default function ShrineDetailHeroCard({ title, imageUrl = null }: Props) 
         </div>
 
         <div className="p-4">
-          <p className="text-sm font-semibold text-slate-900">{title}</p>
+          <p className="text-sm font-semibold text-[var(--kt-color-text-primary)]">{title}</p>
         </div>
       </article>
     </section>

--- a/apps/web/src/components/shrine/detail/ShrineJudgeSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineJudgeSection.tsx
@@ -11,22 +11,22 @@ function isSupplementSection(section: DetailMeaningSection): boolean {
 
 function getItemClassName(item: DetailMeaningItem): string {
   if (item.key === "action_meaning") {
-    return "rounded-2xl border border-amber-200 bg-amber-50 p-4 shadow-sm";
+    return "rounded-[var(--kt-radius-card)] border border-[var(--kt-color-premium-border)] bg-[var(--kt-color-premium-surface)] p-4 shadow-[var(--kt-shadow-medium)]";
   }
 
   if (item.key === "today_flow") {
-    return "rounded-xl border border-slate-100 bg-white p-3";
+    return "rounded-[var(--kt-radius-panel)] border border-slate-100 bg-[var(--kt-color-surface-default)] p-3";
   }
 
   if (item.key === "after_visit_reflection") {
-    return "rounded-xl border border-emerald-100 bg-emerald-50/70 p-3";
+    return "rounded-[var(--kt-radius-panel)] border border-emerald-100 bg-emerald-50/70 p-3";
   }
 
   if (item.key === "history_context" || item.key === "deity_symbol" || item.key === "benefit_action") {
-    return "rounded-xl border border-slate-100 bg-slate-50/70 p-3";
+    return "rounded-[var(--kt-radius-panel)] border border-slate-100 bg-slate-50/70 p-3";
   }
 
-  return "rounded-xl bg-slate-50 p-3";
+  return "rounded-[var(--kt-radius-panel)] bg-[var(--kt-color-background-subtle)] p-3";
 }
 
 function getTitleClassName(item: DetailMeaningItem): string {
@@ -39,10 +39,10 @@ function getTitleClassName(item: DetailMeaningItem): string {
   }
 
   if (item.key === "history_context" || item.key === "deity_symbol" || item.key === "benefit_action") {
-    return "text-xs font-semibold tracking-[0.04em] text-slate-500";
+    return "text-xs font-semibold tracking-[0.04em] text-[var(--kt-color-text-muted)]";
   }
 
-  return "text-sm font-medium text-slate-700";
+  return "text-sm font-medium text-[var(--kt-color-text-secondary)]";
 }
 
 function getBodyClassName(item: DetailMeaningItem): string {
@@ -51,7 +51,7 @@ function getBodyClassName(item: DetailMeaningItem): string {
   }
 
   if (item.key === "history_context" || item.key === "deity_symbol" || item.key === "benefit_action") {
-    return "mt-1 text-xs leading-6 text-slate-500";
+    return "mt-1 text-xs leading-6 text-[var(--kt-color-text-muted)]";
   }
 
   return "mt-1 text-sm leading-7 text-slate-600";
@@ -73,9 +73,9 @@ function MeaningItems({ items }: { items: DetailMeaningItem[] }) {
 export default function ShrineJudgeSection({ section }: Props) {
   if (isSupplementSection(section)) {
     return (
-      <details className="rounded-2xl border border-slate-200 bg-white p-4">
-        <summary className="cursor-pointer list-none text-sm font-medium text-slate-700">
-          <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-sm text-slate-700">
+      <details className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+        <summary className="cursor-pointer list-none text-sm font-medium text-[var(--kt-color-text-secondary)]">
+          <span className="inline-flex items-center rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] px-3 py-1.5 text-sm text-[var(--kt-color-text-secondary)]">
             {section.heading}
           </span>
         </summary>
@@ -88,8 +88,8 @@ export default function ShrineJudgeSection({ section }: Props) {
   }
 
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4">
-      <h2 className="text-base font-semibold text-slate-900">{section.heading}</h2>
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">{section.heading}</h2>
 
       <div className="mt-4">
         <MeaningItems items={section.items} />

--- a/apps/web/src/components/shrine/detail/ShrineProposalSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineProposalSection.tsx
@@ -3,8 +3,8 @@ import type { DetailProposalSection } from "@/components/shrine/detail/types";
 
 export default function ShrineProposalSection({ section }: { section: DetailProposalSection }) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4">
-      <h2 className="text-base font-semibold text-slate-900">{section.heading}</h2>
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">{section.heading}</h2>
 
       <div className="mt-3 space-y-2">
         <p className="text-sm leading-7 text-slate-800">{section.lead}</p>

--- a/apps/web/src/components/shrine/detail/ShrineReasonSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReasonSection.tsx
@@ -13,18 +13,18 @@ import type { DetailReasonSection } from "@/components/shrine/detail/types";
  */
 export default function ShrineReasonSection({ section }: { section: DetailReasonSection }) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4">
-      <h2 className="text-base font-semibold text-slate-900">{section.heading}</h2>
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">{section.heading}</h2>
 
       <div className="mt-3 space-y-4">
         {section.groups.map((group) => (
           <div key={group.title} className="space-y-2">
-            <h3 className="text-sm font-medium text-slate-700">{group.title}</h3>
+            <h3 className="text-sm font-medium text-[var(--kt-color-text-secondary)]">{group.title}</h3>
             <div className="space-y-2">
               {group.items.map((item) => (
                 <p
                   key={`${group.title}:${item}`}
-                  className="text-sm leading-7 text-slate-700"
+                  className="text-sm leading-7 text-[var(--kt-color-text-secondary)]"
                 >
                   {item}
                 </p>

--- a/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
@@ -101,7 +101,7 @@ export function ShrineReflectionPrompt({
         onChange={(event) => setAnswer(event.target.value)}
         rows={4}
         placeholder="例：少し落ち着いた / 次にやることが見えた / まだ迷いはあるけれど一度区切れた"
-        className="mt-3 w-full rounded-xl border border-emerald-100 bg-white px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-emerald-300"
+        className="mt-3 w-full rounded-[var(--kt-radius-panel)] border border-emerald-100 bg-[var(--kt-color-surface-default)] px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-[var(--kt-color-border-focus)]"
       />
 
       <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -109,13 +109,13 @@ export function ShrineReflectionPrompt({
           value={moodBefore}
           onChange={(event) => setMoodBefore(event.target.value)}
           placeholder="参拝前の気分 任意"
-          className="rounded-xl border border-emerald-100 bg-white px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-emerald-300"
+          className="rounded-[var(--kt-radius-panel)] border border-emerald-100 bg-[var(--kt-color-surface-default)] px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-[var(--kt-color-border-focus)]"
         />
         <input
           value={moodAfter}
           onChange={(event) => setMoodAfter(event.target.value)}
           placeholder="参拝後の気分 任意"
-          className="rounded-xl border border-emerald-100 bg-white px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-emerald-300"
+          className="rounded-[var(--kt-radius-panel)] border border-emerald-100 bg-[var(--kt-color-surface-default)] px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-[var(--kt-color-border-focus)]"
         />
       </div>
 

--- a/apps/web/src/components/shrine/detail/ShrineSupplementSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineSupplementSection.tsx
@@ -2,18 +2,18 @@ import type { DetailSupplementSection } from "@/components/shrine/detail/types";
 
 export default function ShrineSupplementSection({ section }: { section: DetailSupplementSection }) {
   return (
-    <section className="rounded-2xl border border-slate-200 bg-white p-4">
-      <h2 className="text-base font-semibold text-slate-900">{section.heading}</h2>
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">{section.heading}</h2>
 
       <div className="mt-3 space-y-3">
         {section.groups.map((group) => (
           <div key={group.title} className="space-y-1">
-            <h3 className="text-sm font-medium text-slate-700">{group.title}</h3>
+            <h3 className="text-sm font-medium text-[var(--kt-color-text-secondary)]">{group.title}</h3>
             <div className="flex flex-wrap gap-1.5">
               {group.items.map((item) => (
                 <span
                   key={`${group.title}:${item}`}
-                  className="inline-flex items-center rounded-full bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
+                  className="inline-flex items-center rounded-[var(--kt-radius-pill)] bg-emerald-50 px-2 py-0.5 text-xs text-emerald-700"
                 >
                   {item}
                 </span>

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineActionSection.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineActionSection.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineActionSection from "../ShrineActionSection";
+import type { DetailActionSection } from "../types";
+
+const section: DetailActionSection = {
+  kind: "action",
+  heading: "参拝するときの視点",
+  items: [{ key: "action_meaning", title: "向き合い方", body: "本文" }],
+};
+
+describe("ShrineActionSection", () => {
+  it("見出しとitemのtitle/bodyを表示する", () => {
+    render(<ShrineActionSection section={section} />);
+    expect(screen.getByText("参拝するときの視点")).toBeInTheDocument();
+    expect(screen.getByText("向き合い方")).toBeInTheDocument();
+    expect(screen.getByText("本文")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("外枠sectionがradius-card / border-default / surface-defaultを参照する", () => {
+      const { container } = render(<ShrineActionSection section={section} />);
+      const outer = container.querySelector("section");
+      expect(outer?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(outer?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(outer?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+
+    it("見出しがtext-primaryを参照する", () => {
+      render(<ShrineActionSection section={section} />);
+      expect(screen.getByText("参拝するときの視点").className).toContain(
+        "text-[var(--kt-color-text-primary)]",
+      );
+    });
+
+    it("itemカードがpremium-border / premium-surface / shadow-mediumを参照する", () => {
+      render(<ShrineActionSection section={section} />);
+      const item = screen.getByText("向き合い方").closest("div");
+      expect(item?.className).toContain("border-[var(--kt-color-premium-border)]");
+      expect(item?.className).toContain("bg-[var(--kt-color-premium-surface)]");
+      expect(item?.className).toContain("shadow-[var(--kt-shadow-medium)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
@@ -596,4 +596,70 @@ describe("ShrineDetailArticle", () => {
       expect(retryButton).not.toBeDisabled();
     });
   });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("Hero Headerがradius-card / surface-default / shadow-medium / text-primary / text-mutedを参照する", () => {
+      render(
+        <ShrineDetailArticle
+          cardProps={{
+            title: "乃木神社",
+            href: "/shrines/17",
+            imageUrl: null,
+            badges: [],
+            metaChips: [],
+            address: "東京都港区赤坂",
+          } as any}
+          heroImageUrl={null}
+          heroMeaningCopy={null}
+          benefitLabels={[]}
+          tags={[]}
+          publicGoshuinsPreview={[]}
+          publicGoshuinsViewAllHref=""
+          sections={[]}
+          recommendationMeta={null}
+          saveActionNode={null}
+        />,
+      );
+
+      const heading = screen.getByRole("heading", { name: "乃木神社" });
+      const heroSection = heading.closest("section");
+      expect(heroSection?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(heroSection?.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(heroSection?.className).toContain("shadow-[var(--kt-shadow-medium)]");
+      expect(heading.className).toContain("text-[var(--kt-color-text-primary)]");
+      expect(screen.getByText("この神社の意味").className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+
+    it("directionSupportCopyがradius-card / border-default / background-subtle / text-mutedを参照する", () => {
+      render(
+        <ShrineDetailArticle
+          cardProps={{
+            title: "乃木神社",
+            href: "/shrines/17",
+            imageUrl: null,
+            badges: [],
+            metaChips: [],
+            address: "東京都港区赤坂",
+          } as any}
+          heroImageUrl={null}
+          heroMeaningCopy={null}
+          benefitLabels={[]}
+          tags={[]}
+          publicGoshuinsPreview={[]}
+          publicGoshuinsViewAllHref=""
+          sections={[]}
+          recommendationMeta={null}
+          saveActionNode={null}
+          directionSupportCopy="方位は主理由ではなく、補助要素として参考にしています。"
+        />,
+      );
+
+      const copy = screen.getByText("方位は主理由ではなく、補助要素として参考にしています。");
+      expect(copy.className).toContain("text-[var(--kt-color-text-muted)]");
+      const wrapper = copy.parentElement;
+      expect(wrapper?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(wrapper?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(wrapper?.className).toContain("bg-[var(--kt-color-background-subtle)]");
+    });
+  });
 });

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailHeroCard.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailHeroCard.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineDetailHeroCard from "../ShrineDetailHeroCard";
+
+describe("ShrineDetailHeroCard", () => {
+  it("神社名を表示する", () => {
+    render(<ShrineDetailHeroCard title="乃木神社" />);
+    expect(screen.getByText("乃木神社")).toBeInTheDocument();
+  });
+
+  it("imageUrlがない場合はimg要素を表示しない", () => {
+    const { container } = render(<ShrineDetailHeroCard title="乃木神社" imageUrl={null} />);
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+  });
+
+  it("imageUrlがある場合はimg要素を表示する", () => {
+    render(<ShrineDetailHeroCard title="乃木神社" imageUrl="https://example.com/photo.jpg" />);
+    expect(screen.getByAltText("乃木神社")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("外枠カードがradius-card / border-default / surface-default / shadow-mediumを参照する", () => {
+      const { container } = render(<ShrineDetailHeroCard title="乃木神社" />);
+
+      const article = container.querySelector("article");
+      expect(article?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(article?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(article?.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(article?.className).toContain("shadow-[var(--kt-shadow-medium)]");
+    });
+
+    it("神社名がtext-primaryを参照する", () => {
+      render(<ShrineDetailHeroCard title="乃木神社" />);
+      expect(screen.getByText("乃木神社").className).toContain("text-[var(--kt-color-text-primary)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineJudgeSection.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineJudgeSection.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineJudgeSection from "../ShrineJudgeSection";
+import type { DetailMeaningSection } from "../types";
+
+function buildSection(overrides: Partial<DetailMeaningSection> = {}): DetailMeaningSection {
+  return {
+    kind: "meaning",
+    heading: "この神社で受け取る意味",
+    items: [
+      { key: "shrine_meaning", title: "この神社の意味", body: "本文A" },
+      { key: "action_meaning", title: "参拝するときの視点", body: "本文B" },
+      { key: "today_flow", title: "今日の流れ", body: "本文C" },
+      { key: "history_context", title: "由緒", body: "本文D" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("ShrineJudgeSection", () => {
+  it("free/premium区分にかかわらずitemsのtitle/bodyを表示する", () => {
+    render(<ShrineJudgeSection section={buildSection()} />);
+
+    expect(screen.getByText("この神社の意味")).toBeInTheDocument();
+    expect(screen.getByText("本文A")).toBeInTheDocument();
+    expect(screen.getByText("参拝するときの視点")).toBeInTheDocument();
+    expect(screen.getByText("本文B")).toBeInTheDocument();
+  });
+
+  it("見出しが「補足」で始まる場合、details/summaryのfallback表示になる", () => {
+    const { container } = render(
+      <ShrineJudgeSection section={buildSection({ heading: "補足情報" })} />,
+    );
+
+    expect(container.querySelector("details")).toBeInTheDocument();
+    expect(container.querySelector("summary")).toBeInTheDocument();
+    expect(screen.getByText("補足情報")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("通常sectionがradius-card / border-default / surface-defaultを参照する", () => {
+      const { container } = render(<ShrineJudgeSection section={buildSection()} />);
+      const section = container.querySelector("section");
+      expect(section?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(section?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(section?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+
+    it("見出しがtext-primaryを参照する", () => {
+      render(<ShrineJudgeSection section={buildSection()} />);
+      expect(screen.getByText("この神社で受け取る意味").className).toContain(
+        "text-[var(--kt-color-text-primary)]",
+      );
+    });
+
+    it("action_meaning itemがpremium-border / premium-surface / shadow-mediumを参照する", () => {
+      render(<ShrineJudgeSection section={buildSection()} />);
+      const item = screen.getByText("参拝するときの視点").closest("div");
+      expect(item?.className).toContain("border-[var(--kt-color-premium-border)]");
+      expect(item?.className).toContain("bg-[var(--kt-color-premium-surface)]");
+      expect(item?.className).toContain("shadow-[var(--kt-shadow-medium)]");
+    });
+
+    it("history_context itemのtitleとbodyがtext-mutedを参照する", () => {
+      render(<ShrineJudgeSection section={buildSection()} />);
+      expect(screen.getByText("由緒").className).toContain("text-[var(--kt-color-text-muted)]");
+      expect(screen.getByText("本文D").className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+
+    it("補足sectionのdetails/summaryがradius-card / border-default / surface-defaultを参照する", () => {
+      const { container } = render(
+        <ShrineJudgeSection section={buildSection({ heading: "補足情報" })} />,
+      );
+      const details = container.querySelector("details");
+      expect(details?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(details?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(details?.className).toContain("bg-[var(--kt-color-surface-default)]");
+
+      const badge = screen.getByText("補足情報");
+      expect(badge.className).toContain("rounded-[var(--kt-radius-pill)]");
+      expect(badge.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(badge.className).toContain("bg-[var(--kt-color-background-subtle)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineProposalSection.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineProposalSection.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineProposalSection from "../ShrineProposalSection";
+import type { DetailProposalSection } from "../types";
+
+const section: DetailProposalSection = {
+  kind: "proposal",
+  heading: "今の状態整理",
+  lead: "リード文",
+  body: "本文",
+};
+
+describe("ShrineProposalSection", () => {
+  it("見出し・lead・bodyを表示する", () => {
+    render(<ShrineProposalSection section={section} />);
+    expect(screen.getByText("今の状態整理")).toBeInTheDocument();
+    expect(screen.getByText("リード文")).toBeInTheDocument();
+    expect(screen.getByText("本文")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("sectionがradius-card / border-default / surface-defaultを参照する", () => {
+      const { container } = render(<ShrineProposalSection section={section} />);
+      const outer = container.querySelector("section");
+      expect(outer?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(outer?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(outer?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+
+    it("見出しがtext-primaryを参照する", () => {
+      render(<ShrineProposalSection section={section} />);
+      expect(screen.getByText("今の状態整理").className).toContain("text-[var(--kt-color-text-primary)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineReasonSection.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineReasonSection.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineReasonSection from "../ShrineReasonSection";
+import type { DetailReasonSection } from "../types";
+
+const section: DetailReasonSection = {
+  kind: "reason",
+  heading: "この神社が候補に入った理由",
+  groups: [{ title: "主理由", items: ["理由テキスト"] }],
+};
+
+describe("ShrineReasonSection", () => {
+  it("見出し・group.title・itemを表示する", () => {
+    render(<ShrineReasonSection section={section} />);
+    expect(screen.getByText("この神社が候補に入った理由")).toBeInTheDocument();
+    expect(screen.getByText("主理由")).toBeInTheDocument();
+    expect(screen.getByText("理由テキスト")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("sectionがradius-card / border-default / surface-defaultを参照する", () => {
+      const { container } = render(<ShrineReasonSection section={section} />);
+      const outer = container.querySelector("section");
+      expect(outer?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(outer?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(outer?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+
+    it("見出しがtext-primaryを、group.titleとitemがtext-secondaryを参照する", () => {
+      render(<ShrineReasonSection section={section} />);
+      expect(screen.getByText("この神社が候補に入った理由").className).toContain(
+        "text-[var(--kt-color-text-primary)]",
+      );
+      expect(screen.getByText("主理由").className).toContain("text-[var(--kt-color-text-secondary)]");
+      expect(screen.getByText("理由テキスト").className).toContain("text-[var(--kt-color-text-secondary)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
@@ -176,4 +176,20 @@ describe("ShrineReflectionPrompt", () => {
 
     expect(await screen.findByText("振り返りの保存に失敗しました。")).toBeInTheDocument();
   });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("textareaとinputがradius-panel / surface-default / border-focusを参照する", () => {
+      render(<ShrineReflectionPrompt shrineId={17} />);
+
+      const textarea = screen.getByPlaceholderText(/少し落ち着いた/);
+      expect(textarea.className).toContain("rounded-[var(--kt-radius-panel)]");
+      expect(textarea.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(textarea.className).toContain("focus:border-[var(--kt-color-border-focus)]");
+
+      const moodBefore = screen.getByPlaceholderText("参拝前の気分 任意");
+      expect(moodBefore.className).toContain("rounded-[var(--kt-radius-panel)]");
+      expect(moodBefore.className).toContain("bg-[var(--kt-color-surface-default)]");
+      expect(moodBefore.className).toContain("focus:border-[var(--kt-color-border-focus)]");
+    });
+  });
 });

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineSupplementSection.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineSupplementSection.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineSupplementSection from "../ShrineSupplementSection";
+import type { DetailSupplementSection } from "../types";
+
+const section: DetailSupplementSection = {
+  kind: "supplement",
+  heading: "神社情報",
+  groups: [{ title: "ご利益", items: ["健康"] }],
+};
+
+describe("ShrineSupplementSection", () => {
+  it("見出し・group.title・タグを表示する", () => {
+    render(<ShrineSupplementSection section={section} />);
+    expect(screen.getByText("神社情報")).toBeInTheDocument();
+    expect(screen.getByText("ご利益")).toBeInTheDocument();
+    expect(screen.getByText("健康")).toBeInTheDocument();
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("sectionがradius-card / border-default / surface-defaultを参照する", () => {
+      const { container } = render(<ShrineSupplementSection section={section} />);
+      const outer = container.querySelector("section");
+      expect(outer?.className).toContain("rounded-[var(--kt-radius-card)]");
+      expect(outer?.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(outer?.className).toContain("bg-[var(--kt-color-surface-default)]");
+    });
+
+    it("見出しがtext-primaryを、group.titleがtext-secondaryを参照する", () => {
+      render(<ShrineSupplementSection section={section} />);
+      expect(screen.getByText("神社情報").className).toContain("text-[var(--kt-color-text-primary)]");
+      expect(screen.getByText("ご利益").className).toContain("text-[var(--kt-color-text-secondary)]");
+    });
+
+    it("タグがradius-pillを参照する", () => {
+      render(<ShrineSupplementSection section={section} />);
+      expect(screen.getByText("健康").className).toContain("rounded-[var(--kt-radius-pill)]");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Shrine Detail画面（Shell / Hero / Meaning Section群 / Premium導線 / 保存・参拝CTA / Reflection / Disclosure）のColor / Radius / Shadow指定をKAMI MUSUBI Semantic Token参照へ変更
- 現行値と`apps/web/src/styles/tokens.css`のSemantic Token実値が完全一致する箇所だけを置換し、それ以外は現状維持
- 見た目・情報階層・CTA配置・Premium境界・Disclosure挙動・Recommendation Reason文言・Analytics契約は変更なし

## Scope

- `ShrineDetailArticle` / `ShrineDetailShell` / `ShrineDetailHeroCard`
- `ShrineReasonSection` / `ShrineProposalSection` / `ShrineJudgeSection` / `ShrineActionSection` / `ShrineSupplementSection`
- `DetailDisclosureBlock` / `ShrineSaveButton` / `ShrineReflectionPrompt`
- 関連テスト（新規追加含む）

## Design decisions

- SpacingとTypographyは今回の対象外
- Emerald/Amberの半透明Surface（例: `bg-emerald-50/70`）と、対応Tokenと完全一致しないborder色（`border-emerald-100`/`200`等）は未適用
- `border-focus` Tokenは実際にfocusリング用途で使われている箇所（`ShrineReflectionPrompt`の入力欄の`focus:border-emerald-300`）にのみ適用し、`ShrineSaveButton`の選択状態表現（`border-emerald-300`）には意味が異なるため流用しない
- `DetailSection.tsx`はRecommendation画面（`ConciergeSectionsRenderer`）とも共有するコンポーネントのため対象外
- `PublicGoshuinSection` / `ShrineCloseLink`は明示的な対象一覧に含まれず対象外。`GoshuinLimitBadge` / `RecommendationMetaSection`はアプリ内未使用のため対象外
- `ShrineSaveButton`はConcierge画面とも共有されるが、実値完全一致のみ置換するため両画面とも見た目は変化しない

## Non-goals

- 情報階層変更
- CTA位置・挙動変更
- Premium境界変更
- Disclosure挙動変更
- Recommendation Reason文言変更
- Analytics変更
- Backend / API変更
- Mobile変更

## Test plan

- [x] 対象テスト69件成功
- [x] Web全545テスト成功
- [x] TypeScript成功
- [x] ESLint成功
- [x] Contract test成功
- [x] `git diff --check`成功
- [x] 375px / 390px / 430pxで表示確認（横スクロールなし、コンソールエラーなし）
- [x] CSS変数（`--kt-*`）の実解決を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)