### PR TITLE
Mobileのテストと型確認をCIへ追加

### DIFF
--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -1,0 +1,48 @@
+name: mobile-ci
+
+on:
+  pull_request:
+    branches:
+      - develop
+    paths:
+      - "apps/mobile/**"
+      - ".github/workflows/mobile-ci.yml"
+  push:
+    branches:
+      - develop
+    paths:
+      - "apps/mobile/**"
+      - ".github/workflows/mobile-ci.yml"
+
+jobs:
+  mobile-test:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: apps/mobile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.3
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: apps/mobile/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Run typecheck
+        run: pnpm typecheck


### PR DESCRIPTION
- Mobile専用CI workflowを追加

- apps/mobileの独立pnpm-lock.yamlを使用

- pull requestおよびdevelop push時にMobileテストとtypecheckを実行

- Mobile関連ファイル変更時のみ起動

## CI steps

- pnpm 9.12.3をセットアップ

- Node.js 20をセットアップ

- apps/mobile/pnpm-lock.yamlをcache keyとして使用

- apps/mobileでpnpm install --frozen-lockfile --ignore-workspaceを実行

- pnpm testを実行

- pnpm typecheckを実行

## Design decisions

- Mobileはroot pnpm workspaceへ追加しない

- Web CIは変更しない

- Expo buildは追加しない

- 本番コード・テスト内容・依存バージョンは変更しない

## Validation

- Mobile frozen install成功

- Mobile 5ファイル57テスト成功

- Mobile typecheck成功

- YAML構文確認成功

- actionlint成功

- git diff --check成功"