### PR TITLE
既存検索画面に神社地図と選択カードを追加

### DIFF
--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -1,13 +1,48 @@
+import * as React from "react";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { View, Text, ScrollView, Pressable, Image, StyleSheet } from "react-native";
 import { SHRINES } from "../../data/shrines";
 import { kamimusubiDark as theme } from "../../design/theme";
+import { spacing } from "../../design/spacing";
+import { StateCard } from "../../components/common/StateCard";
+import Button from "../../components/ui/Button";
+import { ShrineSearchMap } from "../../components/search/ShrineSearchMap";
+import { SelectedShrineMapCard } from "../../components/search/SelectedShrineMapCard";
+import { fetchShrineMapPoints, type ShrineMapPoint } from "../../lib/shrineMap";
 
 export default function SearchPage() {
   const router = useRouter();
   const { q, filters } = useLocalSearchParams<{ q?: string; filters?: string }>();
   const query = (q ?? "").toLowerCase();
   const selected = (filters ?? "").split(",").filter(Boolean);
+
+  const [mapPoints, setMapPoints] = React.useState<ShrineMapPoint[]>([]);
+  const [mapStatus, setMapStatus] = React.useState<"loading" | "ready" | "error">("loading");
+  const [selectedShrineId, setSelectedShrineId] = React.useState<string | null>(null);
+
+  const loadMapPoints = React.useCallback(async () => {
+    setMapStatus("loading");
+    try {
+      const points = await fetchShrineMapPoints({ query: q, limit: 50 });
+      setMapPoints(points);
+      setMapStatus("ready");
+    } catch {
+      setMapPoints([]);
+      setMapStatus("error");
+    }
+  }, [q]);
+
+  React.useEffect(() => {
+    void loadMapPoints();
+  }, [loadMapPoints]);
+
+  React.useEffect(() => {
+    if (selectedShrineId && !mapPoints.some((point) => point.id === selectedShrineId)) {
+      setSelectedShrineId(null);
+    }
+  }, [mapPoints, selectedShrineId]);
+
+  const selectedMapShrine = mapPoints.find((point) => point.id === selectedShrineId) ?? null;
 
   const filtered = SHRINES.filter((s) => {
     const textHit =
@@ -54,6 +89,39 @@ export default function SearchPage() {
         ) : (
           <Text style={styles.summaryHint}>条件なしで、登録神社を一覧表示しています。</Text>
         )}
+      </View>
+
+      <View style={styles.mapSection}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>地図で探す</Text>
+        </View>
+
+        {mapStatus === "loading" ? (
+          <StateCard title="地図を読み込み中" description="神社の位置情報を確認しています。" />
+        ) : null}
+
+        {mapStatus === "error" ? (
+          <View style={styles.mapErrorWrap}>
+            <StateCard title="地図を読み込めませんでした" description="通信状況を確認して、もう一度お試しください。" />
+            <Button title="もう一度試す" variant="outline" size="compact" onPress={() => void loadMapPoints()} accessibilityLabel="地図をもう一度読み込む" />
+          </View>
+        ) : null}
+
+        {mapStatus === "ready" && mapPoints.length === 0 ? (
+          <StateCard
+            title="地図に表示できる神社がありません"
+            description="この検索結果には地図へ表示できる位置情報がありません。神社一覧はそのままご覧いただけます。"
+          />
+        ) : null}
+
+        {mapStatus === "ready" && mapPoints.length > 0 ? (
+          <View style={styles.mapReadyWrap}>
+            <ShrineSearchMap points={mapPoints} selectedId={selectedShrineId} onSelect={setSelectedShrineId} />
+            {selectedMapShrine ? (
+              <SelectedShrineMapCard shrine={selectedMapShrine} onDetail={() => router.push(`/shrines/${selectedMapShrine.id}`)} />
+            ) : null}
+          </View>
+        ) : null}
       </View>
 
       <View style={styles.popularSection}>
@@ -209,6 +277,16 @@ const styles = StyleSheet.create({
     flexWrap: "wrap",
     gap: 8,
     marginTop: 12,
+  },
+  mapSection: {
+    marginBottom: 26,
+  },
+  mapReadyWrap: {
+    gap: spacing.mdGap,
+  },
+  mapErrorWrap: {
+    gap: spacing.mdGap,
+    alignItems: "flex-start",
   },
   tag: {
     borderRadius: 999,

--- a/apps/mobile/components/search/SelectedShrineMapCard.tsx
+++ b/apps/mobile/components/search/SelectedShrineMapCard.tsx
@@ -1,0 +1,98 @@
+// apps/mobile/components/search/SelectedShrineMapCard.tsx
+import * as React from "react";
+import { Image, StyleSheet, Text, View } from "react-native";
+
+import { kamimusubiDark as theme } from "../../design/theme";
+import { cardSizes } from "../../design/cardSizes";
+import { radius } from "../../design/radius";
+import { spacing } from "../../design/spacing";
+import Button from "../ui/Button";
+import type { ShrineMapPoint } from "../../lib/shrineMap";
+
+type Props = {
+  shrine: ShrineMapPoint;
+  onDetail: () => void;
+};
+
+export function SelectedShrineMapCard({ shrine, onDetail }: Props) {
+  return (
+    <View style={styles.card} accessibilityLabel={`選択中の神社: ${shrine.name}`}>
+      {shrine.imageUrl ? (
+        <Image source={{ uri: shrine.imageUrl }} style={styles.image} />
+      ) : (
+        <View style={styles.imagePlaceholder}>
+          <Text style={styles.imagePlaceholderText}>⛩</Text>
+        </View>
+      )}
+
+      <View style={styles.body}>
+        <Text style={styles.name} numberOfLines={1}>
+          {shrine.name}
+        </Text>
+        {shrine.address ? (
+          <Text style={styles.address} numberOfLines={1}>
+            {shrine.address}
+          </Text>
+        ) : null}
+
+        <View style={styles.detailWrap}>
+          <Button
+            title="詳細を見る"
+            variant="primary"
+            size="compact"
+            onPress={onDetail}
+            accessibilityLabel={`${shrine.name}の詳細を見る`}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: theme.surface,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderGold,
+    borderRadius: radius.lg,
+    padding: cardSizes.cardPaddingMd,
+    gap: spacing.mdGap,
+  },
+  image: {
+    width: cardSizes.imageSm,
+    height: cardSizes.imageSm,
+    borderRadius: radius.xs,
+    backgroundColor: theme.surfaceSoft,
+  },
+  imagePlaceholder: {
+    width: cardSizes.imageSm,
+    height: cardSizes.imageSm,
+    borderRadius: radius.xs,
+    backgroundColor: theme.surfaceSoft,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  imagePlaceholderText: {
+    fontSize: 26,
+  },
+  body: {
+    flex: 1,
+    gap: spacing.tightGap,
+  },
+  name: {
+    color: theme.text,
+    fontSize: 15,
+    fontWeight: "900",
+  },
+  address: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  detailWrap: {
+    alignSelf: "flex-start",
+    marginTop: spacing.tightGap,
+  },
+});

--- a/apps/mobile/components/search/ShrineSearchMap.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.tsx
@@ -1,0 +1,88 @@
+// apps/mobile/components/search/ShrineSearchMap.tsx
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+import MapView, { Marker, type Region } from "react-native-maps";
+
+import { kamimusubiDark as theme } from "../../design/theme";
+import { radius } from "../../design/radius";
+import { prefectureOrigin } from "../../../../packages/shared/userOrigin";
+import type { ShrineMapPoint } from "../../lib/shrineMap";
+
+const FALLBACK_ORIGIN = prefectureOrigin("東京都");
+const FALLBACK_REGION: Region = {
+  latitude: FALLBACK_ORIGIN?.latitude ?? 35.6762,
+  longitude: FALLBACK_ORIGIN?.longitude ?? 139.6503,
+  latitudeDelta: 0.15,
+  longitudeDelta: 0.15,
+};
+
+const MIN_DELTA = 0.05;
+const REGION_PADDING = 1.4;
+
+function buildInitialRegion(points: ShrineMapPoint[]): Region {
+  if (points.length === 0) return FALLBACK_REGION;
+
+  let minLat = points[0].latitude;
+  let maxLat = points[0].latitude;
+  let minLng = points[0].longitude;
+  let maxLng = points[0].longitude;
+
+  for (const point of points) {
+    minLat = Math.min(minLat, point.latitude);
+    maxLat = Math.max(maxLat, point.latitude);
+    minLng = Math.min(minLng, point.longitude);
+    maxLng = Math.max(maxLng, point.longitude);
+  }
+
+  const latitude = (minLat + maxLat) / 2;
+  const longitude = (minLng + maxLng) / 2;
+  const latitudeDelta = Math.max((maxLat - minLat) * REGION_PADDING, MIN_DELTA);
+  const longitudeDelta = Math.max((maxLng - minLng) * REGION_PADDING, MIN_DELTA);
+
+  return { latitude, longitude, latitudeDelta, longitudeDelta };
+}
+
+type Props = {
+  points: ShrineMapPoint[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+export function ShrineSearchMap({ points, selectedId, onSelect }: Props) {
+  const initialRegion = React.useMemo(() => buildInitialRegion(points), [points]);
+
+  return (
+    <View style={styles.wrap} accessibilityLabel="検索結果の神社を地図で見る">
+      <MapView style={styles.map} initialRegion={initialRegion}>
+        {points.map((point) => {
+          const selected = point.id === selectedId;
+          return (
+            <Marker
+              key={point.id}
+              coordinate={{ latitude: point.latitude, longitude: point.longitude }}
+              title={point.name}
+              onPress={() => onSelect(point.id)}
+              accessibilityRole="button"
+              accessibilityLabel={`${point.name}を選択`}
+              accessibilityState={{ selected }}
+              opacity={selected ? 1 : 0.85}
+              zIndex={selected ? 1 : 0}
+            />
+          );
+        })}
+      </MapView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    height: 240,
+    borderRadius: radius.lg,
+    overflow: "hidden",
+    backgroundColor: theme.surfaceSoft,
+  },
+  map: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/lib/__tests__/shrineMap.test.ts
+++ b/apps/mobile/lib/__tests__/shrineMap.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { toShrineMapPoints } from "../shrineMap";
+
+describe("toShrineMapPoints", () => {
+  it("正常な数値座標を通す", () => {
+    const points = toShrineMapPoints({
+      results: [{ id: 1, name_jp: "明治神宮", address: "東京都渋谷区", latitude: 35.676, longitude: 139.699 }],
+    });
+    expect(points).toEqual([
+      { id: "1", name: "明治神宮", latitude: 35.676, longitude: 139.699, address: "東京都渋谷区", imageUrl: undefined },
+    ]);
+  });
+
+  it("配列を直接渡してもitemsキーでも受け取れる", () => {
+    const arrayInput = toShrineMapPoints([{ id: 2, name_jp: "伏見稲荷大社", latitude: 34.9, longitude: 135.7 }]);
+    expect(arrayInput).toHaveLength(1);
+
+    const itemsInput = toShrineMapPoints({ items: [{ id: 3, name_jp: "神田明神", latitude: 35.7, longitude: 139.77 }] });
+    expect(itemsInput).toHaveLength(1);
+  });
+
+  it("数字文字列の座標を数値へ変換する", () => {
+    const points = toShrineMapPoints({
+      results: [{ id: "4", name_jp: "住吉神社", latitude: "35.667", longitude: "139.779" }],
+    });
+    expect(points).toEqual([{ id: "4", name: "住吉神社", latitude: 35.667, longitude: 139.779, address: undefined, imageUrl: undefined }]);
+  });
+
+  it("location.lat/lngからも座標を取得できる", () => {
+    const points = toShrineMapPoints({
+      results: [{ id: 5, name_jp: "location経由", location: { lat: 35.1, lng: 139.1 } }],
+    });
+    expect(points).toEqual([{ id: "5", name: "location経由", latitude: 35.1, longitude: 139.1, address: undefined, imageUrl: undefined }]);
+  });
+
+  it("null座標を除外する", () => {
+    const points = toShrineMapPoints({ results: [{ id: 6, name_jp: "座標なし", latitude: null, longitude: null }] });
+    expect(points).toEqual([]);
+  });
+
+  it("NaNを除外する", () => {
+    const points = toShrineMapPoints({ results: [{ id: 7, name_jp: "不正値", latitude: "abc", longitude: 139.0 }] });
+    expect(points).toEqual([]);
+  });
+
+  it("Infinityを除外する", () => {
+    const points = toShrineMapPoints({ results: [{ id: 8, name_jp: "無限大", latitude: Infinity, longitude: 139.0 }] });
+    expect(points).toEqual([]);
+  });
+
+  it("範囲外座標を除外する", () => {
+    const overLat = toShrineMapPoints({ results: [{ id: 9, name_jp: "緯度範囲外", latitude: 95, longitude: 139.0 }] });
+    const overLng = toShrineMapPoints({ results: [{ id: 10, name_jp: "経度範囲外", latitude: 35.0, longitude: 200 }] });
+    expect(overLat).toEqual([]);
+    expect(overLng).toEqual([]);
+  });
+
+  it("id欠損を安全に扱う", () => {
+    const points = toShrineMapPoints({
+      results: [
+        { name_jp: "id無し", latitude: 35.0, longitude: 139.0 },
+        { id: null, name_jp: "id null", latitude: 35.0, longitude: 139.0 },
+        { id: "", name_jp: "id空文字", latitude: 35.0, longitude: 139.0 },
+      ],
+    });
+    expect(points).toEqual([]);
+  });
+
+  it("name欠損を安全に扱う", () => {
+    const points = toShrineMapPoints({ results: [{ id: 11, latitude: 35.0, longitude: 139.0 }] });
+    expect(points).toEqual([]);
+  });
+
+  it("不正な入力全体（null・非配列）でも例外を投げない", () => {
+    expect(toShrineMapPoints(null)).toEqual([]);
+    expect(toShrineMapPoints(undefined)).toEqual([]);
+    expect(toShrineMapPoints("not an object")).toEqual([]);
+    expect(toShrineMapPoints({})).toEqual([]);
+  });
+
+  it("image_url・photo_urlのどちらからも画像URLを拾う", () => {
+    const viaImageUrl = toShrineMapPoints({ results: [{ id: 12, name_jp: "画像A", latitude: 1, longitude: 1, image_url: "https://x/a.jpg" }] });
+    const viaPhotoUrl = toShrineMapPoints({ results: [{ id: 13, name_jp: "画像B", latitude: 1, longitude: 1, photo_url: "https://x/b.jpg" }] });
+    expect(viaImageUrl[0]?.imageUrl).toBe("https://x/a.jpg");
+    expect(viaPhotoUrl[0]?.imageUrl).toBe("https://x/b.jpg");
+  });
+});

--- a/apps/mobile/lib/shrineMap.ts
+++ b/apps/mobile/lib/shrineMap.ts
@@ -1,0 +1,95 @@
+// apps/mobile/lib/shrineMap.ts
+import { get } from "./http";
+
+export type ShrineMapPoint = {
+  id: string;
+  name: string;
+  latitude: number;
+  longitude: number;
+  address?: string;
+  imageUrl?: string;
+};
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isValidLatitude(value: number): boolean {
+  return value >= -90 && value <= 90;
+}
+
+function isValidLongitude(value: number): boolean {
+  return value >= -180 && value <= 180;
+}
+
+/**
+ * APIレスポンスの生データを安全にShrineMapPointへ変換する。
+ * id・nameが欠けている、または座標が数値として有効でない項目は除外する。
+ */
+export function toShrineMapPoints(raw: unknown): ShrineMapPoint[] {
+  const items: unknown[] = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as any)?.results)
+      ? (raw as any).results
+      : Array.isArray((raw as any)?.items)
+        ? (raw as any).items
+        : [];
+
+  const points: ShrineMapPoint[] = [];
+
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+
+    const idRaw = record.id;
+    if (idRaw === null || idRaw === undefined || idRaw === "") continue;
+    const id = String(idRaw);
+
+    const name = String(record.name_jp ?? record.name ?? "").trim();
+    if (!name) continue;
+
+    const location = (record.location ?? null) as { lat?: unknown; lng?: unknown } | null;
+    const latitude = toFiniteNumber(record.latitude ?? location?.lat);
+    const longitude = toFiniteNumber(record.longitude ?? location?.lng);
+    if (latitude === null || longitude === null) continue;
+    if (!isValidLatitude(latitude) || !isValidLongitude(longitude)) continue;
+
+    const address = typeof record.address === "string" && record.address.trim() ? record.address.trim() : undefined;
+    const imageUrl =
+      typeof record.imageUrl === "string"
+        ? record.imageUrl
+        : typeof record.image_url === "string"
+          ? record.image_url
+          : typeof record.photo_url === "string"
+            ? record.photo_url
+            : undefined;
+
+    points.push({ id, name, latitude, longitude, address, imageUrl });
+  }
+
+  return points;
+}
+
+export type FetchShrineMapPointsParams = {
+  query?: string;
+  limit?: number;
+};
+
+/**
+ * Search画面が利用している神社一覧APIから、地図表示用の安全な座標データだけを取得する。
+ * 失敗時は例外を投げず、呼び出し側でLoading/Errorを制御できるようにErrorを再送出する。
+ */
+export async function fetchShrineMapPoints(params: FetchShrineMapPointsParams = {}): Promise<ShrineMapPoint[]> {
+  const qs = new URLSearchParams();
+  if (params.query && params.query.trim()) qs.set("q", params.query.trim());
+  if (params.limit) qs.set("limit", String(params.limit));
+
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  const raw = await get<unknown>(`/shrines/${suffix}`);
+  return toShrineMapPoints(raw);
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -30,6 +30,7 @@
     "react-dom": "19.2.3",
     "react-native": "0.86.0",
     "react-native-gesture-handler": "~2.32.0",
+    "react-native-maps": "1.27.2",
     "react-native-safe-area-context": "5.7.0",
     "react-native-screens": "~4.25.2",
     "react-native-web": "^0.21.2",

--- a/apps/mobile/pnpm-lock.yaml
+++ b/apps/mobile/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.32.0
         version: 2.32.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      react-native-maps:
+        specifier: 1.27.2
+        version: 1.27.2(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
       react-native-safe-area-context:
         specifier: 5.7.0
         version: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
@@ -1164,6 +1167,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hammerjs@2.0.46':
     resolution: {integrity: sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==}
@@ -2534,6 +2540,17 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-maps@1.27.2:
+    resolution: {integrity: sha512-VKr+xZ2RZGHHJlY6KhlafvGSmK0dq/tUu5uhfJ7K9rwN5pUdubdugzMKGDU/16lXmQSg7xbClKhRctj3Pm5F5g==}
+    engines: {node: '>= 20.19.4'}
+    peerDependencies:
+      react: '>= 18.3.1'
+      react-native: '>= 0.76.0'
+      react-native-web: '>= 0.11'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
 
   react-native-reanimated@4.5.2:
     resolution: {integrity: sha512-2XF4a2VyKTy3bxugm9teClxwQ9X4pIkFmoKxIwMQqJdhoFQvjN7In/faKWtjQ8bxTYG+uIJyl6F7oxEwkngjKA==}
@@ -4453,7 +4470,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -4562,6 +4581,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hammerjs@2.0.46': {}
 
@@ -5982,6 +6003,14 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-native: 0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+
+  react-native-maps@1.27.2(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@types/geojson': 7946.0.16
+      react: 19.2.3
+      react-native: 0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   react-native-reanimated@4.5.2(react-native-worklets@0.10.2(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3):
     dependencies:


### PR DESCRIPTION
## Summary
- 既存Search画面(`apps/mobile/app/search/index.tsx`)を最小変更で拡張し、地図表示・Marker・選択中神社カード・既存詳細画面への遷移を追加した
- 新しいSearch画面は作らず、既存の一覧・フィルターUI・Design Tokenはそのまま維持
- 地図用データのみ、実在するバックエンドAPI `GET /api/shrines/`（`ShrineViewSet` / `ShrineListSerializer`、実座標・実タグを含む）を新規に呼び出す。ダミー配列は作らず、新しいBackend APIも新設していない
- 既存の一覧（人気の神社・神社一覧）は引き続きローカルモック（`data/shrines.ts`）のまま、地図とは独立したデータソースとした（監査の結果、既存モックには座標が一切なく、地図の要件を満たせないため。詳細は以下「監査で分かったこと」を参照）

## 監査で分かったこと
- Search画面の既存データ（`data/shrines.ts`）は座標フィールドを持たない簡易モックで、これをそのまま地図に使うとMarkerが常に0件になる
- 既にモバイル側に用意されていた `fetchPopular()`（`lib/shrines.ts`）は、実際にはマウントされていないURL（`/shrines/popular`）を呼んでおり、常に機能しない未配線コードだった
- バックエンドの実際のshrine一覧エンドポイントは `GET /api/shrines/`（`ShrineViewSet`）で、実座標・`goriyaku_tags`を含む
- これらを踏まえ、地図レイヤーだけ実APIに接続し、既存の検索・フィルターUIは変更しない方針とした（詳細はコミット履歴のセッションログを参照）

## データ契約
- `apps/mobile/lib/shrineMap.ts`: `ShrineMapPoint`型と安全な変換ヘルパー`toShrineMapPoints()`を新設
  - `id`欠損・`name`欠損・座標が非finite・緯度±90/経度±180範囲外は安全に除外（クラッシュさせない、内部エラーを露出しない、座標をAnalyticsへ送らない）
- Marker選択 → 選択中神社カード表示 → 「詳細を見る」→ 既存の `/shrines/[id]` へ遷移（実IDのため神社詳細が正しく表示される）

## Test plan
- [x] `pnpm typecheck` 成功
- [x] `pnpm test` 成功（102/102、新規12件は`shrineMap.test.ts`の座標変換テスト）
- [x] `git diff --check` 成功
- [x] iOS Simulator（iPhone 16e / iOS 26.1 / Expo Go）で実データにより対話確認
  - [x] 地図に実座標のMarkerが表示される
  - [x] Marker選択→選択カード表示→「詳細を見る」→実際の神社詳細画面へ遷移
  - [x] Loading／Error（Retry付き）／Empty（座標0件時の専用メッセージ）を実際に発生させて確認
  - [x] 既存の「人気の神社」「神社一覧」セクションは地図の状態に関わらず維持される
  - [x] 現在地権限なしで全機能が利用できる
- [ ] Android Emulator（この環境にAndroid SDKが存在せず未実施）
- [ ] 375px/430px幅、文字拡大（iPhone 16e・390pt相当のみ確認）

## 依存関係
- `react-native-maps@1.27.2` を追加（`apps/mobile/package.json` / `apps/mobile/pnpm-lock.yaml` のみ更新、ルートの `pnpm-lock.yaml` は無変更）
- Google Maps API keyはコードに含めていない（Expo Go既定のプロバイダのみ使用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)