### PR TITLE
feat: 方位分析ダッシュボード契約を整備

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -95,7 +95,6 @@ type RecommendationCard = {
   actionSuggestionV4Preview?: ActionSuggestionV4Preview | null;
   directionReference?: DirectionReference | null;
 };
-const directionImpressions = new Set<string>();
 
 type ActionSuggestionV4Action = {
   label: string;
@@ -473,6 +472,7 @@ function ResultCard({
     slot: "primary" | "secondary";
   }) => void;
 }) {
+  const directionImpressed = React.useRef(false);
   const reasonFactItems = buildReasonFactItems(card.reasonFacts);
   const actionSuggestionV4Preview = card.actionSuggestionV4Preview;
   const reasonDisplay = buildRecommendationReasonDisplay({
@@ -480,7 +480,7 @@ function ResultCard({
     reason: card.reason,
     directionReference: card.directionReference,
   });
-  React.useEffect(() => { if (!card.directionReference?.matched || directionImpressions.has(card.id)) return; directionImpressions.add(card.id); trackMobileDirection("direction_match_impression", { matched: true, recommendation_rank: rank }); }, [card.directionReference?.matched, card.id, rank]);
+  React.useEffect(() => { if (!card.directionReference || directionImpressed.current) return; directionImpressed.current = true; trackMobileDirection("direction_match_impression", { matched: card.directionReference.matched, recommendation_rank: rank }); }, [card.directionReference, rank]);
   return (
     <View style={styles.card}>
       {/* ランクバッジ */}
@@ -782,8 +782,8 @@ export default function ConciergeScreen() {
     });
   };
 
-  const handleDetail = (card: RecommendationCard) => {
-    if (card.directionReference?.matched) trackMobileDirection("direction_match_detail_opened", { matched: true });
+  const handleDetail = (card: RecommendationCard, rank: number) => {
+    if (card.directionReference?.matched) trackMobileDirection("direction_match_detail_opened", { matched: true, recommendation_rank: rank });
     if (!card.shrineId) return;
     router.push({
       pathname: "/shrines/[id]",
@@ -902,7 +902,7 @@ export default function ConciergeScreen() {
                 key={card.id}
                 card={card}
                 rank={i + 1}
-                onDetail={() => handleDetail(card)}
+                onDetail={() => handleDetail(card, i + 1)}
                 onActionEvent={({ actionType, action, slot }) =>
                   handleActionEvent({
                     card,

--- a/apps/mobile/lib/__tests__/directionEvents.test.ts
+++ b/apps/mobile/lib/__tests__/directionEvents.test.ts
@@ -1,4 +1,49 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-const {track}=vi.hoisted(()=>({track:vi.fn()}));vi.mock("../analytics",()=>({track}));
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../analytics", () => ({ track }));
+
+import { DIRECTION_EVENT_NAMES } from "../../../../packages/shared/directionAnalytics";
 import { trackMobileDirection } from "../directionEvents";
-describe("direction analytics",()=>{beforeEach(()=>track.mockClear());it("個人情報を含まない共通契約だけを送る",()=>{trackMobileDirection("direction_condition_submitted",{has_visit_date:true,has_origin:true});expect(track).toHaveBeenCalledWith("direction_condition_submitted",{platform:"mobile",has_visit_date:true,has_origin:true});});});
+
+describe("direction analytics", () => {
+  beforeEach(() => track.mockClear());
+
+  it("Webとモバイルで共有するイベント名をすべて受け付ける", () => {
+    for (const name of DIRECTION_EVENT_NAMES) trackMobileDirection(name);
+    expect(track.mock.calls.map(([name]) => name)).toEqual(DIRECTION_EVENT_NAMES);
+  });
+
+  it("イベント別allowlist以外の位置情報・個人情報を送らない", () => {
+    trackMobileDirection("direction_condition_submitted", {
+      has_visit_date: true,
+      has_origin: true,
+      latitude: 35.6812,
+      longitude: 139.7671,
+      address: "東京都千代田区",
+      station_name: "東京駅",
+      prefecture_name: "東京都",
+      birthdate: "1990-01-01",
+      consultation: "相談文",
+      query: "検索語",
+    } as never);
+
+    expect(track).toHaveBeenCalledWith("direction_condition_submitted", {
+      platform: "mobile",
+      has_visit_date: true,
+      has_origin: true,
+    });
+  });
+
+  it("不正なenum値と順位を除外する", () => {
+    trackMobileDirection("direction_match_impression", {
+      matched: true,
+      recommendation_rank: -1,
+      origin_type: "Tokyo",
+    } as never);
+    expect(track).toHaveBeenCalledWith("direction_match_impression", {
+      platform: "mobile",
+      matched: true,
+    });
+  });
+});

--- a/apps/web/e2e/05_direction_flow.spec.ts
+++ b/apps/web/e2e/05_direction_flow.spec.ts
@@ -77,7 +77,9 @@ test.describe("方位条件のWeb E2E", () => {
     await expect(page.getByText("現在地から見た方角は、予定日の参考方位とは異なります。")).toBeVisible();
     expect(captured.geocodeRequests).toHaveLength(1);
     expect(captured.chatPayloads[0]).toMatchObject({ location: { lat: 35.681236, lng: 139.767125 } });
-    expect(captured.analyticsEvents.filter((event) => event.eventName === "direction_match_impression")).toHaveLength(0);
+    expect(captured.analyticsEvents.filter((event) => event.eventName === "direction_match_impression")).toEqual([
+      expect.objectContaining({ payload: expect.objectContaining({ matched: false }) }),
+    ]);
     expectPrivateDataAbsent(captured.analyticsEvents);
   });
 

--- a/apps/web/src/features/concierge/components/DirectionReferenceCard.tsx
+++ b/apps/web/src/features/concierge/components/DirectionReferenceCard.tsx
@@ -2,13 +2,13 @@ import {
   directionReferenceMatchCopy,
   type DirectionReference,
 } from "../../../../../../packages/shared/directionReference";
-import { useEffect, useId } from "react";
+import { useEffect, useId, useRef } from "react";
 import { trackWebDirection } from "@/lib/analytics/directionEvents";
-const impressed = new Set<string>();
 
 export default function DirectionReferenceCard({ reference, recommendationKey = "unknown", rank }: { reference?: DirectionReference | null; recommendationKey?: string | number; rank?: number }) {
   const headingId = useId();
-  useEffect(() => { if (!reference?.matched) return; const key = String(recommendationKey); if (impressed.has(key)) return; impressed.add(key); trackWebDirection("direction_match_impression", { matched: true, recommendation_rank: rank }); }, [reference, recommendationKey, rank]);
+  const impressed = useRef(false);
+  useEffect(() => { if (!reference || impressed.current) return; impressed.current = true; trackWebDirection("direction_match_impression", { matched: reference.matched, recommendation_rank: rank }); }, [reference, recommendationKey, rank]);
   if (!reference) return null;
 
   return (

--- a/apps/web/src/features/concierge/components/__tests__/DirectionReferenceCard.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/DirectionReferenceCard.test.tsx
@@ -1,4 +1,9 @@
 import { render, screen } from "@testing-library/react";
+import { beforeEach, vi } from "vitest";
+
+const { trackWebDirection } = vi.hoisted(() => ({ trackWebDirection: vi.fn() }));
+vi.mock("@/lib/analytics/directionEvents", () => ({ trackWebDirection }));
+
 import DirectionReferenceCard from "../DirectionReferenceCard";
 
 const reference = {
@@ -11,6 +16,8 @@ const reference = {
 };
 
 describe("DirectionReferenceCard", () => {
+  beforeEach(() => trackWebDirection.mockClear());
+
   it("Backend契約がある場合だけ非断定的な方位情報を表示する", () => {
     const { rerender } = render(<DirectionReferenceCard reference={reference} />);
     expect(screen.getByRole("heading", { level: 3, name: "方位の参考情報" })).toBeInTheDocument();
@@ -22,7 +29,12 @@ describe("DirectionReferenceCard", () => {
   });
 
   it("不一致を優劣ではなく差異として表示する", () => {
-    render(<DirectionReferenceCard reference={{ ...reference, matched: false }} />);
+    const mismatched = { ...reference, matched: false };
+    const { rerender } = render(<DirectionReferenceCard reference={mismatched} recommendationKey="result-1" rank={2} />);
     expect(screen.getByText("現在地から見た方角は、予定日の参考方位とは異なります。")).toBeInTheDocument();
+    expect(trackWebDirection).toHaveBeenCalledWith("direction_match_impression", { matched: false, recommendation_rank: 2 });
+
+    rerender(<DirectionReferenceCard reference={mismatched} recommendationKey="result-1" rank={2} />);
+    expect(trackWebDirection).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/lib/analytics/__tests__/directionEvents.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/directionEvents.test.ts
@@ -1,4 +1,45 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-const {track}=vi.hoisted(()=>({track:vi.fn()}));vi.mock("../track",()=>({track}));
+
+const { track } = vi.hoisted(() => ({ track: vi.fn() }));
+vi.mock("../track", () => ({ track }));
+
+import { DIRECTION_EVENT_NAMES } from "../../../../../../packages/shared/directionAnalytics";
 import { trackWebDirection } from "../directionEvents";
-describe("direction analytics",()=>{beforeEach(()=>track.mockClear());it("個人情報を含まない共通契約だけを送る",()=>{trackWebDirection("direction_origin_result",{origin_type:"prefecture",result:"selected"});expect(track).toHaveBeenCalledWith("direction_origin_result",{platform:"web",origin_type:"prefecture",result:"selected"});});});
+
+describe("direction analytics", () => {
+  beforeEach(() => track.mockClear());
+
+  it("Webとモバイルで共有するイベント名をすべて受け付ける", () => {
+    for (const name of DIRECTION_EVENT_NAMES) trackWebDirection(name);
+    expect(track.mock.calls.map(([name]) => name)).toEqual(DIRECTION_EVENT_NAMES);
+  });
+
+  it("イベント別allowlist以外の位置情報・個人情報を送らない", () => {
+    trackWebDirection("direction_origin_result", {
+      origin_type: "prefecture",
+      result: "selected",
+      latitude: 35.6812,
+      longitude: 139.7671,
+      address: "東京都千代田区",
+      station_name: "東京駅",
+      prefecture_name: "東京都",
+      birthdate: "1990-01-01",
+      consultation: "相談文",
+      query: "検索語",
+    } as never);
+
+    expect(track).toHaveBeenCalledWith("direction_origin_result", {
+      platform: "web",
+      origin_type: "prefecture",
+      result: "selected",
+    });
+  });
+
+  it("イベントと無関係な共通属性も除外する", () => {
+    trackWebDirection("direction_visit_date_set", {
+      has_visit_date: true,
+      recommendation_rank: 1,
+    } as never);
+    expect(track).toHaveBeenCalledWith("direction_visit_date_set", { platform: "web" });
+  });
+});

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -16,6 +16,8 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 
 | ドキュメント | 責務 |
 | --- | --- |
+| `direction-events.md` | Web／Mobile共通の方位分析Event名・Payload・禁止属性契約を管理する |
+| `direction-analytics-dashboard.md` | 方位利用ファネル、KPI、PostHog設定案、異常値・日盤検討基準を管理する |
 | `action-suggestion-funnel.md` | Action Suggestion関連Event（PostHog view計測 / Backend `ActionEvent`）の現状を管理する |
 | `monetization-funnel.md` | Premium / Monetization FunnelのEvent名を管理する |
 | `save-premium-correlation.md` | 保存行動とPremium転換に関するEvent間の相関分析の読み方を管理する |

--- a/docs/analytics/direction-analytics-dashboard.md
+++ b/docs/analytics/direction-analytics-dashboard.md
@@ -1,0 +1,110 @@
+> **Status: Proposed Dashboard Configuration / Implementation Active**
+
+# 方位機能 分析ダッシュボード
+
+この文書は既存の方位イベントから、個人情報を使わずに利用状況と改善箇所を把握するための指標・ファネル・PostHog設定案を定義する。外部ダッシュボード自体はこのPRでは変更せず、母艦で設定・レビューする。
+
+## 分析単位と共通条件
+
+- 期間: まず直近28日、比較期間はその直前28日
+- 集計: ユニークセッションを基本、操作品質はイベント回数も併記
+- 比較軸: `platform = web | mobile`、`origin_type`、`recommendation_rank`
+- Web／モバイルの母数は混ぜず、全体値は各platform値を併記してから表示する
+- 少数データから個人を推測しない。少数セルは非表示または期間を延長する
+- `matched`を利用者属性として保存・cohort化しない
+
+## 推奨ファネル
+
+| Step | Event / filter | 備考 |
+|---|---|---|
+| 1. 参拝予定日を設定 | `direction_visit_date_set` | 日付値は取得しない |
+| 2. 出発地点を選択 | `direction_origin_result`, `result in (success, selected)`, `origin_type != disabled` | device成功または明示選択 |
+| 3. 方位条件付き相談を送信 | `direction_condition_submitted`, `has_visit_date=true`, `has_origin=true` | ファネルの基準母数 |
+| 4. 方位参考情報を表示 | `direction_match_impression` | 一致候補の後続率は`matched=true`で絞る |
+| 5. 候補詳細を開く | `direction_match_detail_opened`, `matched=true` | 順位別も確認 |
+| 6. 経路を確認 | `direction_match_route_clicked`, `matched=true` | 現状はモバイルのみ比較可能 |
+
+厳密順序、同一セッション、推奨コンバージョン窓24時間で作成する。結果の再送信を別試行として分析したい場合はイベント回数ビューを補助的に使う。
+
+## 指標定義
+
+| 指標 | 分子 | 分母 | 注意 |
+|---|---|---|---|
+| 方位条件付き相談率 | submitで`has_visit_date=true AND has_origin=true` | 全`direction_condition_submitted` | 日付だけ／地点だけは含めない |
+| 現在地取得成功率 | device + success | deviceのsuccess + denied + failed | `selected`を混ぜない |
+| 位置情報拒否率 | device + denied | deviceのsuccess + denied + failed | OS拒否のみ |
+| 現在地取得失敗率 | device + failed | deviceのsuccess + denied + failed | 拒否と技術失敗を分離 |
+| 手動入力への移行率 | denied後にstation/address selected | device denied | 同一セッション、24時間以内、順序あり |
+| 駅名・住所選択率 | station/address + selected | disabledを除く全selectedとdevice success | 地名は収集しない |
+| 都道府県選択率 | prefecture + selected | disabledを除く全selectedとdevice success | 都道府県名は収集しない |
+| 方位情報無効化率 | disabled + selected | 出発地点方法の全選択結果 | device結果の再試行による重複に注意 |
+| 方位参考情報の表示率 | match impressionのあるセッション | 方位条件付き相談セッション | matched true/falseを含む |
+| 方位一致候補表示率 | matched=trueのmatch impressionがあるセッション | 方位条件付き相談セッション | 不一致を分子に含めない |
+| 詳細表示率 | matched=trueのmatch detail openedがあるセッション | matched=trueのmatch impressionがあるセッション | Web／mobile、rank別 |
+| 経路クリック率 | matched=trueのmatch route clickedがあるセッション | matched=trueのmatch impressionがあるセッション | 現状mobileのみ有効 |
+
+`direction_match_impression`は名前を維持しつつ、`direction_reference`表示時に`matched=true/false`を送る。`direction_reference`欠落時は送らないため、情報なしを不一致へ含めない。
+
+## PostHog設定手順（母艦への設定案）
+
+1. Dashboard「Direction feature health」を1つ作成する。
+2. Date rangeをLast 28 days、comparisonをPrevious periodにする。
+3. 上記6段階をStrict order / Unique sessions / 24 hour windowでFunnel insightへ登録する。
+4. Funnel breakdownは`platform`だけを既定表示にする。`origin_type`と`recommendation_rank`は別Insightに分離する。
+5. Trendsで現在地取得結果を`direction_origin_result`の`result`別に積み上げ表示する。filterは`origin_type=device`。
+6. 手動移行は`direction_origin_result(result=denied, origin_type=device)`から`direction_origin_result(result=selected, origin_type in station,address)`の2段階ファネルにする。
+7. 出発地点構成比はsuccess/selectedのみを対象に`origin_type`でbreakdownする。
+8. 一致表示→詳細、一致表示→経路を別Funnelにし、後者は`platform=mobile`を固定する。
+9. Dashboard descriptionへ本書、イベント契約、欠測条件、最終レビュー日を記載する。
+10. 作成後に本番ではない固定テストイベントが混ざっていないことを確認してから共有する。
+
+新しい分析サービス、Person property、住所系プロパティ、個別ユーザーcohortは作成しない。
+
+## 異常値の確認基準
+
+次を「調査開始の目安」とし、機能の良否や因果を断定しない。
+
+- イベント件数が過去4週の同曜日中央値から±30%以上、かつ50セッション以上の差
+- 現在地取得成功率が前期間比10ポイント以上低下
+- deniedまたはfailedが前期間比5ポイント以上増加
+- 手動入力への移行率が前期間比10ポイント以上低下
+- Step間CVRが前期間比10ポイント以上低下
+- Web／モバイル差が20ポイント以上で、各platform 100セッション以上
+- 同一セッション・同一候補のimpressionが複数回観測される
+- 禁止属性または契約外属性が1件でも見つかる（即時停止・調査）
+
+確認順は、リリース・障害・母数変化、イベント欠損／重複、platform差、UI導線、初めて最後に利用傾向とする。
+
+## 日盤検討へ進む判断材料
+
+日盤実装の可否はダッシュボードだけで決めない。少なくとも連続2期間（各28日）で以下を満たした場合に、ユーザー調査と技術設計を始める候補とする。
+
+- 方位条件付き相談が各期間500セッション以上
+- 方位条件付き相談率が20%以上
+- 一致表示→詳細率が全相談の詳細率と比べて継続的に低くない
+- モバイル一致表示→経路率が10%以上
+- 拒否後の手動移行率が30%以上で、代替導線が機能している
+- 技術失敗率が5%未満で、現行年盤・月盤の品質問題が先に残っていない
+- 定性調査で「日単位の判断」が実際の課題として確認される
+
+満たしても日盤の有効性は確定しない。時盤は別の利用課題・精度・説明責任を要するため、この判断に含めない。
+
+## 運用チェックリスト
+
+- [ ] Dashboard期間・timezone・conversion windowを確認
+- [ ] Web／mobileを分け、経路率はmobile限定であることを表示
+- [ ] イベント名と属性が契約通りかLive Eventsで標本確認
+- [ ] 緯度経度、住所、駅名、都道府県名、生年月日、相談文、検索語がない
+- [ ] impression重複とsubmit欠損を確認
+- [ ] 拒否と技術失敗を混同していない
+- [ ] 不一致・情報なし・エラー・離脱を推測で分解していない
+- [ ] 少数セルから個人を推測できない表示になっている
+- [ ] 前期間差の母数とリリース履歴を確認
+- [ ] 数値だけで機能の良否や日盤実装を断定していない
+- [ ] 確認日、担当、判断、追加調査をDashboard descriptionへ記録
+
+## 関連資料
+
+- `docs/analytics/direction-events.md`
+- `packages/shared/directionAnalytics.ts`
+- `docs/analytics/recommendation-funnel-analysis.md`

--- a/docs/analytics/direction-events.md
+++ b/docs/analytics/direction-events.md
@@ -1,15 +1,39 @@
-> **Status: Active**
+> **Status: Active / Contract**
 
-# 方位条件分析イベント
+# 方位分析イベント契約
 
-Webとモバイルは`packages/shared/directionAnalytics.ts`をイベント契約の正本とし、既存の分析Providerを使用する。
+Webとモバイルは`packages/shared/directionAnalytics.ts`を正本とし、既存のPostHog Providerだけを使用する。イベント名・属性・意味は両者で共通であり、`platform`だけが異なる。
 
-- `direction_visit_date_set`: 参拝予定日を設定（値は送らない）
-- `direction_origin_result`: 出発地点種別と成功・拒否・失敗・選択
-- `direction_condition_submitted`: 予定日・確定地点の有無
-- `direction_match_impression`: Backendが`matched: true`を返した候補の初回表示
-- `direction_match_detail_opened`: 一致候補から詳細へ遷移
-- `direction_match_route_clicked`: 一致候補の経路行動
+| Event | 発火条件 | 許可する属性 | 重複の単位 |
+|---|---|---|---|
+| `direction_visit_date_set` | 空でない参拝予定日を設定・変更する操作 | `platform` | 日付変更ごと。日付値は送らない |
+| `direction_origin_result` | 現在地取得結果、または出発地点種別の選択 | `platform`, `origin_type`, `result` | 操作結果ごと |
+| `direction_condition_submitted` | 方位条件を含み得る相談送信 | `platform`, `has_visit_date`, `has_origin` | 送信試行ごと |
+| `direction_match_impression` | Backendの`direction_reference`付き候補を初めて表示 | `platform`, `matched`, `recommendation_rank` | 表示カードのマウントごとに1回 |
+| `direction_match_detail_opened` | 方位一致候補から詳細を開く | `platform`, `matched`, `recommendation_rank` | クリックごと |
+| `direction_match_route_clicked` | 方位一致候補に紐づく経路行動 | `platform`, `matched`, `recommendation_rank` | クリックごと |
 
-緯度・経度、住所、駅名、都道府県名、生年月日、相談文、検索語は送信しない。表示イベントは候補キーで重複排除する。
-方位は相談内容に対する補助情報であり、推薦の主理由として扱わない。
+`origin_type`は`device | station | address | prefecture | disabled`、`result`は`success | denied | failed | selected`だけを許可する。共有serializerはイベント別allowlist以外を破棄するため、型を迂回した呼び出しでも余分な値をProviderへ渡さない。
+
+## 禁止属性
+
+次の値はイベント名を問わず送信しない。
+
+- 緯度・経度、住所、駅名、都道府県名、検索語
+- 生年月日、相談文、プロフィール入力
+- 実際の方位、吉凶、予定日そのもの
+- shrine名、個別ユーザーを方位評価する属性
+
+`has_visit_date`と`has_origin`は値そのものではなく有無だけを表す。`matched`は候補単位のUI条件であり、利用者個人の吉凶判定やセグメント作成には使わない。
+
+## Web／モバイル監査結果
+
+- 6イベントは共有型から送信され、名前と属性の意味は一致している。
+- 方位参考情報の表示は一致・不一致とも送り、Web／モバイルとも表示カードのマウント中に1回だけ送る。再相談で同じ候補が再表示された場合は新しい表示として送る。
+- 詳細クリックは両方で取得でき、順位も共通属性として送る。
+- 経路クリックは現行モバイル結果の`route_open`でのみ方位一致との関連を保持できる。Web詳細画面へ遷移した後は方位一致コンテキストを保持していないため、Web値は欠測として扱う。
+- 相談送信後に一致候補が出ない場合は「不一致」「根拠不足」「通信エラー」「離脱」をこのイベント群だけでは分離できない。既存の一般エラー監視と併記し、0件をエラーと断定しない。
+
+## 変更ルール
+
+イベント追加より既存属性による集計を優先する。追加が必要な場合は、目的、発火箇所、重複単位、保持期間、禁止属性検査、Web／モバイル差を先に本書へ追記する。日盤・時盤の値はこの契約に追加しない。

--- a/packages/shared/directionAnalytics.ts
+++ b/packages/shared/directionAnalytics.ts
@@ -1,5 +1,62 @@
+export const DIRECTION_EVENT_NAMES = [
+  "direction_visit_date_set",
+  "direction_origin_result",
+  "direction_condition_submitted",
+  "direction_match_impression",
+  "direction_match_detail_opened",
+  "direction_match_route_clicked",
+] as const;
+
 export type DirectionPlatform = "web" | "mobile";
 export type DirectionOriginType = "device" | "station" | "address" | "prefecture" | "disabled";
-export type DirectionEventName = "direction_visit_date_set" | "direction_origin_result" | "direction_condition_submitted" | "direction_match_impression" | "direction_match_detail_opened" | "direction_match_route_clicked";
-export type DirectionEventPayload = { platform: DirectionPlatform; origin_type?: DirectionOriginType; result?: "success" | "denied" | "failed" | "selected"; has_visit_date?: boolean; has_origin?: boolean; matched?: boolean; recommendation_rank?: number };
-export function directionEvent(name: DirectionEventName, payload: DirectionEventPayload) { return { name, payload }; }
+export type DirectionOriginResult = "success" | "denied" | "failed" | "selected";
+export type DirectionEventName = (typeof DIRECTION_EVENT_NAMES)[number];
+export type DirectionEventPayload = {
+  platform: DirectionPlatform;
+  origin_type?: DirectionOriginType;
+  result?: DirectionOriginResult;
+  has_visit_date?: boolean;
+  has_origin?: boolean;
+  matched?: boolean;
+  recommendation_rank?: number;
+};
+
+const ORIGIN_TYPES = new Set<DirectionOriginType>(["device", "station", "address", "prefecture", "disabled"]);
+const ORIGIN_RESULTS = new Set<DirectionOriginResult>(["success", "denied", "failed", "selected"]);
+
+/**
+ * Direction analytics uses an event-specific allowlist. Unknown keys are dropped
+ * even when an untyped caller reaches this boundary, preventing location or form
+ * values from leaking into the analytics provider.
+ */
+export function sanitizeDirectionEventPayload(
+  name: DirectionEventName,
+  payload: DirectionEventPayload & Record<string, unknown>,
+): DirectionEventPayload {
+  const safe: DirectionEventPayload = { platform: payload.platform === "mobile" ? "mobile" : "web" };
+
+  if (name === "direction_origin_result") {
+    const originType = payload.origin_type as DirectionOriginType;
+    const result = payload.result as DirectionOriginResult;
+    if (ORIGIN_TYPES.has(originType)) safe.origin_type = originType;
+    if (ORIGIN_RESULTS.has(result)) safe.result = result;
+  }
+
+  if (name === "direction_condition_submitted") {
+    if (typeof payload.has_visit_date === "boolean") safe.has_visit_date = payload.has_visit_date;
+    if (typeof payload.has_origin === "boolean") safe.has_origin = payload.has_origin;
+  }
+
+  if (name === "direction_match_impression" || name === "direction_match_detail_opened" || name === "direction_match_route_clicked") {
+    if (typeof payload.matched === "boolean") safe.matched = payload.matched;
+    if (typeof payload.recommendation_rank === "number" && Number.isInteger(payload.recommendation_rank) && payload.recommendation_rank > 0) {
+      safe.recommendation_rank = payload.recommendation_rank;
+    }
+  }
+
+  return safe;
+}
+
+export function directionEvent(name: DirectionEventName, payload: DirectionEventPayload & Record<string, unknown>) {
+  return { name, payload: sanitizeDirectionEventPayload(name, payload) };
+}


### PR DESCRIPTION
## 概要\n\n既存の方位分析イベントを監査し、個人情報を含めずに利用ファネル・位置情報結果・手動移行・方位参考表示・詳細／経路行動を分析する契約とPostHog設定案を整備しました。\n\n## 実装\n\n- 既存6イベントをWeb／Mobile共通の正本へ集約\n- イベント別allowlistで契約外属性を実行時に除外\n- 緯度経度、住所、駅名、都道府県名、生年月日、相談文、検索語の回帰テスト\n- direction_reference表示をmatched true/falseとも重複なく計測\n- Mobile詳細クリックへrecommendation_rankを追加\n- グローバル重複排除をカード単位へ変更し、再相談時の欠損を防止\n- 指標・ファネル・比較軸・異常値・日盤検討基準を文書化\n- PostHog設定案と運用チェックリストを文書化\n\n## 既知の計測境界\n\n- Webの経路クリックは方位一致コンテキストを詳細画面へ保持していないため、現状はMobileのみ有効\n- 不一致・根拠不足・通信エラー・離脱は、方位イベントだけから推測して分解しない\n- 外部PostHogダッシュボードは変更せず、設定案を母艦へ差し戻す\n\n## 検証\n\n- Web: 99 files / 566 tests passed\n- Mobile: 13 files / 85 tests passed\n- Web／Mobile typecheck passed\n- Direction E2E: Chromium 7 tests passed\n- Web lint: errors 0（既存警告2件）\n- pre-push OpenAPI lint / contract tests passed