### PR TITLE
Login画面の送信CTAを共通Buttonへ置き換え

### DIFF
--- a/apps/mobile/app/login.tsx
+++ b/apps/mobile/app/login.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import { useRouter } from "expo-router";
 import { post } from "../lib/http";
+import Button from "../components/ui/Button";
 import { setTokens } from "../lib/authTokens";
 import { kamimusubiDark as theme } from "./theme";
 import { spacing } from "./design/spacing";
@@ -81,22 +82,14 @@ export default function LoginScreen() {
 
           {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-          <Pressable
+          <Button
+            title="ログインする"
+            variant="primary"
             onPress={onSubmit}
             disabled={!canSubmit}
-            style={({ pressed }) => [
-              styles.submitButton,
-              !canSubmit && styles.submitButtonDisabled,
-              pressed && styles.submitButtonPressed,
-            ]}
-            accessibilityRole="button"
-          >
-            {submitting ? (
-              <ActivityIndicator color={theme.background} />
-            ) : (
-              <Text style={styles.submitButtonText}>ログインする</Text>
-            )}
-          </Pressable>
+            loading={submitting}
+            accessibilityLabel="ログインする"
+          />
 
           <Pressable
             onPress={() => (router.canGoBack() ? router.back() : router.replace("/mypage"))}
@@ -167,24 +160,6 @@ const styles = StyleSheet.create({
     color: "#FCA5A5",
     fontSize: 13,
     lineHeight: 19,
-  },
-  submitButton: {
-    minHeight: 48,
-    borderRadius: radius.md,
-    backgroundColor: theme.gold,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  submitButtonDisabled: {
-    opacity: 0.5,
-  },
-  submitButtonPressed: {
-    opacity: 0.85,
-  },
-  submitButtonText: {
-    color: theme.background,
-    fontSize: 15,
-    fontWeight: "800",
   },
   backButton: {
     minHeight: 44,


### PR DESCRIPTION
- Mobile Login画面の送信CTAを共通Buttonへ置き換え

- disabled / loading / pressed状態を共通Buttonへ委譲

- loading中はActivityIndicatorを表示

- accessibilityLabelを明示

- 旧submitButton用StyleSheetとActivityIndicator直接importを削除

## Design decisions

- 共通ButtonのTypographyとbrand shadowを採用

- Login固有のButtonスタイルは維持しない

- 共通Button APIの追加変更は行わない

- 認証処理・エラー表示・戻る導線は変更しない

## Scope

- apps/mobile/app/login.tsxのみ変更

- components/ui/Button.tsxは変更しない

- TextInput・認証API・Token値・テスト基盤は変更しない

## Validation

- Mobile typecheck実行

- developと同一の既存vitest未解決エラー5件のみ

- login.tsx由来の新規TypeScriptエラーなし

- ActivityIndicatorおよび旧submitButton StyleSheetの残存参照なし

- git diff --check成功

- Expo上で通常 / disabled / loading / エラー状態を確認

## Known existing issue

apps/mobileにはvitest実行基盤がなく、lib/__tests__配下5ファイルのimport解決エラーが既存状態として残っている。本PRでは対応しない。"