### PR TITLE
Mobile Search画面を一覧主導へ変更

### DIFF
--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { useLocalSearchParams, useRouter } from "expo-router";
-import { View, Text, ScrollView, Pressable, Image, StyleSheet } from "react-native";
+import { View, Text, ScrollView, Pressable, Image, StyleSheet, Platform } from "react-native";
 import { SHRINES } from "../../data/shrines";
 import { kamimusubiDark as theme } from "../../design/theme";
 import { spacing } from "../../design/spacing";
@@ -8,7 +8,14 @@ import { StateCard } from "../../components/common/StateCard";
 import Button from "../../components/ui/Button";
 import { ShrineSearchMap } from "../../components/search/ShrineSearchMap";
 import { SelectedShrineMapCard } from "../../components/search/SelectedShrineMapCard";
-import { fetchShrineMapPoints, findShrineMapPointById, type ShrineMapPoint } from "../../lib/shrineMap";
+import {
+  fetchShrineMapPoints,
+  findShrineMapPointById,
+  isSearchMapSectionAvailable,
+  type ShrineMapPoint,
+} from "../../lib/shrineMap";
+
+const isMapSectionAvailable = isSearchMapSectionAvailable(Platform.OS, process.env.EXPO_PUBLIC_WEB_MAP_STYLE_URL);
 
 export default function SearchPage() {
   const router = useRouter();
@@ -91,69 +98,7 @@ export default function SearchPage() {
         )}
       </View>
 
-      <View style={styles.mapSection}>
-        <View style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>地図で探す</Text>
-        </View>
-
-        {mapStatus === "loading" ? (
-          <StateCard title="地図を読み込み中" description="神社の位置情報を確認しています。" />
-        ) : null}
-
-        {mapStatus === "error" ? (
-          <View style={styles.mapErrorWrap}>
-            <StateCard title="地図を読み込めませんでした" description="通信状況を確認して、もう一度お試しください。" />
-            <Button title="もう一度試す" variant="outline" size="compact" onPress={() => void loadMapPoints()} accessibilityLabel="地図をもう一度読み込む" />
-          </View>
-        ) : null}
-
-        {mapStatus === "ready" && mapPoints.length === 0 ? (
-          <StateCard
-            title="神社が見つかりませんでした"
-            description="この検索条件に一致する神社がありません。条件を変えてもう一度お試しください。"
-          />
-        ) : null}
-
-        {mapStatus === "ready" && mapPoints.length > 0 ? (
-          <View style={styles.mapReadyWrap}>
-            <ShrineSearchMap points={mapPoints} selectedId={selectedShrineId} onSelect={setSelectedShrineId} />
-            {selectedMapShrine ? (
-              <SelectedShrineMapCard shrine={selectedMapShrine} onDetail={() => router.push(`/shrines/${selectedMapShrine.id}`)} />
-            ) : null}
-          </View>
-        ) : null}
-      </View>
-
-      <View style={styles.popularSection}>
-        <View style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>人気の神社</Text>
-          <Text style={styles.sectionCount}>3件</Text>
-        </View>
-
-        <View style={styles.popularList}>
-          {popularShrines.map((s, index) => (
-            <Pressable
-              key={s.id}
-              onPress={() => router.push(`/shrines/${s.id}`)}
-              style={({ pressed }) => [styles.popularCard, pressed && styles.cardPressed]}
-            >
-              <Text style={styles.popularRank}>{index + 1}</Text>
-              <Image source={{ uri: s.imageUrl }} style={styles.popularImage} />
-              <View style={styles.cardBody}>
-                <Text style={styles.cardName}>{s.name}</Text>
-                <Text style={styles.cardArea}>{s.prefecture}</Text>
-                <Text style={styles.popularMeta}>
-                  ★ {(s.rating ?? 4.6).toFixed(1)}　♡ {s.favorites ?? 0}
-                </Text>
-              </View>
-              <Text accessibilityElementsHidden style={styles.chevron}>
-                ›
-              </Text>
-            </Pressable>
-          ))}
-        </View>
-      </View>
-
+      {/* 神社一覧: 主要探索UI(docs/product/mobile-user-flow.md 10節) */}
       {visibleShrines.length > 0 ? (
         <>
           <View style={styles.sectionHeader}>
@@ -209,6 +154,76 @@ export default function SearchPage() {
             })}
           </View>
         </>
+      ) : null}
+
+      {selectedMapShrine ? (
+        <View style={styles.selectedShrineWrap}>
+          <SelectedShrineMapCard
+            shrine={selectedMapShrine}
+            onDetail={() => router.push(`/shrines/${selectedMapShrine.id}`)}
+          />
+        </View>
+      ) : null}
+
+      <View style={styles.popularSection}>
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sectionTitle}>人気の神社</Text>
+          <Text style={styles.sectionCount}>3件</Text>
+        </View>
+
+        <View style={styles.popularList}>
+          {popularShrines.map((s, index) => (
+            <Pressable
+              key={s.id}
+              onPress={() => router.push(`/shrines/${s.id}`)}
+              style={({ pressed }) => [styles.popularCard, pressed && styles.cardPressed]}
+            >
+              <Text style={styles.popularRank}>{index + 1}</Text>
+              <Image source={{ uri: s.imageUrl }} style={styles.popularImage} />
+              <View style={styles.cardBody}>
+                <Text style={styles.cardName}>{s.name}</Text>
+                <Text style={styles.cardArea}>{s.prefecture}</Text>
+                <Text style={styles.popularMeta}>
+                  ★ {(s.rating ?? 4.6).toFixed(1)}　♡ {s.favorites ?? 0}
+                </Text>
+              </View>
+              <Text accessibilityElementsHidden style={styles.chevron}>
+                ›
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      </View>
+
+      {/* 地図で探す: 補助表示。Webでstyle URL未設定の間はセクション自体を表示しない */}
+      {isMapSectionAvailable ? (
+        <View style={styles.mapSection}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>地図で探す</Text>
+          </View>
+
+          {mapStatus === "loading" ? (
+            <StateCard title="地図を読み込み中" description="神社の位置情報を確認しています。" />
+          ) : null}
+
+          {mapStatus === "error" ? (
+            <View style={styles.mapErrorWrap}>
+              <StateCard title="地図を読み込めませんでした" description="通信状況を確認して、もう一度お試しください。" />
+              <Button title="もう一度試す" variant="outline" size="compact" onPress={() => void loadMapPoints()} accessibilityLabel="地図をもう一度読み込む" />
+            </View>
+          ) : null}
+
+          {mapStatus === "ready" && mapPoints.length === 0 ? (
+            <StateCard
+              title="神社が見つかりませんでした"
+              description="この検索条件に一致する神社がありません。条件を変えてもう一度お試しください。"
+            />
+          ) : null}
+
+          {mapStatus === "ready" && mapPoints.length > 0 ? (
+            <ShrineSearchMap points={mapPoints} selectedId={selectedShrineId} onSelect={setSelectedShrineId} />
+          ) : null}
+        </View>
       ) : null}
     </ScrollView>
   );
@@ -303,12 +318,12 @@ const styles = StyleSheet.create({
   mapSection: {
     marginBottom: 26,
   },
-  mapReadyWrap: {
-    gap: spacing.mdGap,
-  },
   mapErrorWrap: {
     gap: spacing.mdGap,
     alignItems: "flex-start",
+  },
+  selectedShrineWrap: {
+    marginBottom: 24,
   },
   tag: {
     borderRadius: 999,
@@ -380,6 +395,7 @@ const styles = StyleSheet.create({
   },
   list: {
     gap: 12,
+    marginBottom: 26,
   },
   card: {
     backgroundColor: theme.surface,

--- a/apps/mobile/lib/__tests__/shrineMap.test.ts
+++ b/apps/mobile/lib/__tests__/shrineMap.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { computeWebMapViewport, findShrineMapPointById, hasValidCoordinates, toShrineMapPoints } from "../shrineMap";
+import {
+  computeWebMapViewport,
+  findShrineMapPointById,
+  hasValidCoordinates,
+  isSearchMapSectionAvailable,
+  toShrineMapPoints,
+} from "../shrineMap";
 
 describe("toShrineMapPoints", () => {
   it("正常な数値座標を通す", () => {
@@ -136,6 +142,29 @@ describe("findShrineMapPointById", () => {
 
   it("idがnullならnullを返す", () => {
     expect(findShrineMapPointById(points, null)).toBeNull();
+  });
+});
+
+describe("isSearchMapSectionAvailable", () => {
+  it("Webでstyle URLが未設定の場合はfalse(地図で探すセクションを表示しない)", () => {
+    expect(isSearchMapSectionAvailable("web", undefined)).toBe(false);
+  });
+
+  it("Webでstyle URLが空文字の場合もfalse", () => {
+    expect(isSearchMapSectionAvailable("web", "")).toBe(false);
+  });
+
+  it("Webでstyle URLが設定済みの場合はtrue", () => {
+    expect(isSearchMapSectionAvailable("web", "https://example.com/style.json")).toBe(true);
+  });
+
+  it("iOSはstyle URLの有無に関わらずtrue(Nativeは常時react-native-mapsを表示する)", () => {
+    expect(isSearchMapSectionAvailable("ios", undefined)).toBe(true);
+    expect(isSearchMapSectionAvailable("ios", "https://example.com/style.json")).toBe(true);
+  });
+
+  it("Androidもstyle URLの有無に関わらずtrue", () => {
+    expect(isSearchMapSectionAvailable("android", undefined)).toBe(true);
   });
 });
 

--- a/apps/mobile/lib/shrineMap.ts
+++ b/apps/mobile/lib/shrineMap.ts
@@ -27,6 +27,16 @@ export function hasValidCoordinates(
   return point.latitude !== null && point.longitude !== null;
 }
 
+/**
+ * Search画面で「地図で探す」セクションを表示してよいか判定する。
+ * Web版はEXPO_PUBLIC_WEB_MAP_STYLE_URL未設定を初期公開の通常状態として扱い、
+ * セクション自体を表示しない(docs/product/mobile-user-flow.md 11節)。
+ * Nativeはreact-native-mapsを常時表示するため、platformOSが"web"でなければ常にtrueとする。
+ */
+export function isSearchMapSectionAvailable(platformOS: string, styleUrl: string | undefined): boolean {
+  return platformOS !== "web" || Boolean(styleUrl);
+}
+
 // selectedShrineIdから選択中の神社を導出する。Search画面・Web地図の両方から
 // 同じロジックを参照させ、selectedShrineIdの導出方法を1箇所に保つ。
 export function findShrineMapPointById(points: ShrineMapPoint[], id: string | null): ShrineMapPoint | null {


### PR DESCRIPTION
## 目的
マージ済みのProduct正本 `docs/product/mobile-user-flow.md` に合わせ、Mobile／Expo WebのSearch画面を「一覧主導」の構成へ変更する。中心課題は、地図セクションを補助的な位置へ移し、Web地図未設定時に通常一覧とfallback一覧が重複する状態を解消すること。新規監査文書は作成していない。

## 参照したProduct正本
- `docs/product/mobile-user-flow.md`(10節: 一覧の責務、11節: Web地図の責務、12節: Native地図の扱い、13節: 人気神社の責務)
- `docs/audit/mobile-user-flow-inventory.md`(12.5節: 現行のSearch画面構造・地図が主役か補助かの事実確認)

## 調査結果(実装前の確認)
- `selectedShrineId`は`apps/mobile/app/search/index.tsx`の`useState`が唯一の管理元。二重管理は元々存在しなかった
- 一覧選択・Marker選択はいずれも同じ`onSelect`(=`setSelectedShrineId`)を呼ぶ単一経路
- 選択カード(`SelectedShrineMapCard`)は`findShrineMapPointById(mapPoints, selectedShrineId)`の真偽のみで表示条件が決まり、地図の可視性とは本来独立していた(従来は地図セクション内にネストされていただけ)
- Web版`EXPO_PUBLIC_WEB_MAP_STYLE_URL`未設定時、`ShrineSearchMap.web.tsx`はMapを初期化せず内部fallback一覧を表示する一方、画面側には別データソース(`SHRINES`固定データ)による「神社一覧」セクションが常に別途存在し、未設定時は両方が表示され実質的に重複していた
- `apps/mobile/lib/shrineMap.ts`の座標欠損・選択処理(`hasValidCoordinates`/`toShrineMapPoints`/`findShrineMapPointById`)は本PRの要件に対してそのまま維持可能で、変更不要と判断した
- Search画面に直接対応する既存テストはなし(`lib/__tests__/routerStructure.test.ts`はRoute登録のみ対象)

## 変更前の表示順
戻る → Hero → 検索条件 → 地図で探す(Web未設定時はfallback一覧を含む) → 人気の神社 → 神社一覧

## 変更後の表示順
戻る → Hero → 検索条件 → 神社一覧 → (選択中の神社があれば選択カード) → 人気の神社 → 地図で探す(利用可能な場合のみ)

## Web地図未設定時の変更
- `isSearchMapSectionAvailable(Platform.OS, EXPO_PUBLIC_WEB_MAP_STYLE_URL)`(新規の純粋関数、`lib/shrineMap.ts`)がfalseを返す間、「地図で探す」セクション自体(見出し・loading/error/エラー風文言・fallback一覧のすべて)を描画しない
- 通常の神社一覧のみが主要UIとして表示される
- ブラウザ実地確認: devサーバーを再起動しstyle URL未設定のデフォルト状態で`/search`を確認し、「地図で探す」の文字列・「地図を読み込めないため一覧を表示しています。」の文言・MapLibre属性表示のいずれも一切出力されないことを確認した

## Web地図設定時に維持した挙動
- `.env`へ一時的に`EXPO_PUBLIC_WEB_MAP_STYLE_URL`(MapLibre公式デモstyle、コミットはしていない)を設定し実地確認
- 「地図で探す」が人気の神社の後に表示され、MapLibre地図・Marker・attributionが表示された
- Marker(一覧項目)クリックで`selectedShrineId`が更新され、検索条件直後の選択カードに即座に反映されることを確認
- 選択カードの「詳細を見る」から神社詳細ページへの遷移を確認
- コンソールエラーなし

## Native地図への影響
`ShrineSearchMap.native.tsx`は無変更。`isSearchMapSectionAvailable`はNativeで常にtrueを返すため、「地図で探す」セクションは従来どおり常時表示される(表示位置のみ末尾へ移動)。react-native-mapsの削除・無効化は行っていない。最終的な表示継続・優先度判断は本PRでは決定しない。

## Marker・一覧・選択カード同期への影響
壊していない。`selectedShrineId`の管理元・更新経路(一覧選択・Marker選択とも`setSelectedShrineId`)は無変更。選択カードの表示条件を地図セクションの可視性から切り離し、`selectedMapShrine`の真偽のみに単純化した(独立stateの追加はしていない)。

## 座標欠損神社への影響
`lib/shrineMap.ts`の座標欠損処理(`hasValidCoordinates`/`toShrineMapPoints`)・関連テストは無変更。既存の「地図で選択」ボタン(神社一覧内)は`mapPoints`とのID照合のみで有効/無効を判定しており、座標の有無に依存しないため、座標欠損神社も引き続き選択・選択カード表示・詳細遷移の対象として残る。

## 変更ファイル
- `apps/mobile/app/search/index.tsx`
- `apps/mobile/lib/shrineMap.ts`(`isSearchMapSectionAvailable`追加のみ、既存関数は無変更)
- `apps/mobile/lib/__tests__/shrineMap.test.ts`(上記関数のテスト追加)

`ShrineSearchMap.web.tsx`・`ShrineSearchMap.native.tsx`・`SelectedShrineMapCard.tsx`はいずれも無変更。Web未設定時、`ShrineSearchMap.web.tsx`は親から一切マウントされなくなるため、既存の内部fallback処理は安全なデッドコードとして残るのみで、動作に影響しない。

## 実行したテスト
```
pnpm install --frozen-lockfile --ignore-workspace → 成功
CI=1 pnpm exec expo install --check → 成功
pnpm typecheck → 成功
pnpm test → Test Files 15 passed / Tests 121 passed(既存116件+新規5件)
pnpm exec expo export -p web → 成功
git diff --check → 成功
```
表示順は`indexOf`等の脆い文字列比較テストでは固定せず、実装のJSX構造(コードレビューで確認可能)とブラウザでの実地確認(上記)で担保した。

## 今回変更していない範囲
Backend、`apps/web`、Recommendationロジック、API schema、Billing、Analytics event名/payload/新規追加、Home画面、Concierge画面、神社詳細画面、Searchフィルターの接続/削除、ランキング画面、人気神社の算出ロジック、Orphan画面、認証、returnTo、EAS Environment、MapTiler設定、環境変数実値、`package.json`、root `pnpm-lock.yaml`、`apps/mobile/pnpm-lock.yaml`、Mobileの`react-native-maps`依存、WebのMapLibre依存、既存監査文書、Product正本文書。

## 残存リスク
- Search画面には元々ローカルモックデータ(`SHRINES`、3件のみ)が「人気の神社」に全件割り当たり「神社一覧」が空になるため、多件数での表示順を今回のモックデータでは目視確認できなかった(既存の制約であり本PR起因ではない)。JSX構造上は神社一覧が先に定義されているため、件数が増えれば意図通りの順で表示される
- Native実機・シミュレータでの確認は今回のセッションでは実施していない(コードは無変更のため回帰リスクは低いと判断)
- 表示順の自動テストは追加していない(脆い文字列比較を避ける方針のため)。将来的な回帰は目視確認に依存する

## Rollback方法
Search画面の表示順変更・Web未設定時の分岐(`isSearchMapSectionAvailable`)・関連テストの変更をrevertすれば、従来の「地図で探す」先行表示へ戻せる。本PRの変更は3ファイル(`app/search/index.tsx`、`lib/shrineMap.ts`、`lib/__tests__/shrineMap.test.ts`)に閉じており、依存関係・lockfile・他画面への影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)