### PR TITLE
Webの方位候補で経路クリック計測を追加

### DIFF
--- a/apps/mobile/lib/__tests__/directionEvents.test.ts
+++ b/apps/mobile/lib/__tests__/directionEvents.test.ts
@@ -46,4 +46,18 @@ describe("direction analytics", () => {
       matched: true,
     });
   });
+
+  it("Webと共通の経路候補位置を同じ分類値で扱う", () => {
+    trackMobileDirection("direction_match_route_clicked", {
+      matched: true,
+      candidate_position: "hero",
+      route_url: "https://www.google.com/maps/dir/?destination=35,139",
+      shrine_name: "テスト神社",
+    } as never);
+    expect(track).toHaveBeenCalledWith("direction_match_route_clicked", {
+      platform: "mobile",
+      matched: true,
+      candidate_position: "hero",
+    });
+  });
 });

--- a/apps/web/e2e/05_direction_flow.spec.ts
+++ b/apps/web/e2e/05_direction_flow.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { createServer, type Server } from "node:http";
 import {
   installDirectionScenario,
   matchedDirectionReference,
@@ -6,6 +7,32 @@ import {
 } from "./fixtures/directionScenario";
 
 const consultation = "テスト用の相談です";
+let fixedBackend: Server;
+
+test.beforeAll(async () => {
+  fixedBackend = createServer((request, response) => {
+    response.setHeader("Content-Type", "application/json");
+    if (/^\/api\/public\/shrines\/\d+\/$/.test(request.url ?? "")) {
+      const id = Number(request.url?.match(/\d+/)?.[0] ?? 508);
+      response.end(JSON.stringify({ id, name_jp: `固定詳細神社${id}`, latitude: 35.68, longitude: 139.76, address: "固定テスト所在地" }));
+      return;
+    }
+    if ((request.url ?? "").includes("goshuin")) {
+      response.end(JSON.stringify([]));
+      return;
+    }
+    response.statusCode = 404;
+    response.end(JSON.stringify({ detail: "fixed e2e response" }));
+  });
+  await new Promise<void>((resolve, reject) => {
+    fixedBackend.once("error", reject);
+    fixedBackend.listen(8000, "127.0.0.1", resolve);
+  });
+});
+
+test.afterAll(async () => {
+  await new Promise<void>((resolve, reject) => fixedBackend.close((error) => error ? reject(error) : resolve()));
+});
 const forbiddenAnalyticsKeys = new Set([
   "lat", "lng", "latitude", "longitude", "address", "birthdate", "birthday", "query", "free_text",
 ]);
@@ -26,6 +53,7 @@ function expectPrivateDataAbsent(events: Array<{ payload: Record<string, unknown
   }
 }
 
+test.describe.configure({ mode: "serial" });
 test.describe("方位条件のWeb E2E", () => {
   test("位置情報を許可し、予定日から方位参考情報を表示し、表示イベントを1回だけ送る", async ({ page, context }) => {
     const captured = await installDirectionScenario(page, { recommendationId: 501, directionReference: matchedDirectionReference });
@@ -161,5 +189,80 @@ test.describe("方位条件のWeb E2E", () => {
     for (const radio of await page.getByRole("radio").all()) {
       expect((await radio.boundingBox())?.height ?? 0).toBeGreaterThanOrEqual(44);
     }
+  });
+
+  test("方位参考情報付きHero候補からキーボードで経路を開き、1回だけ送信する", async ({ page, context }) => {
+    const captured = await installDirectionScenario(page, {
+      recommendationId: 508,
+      directionReference: matchedDirectionReference,
+    });
+    await context.route("https://www.google.com/maps/**", (route) => route.fulfill({ status: 200, body: "fixed map" }));
+    await page.goto("/concierge");
+    await fillAndSubmit(page);
+
+    const heroLink = page.getByRole("link", { name: "神社の詳細を見る" });
+    await expect(heroLink).toHaveAttribute("href", /direction_matched=1/);
+    await expect(heroLink).toHaveAttribute("href", /direction_position=hero/);
+    await heroLink.focus();
+    await page.keyboard.press("Enter");
+    await expect(page).toHaveURL(/\/shrines\/508.*direction_position=hero/);
+
+    const routeLink = page.getByRole("link", { name: "Googleマップで経路案内" });
+    await expect(routeLink).toHaveAttribute("href", /^https:\/\/www\.google\.com\/maps\/dir\//);
+    await routeLink.focus();
+    const popupPromise = page.waitForEvent("popup");
+    await page.keyboard.press("Enter");
+    const popup = await popupPromise;
+    await popup.close();
+
+    const events = captured.analyticsEvents.filter((event) => event.eventName === "direction_match_route_clicked");
+    expect(events).toEqual([expect.objectContaining({ payload: expect.objectContaining({ matched: true, candidate_position: "hero" }) })]);
+    expectPrivateDataAbsent(events);
+    expect(JSON.stringify(events)).not.toMatch(/固定詳細神社|固定テスト所在地|google\.com\/maps/);
+  });
+
+  test("方位参考情報付きその他候補の経路操作をotherとして1回送信する", async ({ page, context }) => {
+    const captured = await installDirectionScenario(page, {
+      recommendationId: 508,
+      directionReference: matchedDirectionReference,
+      additionalRecommendation: { id: 509, directionReference: matchedDirectionReference },
+    });
+    await context.route("https://www.google.com/maps/**", (route) => route.fulfill({ status: 200, body: "fixed map" }));
+    await page.goto("/concierge");
+    await fillAndSubmit(page);
+
+    await page.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }).click();
+    const otherLink = page.getByRole("link", { name: "詳細だけ見る" });
+    await expect(otherLink).toHaveAttribute("href", /direction_matched=1/);
+    await expect(otherLink).toHaveAttribute("href", /direction_position=other/);
+    expect(await otherLink.getAttribute("href")).not.toMatch(/固定レスポンス神社|テスト用所在地|google\.com|35\.681|139\.767/);
+    await otherLink.click();
+    await expect(page).toHaveURL(/\/shrines\/509.*direction_position=other/);
+
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "Googleマップで経路案内" }).click();
+    const popup = await popupPromise;
+    await popup.close();
+    expect(captured.analyticsEvents.filter((event) => event.eventName === "direction_match_route_clicked")).toEqual([
+      expect.objectContaining({ payload: expect.objectContaining({ matched: true, candidate_position: "other" }) }),
+    ]);
+  });
+
+  test("方位参考情報のない候補の経路操作では方位イベントを送らない", async ({ page, context }) => {
+    const captured = await installDirectionScenario(page, { recommendationId: 510 });
+    await context.route("https://www.google.com/maps/**", (route) => route.fulfill({ status: 200, body: "fixed map" }));
+    await page.goto("/concierge");
+    await fillAndSubmit(page);
+
+    const detailLink = page.getByRole("link", { name: "神社の詳細を見る" });
+    const href = await detailLink.getAttribute("href");
+    expect(href).not.toContain("direction_matched");
+    expect(href).not.toContain("direction_position");
+    await detailLink.click();
+    const popupPromise = page.waitForEvent("popup");
+    await page.getByRole("link", { name: "Googleマップで経路案内" }).click();
+    const popup = await popupPromise;
+    await popup.close();
+    expect(captured.analyticsEvents.filter((event) => event.eventName === "direction_match_route_clicked")).toHaveLength(0);
   });
 });

--- a/apps/web/e2e/fixtures/directionScenario.ts
+++ b/apps/web/e2e/fixtures/directionScenario.ts
@@ -20,6 +20,10 @@ export async function installDirectionScenario(
   options: {
     recommendationId: number;
     directionReference?: DirectionReference;
+    additionalRecommendation?: {
+      id: number;
+      directionReference?: DirectionReference;
+    };
   },
 ): Promise<CapturedDirectionScenario> {
   const captured: CapturedDirectionScenario = {
@@ -83,12 +87,26 @@ export async function installDirectionScenario(
       reason_facts: { primary_axis: "benefit", shrine_benefit: "仕事運を整えるご利益" },
       ...(options.directionReference ? { direction_reference: options.directionReference } : {}),
     };
+    const recommendations = [recommendation];
+    if (options.additionalRecommendation) {
+      recommendations.push({
+        shrine_id: options.additionalRecommendation.id,
+        display_name: `固定レスポンス神社${options.additionalRecommendation.id}`,
+        display_address: "テスト用所在地",
+        reason: "固定レスポンスによる推薦です。",
+        breakdown: { matched_need_tags: ["career"] },
+        reason_facts: { primary_axis: "benefit", shrine_benefit: "仕事運を整えるご利益" },
+        ...(options.additionalRecommendation.directionReference
+          ? { direction_reference: options.additionalRecommendation.directionReference }
+          : {}),
+      });
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
         ok: true,
-        data: { recommendations: [recommendation], recommendations_v2: [recommendation] },
+        data: { recommendations, recommendations_v2: recommendations },
         thread: { id: options.recommendationId },
         remaining: 9,
       }),

--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -45,6 +45,7 @@ import { fetchShrineMeaningPayloadV2Server } from "@/lib/api/shrineMeaning.serve
 import { buildPreviousConsultationSummary } from "@/lib/concierge/buildPreviousConsultationSummary";
 import { compareState } from "@/lib/concierge/compareState";
 import type { StateDelta } from "@/lib/concierge/stateComparison";
+import { parseDirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 
 function normalizeCtx(v?: string | null): "map" | "concierge" | null {
   return v === "map" || v === "concierge" ? v : null;
@@ -52,7 +53,7 @@ function normalizeCtx(v?: string | null): "map" | "concierge" | null {
 
 type Props = {
   params: Promise<{ id: string }>;
-  searchParams?: Promise<{ ctx?: string; tid?: string }>;
+  searchParams?: Promise<{ ctx?: string; tid?: string; direction_matched?: string; direction_position?: string }>;
 };
 
 type RecommendationReasonDetailInput = NonNullable<
@@ -171,6 +172,7 @@ export default async function Page({ params, searchParams }: Props) {
   const sp = (await searchParams) ?? {};
   const ctx = normalizeCtx(sp?.ctx ?? null);
   const tid = sp?.tid ?? null;
+  const directionRouteContext = parseDirectionRouteContext(sp);
 
   const hideActions = false;
   const close = buildShrineClose({ ctx, tid });
@@ -436,6 +438,7 @@ export default async function Page({ params, searchParams }: Props) {
         ctx={ctx}
         tid={tid}
         historyTheme={historyThemeForAnalytics}
+        directionRouteContext={directionRouteContext}
         addGoshuinHref={null}
         googleDirHref={googleDirHref}
         googleDirLabel="Googleマップで経路案内"

--- a/apps/web/src/components/shrine/GoogleMapRouteLink.tsx
+++ b/apps/web/src/components/shrine/GoogleMapRouteLink.tsx
@@ -2,6 +2,8 @@
 
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { trackShrineInteraction } from "@/lib/api/shrineInteractions";
+import { trackWebDirection } from "@/lib/analytics/directionEvents";
+import type { DirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 
 type Props = {
   href: string;
@@ -11,6 +13,7 @@ type Props = {
   tid?: string | number | null;
   historyTheme?: string | null;
   className?: string;
+  directionRouteContext?: DirectionRouteContext | null;
 };
 
 export default function GoogleMapRouteLink({
@@ -21,6 +24,7 @@ export default function GoogleMapRouteLink({
   tid = null,
   historyTheme = null,
   className,
+  directionRouteContext = null,
 }: Props) {
   return (
     <a
@@ -29,6 +33,16 @@ export default function GoogleMapRouteLink({
       rel="noopener noreferrer"
       className={className}
       onClick={() => {
+        if (directionRouteContext?.matched) {
+          try {
+            trackWebDirection("direction_match_route_clicked", {
+              matched: true,
+              candidate_position: directionRouteContext.candidatePosition,
+            });
+          } catch {
+            // Analytics must never delay or block the external route navigation.
+          }
+        }
         trackSearchEvent("route_open", {
           source: "shrine_detail",
           routeTarget: "google_maps",

--- a/apps/web/src/components/shrine/ShrineDetailShell.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailShell.tsx
@@ -6,6 +6,7 @@ import ShrineCloseLink from "@/components/shrine/ShrineCloseLink";
 import { LABELS } from "@/lib/ui/labels";
 import DetailSection from "@/components/shrine/DetailSection";
 import GoogleMapRouteLink from "@/components/shrine/GoogleMapRouteLink";
+import type { DirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 
 type SaveAction = {
   shrineId: number;
@@ -35,6 +36,7 @@ type Props = {
   ctx?: string | null;
   tid?: string | number | null;
   historyTheme?: string | null;
+  directionRouteContext?: DirectionRouteContext | null;
 };
 
 export default function ShrineDetailShell({
@@ -53,6 +55,7 @@ export default function ShrineDetailShell({
   ctx = null,
   tid = null,
   historyTheme = null,
+  directionRouteContext = null,
 }: Props) {
   const shouldShowActions = !hideActions && Boolean(googleDirHref || saveAction?.node || addGoshuinHref);
 
@@ -86,6 +89,7 @@ export default function ShrineDetailShell({
                 ctx={ctx}
                 tid={tid}
                 historyTheme={historyTheme}
+                directionRouteContext={directionRouteContext}
                 className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] bg-slate-900 px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-inverse)] hover:bg-slate-800"
               />
             ) : null}

--- a/apps/web/src/components/shrine/__tests__/GoogleMapRouteLink.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/GoogleMapRouteLink.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { trackWebDirection, trackSearchEvent, trackShrineInteraction } = vi.hoisted(() => ({
+  trackWebDirection: vi.fn(),
+  trackSearchEvent: vi.fn(),
+  trackShrineInteraction: vi.fn(),
+}));
+vi.mock("@/lib/analytics/directionEvents", () => ({ trackWebDirection }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent }));
+vi.mock("@/lib/api/shrineInteractions", () => ({ trackShrineInteraction }));
+
+import GoogleMapRouteLink from "../GoogleMapRouteLink";
+
+const href = "https://www.google.com/maps/dir/?api=1&destination=35,139";
+
+describe("GoogleMapRouteLink direction analytics", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    ["Hero", "hero" as const],
+    ["その他", "other" as const],
+  ])("一致した%s候補の明示クリックで分類値だけを1回送る", (_label, candidatePosition) => {
+    const { rerender } = render(
+      <GoogleMapRouteLink
+        href={href}
+        label="Googleマップで経路案内"
+        directionRouteContext={{ matched: true, candidatePosition }}
+      />,
+    );
+    expect(trackWebDirection).not.toHaveBeenCalled();
+    rerender(
+      <GoogleMapRouteLink
+        href={href}
+        label="Googleマップで経路案内"
+        directionRouteContext={{ matched: true, candidatePosition }}
+      />,
+    );
+    expect(trackWebDirection).not.toHaveBeenCalled();
+
+    const link = screen.getByRole("link", { name: "Googleマップで経路案内" });
+    fireEvent.focus(link);
+    expect(trackWebDirection).not.toHaveBeenCalled();
+    fireEvent.click(link);
+
+    expect(trackWebDirection).toHaveBeenCalledTimes(1);
+    expect(trackWebDirection).toHaveBeenCalledWith("direction_match_route_clicked", {
+      matched: true,
+      candidate_position: candidatePosition,
+    });
+    expect(link).toHaveAttribute("href", href);
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("direction_reference由来のcontextがなければ方位イベントを送らない", () => {
+    render(<GoogleMapRouteLink href={href} label="Googleマップで経路案内" />);
+    fireEvent.click(screen.getByRole("link", { name: "Googleマップで経路案内" }));
+    expect(trackWebDirection).not.toHaveBeenCalled();
+  });
+
+  it("既存契約どおり不一致候補では方位経路イベントを送らない", () => {
+    render(
+      <GoogleMapRouteLink
+        href={href}
+        label="Googleマップで経路案内"
+        directionRouteContext={{ matched: false, candidatePosition: "other" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("link", { name: "Googleマップで経路案内" }));
+    expect(trackWebDirection).not.toHaveBeenCalled();
+  });
+
+  it("方位分析が失敗しても既存リンクと既存経路イベントを維持する", () => {
+    trackWebDirection.mockImplementationOnce(() => { throw new Error("analytics unavailable"); });
+    render(
+      <GoogleMapRouteLink
+        href={href}
+        label="Googleマップで経路案内"
+        directionRouteContext={{ matched: true, candidatePosition: "hero" }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: "Googleマップで経路案内" });
+    expect(() => fireEvent.click(link)).not.toThrow();
+    expect(trackSearchEvent).toHaveBeenCalledWith("route_open", expect.any(Object));
+    expect(link).toHaveAttribute("href", href);
+  });
+
+});

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -21,6 +21,7 @@ import DirectionReferenceCard from "@/features/concierge/components/DirectionRef
 import { trackCardEvent, type CardAnalyticsPayload } from "@/lib/analytics/cardEvents";
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { trackWebDirection } from "@/lib/analytics/directionEvents";
+import { withDirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 import { buildRecommendationReasonDisplay } from "../../../../../../packages/shared/recommendationReasonDisplay";
 
 import type {
@@ -841,7 +842,7 @@ export default function ConciergeSectionsRenderer({
                           <div key={`rec-${i}-hero-${heroItem.shrineId}`} className="space-y-2">
                             <ConciergeTopRecommendationHero
                               name={heroItem.title}
-                              href={heroItem.detailHref}
+                              href={withDirectionRouteContext(heroItem.detailHref, heroItem.directionReference, "hero")}
                               imageUrl={heroItem.imageUrl}
                               address={null}
                               topReasonLabel={reasonVm.hero.topReasonLabel ?? null}
@@ -1023,7 +1024,7 @@ export default function ConciergeSectionsRenderer({
                                 <div key={`rec-${i}-compact-${item.shrineId}`} className="space-y-2">
                                   <ShrineCardCompact
                                     name={item.title}
-                                    href={item.detailHref}
+                                    href={withDirectionRouteContext(item.detailHref, item.directionReference, "other")}
                                     imageUrl={item.imageUrl}
                                     address={item.address ?? null}
                                     summary={compactReasonDisplay.reason}

--- a/apps/web/src/features/concierge/detailHref.ts
+++ b/apps/web/src/features/concierge/detailHref.ts
@@ -12,7 +12,7 @@ import { buildShrineResolveHref } from "@/lib/nav/buildShrineResolveHref";
  * 注意:
  * recommendation の `id` は shrine_id ではない可能性があるため使わない。
  * 実在 shrine への導線は shrine_id / shrineId / shrine.id のみを採用する。
- * 詳細URLに載せる query は ctx / tid / place_id / toast のみ。
+ * 詳細URLに載せる query はallowlist対象のみ。方位候補の表示位置は描画側で安全な分類値として追加する。
  */
 
 type AnyObj = Record<string, any>;

--- a/apps/web/src/lib/analytics/__tests__/directionEvents.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/directionEvents.test.ts
@@ -42,4 +42,22 @@ describe("direction analytics", () => {
     } as never);
     expect(track).toHaveBeenCalledWith("direction_visit_date_set", { platform: "web" });
   });
+
+  it("経路クリックは候補位置と一致状態だけを許可し、候補情報とURLを除外する", () => {
+    trackWebDirection("direction_match_route_clicked", {
+      matched: false,
+      candidate_position: "other",
+      shrine_name: "テスト神社",
+      shrine_address: "東京都千代田区",
+      route_url: "https://www.google.com/maps/dir/?destination=35,139",
+      place_id: "secret-place-id",
+      latitude: 35,
+      longitude: 139,
+    } as never);
+    expect(track).toHaveBeenCalledWith("direction_match_route_clicked", {
+      platform: "web",
+      matched: false,
+      candidate_position: "other",
+    });
+  });
 });

--- a/apps/web/src/lib/analytics/__tests__/directionRouteContext.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/directionRouteContext.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseDirectionRouteContext, withDirectionRouteContext } from "../directionRouteContext";
+
+const reference = {
+  visit_date: "2026-09-15",
+  actual_direction: "東",
+  reference_directions: ["東", "北西"],
+  matched: true,
+  calculation_method: "annual_monthly_kyusei_v1" as const,
+  note: "年盤と月盤による参考情報です。日盤は使用していません。",
+};
+
+describe("direction route context", () => {
+  it("有効な方位参考情報の分類値だけを詳細URLへ引き継ぐ", () => {
+    expect(withDirectionRouteContext("/shrines/1?ctx=concierge", reference, "hero")).toBe(
+      "/shrines/1?ctx=concierge&direction_matched=1&direction_position=hero",
+    );
+    expect(withDirectionRouteContext("/shrines/2", { ...reference, matched: false }, "other")).toBe(
+      "/shrines/2?direction_matched=0&direction_position=other",
+    );
+  });
+
+  it("方位参考情報がない、または契約上無効ならURLを変更しない", () => {
+    expect(withDirectionRouteContext("/shrines/1", null, "hero")).toBe("/shrines/1");
+    expect(withDirectionRouteContext("/shrines/1", { ...reference, calculation_method: "daily" } as never, "hero")).toBe(
+      "/shrines/1",
+    );
+  });
+
+  it("許可したbooleanと候補位置だけを読み取る", () => {
+    expect(parseDirectionRouteContext({ direction_matched: "0", direction_position: "other" })).toEqual({
+      matched: false,
+      candidatePosition: "other",
+    });
+    expect(parseDirectionRouteContext({ direction_matched: "true", direction_position: "hero" })).toBeNull();
+    expect(parseDirectionRouteContext({ direction_matched: "1", direction_position: "first" })).toBeNull();
+  });
+});

--- a/apps/web/src/lib/analytics/directionRouteContext.ts
+++ b/apps/web/src/lib/analytics/directionRouteContext.ts
@@ -1,0 +1,33 @@
+import type { DirectionCandidatePosition } from "../../../../../packages/shared/directionAnalytics";
+import { isValidDirectionReference, type DirectionReference } from "../../../../../packages/shared/directionReference";
+
+export type DirectionRouteContext = {
+  matched: boolean;
+  candidatePosition: DirectionCandidatePosition;
+};
+
+export function withDirectionRouteContext(
+  href: string | null | undefined,
+  reference: DirectionReference | null | undefined,
+  candidatePosition: DirectionCandidatePosition,
+): string | null | undefined {
+  if (!href || !isValidDirectionReference(reference)) return href;
+  const [pathAndQuery, hash = ""] = href.split("#", 2);
+  const [path, query = ""] = pathAndQuery.split("?", 2);
+  const params = new URLSearchParams(query);
+  params.set("direction_matched", reference.matched ? "1" : "0");
+  params.set("direction_position", candidatePosition);
+  return `${path}?${params.toString()}${hash ? `#${hash}` : ""}`;
+}
+
+export function parseDirectionRouteContext(input: {
+  direction_matched?: string | null;
+  direction_position?: string | null;
+}): DirectionRouteContext | null {
+  if (input.direction_matched !== "1" && input.direction_matched !== "0") return null;
+  if (input.direction_position !== "hero" && input.direction_position !== "other") return null;
+  return {
+    matched: input.direction_matched === "1",
+    candidatePosition: input.direction_position,
+  };
+}

--- a/docs/analytics/direction-analytics-dashboard.md
+++ b/docs/analytics/direction-analytics-dashboard.md
@@ -8,7 +8,7 @@
 
 - 期間: まず直近28日、比較期間はその直前28日
 - 集計: ユニークセッションを基本、操作品質はイベント回数も併記
-- 比較軸: `platform = web | mobile`、`origin_type`、`recommendation_rank`
+- 比較軸: `platform = web | mobile`、`origin_type`、`recommendation_rank`。Web経路は`candidate_position = hero | other`も利用できる
 - Web／モバイルの母数は混ぜず、全体値は各platform値を併記してから表示する
 - 少数データから個人を推測しない。少数セルは非表示または期間を延長する
 - `matched`を利用者属性として保存・cohort化しない
@@ -22,7 +22,7 @@
 | 3. 方位条件付き相談を送信 | `direction_condition_submitted`, `has_visit_date=true`, `has_origin=true` | ファネルの基準母数 |
 | 4. 方位参考情報を表示 | `direction_match_impression` | 一致候補の後続率は`matched=true`で絞る |
 | 5. 候補詳細を開く | `direction_match_detail_opened`, `matched=true` | 順位別も確認 |
-| 6. 経路を確認 | `direction_match_route_clicked`, `matched=true` | 現状はモバイルのみ比較可能 |
+| 6. 経路を確認 | `direction_match_route_clicked`, `matched=true` | Web／モバイル共通。Webは詳細画面の既存Google Mapsリンク |
 
 厳密順序、同一セッション、推奨コンバージョン窓24時間で作成する。結果の再送信を別試行として分析したい場合はイベント回数ビューを補助的に使う。
 
@@ -41,7 +41,7 @@
 | 方位参考情報の表示率 | match impressionのあるセッション | 方位条件付き相談セッション | matched true/falseを含む |
 | 方位一致候補表示率 | matched=trueのmatch impressionがあるセッション | 方位条件付き相談セッション | 不一致を分子に含めない |
 | 詳細表示率 | matched=trueのmatch detail openedがあるセッション | matched=trueのmatch impressionがあるセッション | Web／mobile、rank別 |
-| 経路クリック率 | matched=trueのmatch route clickedがあるセッション | matched=trueのmatch impressionがあるセッション | 現状mobileのみ有効 |
+| 経路クリック率 | matched=trueのmatch route clickedがあるセッション | matched=trueのmatch impressionがあるセッション | Web／mobileを比較。Webはhero/other別も確認 |
 
 `direction_match_impression`は名前を維持しつつ、`direction_reference`表示時に`matched=true/false`を送る。`direction_reference`欠落時は送らないため、情報なしを不一致へ含めない。
 
@@ -54,7 +54,7 @@
 5. Trendsで現在地取得結果を`direction_origin_result`の`result`別に積み上げ表示する。filterは`origin_type=device`。
 6. 手動移行は`direction_origin_result(result=denied, origin_type=device)`から`direction_origin_result(result=selected, origin_type in station,address)`の2段階ファネルにする。
 7. 出発地点構成比はsuccess/selectedのみを対象に`origin_type`でbreakdownする。
-8. 一致表示→詳細、一致表示→経路を別Funnelにし、後者は`platform=mobile`を固定する。
+8. 一致表示→詳細、一致表示→経路を別Funnelにし、両方を`platform`でbreakdownする。Web経路だけを確認する補助Insightでは`candidate_position`もbreakdownする。
 9. Dashboard descriptionへ本書、イベント契約、欠測条件、最終レビュー日を記載する。
 10. 作成後に本番ではない固定テストイベントが混ざっていないことを確認してから共有する。
 
@@ -82,7 +82,7 @@
 - 方位条件付き相談が各期間500セッション以上
 - 方位条件付き相談率が20%以上
 - 一致表示→詳細率が全相談の詳細率と比べて継続的に低くない
-- モバイル一致表示→経路率が10%以上
+- Web／モバイルの一致表示→経路率が各10%以上
 - 拒否後の手動移行率が30%以上で、代替導線が機能している
 - 技術失敗率が5%未満で、現行年盤・月盤の品質問題が先に残っていない
 - 定性調査で「日単位の判断」が実際の課題として確認される
@@ -92,7 +92,7 @@
 ## 運用チェックリスト
 
 - [ ] Dashboard期間・timezone・conversion windowを確認
-- [ ] Web／mobileを分け、経路率はmobile限定であることを表示
+- [ ] Web／mobileを分け、Webのhero／otherは候補詳細へ入った表示位置であることを表示
 - [ ] イベント名と属性が契約通りかLive Eventsで標本確認
 - [ ] 緯度経度、住所、駅名、都道府県名、生年月日、相談文、検索語がない
 - [ ] impression重複とsubmit欠損を確認

--- a/docs/analytics/direction-events.md
+++ b/docs/analytics/direction-events.md
@@ -11,9 +11,9 @@ Webとモバイルは`packages/shared/directionAnalytics.ts`を正本とし、�
 | `direction_condition_submitted` | 方位条件を含み得る相談送信 | `platform`, `has_visit_date`, `has_origin` | 送信試行ごと |
 | `direction_match_impression` | Backendの`direction_reference`付き候補を初めて表示 | `platform`, `matched`, `recommendation_rank` | 表示カードのマウントごとに1回 |
 | `direction_match_detail_opened` | 方位一致候補から詳細を開く | `platform`, `matched`, `recommendation_rank` | クリックごと |
-| `direction_match_route_clicked` | 方位一致候補に紐づく経路行動 | `platform`, `matched`, `recommendation_rank` | クリックごと |
+| `direction_match_route_clicked` | 方位一致候補に紐づく既存経路導線の明示操作 | `platform`, `matched`, `recommendation_rank`, `candidate_position` | クリックごと |
 
-`origin_type`は`device | station | address | prefecture | disabled`、`result`は`success | denied | failed | selected`だけを許可する。共有serializerはイベント別allowlist以外を破棄するため、型を迂回した呼び出しでも余分な値をProviderへ渡さない。
+`origin_type`は`device | station | address | prefecture | disabled`、`result`は`success | denied | failed | selected`、`candidate_position`は`hero | other`だけを許可する。共有serializerはイベント別allowlist以外を破棄するため、型を迂回した呼び出しでも余分な値をProviderへ渡さない。
 
 ## 禁止属性
 
@@ -31,7 +31,10 @@ Webとモバイルは`packages/shared/directionAnalytics.ts`を正本とし、�
 - 6イベントは共有型から送信され、名前と属性の意味は一致している。
 - 方位参考情報の表示は一致・不一致とも送り、Web／モバイルとも表示カードのマウント中に1回だけ送る。再相談で同じ候補が再表示された場合は新しい表示として送る。
 - 詳細クリックは両方で取得でき、順位も共通属性として送る。
-- 経路クリックは現行モバイル結果の`route_open`でのみ方位一致との関連を保持できる。Web詳細画面へ遷移した後は方位一致コンテキストを保持していないため、Web値は欠測として扱う。
+- Webの推薦結果には直接の経路ボタンはなく、Hero／その他候補の詳細導線と詳細画面の既存「Googleマップで経路案内」が実在する。契約上有効な`direction_reference`を持つ候補だけ、`matched`と`candidate_position`の分類値を詳細URLへ引き継ぐ。
+- Webは詳細画面の既存経路リンクを利用者が明示操作した時だけ送る。描画、再描画、フォーカス、詳細遷移では送らない。URL、候補、神社、方位カードの内容は渡さない。
+- `direction_match_route_clicked`は既存契約どおり一致候補（`matched=true`）を対象とする。不一致候補の通常の`route_open`は維持するが、方位経路イベントには含めない。
+- `candidate_position`はWebでは`hero | other`を送る。既存モバイル実装は`recommendation_rank`を継続し、属性欠落を0やunknownへ置換しない。
 - 相談送信後に一致候補が出ない場合は「不一致」「根拠不足」「通信エラー」「離脱」をこのイベント群だけでは分離できない。既存の一般エラー監視と併記し、0件をエラーと断定しない。
 
 ## 変更ルール

--- a/packages/shared/directionAnalytics.ts
+++ b/packages/shared/directionAnalytics.ts
@@ -10,6 +10,7 @@ export const DIRECTION_EVENT_NAMES = [
 export type DirectionPlatform = "web" | "mobile";
 export type DirectionOriginType = "device" | "station" | "address" | "prefecture" | "disabled";
 export type DirectionOriginResult = "success" | "denied" | "failed" | "selected";
+export type DirectionCandidatePosition = "hero" | "other";
 export type DirectionEventName = (typeof DIRECTION_EVENT_NAMES)[number];
 export type DirectionEventPayload = {
   platform: DirectionPlatform;
@@ -19,6 +20,7 @@ export type DirectionEventPayload = {
   has_origin?: boolean;
   matched?: boolean;
   recommendation_rank?: number;
+  candidate_position?: DirectionCandidatePosition;
 };
 
 const ORIGIN_TYPES = new Set<DirectionOriginType>(["device", "station", "address", "prefecture", "disabled"]);
@@ -52,6 +54,10 @@ export function sanitizeDirectionEventPayload(
     if (typeof payload.recommendation_rank === "number" && Number.isInteger(payload.recommendation_rank) && payload.recommendation_rank > 0) {
       safe.recommendation_rank = payload.recommendation_rank;
     }
+  }
+
+  if (name === "direction_match_route_clicked" && (payload.candidate_position === "hero" || payload.candidate_position === "other")) {
+    safe.candidate_position = payload.candidate_position;
   }
 
   return safe;

--- a/packages/shared/directionReference.ts
+++ b/packages/shared/directionReference.ts
@@ -7,6 +7,21 @@ export type DirectionReference = {
   note: string;
 };
 
+export function isValidDirectionReference(value: unknown): value is DirectionReference {
+  if (!value || typeof value !== "object") return false;
+  const reference = value as Partial<DirectionReference>;
+  return (
+    typeof reference.visit_date === "string" && reference.visit_date.trim().length > 0 &&
+    typeof reference.actual_direction === "string" && reference.actual_direction.trim().length > 0 &&
+    Array.isArray(reference.reference_directions) &&
+    reference.reference_directions.length > 0 &&
+    reference.reference_directions.every((direction) => typeof direction === "string" && direction.trim().length > 0) &&
+    typeof reference.matched === "boolean" &&
+    reference.calculation_method === "annual_monthly_kyusei_v1" &&
+    typeof reference.note === "string" && reference.note.trim().length > 0
+  );
+}
+
 export function directionReferenceMatchCopy(reference: DirectionReference): string {
   return reference.matched
     ? "現在地から見た方角が、予定日の参考方位と一致しています。"


### PR DESCRIPTION
## 概要\n\nWebの方位候補から詳細画面の既存「Googleマップで経路案内」へ進んだ操作を、既存のdirection_match_route_clickedで安全に計測します。新しい経路UIは追加していません。\n\n## 監査結果\n\n- 推薦結果のHero／その他CTAは経路ではなく詳細導線\n- 実在する経路導線は神社詳細画面のGoogleMapRouteLink\n- direction_referenceは推薦結果カードまで保持済み\n- 既存契約はmatched=trueの一致候補を対象\n- Mobileはrecommendation_rankで同イベントを計測済み\n\n## 実装\n\n- 契約上有効なdirection_referenceだけを判定\n- 詳細URLへmatchedとcandidate_positionだけを安全な分類値として引き継ぐ\n- 詳細画面の既存Google Mapsリンクのclick時だけイベント送信\n- candidate_positionをhero / otherで共通allowlistへ追加\n- 描画、再描画、フォーカス、詳細遷移では送信しない\n- 分析例外を握り、既存の新規タブ遷移を維持\n- 外部PostHogは変更せず仕様書と設定手順を更新\n\n## Payload\n\n{\n  platform: "web",\n  matched: true,\n  candidate_position: "hero" | "other"\n}\n\n緯度経度、住所、神社名、経路URL、Place ID、生年月日、予定日、相談文、推薦理由は送信しません。\n\n## 検証\n\n- Web: 101 files / 575 tests passed\n- Mobile: 13 files / 86 tests passed\n- Chromium direction E2E: 10 tests passed\n- HeroはEnterキー、その他候補はクリック、方位情報なしも固定レスポンスで確認\n- Google Maps外部通信はE2Eで固定レスポンス化\n- Web／Mobile typecheck passed\n- ESLint errors 0（既存警告2件）\n- git diff --check passed\n- pre-push OpenAPI lint / contract tests passed\n\n## 変更なし\n\n- 新規依存なし\n- 新規環境変数なし\n- API契約変更なし\n- DB migrationなし\n- Backendランキング・方位計算変更なし\n- Mobile本番実装変更なし