### PR TITLE
Concierge再提案CTAへ共通Buttonを適用

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -774,13 +774,14 @@ export default function ConciergeScreen() {
               disabled={loading}
             />
 
-            <Pressable
+            <Button
+              title="この条件で再提案する"
+              variant="primary"
               onPress={handleResuggest}
-              style={[styles.resuggestButton, (loading || (!consultationText && !hasAnyCondition)) && styles.resuggestButtonDisabled]}
-              disabled={loading || (!consultationText && !hasAnyCondition)}
-            >
-              <Text style={styles.resuggestButtonText}>この条件で再提案する</Text>
-            </Pressable>
+              loading={loading}
+              disabled={!consultationText && !hasAnyCondition}
+              accessibilityLabel="この条件で再提案する"
+            />
           </View>
 
           {loading ? (
@@ -974,23 +975,6 @@ const styles = StyleSheet.create({
     lineHeight: 19,
     fontWeight: "700",
   },
-  resuggestButton: {
-    height: 46,
-    borderRadius: 15,
-    alignItems: "center",
-    justifyContent: "center",
-    backgroundColor: theme.gold,
-  },
-  resuggestButtonDisabled: {
-    opacity: 0.45,
-  },
-  resuggestButtonText: {
-    color: theme.background,
-    fontSize: 14,
-    fontWeight: "900",
-    letterSpacing: 0.3,
-  },
-
   loadingRow: {
     paddingVertical: 8,
   },


### PR DESCRIPTION
## 変更内容

- 「この条件で再提案する」CTAを共通Buttonへ置換
- primary / default sizeを使用
- loadingと入力条件disabledを既存契約どおり接続
- 旧専用Styleを削除

## 影響範囲

再提案CTAの表示層のみです。handleResuggest、submit、API URL・payload、状態遷移、Analytics、他CTAは変更していません。

## 検証

- Mobile test: 57 passed
- Mobile typecheck
- git diff --check
- pre-push OpenAPI lint
- pre-push Web contract tests: 545 passed