### PR TITLE
神社詳細の参拝CTAへ共通Buttonを適用

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -740,18 +740,14 @@ export default function ShrineDetail() {
             onPress={openDirections}
             accessibilityLabel="地図で経路を確認する"
           />
-          <Pressable
+          <Button
+            title={visited ? "参拝済みとして記録しました" : "参拝したことを記録する"}
+            variant={visited ? "success" : "primary"}
             onPress={onVisitDone}
-            style={[styles.ctaPrimary, visited && styles.ctaPrimaryDone]}
             disabled={visitSaving || visited}
-            accessibilityRole="button"
-            accessibilityState={{ disabled: visitSaving || visited, busy: visitSaving }}
+            loading={visitSaving}
             accessibilityLabel={visited ? "参拝済みとして記録しました" : "参拝したことを記録する"}
-          >
-            <Text style={styles.ctaPrimaryText}>
-              {visited ? "参拝済みとして記録しました" : "参拝したことを記録する"}
-            </Text>
-          </Pressable>
+          />
         </View>
 
         {visited ? (
@@ -1092,24 +1088,6 @@ const styles = StyleSheet.create({
     lineHeight: 18,
     fontWeight: "600",
     textAlign: "center",
-  },
-  ctaPrimary: {
-    height: ctaSizes.mediumHeight,
-    borderRadius: ctaSizes.mediumRadius,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: theme.gold,
-  },
-  ctaPrimaryDone: {
-    backgroundColor: theme.borderGoldDark,
-    borderWidth: cardSizes.borderWidth,
-    borderColor: theme.borderGold,
-  },
-  ctaPrimaryText: {
-    color: theme.background,
-    fontSize: 14,
-    fontWeight: "900",
-    letterSpacing: 0.3,
   },
   reflectionCard: {
     marginHorizontal: spacing.screenX,


### PR DESCRIPTION
## 変更内容

- 神社詳細の参拝CTAを共通Buttonへ置換
- 未記録時はprimary、記録済み時はsuccessを使用
- visitSavingをloadingへ接続
- 通信中および記録済み時のdisabledを維持
- titleとaccessibilityLabelを状態に応じて切り替え
- 参拝CTA専用の旧Styleを削除

## 背景

PR #2112でVisit送信状態と成功判定を安全化したため、その契約を維持したまま表示層を共通Buttonへ移行します。

## 影響範囲

神社詳細画面の参拝CTA表示のみです。onVisitDone、Visit API、Analytics、認証、Reflection、課金処理、共通Button API、Design Tokenは変更していません。

## 検証

- apps/mobile: pnpm test（57 passed）
- apps/mobile: pnpm typecheck
- git diff --check
- git diff -w
- pre-push OpenAPI lint
- pre-push Web contract tests（545 passed）