### PR TITLE
Mobile共通Buttonへsuccess variantを追加

### DIFF
--- a/apps/mobile/components/ui/Button.tsx
+++ b/apps/mobile/components/ui/Button.tsx
@@ -8,7 +8,7 @@ import { kamimusubiDarkSemanticTheme } from "../../app/theme";
 
 type Props = {
   title: string;
-  variant?: "primary" | "accent" | "neutral" | "outline";
+  variant?: "primary" | "accent" | "neutral" | "outline" | "success";
   size?: "default" | "compact";
   style?: ViewStyle;
   onPress?: () => void;
@@ -36,7 +36,9 @@ export default function Button({
         ? styles.btnAccent
         : variant === "outline"
           ? styles.btnOutline
-          : styles.btnNeutral;
+          : variant === "success"
+            ? styles.btnSuccess
+            : styles.btnNeutral;
 
   const textStyle =
     variant === "primary"
@@ -45,7 +47,9 @@ export default function Button({
         ? styles.btnAccentText
         : variant === "outline"
           ? styles.btnOutlineText
-          : styles.btnText;
+          : variant === "success"
+            ? styles.btnSuccessText
+            : styles.btnText;
 
   const indicatorColor =
     variant === "primary"
@@ -54,7 +58,9 @@ export default function Button({
         ? kamimusubiDarkSemanticTheme["text.inverse"]
         : variant === "outline"
           ? kamimusubiDarkSemanticTheme["premium.accent"]
-          : kamimusubiDarkSemanticTheme["text.primary"];
+          : variant === "success"
+            ? kamimusubiDarkSemanticTheme["status.successText"]
+            : kamimusubiDarkSemanticTheme["text.primary"];
 
   return (
     <Pressable
@@ -117,6 +123,11 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: kamimusubiDarkSemanticTheme["premium.border"],
   },
+  btnSuccess: {
+    backgroundColor: kamimusubiDarkSemanticTheme["status.successSurface"],
+    borderWidth: 1,
+    borderColor: kamimusubiDarkSemanticTheme["status.successBorder"],
+  },
   btnPressed: {
     opacity: 0.85,
   },
@@ -142,5 +153,8 @@ const styles = StyleSheet.create({
   },
   btnOutlineText: {
     color: kamimusubiDarkSemanticTheme["premium.accent"],
+  },
+  btnSuccessText: {
+    color: kamimusubiDarkSemanticTheme["status.successText"],
   },
 });


### PR DESCRIPTION
- Mobile共通Buttonへsuccess variantを追加

- status.successSurfaceを背景色へ接続

- status.successBorderを枠線色へ接続

- status.successTextを文字色とローディング表示へ接続

- 既存variant・size・disabled・loading仕様は維持

## Scope

- apps/mobile/components/ui/Button.tsx

## Validation

- Mobile test: 5 files / 57 tests passed

- Mobile typecheck passed

- git diff --check passed"