### PR TITLE
振り返り詳細の閉じるCTAへ共通Buttonを適用

### DIFF
--- a/apps/mobile/app/reflection-history/index.tsx
+++ b/apps/mobile/app/reflection-history/index.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "expo-router";
 
 import { listShrineReflections, type ShrineReflectionResponse } from "../../lib/reflections";
 import { StateCard } from "../../components/common/StateCard";
+import Button from "../../components/ui/Button";
 import { kamimusubiDark as theme } from "../theme";
 import { spacing } from "../design/spacing";
 import { cardSizes } from "../design/cardSizes";
@@ -166,9 +167,14 @@ function ReflectionDetailModal({
             ) : null}
           </ScrollView>
 
-          <Pressable style={styles.modalCloseButton} onPress={onClose}>
-            <Text style={styles.modalCloseText}>閉じる</Text>
-          </Pressable>
+          <Button
+            title="閉じる"
+            variant="outline"
+            size="compact"
+            onPress={onClose}
+            accessibilityLabel="振り返り詳細を閉じる"
+            style={styles.modalCloseButtonPlacement}
+          />
         </View>
       </View>
     </Modal>
@@ -458,18 +464,7 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     marginTop: spacing.tightGap,
   },
-  modalCloseButton: {
+  modalCloseButtonPlacement: {
     alignSelf: "center",
-    backgroundColor: theme.surfaceSoft,
-    borderColor: theme.borderGold,
-    borderRadius: 999,
-    borderWidth: cardSizes.borderWidth,
-    paddingHorizontal: spacing.lgGap,
-    paddingVertical: spacing.smGap,
-  },
-  modalCloseText: {
-    color: theme.gold,
-    fontSize: 14,
-    fontWeight: "800",
   },
 });


### PR DESCRIPTION
## 変更内容

- 振り返り詳細モーダルの閉じるCTAを共通Buttonへ置換
- outline / compactを使用
- title「閉じる」とonCloseを維持
- accessibilityLabel「振り返り詳細を閉じる」を設定
- ローカルStyleを中央配置専用に縮小
- 旧modalCloseTextを削除

## 影響範囲

振り返り詳細モーダルの閉じるCTA表示だけです。Modalのvisible条件、onRequestClose、selectedReflection、ReflectionCard、記録へ戻るリンク、データ取得処理は変更していません。

## 検証

- apps/mobile: pnpm test（57 passed）
- apps/mobile: pnpm typecheck
- git diff --check
- git diff -w
- pre-push OpenAPI lint
- pre-push Web contract tests（545 passed）