### PR TITLE
Search地図をPlatform別実装へ分離してWeb fallbackを追加

### DIFF
--- a/apps/mobile/components/search/ShrineSearchMap.native.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.native.tsx
@@ -1,4 +1,4 @@
-// apps/mobile/components/search/ShrineSearchMap.tsx
+// apps/mobile/components/search/ShrineSearchMap.native.tsx
 import * as React from "react";
 import { StyleSheet, View } from "react-native";
 import MapView, { Marker, type Region } from "react-native-maps";

--- a/apps/mobile/components/search/ShrineSearchMap.web.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.web.tsx
@@ -1,0 +1,99 @@
+// apps/mobile/components/search/ShrineSearchMap.web.tsx
+import * as React from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+
+import { kamimusubiDark as theme } from "../../design/theme";
+import { radius } from "../../design/radius";
+import { spacing } from "../../design/spacing";
+import type { ShrineMapPoint } from "../../lib/shrineMap";
+
+type Props = {
+  points: ShrineMapPoint[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+export function ShrineSearchMap({ points, selectedId, onSelect }: Props) {
+  return (
+    <View style={styles.wrap} accessibilityRole="summary" accessibilityLabel="検索結果の神社を地図で見る">
+      <Text style={styles.title}>地図表示はモバイルアプリで利用できます</Text>
+      <Text style={styles.description}>この画面では、位置情報のある神社を一覧から選択できます。</Text>
+
+      {points.length > 0 ? (
+        <View style={styles.list}>
+          {points.map((point) => {
+            const selected = point.id === selectedId;
+            return (
+              <Pressable
+                key={point.id}
+                onPress={() => onSelect(point.id)}
+                accessibilityRole="button"
+                accessibilityLabel={`${point.name}を選択`}
+                accessibilityState={{ selected }}
+                style={({ pressed }) => [styles.item, selected && styles.itemSelected, pressed && styles.itemPressed]}
+              >
+                <Text style={styles.itemName} numberOfLines={1}>
+                  {point.name}
+                </Text>
+                {point.address ? (
+                  <Text style={styles.itemAddress} numberOfLines={1}>
+                    {point.address}
+                  </Text>
+                ) : null}
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    borderRadius: radius.lg,
+    backgroundColor: theme.surfaceSoft,
+    padding: spacing.mdGap,
+    gap: spacing.tightGap,
+  },
+  title: {
+    color: theme.text,
+    fontSize: 14,
+    fontWeight: "800",
+  },
+  description: {
+    color: theme.muted,
+    fontSize: 12,
+    lineHeight: 18,
+    fontWeight: "600",
+    marginBottom: spacing.tightGap,
+  },
+  list: {
+    gap: spacing.tightGap,
+  },
+  item: {
+    borderRadius: radius.xs,
+    borderWidth: 1,
+    borderColor: theme.border,
+    backgroundColor: theme.surface,
+    paddingHorizontal: spacing.mdGap,
+    paddingVertical: spacing.tightGap,
+  },
+  itemSelected: {
+    borderColor: theme.borderGold,
+  },
+  itemPressed: {
+    opacity: 0.74,
+  },
+  itemName: {
+    color: theme.text,
+    fontSize: 14,
+    fontWeight: "800",
+  },
+  itemAddress: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "600",
+    marginTop: 2,
+  },
+});

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "jsx": "react-jsx",
-    "types": ["react", "react-native"]
+    "types": ["react", "react-native"],
+    "moduleSuffixes": [".native", ".web", ""]
   }
 }


### PR DESCRIPTION
## Summary
- `react-native-maps` は静的importされるとWeb bundleでも評価されクラッシュするため、`ShrineSearchMap` をNative/Web実装に分離した
- `ShrineSearchMap.native.tsx`: 元の実装をそのままリネーム(ロジック変更なし、`react-native-maps`使用)
- `ShrineSearchMap.web.tsx`: `react-native-maps` を一切importせず、fallback文言と座標を持つ神社の選択可能リストを表示する新規コンポーネント
- Props契約(`points` / `selectedId` / `onSelect`)は既存のまま維持し、`search/index.tsx` 側の変更は不要(元々拡張子なしimportだったため)
- `tsconfig.json` に `moduleSuffixes: [".native", ".web", ""]` を追加。設定がないと `tsc` が拡張子分割ファイルを解決できず `pnpm typecheck` が失敗するため必要になった変更(Metro/Expoの実行時Platform解決には影響しない)

## Scope
- Search画面の地図コンポーネントのPlatform分離のみ。Home画面への入口導線追加(後続PR: `feature/mobile-search-entry-navigation`)、新しい地図ライブラリの追加、Search API契約の変更、神社詳細routeの変更、下部タブの変更は含まない

## Test plan
- [x] `pnpm typecheck` (apps/mobile)
- [x] `pnpm test` (apps/mobile, 102件)
- [x] `git diff --check`
- [x] pre-push hook: OpenAPI lint / Web契約テスト(607件)
- [x] ブラウザで `/search` を直接表示し、codegenNativeComponentエラーが出ないこと、Web fallback文言、神社選択→選択カード表示→神社詳細への遷移を確認
- [ ] iOS Simulator / Android Emulatorでのネイティブ地図の動作確認は、今回の環境でシミュレータ操作が安定せず実施できていません。Native実装ファイル自体は元のコードと完全に同一のため回帰リスクは低いですが、マージ前の実機/シミュレータでの最終確認を推奨します

🤖 Generated with [Claude Code](https://claude.com/claude-code)