### PR TITLE
ランキングのお気に入りフィルターへ共通Buttonを適用

### DIFF
--- a/apps/mobile/app/ranking/index.tsx
+++ b/apps/mobile/app/ranking/index.tsx
@@ -4,6 +4,7 @@ import { Animated, ScrollView, View, Text, Image, Pressable, StyleSheet } from "
 import { useRouter, useFocusEffect } from "expo-router";
 import { SHRINES } from "../../data/shrines";
 import { getFavorites, toggleFavorite } from "../../lib/storage";
+import Button from "../../components/ui/Button";
 import { kamimusubiDark } from "../theme";
 import { spacing } from "../design/spacing";
 import { cardSizes } from "../design/cardSizes";
@@ -108,26 +109,13 @@ export default function RankingPage() {
       </Text>
 
       <View style={{ flexDirection: "row", alignItems: "center", marginBottom: spacing.lgGap }}>
-        <Pressable
+        <Button
+          title={favOnly ? "保存済みだけ表示中" : "お気に入りだけ"}
+          accessibilityLabel={favOnly ? "保存済みだけ表示中" : "お気に入りだけ"}
+          variant={favOnly ? "primary" : "outline"}
+          size="compact"
           onPress={() => setFavOnly((v) => !v)}
-          style={{
-            paddingHorizontal: spacing.mdGap,
-            paddingVertical: spacing.inlineGap - 1,
-            borderRadius: radius.pill,
-            borderWidth: cardSizes.borderWidth,
-            borderColor: favOnly ? kamimusubiDark.gold : kamimusubiDark.borderHeader,
-            backgroundColor: favOnly ? kamimusubiDark.gold : kamimusubiDark.surface,
-          }}
-        >
-          <Text
-            style={{
-              color: favOnly ? kamimusubiDark.background : kamimusubiDark.text,
-              fontSize: 12,
-            }}
-          >
-            {favOnly ? "保存済みだけ表示中" : "お気に入りだけ"}
-          </Text>
-        </Pressable>
+        />
         <Text
           style={{
             marginLeft: spacing.smGap,


### PR DESCRIPTION
## 概要
- rankingの「お気に入りだけ」フィルターを既存の共通Buttonへ置換
- `size="compact"`を使用
- `favOnly`に応じて`primary` / `outline`を切り替え
- 表示文言とトグル契約を維持

## 変更対象
- `apps/mobile/app/ranking/index.tsx` のみ

## 維持する契約
- `setFavOnly((value) => !value)`
- お気に入りのみの絞り込み条件
- ランキングカードの詳細遷移
- お気に入りハートとstorage処理
- Analytics追加なし

## アクセシビリティ
- 現在の表示文言を`accessibilityLabel`として設定
- 共通Button APIは拡張していないため、`accessibilityState.selected`は今回の対象外

## 検証
- Mobile test: 57 passed
- Mobile typecheck: passed
- `git diff --check`: passed
- pre-push OpenAPI lint: passed
- pre-push Web contract tests: 545 passed