### PR TITLE
Mobile共通Buttonに状態APIを追加

### DIFF
--- a/apps/mobile/components/ui/Button.tsx
+++ b/apps/mobile/components/ui/Button.tsx
@@ -1,26 +1,67 @@
 // apps/mobile/components/ui/Button.tsx
-import { Pressable, Text, StyleSheet, ViewStyle } from "react-native";
-import { kamimusubiDarkSemanticTheme } from "../../app/theme";
+import { ActivityIndicator, Pressable, StyleSheet, Text, type ViewStyle } from "react-native";
+
 import { ctaSizes } from "../../app/design/ctaSizes";
 import { semanticRadius } from "../../app/design/radius";
 import { semanticShadow } from "../../app/design/shadow";
+import { kamimusubiDarkSemanticTheme } from "../../app/theme";
 
 type Props = {
   title: string;
   variant?: "primary" | "accent" | "neutral";
   style?: ViewStyle;
   onPress?: () => void;
+  disabled?: boolean;
+  loading?: boolean;
+  accessibilityLabel?: string;
 };
-export default function Button({ title, variant="neutral", style, onPress }: Props) {
-  const theme =
-    variant === "primary" ? styles.btnPrimary :
-    variant === "accent"  ? styles.btnAccent  : styles.btnNeutral;
+
+export default function Button({
+  title,
+  variant = "neutral",
+  style,
+  onPress,
+  disabled = false,
+  loading = false,
+  accessibilityLabel,
+}: Props) {
+  const isDisabled = disabled || loading;
+
+  const theme = variant === "primary" ? styles.btnPrimary : variant === "accent" ? styles.btnAccent : styles.btnNeutral;
+
   const textStyle =
-    variant === "primary" ? styles.btnPrimaryText :
-    variant === "accent"  ? styles.btnAccentText  : styles.btnText;
+    variant === "primary" ? styles.btnPrimaryText : variant === "accent" ? styles.btnAccentText : styles.btnText;
+
+  const indicatorColor =
+    variant === "primary"
+      ? kamimusubiDarkSemanticTheme["action.primaryText"]
+      : variant === "accent"
+        ? kamimusubiDarkSemanticTheme["text.inverse"]
+        : kamimusubiDarkSemanticTheme["text.primary"];
+
   return (
-    <Pressable accessibilityRole="button" onPress={onPress} style={[styles.btn, theme, style]}>
-      <Text style={[styles.btnTextBase, textStyle]}>{title}</Text>
+    <Pressable
+      accessibilityLabel={accessibilityLabel ?? title}
+      accessibilityRole="button"
+      accessibilityState={{
+        disabled: isDisabled,
+        busy: loading,
+      }}
+      disabled={isDisabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.btn,
+        theme,
+        pressed && !isDisabled ? styles.btnPressed : null,
+        isDisabled ? styles.btnDisabled : null,
+        style,
+      ]}
+    >
+      {loading ? (
+        <ActivityIndicator color={indicatorColor} />
+      ) : (
+        <Text style={[styles.btnTextBase, textStyle]}>{title}</Text>
+      )}
     </Pressable>
   );
 }
@@ -44,8 +85,23 @@ const styles = StyleSheet.create({
     backgroundColor: kamimusubiDarkSemanticTheme["surface.default"],
     ...semanticShadow.low,
   },
-  btnTextBase:{ fontWeight: "600", fontSize: 16 },
-  btnText:    { color: kamimusubiDarkSemanticTheme["text.primary"] },
-  btnPrimaryText: { color: kamimusubiDarkSemanticTheme["action.primaryText"] },
-  btnAccentText:{ color: kamimusubiDarkSemanticTheme["text.inverse"] },
+  btnPressed: {
+    opacity: 0.85,
+  },
+  btnDisabled: {
+    opacity: 0.5,
+  },
+  btnTextBase: {
+    fontWeight: "600",
+    fontSize: 16,
+  },
+  btnText: {
+    color: kamimusubiDarkSemanticTheme["text.primary"],
+  },
+  btnPrimaryText: {
+    color: kamimusubiDarkSemanticTheme["action.primaryText"],
+  },
+  btnAccentText: {
+    color: kamimusubiDarkSemanticTheme["text.inverse"],
+  },
 });


### PR DESCRIPTION
- Mobile共通Buttonへdisabled / loading / accessibilityLabelを追加

- loading時はActivityIndicatorを表示し、押下を無効化

- pressed時はopacity 0.85、disabled/loading時はopacity 0.5を適用

- accessibilityState.disabled / busyを追加

- accessibilityLabel未指定時はtitleをフォールバックとして使用

- 既存variant・Props API・サイズを維持

## Design decisions

- 実効disabledはdisabled || loading

- disabled状態は既存variantの背景色を維持し、opacityで表現

- action.disabledは既存Login CTAの見た目と一致しないため今回は非適用

- loading時は表示をActivityIndicatorへ置換するが、アクセシブルネームはtitleで維持

## Scope

- apps/mobile/components/ui/Button.tsxのみ変更

- Login / Birthday / Shrine Detailなどの画面は変更しない

- Token値・ctaSizes・package.json・テスト基盤は変更しない

- size APIは追加しない

## Validation

- git diff --check成功

- 変更ファイルがButton.tsxのみであることを確認

- Mobile typecheck実行

- developと同一の既存vitest未解決エラー5件のみ

- Button.tsx由来の新規TypeScriptエラーなし

## Known existing issue

apps/mobileにはvitest実行基盤がなく、lib/__tests__配下5ファイルのimport解決エラーが既存状態として残っている。本PRでは対応しない。"