### PR TITLE
旧誕生日データをプロフィールStoreへ移行

### DIFF
--- a/apps/mobile/lib/__tests__/profileMigration.test.ts
+++ b/apps/mobile/lib/__tests__/profileMigration.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const asyncStorage = vi.hoisted(() => {
+  const values = new Map<string, string>();
+  return {
+    values,
+    getItem: vi.fn(async (key: string) => values.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: string) => {
+      values.set(key, value);
+    }),
+    removeItem: vi.fn(async (key: string) => {
+      values.delete(key);
+    }),
+  };
+});
+
+vi.mock("@react-native-async-storage/async-storage", () => ({
+  default: asyncStorage,
+}));
+
+import {
+  LEGACY_BIRTHDAY_STORAGE_NAME,
+  migrateLegacyBirthdayIfNeeded,
+} from "../profileMigration";
+
+const PROFILE_STORAGE_NAME = "kamimusubi:mobile:profile:v1";
+
+function migrate(userProfile: { birthday?: string; birthTime?: string; birthPlace?: string; worshipStyle?: string }) {
+  const setBirthday = vi.fn();
+  const result = migrateLegacyBirthdayIfNeeded({
+    userProfile,
+    setBirthday,
+    profileStorageName: PROFILE_STORAGE_NAME,
+    profileStorageVersion: 1,
+  });
+  return { result, setBirthday };
+}
+
+beforeEach(() => {
+  asyncStorage.values.clear();
+  vi.clearAllMocks();
+});
+
+describe("legacy birthday migration", () => {
+  it("migrates a valid legacy birthday when the profile birthday is empty", async () => {
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "1984-05-15");
+
+    const { result, setBirthday } = migrate({ birthPlace: "京都府" });
+
+    await expect(result).resolves.toBe("migrated");
+    expect(setBirthday).toHaveBeenCalledWith("1984-05-15");
+    expect(asyncStorage.values.has(LEGACY_BIRTHDAY_STORAGE_NAME)).toBe(false);
+    expect(JSON.parse(asyncStorage.values.get(PROFILE_STORAGE_NAME) ?? "null")).toEqual({
+      state: { userProfile: { birthday: "1984-05-15", birthPlace: "京都府" } },
+      version: 1,
+    });
+  });
+
+  it("never overwrites an existing profile birthday", async () => {
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "1984-05-15");
+
+    const { result, setBirthday } = migrate({ birthday: "1990-01-01" });
+
+    await expect(result).resolves.toBe("skipped_existing");
+    expect(setBirthday).not.toHaveBeenCalled();
+    expect(asyncStorage.values.get(LEGACY_BIRTHDAY_STORAGE_NAME)).toBe("1984-05-15");
+  });
+
+  it("does nothing when the legacy value is missing or empty", async () => {
+    await expect(migrate({}).result).resolves.toBe("skipped_missing");
+
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "   ");
+    await expect(migrate({}).result).resolves.toBe("skipped_missing");
+  });
+
+  it("does not migrate an invalid legacy value", async () => {
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "not-a-birthday");
+
+    const { result, setBirthday } = migrate({});
+
+    await expect(result).resolves.toBe("skipped_invalid");
+    expect(setBirthday).not.toHaveBeenCalled();
+    expect(asyncStorage.values.get(LEGACY_BIRTHDAY_STORAGE_NAME)).toBe("not-a-birthday");
+  });
+
+  it("continues initialization when reading the legacy value fails", async () => {
+    asyncStorage.getItem.mockRejectedValueOnce(new Error("read failed"));
+
+    await expect(migrate({}).result).resolves.toBe("failed");
+  });
+
+  it("keeps the legacy value and state unchanged when the new profile cannot be saved", async () => {
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "1984-05-15");
+    asyncStorage.setItem.mockRejectedValueOnce(new Error("write failed"));
+
+    const { result, setBirthday } = migrate({});
+
+    await expect(result).resolves.toBe("failed");
+    expect(setBirthday).not.toHaveBeenCalled();
+    expect(asyncStorage.values.get(LEGACY_BIRTHDAY_STORAGE_NAME)).toBe("1984-05-15");
+    expect(asyncStorage.removeItem).not.toHaveBeenCalled();
+  });
+
+  it("is idempotent when run repeatedly", async () => {
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "1984-05-15");
+    const first = migrate({});
+    await expect(first.result).resolves.toBe("migrated");
+
+    const second = migrate({ birthday: "1984-05-15" });
+    await expect(second.result).resolves.toBe("skipped_existing");
+    expect(second.setBirthday).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/lib/__tests__/profileStore.test.ts
+++ b/apps/mobile/lib/__tests__/profileStore.test.ts
@@ -22,6 +22,7 @@ import { buildDerivedProfile, buildDirectionProfile } from "../profile";
 import { useProfileStore } from "../../store/profileStore";
 
 const STORAGE_NAME = "kamimusubi:mobile:profile:v1";
+const LEGACY_BIRTHDAY_STORAGE_NAME = "sanpai:profile:birthday";
 
 function resetInMemoryState() {
   useProfileStore.setState({
@@ -108,5 +109,41 @@ describe("profileStore persistence", () => {
 
     expect(useProfileStore.getState().userProfile.birthday).toBe("2000-01-01");
     expect(useProfileStore.getState().derivedProfile).toEqual(buildDerivedProfile({ birthday: "2000-01-01" }));
+  });
+
+  it("migrates the legacy birthday after hydration and preserves the other profile fields", async () => {
+    const persistedUserProfile = {
+      birthTime: "08:30",
+      birthPlace: "東京都",
+      worshipStyle: "朝参り",
+    };
+    resetInMemoryState();
+    asyncStorage.values.set(
+      STORAGE_NAME,
+      JSON.stringify({ state: { userProfile: persistedUserProfile }, version: 1 }),
+    );
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "1990-04-01");
+
+    await useProfileStore.persist.rehydrate();
+    await vi.waitFor(() => expect(useProfileStore.getState().userProfile.birthday).toBe("1990-04-01"));
+
+    const state = useProfileStore.getState();
+    const expectedUserProfile = { ...persistedUserProfile, birthday: "1990-04-01" };
+    expect(state.userProfile).toEqual(expectedUserProfile);
+    expect(state.derivedProfile).toEqual(buildDerivedProfile(expectedUserProfile));
+    expect(state.directionProfile).toEqual(buildDirectionProfile(expectedUserProfile));
+    expect(asyncStorage.values.has(LEGACY_BIRTHDAY_STORAGE_NAME)).toBe(false);
+  });
+
+  it("does not migrate when the persisted profile cannot be read", async () => {
+    resetInMemoryState();
+    asyncStorage.values.set(LEGACY_BIRTHDAY_STORAGE_NAME, "1984-05-15");
+    asyncStorage.getItem.mockRejectedValueOnce(new Error("profile read failed"));
+
+    await useProfileStore.persist.rehydrate();
+    await Promise.resolve();
+
+    expect(useProfileStore.getState().userProfile.birthday).toBeUndefined();
+    expect(asyncStorage.values.get(LEGACY_BIRTHDAY_STORAGE_NAME)).toBe("1984-05-15");
   });
 });

--- a/apps/mobile/lib/profileMigration.ts
+++ b/apps/mobile/lib/profileMigration.ts
@@ -1,0 +1,65 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+import type { UserProfile } from "../types/profile";
+
+export const LEGACY_BIRTHDAY_STORAGE_NAME = "sanpai:profile:birthday";
+
+const BIRTHDAY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export type LegacyBirthdayMigrationResult =
+  | "migrated"
+  | "skipped_existing"
+  | "skipped_missing"
+  | "skipped_invalid"
+  | "failed";
+
+type LegacyBirthdayMigrationOptions = {
+  userProfile: UserProfile;
+  setBirthday: (value: string) => void;
+  profileStorageName: string;
+  profileStorageVersion: number;
+};
+
+export async function migrateLegacyBirthdayIfNeeded({
+  userProfile,
+  setBirthday,
+  profileStorageName,
+  profileStorageVersion,
+}: LegacyBirthdayMigrationOptions): Promise<LegacyBirthdayMigrationResult> {
+  if (typeof userProfile.birthday === "string" && userProfile.birthday.trim().length > 0) {
+    return "skipped_existing";
+  }
+
+  let legacyBirthday: string | null;
+  try {
+    legacyBirthday = await AsyncStorage.getItem(LEGACY_BIRTHDAY_STORAGE_NAME);
+  } catch {
+    return "failed";
+  }
+
+  if (legacyBirthday === null) return "skipped_missing";
+
+  const normalizedBirthday = legacyBirthday.trim();
+  if (!normalizedBirthday) return "skipped_missing";
+  if (!BIRTHDAY_PATTERN.test(normalizedBirthday)) return "skipped_invalid";
+
+  const nextUserProfile = { ...userProfile, birthday: normalizedBirthday };
+  try {
+    await AsyncStorage.setItem(
+      profileStorageName,
+      JSON.stringify({ state: { userProfile: nextUserProfile }, version: profileStorageVersion }),
+    );
+  } catch {
+    return "failed";
+  }
+
+  setBirthday(normalizedBirthday);
+
+  try {
+    await AsyncStorage.removeItem(LEGACY_BIRTHDAY_STORAGE_NAME);
+  } catch {
+    // The persisted profile is already authoritative; leaving the legacy value is safe.
+  }
+
+  return "migrated";
+}

--- a/apps/mobile/store/profileStore.ts
+++ b/apps/mobile/store/profileStore.ts
@@ -2,6 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 import { buildDerivedProfile, buildDirectionProfile } from "../lib/profile";
+import { migrateLegacyBirthdayIfNeeded } from "../lib/profileMigration";
 import type { DerivedProfile, DirectionProfile, UserProfile } from "../types/profile";
 
 type ProfileState = {
@@ -27,13 +28,7 @@ function recompute(userProfile: UserProfile): { derivedProfile: DerivedProfile; 
 }
 
 const profileStorage = createJSONStorage(() => ({
-  getItem: async (name: string) => {
-    try {
-      return await AsyncStorage.getItem(name);
-    } catch {
-      return null;
-    }
-  },
+  getItem: (name: string) => AsyncStorage.getItem(name),
   setItem: async (name: string, value: string) => {
     try {
       await AsyncStorage.setItem(name, value);
@@ -96,3 +91,17 @@ export const useProfileStore = create<ProfileState>()(
     },
   ),
 );
+
+function migrateLegacyBirthdayAfterHydration(state: ProfileState) {
+  void migrateLegacyBirthdayIfNeeded({
+    userProfile: state.userProfile,
+    setBirthday: state.setBirthday,
+    profileStorageName: PROFILE_STORAGE_NAME,
+    profileStorageVersion: PROFILE_STORAGE_VERSION,
+  });
+}
+
+useProfileStore.persist.onFinishHydration(migrateLegacyBirthdayAfterHydration);
+if (useProfileStore.persist.hasHydrated()) {
+  migrateLegacyBirthdayAfterHydration(useProfileStore.getState());
+}


### PR DESCRIPTION
## 変更概要
- 旧sanpai:profile:birthdayをprofileStoreへ安全に移行
- profileStore側のbirthdayが空の場合のみ移行
- 既存profile値の上書きを防止
- 読込・保存失敗時もアプリ起動を継続
- 移行処理を再実行しても重複しない構造

## 対象外
- birthday画面削除
- /birthday route削除
- mypage誕生日カード削除
- UI・API・Analytics変更

## 検証
- Mobile test成功
- Mobile typecheck成功
- migrationテスト成功
- git diff --check成功