### PR TITLE
Mobile Design Token正本を明確化する

### DIFF
--- a/apps/mobile/app/design/cardSizes.ts
+++ b/apps/mobile/app/design/cardSizes.ts
@@ -1,3 +1,8 @@
+// Mobile Card Component Sizeの正本 (docs/design/design-token.md Migration方針 5)。
+// design-token.mdの5カテゴリ(Color/Typography/Spacing/Radius/Shadow)には属さない
+// Component Token (Phase 6監査のCard優先領域) だが、現行13画面以上から実際に
+// 参照される。lib/tokens/cards.ts (cardTokens) はキー構成が全く異なる別系統の
+// 未使用定義であり、本ファイルの代替にはならない。
 export const cardSizes = {
   borderWidth: 1,
   carouselWidth: 220,

--- a/apps/mobile/app/design/ctaSizes.ts
+++ b/apps/mobile/app/design/ctaSizes.ts
@@ -1,3 +1,8 @@
+// Mobile CTA/Button Component Sizeの正本 (docs/design/design-token.md Migration方針 5)。
+// design-token.mdの5カテゴリには属さないComponent Token (Phase 6監査のButton優先領域)
+// だが、shrines/[id].tsx・premium/index.tsx・components/ui/Button.tsx から参照される。
+// lib/tokens/buttons.ts (buttonTokens) はキー構成が全く異なる別系統の未使用定義であり、
+// 本ファイルの代替にはならない。
 export const ctaSizes = {
   primaryHeight: 52,
   primaryRadius: 16,

--- a/apps/mobile/app/design/radius.ts
+++ b/apps/mobile/app/design/radius.ts
@@ -1,3 +1,9 @@
+// Mobile Radius Primitiveの正本 (docs/design/design-token.md Migration方針 5)。
+// 現行13画面以上・共通Component複数から実際に参照される。
+// 注意: lib/tokens/radius.ts にも同名 `radius` exportが存在するが、
+// 同じキー名 (sm/md/lg/xl) でも実値が異なり (例: md=16 vs 12, lg=18 vs 16, xl=20 vs 24)、
+// 2026-07時点でアプリ内のどこからもimportされていない未使用の重複定義。
+// 削除候補として記録するのみで、本PRでは削除・統合しない (design-token.mdの非対象)。
 export const radius = {
   xs: 12,
   sm: 14,

--- a/apps/mobile/app/design/semanticColorTokens.ts
+++ b/apps/mobile/app/design/semanticColorTokens.ts
@@ -12,6 +12,8 @@
 // Web側のCSS変数命名 (例: --kt-color-background-base) とは
 // 「ハイフンで結合すれば同じ意味になる」という規則で対応させる。
 
+// Mobile Semantic Color Token契約の正本 (キー一覧・型)。実値は app/theme.ts の
+// kamimusubiDarkSemanticTheme。2026-07時点でどの画面・Componentからも未消費。
 export const SEMANTIC_COLOR_KEYS = [
   "background.base",
   "background.subtle",

--- a/apps/mobile/app/design/shadow.ts
+++ b/apps/mobile/app/design/shadow.ts
@@ -1,3 +1,7 @@
+// Mobile Shadow/Elevation Primitiveの正本 (docs/design/design-token.md Migration方針 5)。
+// lib/tokens/*には対応する重複定義は存在しない。
+// 2026-07時点で card / softCard / goldCta が app/index.tsx・app/concierge/index.tsx から
+// 実際に参照されている。lightCard / skeleton は現時点でどこからも未参照。
 export const shadows = {
   card: {
     shadowColor: "#000",

--- a/apps/mobile/app/design/spacing.ts
+++ b/apps/mobile/app/design/spacing.ts
@@ -1,3 +1,9 @@
+// Mobile Spacing Primitiveの正本 (docs/design/design-token.md Migration方針 5)。
+// 現行14画面以上・共通Component複数から実際に参照される。
+// 注意: lib/tokens/spacing.ts にも同名 `spacing` exportが存在するが、
+// キー構成・値ともに別系統 (xs/sm/md/lg/xl/xxl/xxxl の汎用数値スケール) で、
+// 2026-07時点でアプリ内のどこからもimportされていない未使用の重複定義。
+// 削除候補として記録するのみで、本PRでは削除・統合しない (design-token.mdの非対象)。
 export const spacing = {
   screenX: 16,
   screenXWide: 24,

--- a/apps/mobile/app/theme.ts
+++ b/apps/mobile/app/theme.ts
@@ -1,3 +1,9 @@
+// Mobile Color正本 (docs/design/design-token.md Migration方針 5)
+// - colors: Light基調の初期パレット。2026-07時点でアプリ内から到達するimportは
+//   components/ui/Button.tsx のみで、その Button.tsx 自体もアプリ内のどこからも
+//   importされていない (実質未使用の到達不能パス)。削除は本PRの対象外。
+// - kamimusubiDark: 現行Mobile全画面が実際に参照するDark基調の正本Primitive。
+//   Color Primitiveの実質的な正本はこちら。
 export const colors = {
   paper: "#F6F3EE",
   primary: "#E24E33",
@@ -48,6 +54,10 @@ export type KamimusubiDarkColorKey = keyof typeof kamimusubiDark;
 // tscレベルで強制する (1つでも欠けるとコンパイルエラーになる)。
 import type { PlatformColorTheme } from "./design/semanticColorTokens";
 
+// Mobile Semantic Color Token契約の正本実値 (キー一覧・型は design/semanticColorTokens.ts)。
+// 2026-07時点でこのオブジェクトを参照するのは本ファイル (型契約の充足) のみで、
+// 画面・Componentからの消費はまだ無い (design-token.md Migration方針 PR6
+// 「Mobile共通Component適用」で初めて消費される想定)。
 export const kamimusubiDarkSemanticTheme: PlatformColorTheme = {
   "background.base": kamimusubiDark.background,
   "background.subtle": kamimusubiDark.surfaceSoft,


### PR DESCRIPTION
## Summary

- `app/theme.ts` / `app/design/*.ts` へ正本コメントを追加し、Color / Spacing / Radius / Shadow / Semantic Color Tokenの正本と実際の使用実態（参照元ファイル・件数）を明記
- `lib/tokens/*`（index.ts, spacing.ts, radius.ts, buttons.ts, cards.ts）は`docs/design/design-token.md` Migration方針5の変更範囲外（変更範囲は`app/theme.ts`, `app/design/*.ts`のみ）のため一切変更しない
- Token値・export名・Component API・画面StyleSheetは無変更（コメント追加のみ、38行追加・削除0行）

## Token系統一覧・import利用状況（監査結果）

| ファイル | 主なexport | 参照元 | 状態 |
|---|---|---|---|
| `app/theme.ts` | `kamimusubiDark` | 全22画面+3 Component | **実質的な正本**、活発に使用 |
| `app/theme.ts` | `colors` | `components/ui/Button.tsx`のみ | Button.tsx自体が未import＝到達不能 |
| `app/theme.ts` | `kamimusubiDarkSemanticTheme` | theme.ts内(型契約充足)のみ | 未消費(Migration PR6待ち) |
| `app/design/semanticColorTokens.ts` | `SEMANTIC_COLOR_KEYS`等 | theme.tsのみ | 未消費(Migration PR6待ち) |
| `app/design/spacing.ts` | `spacing` | 14画面+2 Component+lib/tokens内部 | **正本**、活発に使用 |
| `app/design/spacing.ts` | `semanticSpacing`等 | spacing.ts内のみ | 未消費 |
| `app/design/radius.ts` | `radius` | 13画面+2 Component+lib/tokens内部 | **正本**、活発に使用 |
| `app/design/radius.ts` | `semanticRadius`等 | radius.ts内のみ | 未消費 |
| `app/design/shadow.ts` | `shadows` | 2画面(card/softCard/goldCta使用、lightCard/skeletonは未使用) | **正本**、対応する重複定義なし |
| `app/design/cardSizes.ts` | `cardSizes` | 13画面以上 | **正本**、活発に使用 |
| `app/design/ctaSizes.ts` | `ctaSizes` | 3ファイル | **正本**、使用あり |
| `lib/tokens/index.ts`（barrel） | 全export | **ゼロ**（barrel/namespace import/require含め網羅的に確認） | 完全未使用 |
| `lib/tokens/spacing.ts` | `spacing` | ゼロ（buttons.ts/cards.tsの内部importのみ） | **同名異値**の重複、削除候補 |
| `lib/tokens/radius.ts` | `radius` | ゼロ（buttons.ts/cards.tsの内部importのみ） | **同名異値**の重複、削除候補 |
| `lib/tokens/buttons.ts` | `buttonTokens` | ゼロ | 削除候補 |
| `lib/tokens/cards.ts` | `cardTokens` | ゼロ | 削除候補 |

## 重複・不一致一覧

- `spacing`: `app/design/spacing.ts`（screenX/contentX等、用途別命名）と`lib/tokens/spacing.ts`（xs/sm/md/lg/xl等、汎用数値スケール）で**キー構成自体が別系統**
- `radius`: `app/design/radius.ts`と`lib/tokens/radius.ts`は同じキー名（sm/md/lg/xl）でも実値が異なる（例: md=16 vs 12, lg=18 vs 16, xl=20 vs 24）。`pill`(999, app/design) と `full`(999, lib/tokens) は**同値異名**
- いずれも`lib/tokens`側が完全未使用のため現状は実害なし。値が異なるため機械的なre-export統合はせず、削除候補として記録するのみに留めた

## 正本方針

- **Color**: `app/theme.ts`の`kamimusubiDark`（Primitive）＋`kamimusubiDarkSemanticTheme`（Semantic実値）。Semantic契約（キー一覧・型）は`app/design/semanticColorTokens.ts`
- **Spacing**: `app/design/spacing.ts`
- **Radius**: `app/design/radius.ts`
- **Shadow/Elevation**: `app/design/shadow.ts`
- **Card/CTA Component Size**（design-token.mdの5カテゴリ外だがPhase6監査のComponent Token優先領域）: `app/design/cardSizes.ts` / `app/design/ctaSizes.ts`
- **`lib/tokens/*`**: 正本ではない。完全未使用の重複定義。削除は本PRで行わず、次の削除PR候補として記録

## 互換export方針

- `lib/tokens/*`は現状ゼロ参照のため、re-export化による互換性リスクは存在しない
- 一方でspacing/radiusはキー構成・値が異なる別系統のため、re-exportで正本側へ寄せると値の意味が変わってしまう。機械的な統合はせず、正本ファイル側にコメントで実態を明記するに留めた（Token値変更ゼロという制約を優先）

## 発見した既存の問題（本PRでは対象外）

- `app/design/semanticColorTokens.ts`のみ、兄弟ファイル（cardSizes/ctaSizes/radius/shadow/spacing）と異なり`app/_layout.tsx`の`Tabs.Screen`の`href: null`抑制リストに含まれていない
- Expo Web起動確認で、タブバーに意図しない`"design/se..."`タブが実際に表示されることを確認した（既存の不具合。今回のコメント追加とは無関係、develop上で既に発生）
- Token関連ファイルではなく`_layout.tsx`の修正が必要なため、本PRのスコープ外として記録し、別PRでの対応を推奨する

## Non-goals

- Token値の変更
- ブランド色・Light/Dark方針の変更
- `lib/tokens/*`の削除
- 個別画面のStyleSheet切り替え
- Componentの見た目変更
- `_layout.tsx`のroute修正（発見のみ、別PR候補）
- Mobileテスト基盤の追加
- Web側の変更

## Test plan

- [x] Mobile typecheck: developと同一の既存エラー5件（`lib/__tests__/*.test.ts`のvitest型未解決、本PR変更と無関係）のみ。新規エラー0件
- [x] circular dependencyなし（madge）
- [x] `git diff --check`成功
- [x] Expo Web起動確認: bundle成功、新規route警告なし（既存7件の「missing default export」警告のみで変化なし）、コンソールエラーなし
- [x] ホーム / 相談 / マイページ画面表示確認（Dark Theme・Token値解決を確認）
- [ ] iOS / Android実機は本環境で未確認

## Rollback方法

`git revert 11365163`（コメント追加のみのコミット）で完全に戻せます。Token値・既存importには一切影響しません。

## 次の削除PR候補

- `apps/mobile/lib/tokens/index.ts` / `spacing.ts` / `radius.ts` / `buttons.ts` / `cards.ts` の削除（Migration方針PR7相当）。本PRで確認した通り、アプリ内のどこからも参照されていないことが確定している
- `app/_layout.tsx`への`<Tabs.Screen name="design/semanticColorTokens" options={{ href: null }} />`追加（意図しないタブバー表示の解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)