### PR TITLE
神社地図と一覧の選択状態を双方向に同期

### DIFF
--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -109,8 +109,8 @@ export default function SearchPage() {
 
         {mapStatus === "ready" && mapPoints.length === 0 ? (
           <StateCard
-            title="地図に表示できる神社がありません"
-            description="この検索結果には地図へ表示できる位置情報がありません。神社一覧はそのままご覧いただけます。"
+            title="神社が見つかりませんでした"
+            description="この検索条件に一致する神社がありません。条件を変えてもう一度お試しください。"
           />
         ) : null}
 

--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -162,29 +162,51 @@ export default function SearchPage() {
           </View>
 
           <View style={styles.list}>
-            {visibleShrines.map((s) => (
-              <Pressable
-                key={s.id}
-                onPress={() => router.push(`/shrines/${s.id}`)}
-                style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
-              >
-                <Image source={{ uri: s.imageUrl }} style={styles.cardImage} />
-                <View style={styles.cardBody}>
-                  <Text style={styles.cardName}>{s.name}</Text>
-                  <Text style={styles.cardArea}>{s.prefecture}</Text>
-                  <View style={styles.miniTagRow}>
-                    {s.tags.slice(0, 3).map((t) => (
-                      <View key={t} style={styles.miniTag}>
-                        <Text style={styles.miniTagText}>{t}</Text>
+            {visibleShrines.map((s) => {
+              const existsOnMap = mapPoints.some((point) => point.id === s.id);
+              const isSelectedOnMap = existsOnMap && selectedShrineId === s.id;
+              return (
+                <View key={s.id} style={styles.card}>
+                  <Pressable
+                    onPress={() => router.push(`/shrines/${s.id}`)}
+                    style={({ pressed }) => [styles.cardMain, pressed && styles.cardPressed]}
+                  >
+                    <Image source={{ uri: s.imageUrl }} style={styles.cardImage} />
+                    <View style={styles.cardBody}>
+                      <Text style={styles.cardName}>{s.name}</Text>
+                      <Text style={styles.cardArea}>{s.prefecture}</Text>
+                      <View style={styles.miniTagRow}>
+                        {s.tags.slice(0, 3).map((t) => (
+                          <View key={t} style={styles.miniTag}>
+                            <Text style={styles.miniTagText}>{t}</Text>
+                          </View>
+                        ))}
                       </View>
-                    ))}
+                    </View>
+                    <Text accessibilityElementsHidden style={styles.chevron}>
+                      ›
+                    </Text>
+                  </Pressable>
+
+                  <View style={styles.cardMapActionRow}>
+                    <Button
+                      title={isSelectedOnMap ? "地図で選択中" : "地図で選択"}
+                      variant="outline"
+                      size="compact"
+                      disabled={!existsOnMap}
+                      onPress={() => setSelectedShrineId(s.id)}
+                      accessibilityLabel={
+                        !existsOnMap
+                          ? `${s.name}は地図に表示されていません`
+                          : isSelectedOnMap
+                            ? `${s.name}を地図で選択中`
+                            : `${s.name}を地図で選択`
+                      }
+                    />
                   </View>
                 </View>
-                <Text accessibilityElementsHidden style={styles.chevron}>
-                  ›
-                </Text>
-              </Pressable>
-            ))}
+              );
+            })}
           </View>
         </>
       ) : null}
@@ -360,14 +382,20 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   card: {
-    flexDirection: "row",
-    alignItems: "center",
     backgroundColor: theme.surface,
     borderWidth: 1,
     borderColor: theme.borderHeader,
     borderRadius: 18,
     padding: 12,
+    gap: 10,
+  },
+  cardMain: {
+    flexDirection: "row",
+    alignItems: "center",
     gap: 12,
+  },
+  cardMapActionRow: {
+    flexDirection: "row",
   },
   cardPressed: {
     opacity: 0.74,

--- a/apps/mobile/components/search/ShrineSearchMap.native.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.native.tsx
@@ -1,12 +1,13 @@
 // apps/mobile/components/search/ShrineSearchMap.native.tsx
 import * as React from "react";
-import { StyleSheet, View } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 import MapView, { Marker, type Region } from "react-native-maps";
 
 import { kamimusubiDark as theme } from "../../design/theme";
 import { radius } from "../../design/radius";
+import { spacing } from "../../design/spacing";
 import { prefectureOrigin } from "../../../../packages/shared/userOrigin";
-import type { ShrineMapPoint } from "../../lib/shrineMap";
+import { hasValidCoordinates, type ShrineSearchMapProps } from "../../lib/shrineMap";
 
 const FALLBACK_ORIGIN = prefectureOrigin("東京都");
 const FALLBACK_REGION: Region = {
@@ -19,7 +20,9 @@ const FALLBACK_REGION: Region = {
 const MIN_DELTA = 0.05;
 const REGION_PADDING = 1.4;
 
-function buildInitialRegion(points: ShrineMapPoint[]): Region {
+type MappablePoint = { id: string; latitude: number; longitude: number };
+
+function buildInitialRegion(points: MappablePoint[]): Region {
   if (points.length === 0) return FALLBACK_REGION;
 
   let minLat = points[0].latitude;
@@ -42,35 +45,65 @@ function buildInitialRegion(points: ShrineMapPoint[]): Region {
   return { latitude, longitude, latitudeDelta, longitudeDelta };
 }
 
-type Props = {
-  points: ShrineMapPoint[];
-  selectedId: string | null;
-  onSelect: (id: string) => void;
-};
-
-export function ShrineSearchMap({ points, selectedId, onSelect }: Props) {
-  const initialRegion = React.useMemo(() => buildInitialRegion(points), [points]);
+export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMapProps) {
+  // pointsの配列参照はSearch画面側でselectedShrineId変更時に変わらないため、
+  // useMemoの依存をpointsのみにしてMapViewのinitialRegionが選択のたびに動かないようにする。
+  const mappablePoints = React.useMemo(() => points.filter(hasValidCoordinates), [points]);
+  const unmappablePoints = React.useMemo(() => points.filter((point) => !hasValidCoordinates(point)), [points]);
+  const initialRegion = React.useMemo(() => buildInitialRegion(mappablePoints), [mappablePoints]);
 
   return (
-    <View style={styles.wrap} accessibilityLabel="検索結果の神社を地図で見る">
-      <MapView style={styles.map} initialRegion={initialRegion}>
-        {points.map((point) => {
-          const selected = point.id === selectedId;
-          return (
-            <Marker
-              key={point.id}
-              coordinate={{ latitude: point.latitude, longitude: point.longitude }}
-              title={point.name}
-              onPress={() => onSelect(point.id)}
-              accessibilityRole="button"
-              accessibilityLabel={`${point.name}を選択`}
-              accessibilityState={{ selected }}
-              opacity={selected ? 1 : 0.85}
-              zIndex={selected ? 1 : 0}
-            />
-          );
-        })}
-      </MapView>
+    <View>
+      <View style={styles.wrap} accessibilityLabel="検索結果の神社を地図で見る">
+        <MapView style={styles.map} initialRegion={initialRegion}>
+          {mappablePoints.map((point) => {
+            const selected = point.id === selectedId;
+            return (
+              <Marker
+                key={point.id}
+                coordinate={{ latitude: point.latitude, longitude: point.longitude }}
+                title={point.name}
+                onPress={() => onSelect(point.id)}
+                accessibilityRole="button"
+                accessibilityLabel={selected ? `${point.name}を選択、選択中` : `${point.name}を選択`}
+                accessibilityState={{ selected }}
+                opacity={selected ? 1 : 0.85}
+                zIndex={selected ? 1 : 0}
+              />
+            );
+          })}
+        </MapView>
+      </View>
+
+      {unmappablePoints.length > 0 ? (
+        <View style={styles.noCoordSection}>
+          <Text style={styles.noCoordLabel}>位置情報のない神社</Text>
+          <View style={styles.noCoordList}>
+            {unmappablePoints.map((point) => {
+              const selected = point.id === selectedId;
+              return (
+                <Pressable
+                  key={point.id}
+                  onPress={() => onSelect(point.id)}
+                  accessibilityRole="button"
+                  accessibilityLabel={selected ? `${point.name}を選択、選択中` : `${point.name}を選択`}
+                  accessibilityState={{ selected }}
+                  style={({ pressed }) => [
+                    styles.noCoordItem,
+                    selected && styles.noCoordItemSelected,
+                    pressed && styles.noCoordItemPressed,
+                  ]}
+                >
+                  <Text style={styles.noCoordItemText} numberOfLines={1}>
+                    {point.name}
+                    {selected ? "・選択中" : ""}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </View>
+      ) : null}
     </View>
   );
 }
@@ -84,5 +117,36 @@ const styles = StyleSheet.create({
   },
   map: {
     flex: 1,
+  },
+  noCoordSection: {
+    marginTop: spacing.mdGap,
+    gap: spacing.tightGap,
+  },
+  noCoordLabel: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  noCoordList: {
+    gap: spacing.tightGap,
+  },
+  noCoordItem: {
+    borderRadius: radius.xs,
+    borderWidth: 1,
+    borderColor: theme.border,
+    backgroundColor: theme.surface,
+    paddingHorizontal: spacing.mdGap,
+    paddingVertical: spacing.tightGap,
+  },
+  noCoordItemSelected: {
+    borderColor: theme.borderGold,
+  },
+  noCoordItemPressed: {
+    opacity: 0.74,
+  },
+  noCoordItemText: {
+    color: theme.text,
+    fontSize: 14,
+    fontWeight: "800",
   },
 });

--- a/apps/mobile/components/search/ShrineSearchMap.web.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.web.tsx
@@ -5,19 +5,13 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import { kamimusubiDark as theme } from "../../design/theme";
 import { radius } from "../../design/radius";
 import { spacing } from "../../design/spacing";
-import type { ShrineMapPoint } from "../../lib/shrineMap";
+import type { ShrineSearchMapProps } from "../../lib/shrineMap";
 
-type Props = {
-  points: ShrineMapPoint[];
-  selectedId: string | null;
-  onSelect: (id: string) => void;
-};
-
-export function ShrineSearchMap({ points, selectedId, onSelect }: Props) {
+export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMapProps) {
   return (
     <View style={styles.wrap} accessibilityRole="summary" accessibilityLabel="検索結果の神社を地図で見る">
       <Text style={styles.title}>地図表示はモバイルアプリで利用できます</Text>
-      <Text style={styles.description}>この画面では、位置情報のある神社を一覧から選択できます。</Text>
+      <Text style={styles.description}>この画面では、神社を一覧から選択できます。</Text>
 
       {points.length > 0 ? (
         <View style={styles.list}>
@@ -28,13 +22,16 @@ export function ShrineSearchMap({ points, selectedId, onSelect }: Props) {
                 key={point.id}
                 onPress={() => onSelect(point.id)}
                 accessibilityRole="button"
-                accessibilityLabel={`${point.name}を選択`}
+                accessibilityLabel={selected ? `${point.name}を選択、選択中` : `${point.name}を選択`}
                 accessibilityState={{ selected }}
                 style={({ pressed }) => [styles.item, selected && styles.itemSelected, pressed && styles.itemPressed]}
               >
-                <Text style={styles.itemName} numberOfLines={1}>
-                  {point.name}
-                </Text>
+                <View style={styles.itemHeader}>
+                  <Text style={styles.itemName} numberOfLines={1}>
+                    {point.name}
+                  </Text>
+                  {selected ? <Text style={styles.itemSelectedBadge}>選択中</Text> : null}
+                </View>
                 {point.address ? (
                   <Text style={styles.itemAddress} numberOfLines={1}>
                     {point.address}
@@ -85,9 +82,20 @@ const styles = StyleSheet.create({
   itemPressed: {
     opacity: 0.74,
   },
+  itemHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.tightGap,
+  },
   itemName: {
     color: theme.text,
     fontSize: 14,
+    fontWeight: "800",
+  },
+  itemSelectedBadge: {
+    color: theme.gold,
+    fontSize: 11,
     fontWeight: "800",
   },
   itemAddress: {

--- a/apps/mobile/lib/__tests__/shrineMap.test.ts
+++ b/apps/mobile/lib/__tests__/shrineMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { toShrineMapPoints } from "../shrineMap";
+import { hasValidCoordinates, toShrineMapPoints } from "../shrineMap";
 
 describe("toShrineMapPoints", () => {
   it("正常な数値座標を通す", () => {
@@ -33,26 +33,42 @@ describe("toShrineMapPoints", () => {
     expect(points).toEqual([{ id: "5", name: "location経由", latitude: 35.1, longitude: 139.1, address: undefined, imageUrl: undefined }]);
   });
 
-  it("null座標を除外する", () => {
+  it("null座標は除外せず、座標欠損として一覧に残す", () => {
     const points = toShrineMapPoints({ results: [{ id: 6, name_jp: "座標なし", latitude: null, longitude: null }] });
-    expect(points).toEqual([]);
+    expect(points).toEqual([{ id: "6", name: "座標なし", latitude: null, longitude: null, address: undefined, imageUrl: undefined }]);
   });
 
-  it("NaNを除外する", () => {
+  it("NaNになる座標は座標欠損として一覧に残す", () => {
     const points = toShrineMapPoints({ results: [{ id: 7, name_jp: "不正値", latitude: "abc", longitude: 139.0 }] });
-    expect(points).toEqual([]);
+    expect(points).toEqual([{ id: "7", name: "不正値", latitude: null, longitude: null, address: undefined, imageUrl: undefined }]);
   });
 
-  it("Infinityを除外する", () => {
+  it("Infinityは座標欠損として一覧に残す", () => {
     const points = toShrineMapPoints({ results: [{ id: 8, name_jp: "無限大", latitude: Infinity, longitude: 139.0 }] });
-    expect(points).toEqual([]);
+    expect(points).toEqual([{ id: "8", name: "無限大", latitude: null, longitude: null, address: undefined, imageUrl: undefined }]);
   });
 
-  it("範囲外座標を除外する", () => {
+  it("範囲外座標は座標欠損として一覧に残す", () => {
     const overLat = toShrineMapPoints({ results: [{ id: 9, name_jp: "緯度範囲外", latitude: 95, longitude: 139.0 }] });
     const overLng = toShrineMapPoints({ results: [{ id: 10, name_jp: "経度範囲外", latitude: 35.0, longitude: 200 }] });
-    expect(overLat).toEqual([]);
-    expect(overLng).toEqual([]);
+    expect(overLat).toEqual([{ id: "9", name: "緯度範囲外", latitude: null, longitude: null, address: undefined, imageUrl: undefined }]);
+    expect(overLng).toEqual([{ id: "10", name: "経度範囲外", latitude: null, longitude: null, address: undefined, imageUrl: undefined }]);
+  });
+
+  it("片方だけ有効な座標も欠損として扱う(Markerを安全に省略するため)", () => {
+    const points = toShrineMapPoints({ results: [{ id: "14", name_jp: "片方欠損", latitude: 35.0, longitude: null }] });
+    expect(points).toEqual([{ id: "14", name: "片方欠損", latitude: null, longitude: null, address: undefined, imageUrl: undefined }]);
+  });
+
+  it("有効座標が0件でも、id・nameがある項目は一覧として返す", () => {
+    const points = toShrineMapPoints({
+      results: [
+        { id: 15, name_jp: "座標なしA", latitude: null, longitude: null },
+        { id: 16, name_jp: "座標なしB", latitude: "abc", longitude: "def" },
+      ],
+    });
+    expect(points).toHaveLength(2);
+    expect(points.every((p) => !hasValidCoordinates(p))).toBe(true);
   });
 
   it("id欠損を安全に扱う", () => {
@@ -83,5 +99,19 @@ describe("toShrineMapPoints", () => {
     const viaPhotoUrl = toShrineMapPoints({ results: [{ id: 13, name_jp: "画像B", latitude: 1, longitude: 1, photo_url: "https://x/b.jpg" }] });
     expect(viaImageUrl[0]?.imageUrl).toBe("https://x/a.jpg");
     expect(viaPhotoUrl[0]?.imageUrl).toBe("https://x/b.jpg");
+  });
+});
+
+describe("hasValidCoordinates", () => {
+  it("有効な緯度経度がそろっている場合はtrue", () => {
+    expect(hasValidCoordinates({ id: "1", name: "有効", latitude: 35.0, longitude: 139.0 })).toBe(true);
+  });
+
+  it("緯度経度がnullの場合はfalse(Marker同期を安全に省略する対象)", () => {
+    expect(hasValidCoordinates({ id: "2", name: "座標なし", latitude: null, longitude: null })).toBe(false);
+  });
+
+  it("片方だけnullの場合もfalse", () => {
+    expect(hasValidCoordinates({ id: "3", name: "片方欠損", latitude: 35.0, longitude: null })).toBe(false);
   });
 });

--- a/apps/mobile/lib/shrineMap.ts
+++ b/apps/mobile/lib/shrineMap.ts
@@ -1,14 +1,31 @@
 // apps/mobile/lib/shrineMap.ts
 import { get } from "./http";
 
+// latitude/longitudeは片方でも欠けている・不正な場合はnullにする。
+// 座標欠損神社も一覧・選択・詳細遷移の対象として残すため、Marker表示可否の判定は
+// hasValidCoordinatesで別途行い、このtype自体では除外しない。
 export type ShrineMapPoint = {
   id: string;
   name: string;
-  latitude: number;
-  longitude: number;
+  latitude: number | null;
+  longitude: number | null;
   address?: string;
   imageUrl?: string;
 };
+
+// Native/Web両方のShrineSearchMapが共有するProps契約。
+// 片方だけ型を変えて挙動が乖離しないよう、両ファイルはこの型をそのまま使う。
+export type ShrineSearchMapProps = {
+  points: ShrineMapPoint[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+};
+
+export function hasValidCoordinates(
+  point: ShrineMapPoint,
+): point is ShrineMapPoint & { latitude: number; longitude: number } {
+  return point.latitude !== null && point.longitude !== null;
+}
 
 function toFiniteNumber(value: unknown): number | null {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
@@ -29,7 +46,9 @@ function isValidLongitude(value: number): boolean {
 
 /**
  * APIレスポンスの生データを安全にShrineMapPointへ変換する。
- * id・nameが欠けている、または座標が数値として有効でない項目は除外する。
+ * id・nameが欠けている項目は除外する。座標が数値として有効でない項目は
+ * 除外せず、latitude/longitudeをnullにして一覧・選択の対象として残す
+ * (Marker表示のみhasValidCoordinatesで別途絞り込む)。
  */
 export function toShrineMapPoints(raw: unknown): ShrineMapPoint[] {
   const items: unknown[] = Array.isArray(raw)
@@ -54,10 +73,12 @@ export function toShrineMapPoints(raw: unknown): ShrineMapPoint[] {
     if (!name) continue;
 
     const location = (record.location ?? null) as { lat?: unknown; lng?: unknown } | null;
-    const latitude = toFiniteNumber(record.latitude ?? location?.lat);
-    const longitude = toFiniteNumber(record.longitude ?? location?.lng);
-    if (latitude === null || longitude === null) continue;
-    if (!isValidLatitude(latitude) || !isValidLongitude(longitude)) continue;
+    const latitudeRaw = toFiniteNumber(record.latitude ?? location?.lat);
+    const longitudeRaw = toFiniteNumber(record.longitude ?? location?.lng);
+    const validPair =
+      latitudeRaw !== null && longitudeRaw !== null && isValidLatitude(latitudeRaw) && isValidLongitude(longitudeRaw);
+    const latitude = validPair ? latitudeRaw : null;
+    const longitude = validPair ? longitudeRaw : null;
 
     const address = typeof record.address === "string" && record.address.trim() ? record.address.trim() : undefined;
     const imageUrl =
@@ -81,7 +102,8 @@ export type FetchShrineMapPointsParams = {
 };
 
 /**
- * Search画面が利用している神社一覧APIから、地図表示用の安全な座標データだけを取得する。
+ * Search画面が利用している神社一覧APIから、地図・一覧表示用のデータを取得する。
+ * 座標欠損神社も一覧・選択の対象として含まれる。
  * 失敗時は例外を投げず、呼び出し側でLoading/Errorを制御できるようにErrorを再送出する。
  */
 export async function fetchShrineMapPoints(params: FetchShrineMapPointsParams = {}): Promise<ShrineMapPoint[]> {


### PR DESCRIPTION
## 変更概要
- selectedShrineIdを地図選択状態の単一正本として維持
- Marker・Web fallback一覧・Native座標欠損一覧・選択カードを同期
- 座標欠損神社を一覧・選択・詳細遷移へ残す
- 通常の神社一覧に独立した「地図で選択」Buttonを追加
- 一覧カード本体の既存詳細遷移を維持
- 選択中状態を文言とアクセシビリティ属性で表示

## 変更ファイル
- apps/mobile/app/search/index.tsx
- apps/mobile/components/search/ShrineSearchMap.native.tsx
- apps/mobile/components/search/ShrineSearchMap.web.tsx
- apps/mobile/lib/shrineMap.ts
- apps/mobile/lib/__tests__/shrineMap.test.ts

## 検証
- Mobile typecheck成功
- Mobile test 107件成功
- git diff --check成功
- Web fallbackで選択切替・選択カード・詳細遷移を確認

## 未確認
- 現在のモックデータは3件すべてが人気枠へ入るため、通常の神社一覧に追加した「地図で選択」Buttonはブラウザで目視確認できていません
- iOS／Android Simulatorでの最終操作確認は環境不安定のため未実施
- マージ前にNativeでMarker・通常一覧・選択カードの同期確認を推奨