### PR TITLE
no-useless-assignmentのESLintエラーを修正

### DIFF
--- a/apps/web/src/app/api/favorites/preload/route.ts
+++ b/apps/web/src/app/api/favorites/preload/route.ts
@@ -3,7 +3,7 @@ import { bffFetchWithAuthFromReq } from "@/lib/server/bffFetch";
 import { favoriteMatchKey } from "@/lib/favorites/normalize";
 
 export async function POST(req: NextRequest) {
-  let shrineIds: number[] = [];
+  let shrineIds: number[];
 
   try {
     const body = await req.json();

--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -261,7 +261,7 @@ export default async function Page({ params, searchParams }: Props) {
 
   const { guestMode, ...initialFavorite } = await getShrineFavoriteInitialState(numericId);
 
-  let publicGoshuins: Awaited<ReturnType<typeof fetchPublicGoshuinsForShrineServer>> = [];
+  let publicGoshuins: Awaited<ReturnType<typeof fetchPublicGoshuinsForShrineServer>>;
   try {
     publicGoshuins = await fetchPublicGoshuinsForShrineServer(numericId);
   } catch (e) {


### PR DESCRIPTION
## Summary
- CIの `pnpm exec eslint . --cache --cache-location .eslintcache` が `no-useless-assignment` で失敗していた2箇所を修正
- `apps/web/src/app/api/favorites/preload/route.ts`: `let shrineIds: number[] = [];` の初期値は try/catch のどちらでも必ず上書きされるため無意味だった
- `apps/web/src/app/shrines/[id]/page.tsx`: `let publicGoshuins: ... = [];` も同様に try/catch で必ず再代入される
- どちらも初期値を削除し、型注釈のみの宣言に変更。ロジックは変更していない

## Test plan
- [x] `pnpm exec eslint .`（対象2ファイル、`.claude/worktrees` を除く）でエラー0件（既存の`react-hooks/exhaustive-deps`警告2件のみ残存、CIの失敗要因ではない）
- [x] `pnpm --filter ./apps/web exec tsc --noEmit` 成功
- [x] 関連テスト `route.test.ts` / `shrines/__tests__/page.test.tsx` 8件成功
- [x] `git diff --check` 成功
- [x] pre-push フック（OpenAPI lint／Web契約テスト607件）成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)