### PR TITLE
Mobileプロフィールデータを永続化

### DIFF
--- a/apps/mobile/lib/__tests__/profileStore.test.ts
+++ b/apps/mobile/lib/__tests__/profileStore.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const asyncStorage = vi.hoisted(() => {
+  const values = new Map<string, string>();
+  return {
+    values,
+    getItem: vi.fn(async (key: string) => values.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      values.delete(key);
+    }),
+  };
+});
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: asyncStorage,
+}));
+
+import { buildDerivedProfile, buildDirectionProfile } from "../profile";
+import { useProfileStore } from "../../store/profileStore";
+
+const STORAGE_NAME = "kamimusubi:mobile:profile:v1";
+
+function resetInMemoryState() {
+  useProfileStore.setState({
+    userProfile: {},
+    derivedProfile: buildDerivedProfile({}),
+    directionProfile: buildDirectionProfile({}),
+  });
+}
+
+beforeEach(async () => {
+  asyncStorage.values.clear();
+  vi.clearAllMocks();
+  resetInMemoryState();
+  await useProfileStore.persist.rehydrate();
+});
+
+describe("profileStore persistence", () => {
+  it("uses the existing empty profile as its initial state when storage has no value", () => {
+    const state = useProfileStore.getState();
+
+    expect(state.userProfile).toEqual({});
+    expect(state.derivedProfile).toEqual(buildDerivedProfile({}));
+    expect(state.directionProfile).toEqual(buildDirectionProfile({}));
+  });
+
+  it("persists every user-entered profile field without functions or derived values", async () => {
+    const state = useProfileStore.getState();
+    state.setBirthday("1990-04-01");
+    state.setBirthTime("08:30");
+    state.setBirthPlace("東京都");
+    state.setWorshipStyle("朝参り");
+
+    await vi.waitFor(() => expect(asyncStorage.setItem).toHaveBeenCalled());
+
+    const saved = JSON.parse(asyncStorage.values.get(STORAGE_NAME) ?? "null");
+    expect(saved).toEqual({
+      state: {
+        userProfile: {
+          birthday: "1990-04-01",
+          birthTime: "08:30",
+          birthPlace: "東京都",
+          worshipStyle: "朝参り",
+        },
+      },
+      version: 1,
+    });
+  });
+
+  it("rehydrates the saved profile and recomputes its derived profiles", async () => {
+    const userProfile = {
+      birthday: "1984-05-15",
+      birthTime: "12:15",
+      birthPlace: "京都府",
+      worshipStyle: "夕参り",
+    };
+    resetInMemoryState();
+    asyncStorage.values.set(STORAGE_NAME, JSON.stringify({ state: { userProfile }, version: 1 }));
+
+    await useProfileStore.persist.rehydrate();
+
+    const state = useProfileStore.getState();
+    expect(state.userProfile).toEqual(userProfile);
+    expect(state.derivedProfile).toEqual(buildDerivedProfile(userProfile));
+    expect(state.directionProfile).toEqual(buildDirectionProfile(userProfile));
+    expect(state.setBirthday).toBeTypeOf("function");
+  });
+
+  it("keeps the initial profile usable when persisted JSON is corrupted", async () => {
+    resetInMemoryState();
+    asyncStorage.values.set(STORAGE_NAME, "not-json");
+
+    await useProfileStore.persist.rehydrate();
+
+    expect(useProfileStore.getState().userProfile).toEqual({});
+    expect(() => useProfileStore.getState().setBirthPlace("大阪府")).not.toThrow();
+    expect(useProfileStore.getState().userProfile.birthPlace).toBe("大阪府");
+  });
+
+  it("keeps profile setters usable when persistence fails", async () => {
+    asyncStorage.setItem.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    expect(() => useProfileStore.getState().setBirthday("2000-01-01")).not.toThrow();
+    await Promise.resolve();
+
+    expect(useProfileStore.getState().userProfile.birthday).toBe("2000-01-01");
+    expect(useProfileStore.getState().derivedProfile).toEqual(buildDerivedProfile({ birthday: "2000-01-01" }));
+  });
+});

--- a/apps/mobile/store/profileStore.ts
+++ b/apps/mobile/store/profileStore.ts
@@ -1,4 +1,6 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 import { buildDerivedProfile, buildDirectionProfile } from "../lib/profile";
 import type { DerivedProfile, DirectionProfile, UserProfile } from "../types/profile";
 
@@ -14,6 +16,8 @@ type ProfileState = {
 };
 
 const initialUserProfile: UserProfile = {};
+const PROFILE_STORAGE_NAME = "kamimusubi:mobile:profile:v1";
+const PROFILE_STORAGE_VERSION = 1;
 
 function recompute(userProfile: UserProfile): { derivedProfile: DerivedProfile; directionProfile: DirectionProfile } {
   return {
@@ -22,34 +26,73 @@ function recompute(userProfile: UserProfile): { derivedProfile: DerivedProfile; 
   };
 }
 
-export const useProfileStore = create<ProfileState>((set) => ({
-  userProfile: initialUserProfile,
-  ...recompute(initialUserProfile),
-
-  setBirthday: (value) =>
-    set((s) => {
-      const next = { ...s.userProfile, birthday: value };
-      return { userProfile: next, ...recompute(next) };
-    }),
-
-  setBirthTime: (value) =>
-    set((s) => {
-      const next = { ...s.userProfile, birthTime: value };
-      return { userProfile: next, ...recompute(next) };
-    }),
-
-  setBirthPlace: (value) =>
-    set((s) => {
-      const next = { ...s.userProfile, birthPlace: value };
-      return { userProfile: next, ...recompute(next) };
-    }),
-
-  setWorshipStyle: (value) =>
-    set((s) => {
-      const next = { ...s.userProfile, worshipStyle: value };
-      return { userProfile: next, ...recompute(next) };
-    }),
-
-  resetProfile: () =>
-    set({ userProfile: initialUserProfile, ...recompute(initialUserProfile) }),
+const profileStorage = createJSONStorage(() => ({
+  getItem: async (name: string) => {
+    try {
+      return await AsyncStorage.getItem(name);
+    } catch {
+      return null;
+    }
+  },
+  setItem: async (name: string, value: string) => {
+    try {
+      await AsyncStorage.setItem(name, value);
+    } catch {
+      // Profile updates remain available in memory when persistence fails.
+    }
+  },
+  removeItem: async (name: string) => {
+    try {
+      await AsyncStorage.removeItem(name);
+    } catch {
+      // A storage cleanup failure must not make the profile unusable.
+    }
+  },
 }));
+
+export const useProfileStore = create<ProfileState>()(
+  persist(
+    (set) => ({
+      userProfile: initialUserProfile,
+      ...recompute(initialUserProfile),
+
+      setBirthday: (value) =>
+        set((s) => {
+          const next = { ...s.userProfile, birthday: value };
+          return { userProfile: next, ...recompute(next) };
+        }),
+
+      setBirthTime: (value) =>
+        set((s) => {
+          const next = { ...s.userProfile, birthTime: value };
+          return { userProfile: next, ...recompute(next) };
+        }),
+
+      setBirthPlace: (value) =>
+        set((s) => {
+          const next = { ...s.userProfile, birthPlace: value };
+          return { userProfile: next, ...recompute(next) };
+        }),
+
+      setWorshipStyle: (value) =>
+        set((s) => {
+          const next = { ...s.userProfile, worshipStyle: value };
+          return { userProfile: next, ...recompute(next) };
+        }),
+
+      resetProfile: () =>
+        set({ userProfile: initialUserProfile, ...recompute(initialUserProfile) }),
+    }),
+    {
+      name: PROFILE_STORAGE_NAME,
+      storage: profileStorage,
+      version: PROFILE_STORAGE_VERSION,
+      partialize: (state) => ({ userProfile: state.userProfile }),
+      merge: (persistedState, currentState) => {
+        const userProfile = (persistedState as Pick<ProfileState, "userProfile"> | undefined)?.userProfile ??
+          initialUserProfile;
+        return { ...currentState, userProfile, ...recompute(userProfile) };
+      },
+    },
+  ),
+);


### PR DESCRIPTION
## 変更概要
- profileStoreをAsyncStorageへ永続化
- userProfile.birthdayを含むプロフィール入力値を正本化
- アプリ再起動後もプロフィール値を復元
- 既存setterと派生プロフィール計算を維持

## 対象外
- 旧sanpai:profile:birthdayデータの移行
- mypage誕生日カード削除
- /birthday route削除
- UI・API・Analytics変更

## 検証
- Mobile test成功
- Mobile typecheck成功
- profileStore永続化テスト成功
- git diff --check成功