### PR TITLE
ホームから神社検索画面への導線を追加

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -4,6 +4,7 @@ import { ScrollView, View, Text, TextInput, StyleSheet, Pressable } from "react-
 import { kamimusubiDark as theme } from "../design/theme";
 import { shadows } from "../design/shadow";
 import { ConditionFieldsCard } from "../components/ConditionFieldsCard";
+import Button from "../components/ui/Button";
 import { resolveGoriyakuTagIds } from "../lib/conditionPayload";
 import * as Location from "expo-location";
 import type { UserOrigin } from "../../../packages/shared/userOrigin";
@@ -46,6 +47,10 @@ export default function Home() {
   ]
     .filter(Boolean)
     .join(" / ");
+
+  const openSearch = () => {
+    router.push("/search");
+  };
 
   const openConcierge = () => {
     // Concierge画面側のgoriyaku_tag_ids解決(resolveGoriyakuTagIds)が使うキャッシュを先読みしておく。
@@ -172,6 +177,15 @@ export default function Home() {
       <Pressable onPress={openConcierge} style={styles.primaryCta}>
         <Text style={styles.primaryCtaText}>この相談からご縁を見る</Text>
       </Pressable>
+
+      {/* Search入口(補助CTA) */}
+      <Button
+        title="神社を地図・一覧から探す"
+        variant="outline"
+        onPress={openSearch}
+        accessibilityLabel="神社を地図・一覧から探す"
+        style={styles.searchEntryCta}
+      />
 
     </ScrollView>
   );
@@ -369,6 +383,9 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "900",
     letterSpacing: 0.3,
+  },
+  searchEntryCta: {
+    marginTop: 12,
   },
 
 });


### PR DESCRIPTION
## Summary
- Home画面に補助CTA「神社を地図・一覧から探す」を追加し、`router.push("/search")` でSearch画面(#2168でPlatform分離済み)へ遷移できるようにした
- 実装は共通の `Button` コンポーネント(`variant="outline"`)を再利用し、既存の主CTA「この相談からご縁を見る」の下に控えめな入口として配置
- 下部4タブ(ホーム/相談/記録/マイページ)は変更なし。`search/index` は#2168マージ時点で既に `_layout.tsx` 上 `href: null` の非表示タブとして登録済みのため、タブ構成自体への変更は不要
- Analyticsイベントは追加していない。既存のHome主CTA(`openConcierge`)がクリックをトラッキングしていない既存契約に合わせた判断

## Scope
- Home→Search間の導線追加のみ。Search画面内部のUI・地図実装(#2168で対応済み)、Search API契約、神社詳細route、Search画面の「戻る」導線には手を加えていない

## Test plan
- [x] `pnpm typecheck` (apps/mobile)
- [x] `pnpm test` (apps/mobile, 102件)
- [x] `git diff --check`
- [x] pre-push hook: OpenAPI lint / Web契約テスト(607件)
- [x] ブラウザでHome→「神社を地図・一覧から探す」→Search画面(Web fallback表示)→「← 戻る」→Homeへ復帰、の一連の動線を確認
- [ ] iOS Simulator / Android Emulatorでの確認は、今回の環境でシミュレータ操作が安定せず実施できていません。変更はHome画面のCTA追加のみで地図コンポーネント自体は対象外のため回帰リスクは低いですが、マージ前の実機確認を推奨します

🤖 Generated with [Claude Code](https://claude.com/claude-code)