### PR TITLE
Mobile参拝記録の送信状態と成功判定を修正

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -326,6 +326,7 @@ export default function ShrineDetail() {
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [fav, setFav] = React.useState(false);
   const [visited, setVisited] = React.useState(false);
+  const [visitSaving, setVisitSaving] = React.useState(false);
   const [reflectionAnswer, setReflectionAnswer] = React.useState("");
   const [reflectionSaved, setReflectionSaved] = React.useState(false);
   const [reflectionSaving, setReflectionSaving] = React.useState(false);
@@ -375,6 +376,7 @@ export default function ShrineDetail() {
 
   const countedRef = React.useRef(false);
   const detailTrackedRef = React.useRef<string | null>(null);
+  const visitInFlightRef = React.useRef(false);
 
   useFocusEffect(
     React.useCallback(() => {
@@ -460,15 +462,19 @@ export default function ShrineDetail() {
 
   const onVisitDone = React.useCallback(async () => {
     const targetShrineId = apiShrineId ?? shrineId;
-    if (!targetShrineId) return;
+    if (!targetShrineId || visited || visitInFlightRef.current) return;
 
-    if (!(await isLoggedIn())) {
-      setAuthPromptVisible(true);
-      return;
-    }
-
+    visitInFlightRef.current = true;
+    setVisitSaving(true);
     try {
-      await createVisitByShrineId(targetShrineId);
+      if (!(await isLoggedIn())) {
+        setAuthPromptVisible(true);
+        return;
+      }
+
+      const result = await createVisitByShrineId(targetShrineId);
+      if (!result) return;
+
       setVisited(true);
       trackVisitDone({
         shrineId: targetShrineId,
@@ -478,8 +484,11 @@ export default function ShrineDetail() {
       if (isUnauthenticatedError(error)) {
         setAuthPromptVisible(true);
       }
+    } finally {
+      visitInFlightRef.current = false;
+      setVisitSaving(false);
     }
-  }, [apiShrineId, contextReasonFacts, shrine, shrineId]);
+  }, [apiShrineId, contextReasonFacts, shrine, shrineId, visited]);
 
   React.useEffect(() => {
     const targetShrineId = apiShrineId ?? shrineId;
@@ -731,7 +740,14 @@ export default function ShrineDetail() {
             onPress={openDirections}
             accessibilityLabel="地図で経路を確認する"
           />
-          <Pressable onPress={onVisitDone} style={[styles.ctaPrimary, visited && styles.ctaPrimaryDone]}>
+          <Pressable
+            onPress={onVisitDone}
+            style={[styles.ctaPrimary, visited && styles.ctaPrimaryDone]}
+            disabled={visitSaving || visited}
+            accessibilityRole="button"
+            accessibilityState={{ disabled: visitSaving || visited, busy: visitSaving }}
+            accessibilityLabel={visited ? "参拝済みとして記録しました" : "参拝したことを記録する"}
+          >
             <Text style={styles.ctaPrimaryText}>
               {visited ? "参拝済みとして記録しました" : "参拝したことを記録する"}
             </Text>


### PR DESCRIPTION
## 変更内容

- Visit送信中のstateと同期refガードを追加
- APIがnullを返した場合はvisitedを更新せず、visit_done Analyticsも送信しない
- 成功時のみvisited更新と既存Analyticsを実行
- 通信中および成功後の参拝CTA再押下を抑止
- 未認証時のAuthPromptを維持

## 背景

従来はcreateVisitByShrineIdの戻り値を確認せず成功表示とAnalyticsへ進み、連打による複数送信も防止されていませんでした。

## 影響範囲

神社詳細画面のVisit送信状態のみです。Button置換、Backend、Analyticsイベント名・payload、認証、Reflection、課金処理は変更していません。

## 検証

- apps/mobile: pnpm test（57 passed）
- apps/mobile: pnpm typecheck
- git diff --check
- pre-push OpenAPI lint
- pre-push Web contract tests（545 passed）