### PR TITLE
お気に入り取得失敗と空状態を分離

### DIFF
--- a/apps/mobile/app/favorites/index.tsx
+++ b/apps/mobile/app/favorites/index.tsx
@@ -12,13 +12,34 @@ export default function FavoritesScreen() {
   const router = useRouter();
   const [items, setItems] = useState<RecentShrineItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   const load = useCallback(() => {
+    let alive = true;
+
     setLoading(true);
-    getFavoriteShrines()
-      .then(setItems)
-      .catch(() => setItems([]))
-      .finally(() => setLoading(false));
+    setError(false);
+
+    void getFavoriteShrines()
+      .then((nextItems) => {
+        if (!alive) return;
+
+        setItems(nextItems);
+        setError(false);
+      })
+      .catch(() => {
+        if (!alive) return;
+
+        setItems([]);
+        setError(true);
+      })
+      .finally(() => {
+        if (alive) setLoading(false);
+      });
+
+    return () => {
+      alive = false;
+    };
   }, []);
 
   useFocusEffect(load);
@@ -54,6 +75,15 @@ export default function FavoritesScreen() {
         <Text style={{ color: theme.muted, textAlign: "center", marginTop: spacing.bottomSpace }}>
           読み込み中…
         </Text>
+      ) : error ? (
+        <View style={{ alignItems: "center", marginTop: spacing.bottomSpace + spacing.sectionTop, gap: spacing.lgGap }}>
+          <Text style={{ color: theme.muted, fontSize: 15 }}>
+            お気に入りを読み込めませんでした
+          </Text>
+          <Text style={{ color: theme.mutedDark, fontSize: 13, textAlign: "center" }}>
+            通信状況を確認して、もう一度画面を開き直してください。
+          </Text>
+        </View>
       ) : items.length === 0 ? (
         <View style={{ alignItems: "center", marginTop: spacing.bottomSpace + spacing.sectionTop, gap: spacing.lgGap }}>
           <Text style={{ fontSize: 40 }}>♡</Text>


### PR DESCRIPTION
## 変更概要
- favorites画面へerror stateを追加
- 取得失敗と正常な0件表示を分離
- 取得成功時にerrorを解除

## 維持した契約
- getFavoriteShrines
- toggleFavorite
- お気に入り解除処理
- 親カードへのイベント伝播停止
- 神社詳細への遷移
- /recordsへの戻る導線
- Analytics追加なし
- 認証処理追加なし

## 検証
- Mobile test成功
- Mobile typecheck成功
- git diff --check成功
- 変更ファイルはfavorites/index.tsxのみ