### PR TITLE
既存ファイルのみでWeb版にMapLibre GL JSの地図表示を実装

### DIFF
--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -8,7 +8,7 @@ import { StateCard } from "../../components/common/StateCard";
 import Button from "../../components/ui/Button";
 import { ShrineSearchMap } from "../../components/search/ShrineSearchMap";
 import { SelectedShrineMapCard } from "../../components/search/SelectedShrineMapCard";
-import { fetchShrineMapPoints, type ShrineMapPoint } from "../../lib/shrineMap";
+import { fetchShrineMapPoints, findShrineMapPointById, type ShrineMapPoint } from "../../lib/shrineMap";
 
 export default function SearchPage() {
   const router = useRouter();
@@ -42,7 +42,7 @@ export default function SearchPage() {
     }
   }, [mapPoints, selectedShrineId]);
 
-  const selectedMapShrine = mapPoints.find((point) => point.id === selectedShrineId) ?? null;
+  const selectedMapShrine = findShrineMapPointById(mapPoints, selectedShrineId);
 
   const filtered = SHRINES.filter((s) => {
     const textHit =

--- a/apps/mobile/components/search/ShrineSearchMap.web.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.web.tsx
@@ -1,17 +1,186 @@
 // apps/mobile/components/search/ShrineSearchMap.web.tsx
 import * as React from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { MapLibreMap, Marker, type ErrorEvent } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
 
 import { kamimusubiDark as theme } from "../../design/theme";
 import { radius } from "../../design/radius";
 import { spacing } from "../../design/spacing";
-import type { ShrineSearchMapProps } from "../../lib/shrineMap";
+import {
+  computeWebMapViewport,
+  hasValidCoordinates,
+  type ShrineMapPoint,
+  type ShrineSearchMapProps,
+} from "../../lib/shrineMap";
+
+// 公開クライアント用のstyle URL。secretはコードへ直書きせず、未設定時は
+// Mapを生成せず既存の一覧fallbackを表示する。domain制限・使用量制限は
+// provider側の設定に委ねる(docs/audit/web-map-tile-provider-selection.md参照)。
+const STYLE_URL = process.env.EXPO_PUBLIC_WEB_MAP_STYLE_URL;
+
+function applyMarkerSelectedState(element: HTMLElement, selected: boolean): void {
+  element.setAttribute("aria-pressed", selected ? "true" : "false");
+  element.style.transform = selected ? "scale(1.35)" : "scale(1)";
+  element.style.boxShadow = selected ? `0 0 0 3px ${theme.gold}` : "none";
+  element.style.zIndex = selected ? "1" : "0";
+}
+
+function createMarkerElement(
+  point: ShrineMapPoint,
+  onSelectRef: React.MutableRefObject<(id: string) => void>,
+): HTMLDivElement {
+  const element = document.createElement("div");
+  element.setAttribute("role", "button");
+  element.setAttribute("tabIndex", "0");
+  element.setAttribute("aria-label", `${point.name}を選択`);
+  element.setAttribute("aria-pressed", "false");
+  element.title = point.name;
+  element.style.width = "16px";
+  element.style.height = "16px";
+  element.style.borderRadius = "999px";
+  element.style.backgroundColor = theme.gold;
+  element.style.border = `2px solid ${theme.background}`;
+  element.style.boxSizing = "border-box";
+  element.style.cursor = "pointer";
+  element.style.transition = "transform 0.1s ease-out";
+
+  const select = () => onSelectRef.current(point.id);
+  element.addEventListener("click", select);
+  element.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
+      event.preventDefault();
+      select();
+    }
+  });
+
+  return element;
+}
 
 export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMapProps) {
+  const containerRef = React.useRef<View>(null);
+  const mapRef = React.useRef<MapLibreMap | null>(null);
+  const markersRef = React.useRef<Map<string, Marker>>(new Map());
+  const onSelectRef = React.useRef(onSelect);
+  onSelectRef.current = onSelect;
+
+  const [mapUnavailable, setMapUnavailable] = React.useState(false);
+
+  const mappablePoints = React.useMemo(() => points.filter(hasValidCoordinates), [points]);
+  const styleUrlConfigured = Boolean(STYLE_URL);
+  const shouldAttemptMap = styleUrlConfigured && !mapUnavailable;
+
+  const teardownMap = React.useCallback(() => {
+    markersRef.current.forEach((marker) => marker.remove());
+    markersRef.current.clear();
+    mapRef.current?.remove();
+    mapRef.current = null;
+  }, []);
+
+  // Unmount時のみ後片付けする。selectedId変更やpoints更新では実行しない。
+  React.useEffect(() => {
+    return () => teardownMap();
+  }, [teardownMap]);
+
+  // Mapの遅延生成とMarkerの同期。selectedIdはこのeffectの依存に含めず、
+  // 選択状態の変更だけでMapやMarkerを作り直さないようにする。
+  React.useEffect(() => {
+    if (!shouldAttemptMap) return;
+
+    if (!mapRef.current) {
+      if (mappablePoints.length === 0) return;
+      const containerEl = containerRef.current as unknown as HTMLElement | null;
+      if (!containerEl) return;
+
+      const viewport = computeWebMapViewport(mappablePoints);
+      if (!viewport) return;
+
+      try {
+        const map = new MapLibreMap({
+          container: containerEl,
+          style: STYLE_URL as string,
+          center: viewport.kind === "point" ? viewport.center : [mappablePoints[0].longitude, mappablePoints[0].latitude],
+          zoom: viewport.kind === "point" ? viewport.zoom : 2,
+        });
+
+        map.on("error", (event: ErrorEvent) => {
+          const message = String(event?.error?.message ?? "").toLowerCase();
+          // 個別タイル1件の読み込み失敗だけではfallbackへ切り替えない。
+          // styleそのものが読み込めない場合のみ一覧fallbackへ切り替える。
+          if (message.includes("style") || message.includes("failed to fetch")) {
+            teardownMap();
+            setMapUnavailable(true);
+          }
+        });
+
+        if (viewport.kind === "bounds") {
+          map.fitBounds(viewport.bounds, { padding: viewport.padding, maxZoom: viewport.maxZoom, duration: 0 });
+        }
+
+        mapRef.current = map;
+      } catch {
+        setMapUnavailable(true);
+        return;
+      }
+    } else if (mappablePoints.length > 0) {
+      const viewport = computeWebMapViewport(mappablePoints);
+      if (viewport?.kind === "bounds") {
+        mapRef.current.fitBounds(viewport.bounds, { padding: viewport.padding, maxZoom: viewport.maxZoom, duration: 0 });
+      } else if (viewport?.kind === "point") {
+        mapRef.current.setCenter(viewport.center);
+        mapRef.current.setZoom(viewport.zoom);
+      }
+    }
+
+    const map = mapRef.current;
+    if (!map) return;
+
+    const nextIds = new Set(mappablePoints.map((point) => point.id));
+    markersRef.current.forEach((marker, id) => {
+      if (!nextIds.has(id)) {
+        marker.remove();
+        markersRef.current.delete(id);
+      }
+    });
+
+    mappablePoints.forEach((point) => {
+      const existing = markersRef.current.get(point.id);
+      if (existing) {
+        existing.setLngLat([point.longitude, point.latitude]);
+        return;
+      }
+      const element = createMarkerElement(point, onSelectRef);
+      applyMarkerSelectedState(element, point.id === selectedId);
+      const marker = new Marker({ element }).setLngLat([point.longitude, point.latitude]).addTo(map);
+      markersRef.current.set(point.id, marker);
+    });
+    // selectedIdは初期表示状態の付与にのみ使う。以降の更新は下の選択同期effectが担う。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mappablePoints, shouldAttemptMap, teardownMap]);
+
+  // 選択状態の同期のみを行う。Marker・Mapの再生成は行わない。
+  React.useEffect(() => {
+    markersRef.current.forEach((marker, id) => {
+      applyMarkerSelectedState(marker.getElement(), id === selectedId);
+    });
+  }, [selectedId]);
+
+  const mapShown = shouldAttemptMap && mappablePoints.length > 0;
+  const showMapUnavailableNotice = !styleUrlConfigured || mapUnavailable;
+  const showNoCoordinatesNotice = !showMapUnavailableNotice && mappablePoints.length === 0;
+
   return (
     <View style={styles.wrap} accessibilityRole="summary" accessibilityLabel="検索結果の神社を地図で見る">
-      <Text style={styles.title}>地図表示はモバイルアプリで利用できます</Text>
-      <Text style={styles.description}>この画面では、神社を一覧から選択できます。</Text>
+      {mapShown ? (
+        <View ref={containerRef} style={styles.mapContainer} />
+      ) : null}
+
+      {showMapUnavailableNotice ? (
+        <Text style={styles.notice}>地図を読み込めないため一覧を表示しています。</Text>
+      ) : null}
+      {showNoCoordinatesNotice ? (
+        <Text style={styles.notice}>位置情報がないため一覧で表示しています。</Text>
+      ) : null}
 
       {points.length > 0 ? (
         <View style={styles.list}>
@@ -53,17 +222,17 @@ const styles = StyleSheet.create({
     padding: spacing.mdGap,
     gap: spacing.tightGap,
   },
-  title: {
-    color: theme.text,
-    fontSize: 14,
-    fontWeight: "800",
+  mapContainer: {
+    height: 240,
+    borderRadius: radius.lg,
+    overflow: "hidden",
+    backgroundColor: theme.surfaceSoft,
   },
-  description: {
+  notice: {
     color: theme.muted,
     fontSize: 12,
     lineHeight: 18,
     fontWeight: "600",
-    marginBottom: spacing.tightGap,
   },
   list: {
     gap: spacing.tightGap,

--- a/apps/mobile/lib/__tests__/shrineMap.test.ts
+++ b/apps/mobile/lib/__tests__/shrineMap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { hasValidCoordinates, toShrineMapPoints } from "../shrineMap";
+import { computeWebMapViewport, findShrineMapPointById, hasValidCoordinates, toShrineMapPoints } from "../shrineMap";
 
 describe("toShrineMapPoints", () => {
   it("正常な数値座標を通す", () => {
@@ -113,5 +113,76 @@ describe("hasValidCoordinates", () => {
 
   it("片方だけnullの場合もfalse", () => {
     expect(hasValidCoordinates({ id: "3", name: "片方欠損", latitude: 35.0, longitude: null })).toBe(false);
+  });
+});
+
+describe("findShrineMapPointById", () => {
+  const points = [
+    { id: "1", name: "明治神宮", latitude: 35.676, longitude: 139.699 },
+    { id: "2", name: "座標なし", latitude: null, longitude: null },
+  ];
+
+  it("selectedIdに対応するpointを導出できる", () => {
+    expect(findShrineMapPointById(points, "1")).toEqual(points[0]);
+  });
+
+  it("座標欠損神社もidが一致すれば導出できる", () => {
+    expect(findShrineMapPointById(points, "2")).toEqual(points[1]);
+  });
+
+  it("該当idがなければnullを返す", () => {
+    expect(findShrineMapPointById(points, "999")).toBeNull();
+  });
+
+  it("idがnullならnullを返す", () => {
+    expect(findShrineMapPointById(points, null)).toBeNull();
+  });
+});
+
+describe("computeWebMapViewport", () => {
+  it("有効座標が0件ならnullを返す(Web地図を生成しない判定に使う)", () => {
+    expect(computeWebMapViewport([])).toBeNull();
+  });
+
+  it("1件のときはcenter+zoomを返す(bounds計算はしない)", () => {
+    const viewport = computeWebMapViewport([{ latitude: 35.676, longitude: 139.699 }]);
+    expect(viewport).toEqual({ kind: "point", center: [139.699, 35.676], zoom: 14 });
+  });
+
+  it("center配列は[経度, 緯度]の順序である(緯度経度を逆にしない)", () => {
+    const viewport = computeWebMapViewport([{ latitude: 10, longitude: 20 }]);
+    expect(viewport?.kind).toBe("point");
+    if (viewport?.kind === "point") {
+      expect(viewport.center[0]).toBe(20); // longitude
+      expect(viewport.center[1]).toBe(10); // latitude
+    }
+  });
+
+  it("2件以上のときはboundsを返す", () => {
+    const viewport = computeWebMapViewport([
+      { latitude: 35.0, longitude: 139.0 },
+      { latitude: 36.0, longitude: 140.0 },
+    ]);
+    expect(viewport).toEqual({
+      kind: "bounds",
+      bounds: [
+        [139.0, 35.0],
+        [140.0, 36.0],
+      ],
+      padding: 48,
+      maxZoom: 15,
+    });
+  });
+
+  it("bounds配列も[経度, 緯度]の順序である", () => {
+    const viewport = computeWebMapViewport([
+      { latitude: 10, longitude: 100 },
+      { latitude: 20, longitude: 200 },
+    ]);
+    expect(viewport?.kind).toBe("bounds");
+    if (viewport?.kind === "bounds") {
+      expect(viewport.bounds[0]).toEqual([100, 10]); // [minLng, minLat]
+      expect(viewport.bounds[1]).toEqual([200, 20]); // [maxLng, maxLat]
+    }
   });
 });

--- a/apps/mobile/lib/shrineMap.ts
+++ b/apps/mobile/lib/shrineMap.ts
@@ -27,6 +27,59 @@ export function hasValidCoordinates(
   return point.latitude !== null && point.longitude !== null;
 }
 
+// selectedShrineIdから選択中の神社を導出する。Search画面・Web地図の両方から
+// 同じロジックを参照させ、selectedShrineIdの導出方法を1箇所に保つ。
+export function findShrineMapPointById(points: ShrineMapPoint[], id: string | null): ShrineMapPoint | null {
+  if (id === null) return null;
+  return points.find((point) => point.id === id) ?? null;
+}
+
+type Coordinate = { latitude: number; longitude: number };
+
+const WEB_MAP_SINGLE_POINT_ZOOM = 14;
+const WEB_MAP_BOUNDS_PADDING = 48;
+const WEB_MAP_BOUNDS_MAX_ZOOM = 15;
+
+export type WebMapViewport =
+  | { kind: "point"; center: [number, number]; zoom: number }
+  | { kind: "bounds"; bounds: [[number, number], [number, number]]; padding: number; maxZoom: number };
+
+/**
+ * Web地図(MapLibre GL JS)の初期viewportを、有効座標のみを持つ点から計算する。
+ * MapLibreの座標順序([経度, 緯度])に合わせて返す。
+ * 0件はnull(地図を出さない)、1件はcenter+zoom、2件以上はboundsを返す。
+ */
+export function computeWebMapViewport(points: Coordinate[]): WebMapViewport | null {
+  if (points.length === 0) return null;
+
+  if (points.length === 1) {
+    const [point] = points;
+    return { kind: "point", center: [point.longitude, point.latitude], zoom: WEB_MAP_SINGLE_POINT_ZOOM };
+  }
+
+  let minLat = points[0].latitude;
+  let maxLat = points[0].latitude;
+  let minLng = points[0].longitude;
+  let maxLng = points[0].longitude;
+
+  for (const point of points) {
+    minLat = Math.min(minLat, point.latitude);
+    maxLat = Math.max(maxLat, point.latitude);
+    minLng = Math.min(minLng, point.longitude);
+    maxLng = Math.max(maxLng, point.longitude);
+  }
+
+  return {
+    kind: "bounds",
+    bounds: [
+      [minLng, minLat],
+      [maxLng, maxLat],
+    ],
+    padding: WEB_MAP_BOUNDS_PADDING,
+    maxZoom: WEB_MAP_BOUNDS_MAX_ZOOM,
+  };
+}
+
 function toFiniteNumber(value: unknown): number | null {
   if (typeof value === "number") return Number.isFinite(value) ? value : null;
   if (typeof value === "string" && value.trim().length > 0) {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -26,6 +26,7 @@
     "expo-router": "~57.0.8",
     "expo-splash-screen": "~57.0.5",
     "expo-status-bar": "~57.0.0",
+    "maplibre-gl": "^6.0.0",
     "posthog-react-native": "^4.55.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/apps/mobile/pnpm-lock.yaml
+++ b/apps/mobile/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       expo-status-bar:
         specifier: ~57.0.0
         version: 57.0.1(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
+      maplibre-gl:
+        specifier: ^6.0.0
+        version: 6.0.0
       posthog-react-native:
         specifier: ^4.55.0
         version: 4.57.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)))(expo-file-system@57.0.1(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3)))(react-native-safe-area-context@5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3))
@@ -719,6 +722,35 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -1595,6 +1627,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -1888,6 +1923,9 @@ packages:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
     engines: {node: '>=6'}
 
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -2033,10 +2071,16 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -2157,6 +2201,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  maplibre-gl@6.0.0:
+    resolution: {integrity: sha512-1wBgEhzTZfA+cDpFdt0fM1mJA5mJ90fifORJ7D8JcKLJCvPT/iTx9bNxkP7DqEYde65DJd7gE7h83khwNRqdyg==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
@@ -2268,6 +2316,9 @@ packages:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2285,6 +2336,9 @@ packages:
 
   multitars@1.0.0:
     resolution: {integrity: sha512-H/J4fMLedtudftaYMOg7ajzLYgT3/rwbWVJbqr/iUgB8DQztn38ys5HOqI1CzSxx8QhXXwOOnnBvd4v3jG5+Mg==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
@@ -2388,6 +2442,10 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2458,6 +2516,9 @@ packages:
       react-native-svg:
         optional: true
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2484,12 +2545,18 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   query-string@7.1.3:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
   queue@6.0.2:
     resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -2672,6 +2739,9 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve-workspace-root@2.0.1:
     resolution: {integrity: sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==}
@@ -2883,6 +2953,9 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -4139,6 +4212,43 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@3.0.0':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@emnapi/core': 1.11.1
@@ -5031,6 +5141,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  earcut@3.2.3: {}
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.393: {}
@@ -5347,6 +5459,8 @@ snapshots:
 
   getenv@2.0.0: {}
 
+  gl-matrix@3.4.4: {}
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -5485,7 +5599,11 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@2.2.3: {}
+
+  kdbush@4.1.0: {}
 
   kleur@3.0.3: {}
 
@@ -5578,6 +5696,26 @@ snapshots:
   makeerror@1.0.12:
     dependencies:
       tmpl: 1.0.5
+
+  maplibre-gl@6.0.0:
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 5.1.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
 
   marky@1.3.0: {}
 
@@ -5792,6 +5930,8 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.7
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
 
   mkdirp@1.0.4: {}
@@ -5801,6 +5941,8 @@ snapshots:
   ms@2.1.3: {}
 
   multitars@1.0.0: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.16: {}
 
@@ -5882,6 +6024,10 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -5913,6 +6059,8 @@ snapshots:
       expo-file-system: 57.0.1(expo@57.0.8)(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))
       react-native-safe-area-context: 5.7.0(react-native@0.86.0(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.2.17)(react@19.2.3))(react@19.2.3)
 
+  potpack@2.1.0: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5942,6 +6090,8 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  protocol-buffers-schema@3.6.1: {}
+
   query-string@7.1.3:
     dependencies:
       decode-uri-component: 0.2.2
@@ -5952,6 +6102,8 @@ snapshots:
   queue@6.0.2:
     dependencies:
       inherits: 2.0.4
+
+  quickselect@3.0.0: {}
 
   range-parser@1.2.1: {}
 
@@ -6177,6 +6329,10 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
+
   resolve-workspace-root@2.0.1: {}
 
   resolve@1.22.12:
@@ -6383,6 +6539,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.1.0: {}
 


### PR DESCRIPTION
apps/mobile独立ワークスペースへmaplibre-glを追加し、Web版
ShrineSearchMap.web.tsxへ地図表示を実装。新規ソースファイルは
作成せず、既存ファイルの改修のみで完結させた。

- apps/mobile/package.json, apps/mobile/pnpm-lock.yaml: `pnpm add maplibre-gl --ignore-workspace`でmaplibre-gl 6.0.0を追加。 root pnpm-lock.yamlは無変更
- lib/shrineMap.ts: `findShrineMapPointById`(selectedShrineIdからの 導出をSearch画面・Web地図で共通化)と`computeWebMapViewport` (有効座標のみを対象に、1件はcenter+zoom、2件以上はboundsを算出、 MapLibreの[経度, 緯度]順序を維持)を追加
- ShrineSearchMap.web.tsx: style URLを`EXPO_PUBLIC_WEB_MAP_STYLE_URL` 経由で取得しコードへ直書きしない。未設定・Map初期化失敗・style 読み込み失敗時は既存の一覧fallbackへ切り替える(個別tile 1件の 失敗では切り替えない)。Mapインスタンス・Markerインスタンスは useRefで保持しReact stateへは保存しない。selectedShrineId変更 だけではMap・Markerを作り直さず、DOM要素のaria-pressed/scaleのみ 更新する。座標欠損神社はMarker化せず一覧・選択・詳細遷移の対象 として残す
- app/search/index.tsx: 選択神社の導出を`findShrineMapPointById` 経由に統一(挙動は変更なし)
- shrineMap.test.ts: `findShrineMapPointById`・`computeWebMapViewport` (0件/1件/複数件、座標順序)のテストを追加

新規.ts/.tsx/.cssファイルなし。Native版(ShrineSearchMap.native.tsx)・ apps/web・Backendは無変更。