### PR TITLE
Mobile Search導線のAnalytics計測を追加

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -9,6 +9,7 @@ import { resolveGoriyakuTagIds } from "../lib/conditionPayload";
 import * as Location from "expo-location";
 import type { UserOrigin } from "../../../packages/shared/userOrigin";
 import { setOriginSession } from "../lib/originSession";
+import { trackSearchEntryClick } from "../lib/searchAnalytics";
 
 const THEMES = [
   "疲れを整えたい",
@@ -49,6 +50,7 @@ export default function Home() {
     .join(" / ");
 
   const openSearch = () => {
+    trackSearchEntryClick();
     router.push("/search");
   };
 

--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -14,6 +14,7 @@ import {
   isSearchMapSectionAvailable,
   type ShrineMapPoint,
 } from "../../lib/shrineMap";
+import { trackSearchScreenView, trackShrineCardClick } from "../../lib/searchAnalytics";
 
 const isMapSectionAvailable = isSearchMapSectionAvailable(Platform.OS, process.env.EXPO_PUBLIC_WEB_MAP_STYLE_URL);
 
@@ -26,6 +27,11 @@ export default function SearchPage() {
   const [mapPoints, setMapPoints] = React.useState<ShrineMapPoint[]>([]);
   const [mapStatus, setMapStatus] = React.useState<"loading" | "ready" | "error">("loading");
   const [selectedShrineId, setSelectedShrineId] = React.useState<string | null>(null);
+
+  // 画面マウント中は1回だけ送る(依存配列を空にして再レンダーでの重複発火を避ける)。
+  React.useEffect(() => {
+    trackSearchScreenView();
+  }, []);
 
   const loadMapPoints = React.useCallback(async () => {
     setMapStatus("loading");
@@ -113,7 +119,10 @@ export default function SearchPage() {
               return (
                 <View key={s.id} style={styles.card}>
                   <Pressable
-                    onPress={() => router.push(`/shrines/${s.id}`)}
+                    onPress={() => {
+                      trackShrineCardClick({ shrineId: s.id, position: "list" });
+                      router.push(`/shrines/${s.id}`);
+                    }}
                     style={({ pressed }) => [styles.cardMain, pressed && styles.cardPressed]}
                   >
                     <Image source={{ uri: s.imageUrl }} style={styles.cardImage} />
@@ -160,7 +169,10 @@ export default function SearchPage() {
         <View style={styles.selectedShrineWrap}>
           <SelectedShrineMapCard
             shrine={selectedMapShrine}
-            onDetail={() => router.push(`/shrines/${selectedMapShrine.id}`)}
+            onDetail={() => {
+              trackShrineCardClick({ shrineId: selectedMapShrine.id, position: "map" });
+              router.push(`/shrines/${selectedMapShrine.id}`);
+            }}
           />
         </View>
       ) : null}
@@ -175,7 +187,10 @@ export default function SearchPage() {
           {popularShrines.map((s, index) => (
             <Pressable
               key={s.id}
-              onPress={() => router.push(`/shrines/${s.id}`)}
+              onPress={() => {
+                trackShrineCardClick({ shrineId: s.id, position: "popular" });
+                router.push(`/shrines/${s.id}`);
+              }}
               style={({ pressed }) => [styles.popularCard, pressed && styles.cardPressed]}
             >
               <Text style={styles.popularRank}>{index + 1}</Text>

--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -8,6 +8,7 @@ import { kamimusubiDark as theme } from "../../design/theme";
 import { get, isUnauthenticatedError } from "../../lib/http";
 import { isLoggedIn } from "../../lib/authTokens";
 import { trackShrineDetailView, trackShrineRouteOpen } from "../../lib/shrineInteractions";
+import { trackRouteOpen } from "../../lib/searchAnalytics";
 import { spacing } from "../../design/spacing";
 import { cardSizes } from "../../design/cardSizes";
 import { radius } from "../../design/radius";
@@ -549,6 +550,9 @@ export default function ShrineDetail() {
           ctx: "mobile_shrine_detail",
         },
       });
+      // Backend保存用(trackShrineRouteOpen)とは別に、PostHog等で可視化するための
+      // track()イベントをWeb版のroute_openと同じ名前・意味で送る。
+      trackRouteOpen({ shrineId: shrineIdNumber });
     }
     const hasLatLng = typeof shrine.latitude === "number" && typeof shrine.longitude === "number";
     const destination = hasLatLng ? `${shrine.latitude},${shrine.longitude}` : encodeURIComponent(shrine.name);

--- a/apps/mobile/components/search/ShrineSearchMap.native.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.native.tsx
@@ -8,6 +8,7 @@ import { radius } from "../../design/radius";
 import { spacing } from "../../design/spacing";
 import { prefectureOrigin } from "../../../../packages/shared/userOrigin";
 import { hasValidCoordinates, type ShrineSearchMapProps } from "../../lib/shrineMap";
+import { trackMapMarkerSelect } from "../../lib/searchAnalytics";
 
 const FALLBACK_ORIGIN = prefectureOrigin("東京都");
 const FALLBACK_REGION: Region = {
@@ -52,6 +53,16 @@ export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMa
   const unmappablePoints = React.useMemo(() => points.filter((point) => !hasValidCoordinates(point)), [points]);
   const initialRegion = React.useMemo(() => buildInitialRegion(mappablePoints), [mappablePoints]);
 
+  // Marker押下・座標欠損リスト押下は「地図で選んだ」という同一の探索行動のため、
+  // 呼び出し元(神社一覧の「地図で選択」ボタン等)とは別に、ここで1箇所だけ計測する。
+  const handleSelect = React.useCallback(
+    (id: string) => {
+      trackMapMarkerSelect({ shrineId: id });
+      onSelect(id);
+    },
+    [onSelect],
+  );
+
   return (
     <View>
       <View style={styles.wrap} accessibilityLabel="検索結果の神社を地図で見る">
@@ -63,7 +74,7 @@ export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMa
                 key={point.id}
                 coordinate={{ latitude: point.latitude, longitude: point.longitude }}
                 title={point.name}
-                onPress={() => onSelect(point.id)}
+                onPress={() => handleSelect(point.id)}
                 accessibilityRole="button"
                 accessibilityLabel={selected ? `${point.name}を選択、選択中` : `${point.name}を選択`}
                 accessibilityState={{ selected }}
@@ -84,7 +95,7 @@ export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMa
               return (
                 <Pressable
                   key={point.id}
-                  onPress={() => onSelect(point.id)}
+                  onPress={() => handleSelect(point.id)}
                   accessibilityRole="button"
                   accessibilityLabel={selected ? `${point.name}を選択、選択中` : `${point.name}を選択`}
                   accessibilityState={{ selected }}

--- a/apps/mobile/components/search/ShrineSearchMap.web.tsx
+++ b/apps/mobile/components/search/ShrineSearchMap.web.tsx
@@ -13,6 +13,7 @@ import {
   type ShrineMapPoint,
   type ShrineSearchMapProps,
 } from "../../lib/shrineMap";
+import { trackMapMarkerSelect } from "../../lib/searchAnalytics";
 
 // 公開クライアント用のstyle URL。secretはコードへ直書きせず、未設定時は
 // Mapを生成せず既存の一覧fallbackを表示する。domain制限・使用量制限は
@@ -45,7 +46,10 @@ function createMarkerElement(
   element.style.cursor = "pointer";
   element.style.transition = "transform 0.1s ease-out";
 
-  const select = () => onSelectRef.current(point.id);
+  const select = () => {
+    trackMapMarkerSelect({ shrineId: point.id });
+    onSelectRef.current(point.id);
+  };
   element.addEventListener("click", select);
   element.addEventListener("keydown", (event) => {
     if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
@@ -189,7 +193,10 @@ export function ShrineSearchMap({ points, selectedId, onSelect }: ShrineSearchMa
             return (
               <Pressable
                 key={point.id}
-                onPress={() => onSelect(point.id)}
+                onPress={() => {
+                  trackMapMarkerSelect({ shrineId: point.id });
+                  onSelect(point.id);
+                }}
                 accessibilityRole="button"
                 accessibilityLabel={selected ? `${point.name}を選択、選択中` : `${point.name}を選択`}
                 accessibilityState={{ selected }}

--- a/apps/mobile/lib/__tests__/searchAnalytics.test.ts
+++ b/apps/mobile/lib/__tests__/searchAnalytics.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { vi } from "vitest";
+
+// __DEV__ は Metro/React Native が注入するグローバルで、vitest実行環境には存在しないため定義する。
+(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+
+import { setAnalyticsProvider, type AnalyticsProvider } from "../analytics";
+import {
+  trackMapMarkerSelect,
+  trackRouteOpen,
+  trackSearchEntryClick,
+  trackSearchScreenView,
+  trackShrineCardClick,
+} from "../searchAnalytics";
+
+describe("searchAnalytics", () => {
+  const trackSpy = vi.fn();
+
+  beforeEach(() => {
+    const customProvider: AnalyticsProvider = { track: trackSpy };
+    setAnalyticsProvider(customProvider);
+  });
+
+  afterEach(() => {
+    trackSpy.mockClear();
+    setAnalyticsProvider(null);
+  });
+
+  it("trackSearchEntryClickはsource:home/platform:mobileのみを送る", () => {
+    trackSearchEntryClick();
+
+    expect(trackSpy).toHaveBeenCalledWith("search_entry_click", { source: "home", platform: "mobile" });
+    expect(trackSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("trackSearchScreenViewはsource:mobile_search/platform:mobileを送る", () => {
+    trackSearchScreenView();
+
+    expect(trackSpy).toHaveBeenCalledWith("search_screen_view", { source: "mobile_search", platform: "mobile" });
+  });
+
+  it("trackShrineCardClickはposition:listでsource:mobile_searchを送る", () => {
+    trackShrineCardClick({ shrineId: "1", position: "list" });
+
+    expect(trackSpy).toHaveBeenCalledWith("shrine_card_click", {
+      source: "mobile_search",
+      shrineId: "1",
+      position: "list",
+      platform: "mobile",
+    });
+  });
+
+  it("trackShrineCardClickはposition:popularでsource:mobile_searchを送り、一覧と区別できる", () => {
+    trackShrineCardClick({ shrineId: "2", position: "popular" });
+
+    expect(trackSpy).toHaveBeenCalledWith("shrine_card_click", {
+      source: "mobile_search",
+      shrineId: "2",
+      position: "popular",
+      platform: "mobile",
+    });
+  });
+
+  it("trackShrineCardClickはposition:mapでsource:mapを送る(選択カードからの詳細遷移)", () => {
+    trackShrineCardClick({ shrineId: "3", position: "map" });
+
+    expect(trackSpy).toHaveBeenCalledWith("shrine_card_click", {
+      source: "map",
+      shrineId: "3",
+      position: "map",
+      platform: "mobile",
+    });
+  });
+
+  it("trackMapMarkerSelectはsource:map/position:mapを送り、shrine_card_clickとは別Event名である", () => {
+    trackMapMarkerSelect({ shrineId: "4" });
+
+    expect(trackSpy).toHaveBeenCalledWith("map_marker_select", {
+      source: "map",
+      shrineId: "4",
+      position: "map",
+      platform: "mobile",
+    });
+    expect(trackSpy.mock.calls[0][0]).not.toBe("shrine_card_click");
+  });
+
+  it("trackRouteOpenはsource:shrine_detail/routeTarget:google_mapsを送る(URL・住所・緯度経度は含まない)", () => {
+    trackRouteOpen({ shrineId: 5 });
+
+    expect(trackSpy).toHaveBeenCalledWith("route_open", {
+      source: "shrine_detail",
+      shrineId: 5,
+      routeTarget: "google_maps",
+      platform: "mobile",
+    });
+    const payload = trackSpy.mock.calls[0][1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("url");
+    expect(payload).not.toHaveProperty("address");
+    expect(payload).not.toHaveProperty("latitude");
+    expect(payload).not.toHaveProperty("longitude");
+  });
+
+  it("全EventのPayloadはprimitive値のみで構成される(nested object・配列を含まない)", () => {
+    trackSearchEntryClick();
+    trackSearchScreenView();
+    trackShrineCardClick({ shrineId: "1", position: "list" });
+    trackMapMarkerSelect({ shrineId: "1" });
+    trackRouteOpen({ shrineId: "1" });
+
+    for (const call of trackSpy.mock.calls) {
+      const payload = call[1] as Record<string, unknown>;
+      for (const value of Object.values(payload)) {
+        expect(value === null || ["string", "number", "boolean"].includes(typeof value)).toBe(true);
+      }
+    }
+  });
+
+  it("禁止属性(相談文・検索語・住所・緯度経度・style URL・APIキー等)を一切含まない", () => {
+    trackSearchEntryClick();
+    trackSearchScreenView();
+    trackShrineCardClick({ shrineId: "1", position: "popular" });
+    trackMapMarkerSelect({ shrineId: "1" });
+    trackRouteOpen({ shrineId: "1" });
+
+    const forbiddenKeys = [
+      "query",
+      "consultationText",
+      "address",
+      "stationName",
+      "prefecture",
+      "latitude",
+      "longitude",
+      "birthdate",
+      "plannedVisitDate",
+      "supportText",
+      "styleUrl",
+      "apiKey",
+      "mapTilerKey",
+      "googleMapsUrl",
+      "username",
+      "email",
+      "token",
+      "cookie",
+    ];
+
+    for (const call of trackSpy.mock.calls) {
+      const payload = call[1] as Record<string, unknown>;
+      for (const key of forbiddenKeys) {
+        expect(payload).not.toHaveProperty(key);
+      }
+    }
+  });
+});

--- a/apps/mobile/lib/searchAnalytics.ts
+++ b/apps/mobile/lib/searchAnalytics.ts
@@ -1,0 +1,55 @@
+// Mobile Search導線(Home入口・Search画面・一覧/人気神社/地図からの選択・詳細遷移・
+// 外部経路CTA)のAnalytics契約を集約するhelper。
+//
+// Event名・Payloadの根拠は docs/analytics/mobile-search-events.md を正本とする。
+// track()自体がnull/undefined除去・primitive型への制限・送信失敗の握り潰しを担うため、
+// ここではEvent名とPayloadの型・組み立てのみに責務を絞る(UIからPostHog providerを直接呼ばない)。
+import { track } from "./analytics";
+
+const SOURCE_HOME = "home";
+const SOURCE_SEARCH = "mobile_search";
+const SOURCE_MAP = "map";
+const SOURCE_SHRINE_DETAIL = "shrine_detail";
+
+export type SearchCardPosition = "list" | "popular" | "map";
+
+export function trackSearchEntryClick(): void {
+  track("search_entry_click", { source: SOURCE_HOME, platform: "mobile" });
+}
+
+export function trackSearchScreenView(): void {
+  track("search_screen_view", { source: SOURCE_SEARCH, platform: "mobile" });
+}
+
+// 神社一覧・人気の神社・地図選択カードいずれも「カードを押して神社詳細へ進む」という
+// 同じ行動のため、position(list/popular/map)だけで区別しEvent名は1つに揃える。
+export function trackShrineCardClick(params: { shrineId: string; position: SearchCardPosition }): void {
+  track("shrine_card_click", {
+    source: params.position === "map" ? SOURCE_MAP : SOURCE_SEARCH,
+    shrineId: params.shrineId,
+    position: params.position,
+    platform: "mobile",
+  });
+}
+
+// 地図上でMarker(または座標欠損リスト・Web fallback一覧)を選択した操作。
+// 神社詳細への遷移ではないため、trackShrineCardClickとは別Eventとして扱う。
+export function trackMapMarkerSelect(params: { shrineId: string }): void {
+  track("map_marker_select", {
+    source: SOURCE_MAP,
+    shrineId: params.shrineId,
+    position: "map",
+    platform: "mobile",
+  });
+}
+
+// 神社詳細画面の外部経路CTA(Googleマップ起動)。Web版のroute_openと同一Event名・
+// 同一の意味で送る(source/routeTargetの値も揃える)。
+export function trackRouteOpen(params: { shrineId: string | number }): void {
+  track("route_open", {
+    source: SOURCE_SHRINE_DETAIL,
+    shrineId: params.shrineId,
+    routeTarget: "google_maps",
+    platform: "mobile",
+  });
+}

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -17,6 +17,7 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 | ドキュメント | 責務 |
 | --- | --- |
 | `direction-events.md` | Web／Mobile共通の方位分析Event名・Payload・禁止属性契約を管理する |
+| `mobile-search-events.md` | Mobile Search導線(Home入口・画面表示・一覧/人気神社/地図からの詳細遷移・外部経路CTA)のEvent名・Payload・禁止属性契約を管理する |
 | `direction-analytics-dashboard.md` | 方位利用ファネル、KPI、PostHog設定案、異常値・日盤検討基準を管理する |
 | `direction-analytics-data-quality.md` | 方位Eventの機械可読品質契約、重複・欠損・禁止属性、障害調査手順を管理する |
 | `action-suggestion-funnel.md` | Action Suggestion関連Event（PostHog view計測 / Backend `ActionEvent`）の現状を管理する |

--- a/docs/analytics/mobile-search-events.md
+++ b/docs/analytics/mobile-search-events.md
@@ -1,0 +1,74 @@
+> **Status: Active / Contract**
+
+# Mobile Search導線のイベント契約
+
+Mobile／Expo WebのHome→Search入口、Search画面、神社一覧・人気の神社・地図(Marker/選択カード)からの神社詳細遷移、および神社詳細の外部経路CTAを対象とするEvent契約を管理する。実装は`apps/mobile/lib/searchAnalytics.ts`を正本とし、送信はMobile既存の`track()`パイプライン(`apps/mobile/lib/analytics.ts`)へ委譲する。
+
+`shrine_card_click`・`route_open`はWeb版(`apps/web/src/lib/analytics/searchEvents.ts`)と同一のEvent名を再利用する。Web側にこれらのEvent専用のActive契約文書は存在しないため(実装コードのみが正本)、本書はMobile側の発火条件・Payloadのみを規定し、Web側の実装・契約は変更しない。
+
+| Event | 発火条件 | Payload | 重複の単位 |
+| --- | --- | --- | --- |
+| `search_entry_click` | Homeの「神社を地図・一覧から探す」CTAを押した操作 | `source: "home"`, `platform: "mobile"` | クリックごと |
+| `search_screen_view` | Search画面(`/search`)がマウントされたとき | `source: "mobile_search"`, `platform: "mobile"` | 画面マウント中に1回(`React.useEffect`の空配列依存で再レンダーでの重複を防ぐ) |
+| `shrine_card_click` | 神社一覧・人気の神社・地図選択カードのいずれかから、神社詳細への遷移操作を行ったとき(カードの単なる表示では発火しない) | `source`(`"mobile_search"` \| `"map"`), `shrineId`, `position`(`"list"` \| `"popular"` \| `"map"`), `platform: "mobile"` | 遷移操作ごと |
+| `map_marker_select` | Marker(Native/Web)、Native座標欠損リスト、Web fallback一覧のいずれかで神社を選択した操作(神社詳細への遷移ではない) | `source: "map"`, `shrineId`, `position: "map"`, `platform: "mobile"` | 選択操作ごと(同じ神社の再選択も1回として送る) |
+| `route_open` | 神社詳細画面の外部経路CTA(Googleマップ起動)を押した操作 | `source: "shrine_detail"`, `shrineId`, `routeTarget: "google_maps"`, `platform: "mobile"` | クリックごと |
+
+## `position`の扱い(Webとの差分)
+
+Web版`SearchAnalyticsPayload`の`position`型は`"hero_primary" | "compact" | "map" | "list"`であり、`"popular"`を含まない。Mobile側のSearch画面には「人気の神社」という、Web側に存在しない独立セクションがあるため、Mobile専用の`position: "popular"`を追加する。
+
+- `shrine_card_click`のEvent名自体はWebと共通のまま再利用する
+- `position`の値は、Webの既存3値(`hero_primary`/`compact`/`map`/`list`のうちMobileで使うのは`map`/`list`)に`popular`を追加した形で送信する
+- Web側の型定義・実装は変更しない(`SearchAnalyticsPayload`は`[key: string]: SearchAnalyticsPrimitive`という索引シグネチャを持ち、追加のprimitive値を許容する構造のため、Mobileからの`position: "popular"`送信はWeb側の契約を破壊しない)
+
+## `map_marker_select`と`shrine_card_click`の分離
+
+地図上でMarker(または座標欠損リスト、Web fallback一覧)を選択する行動と、選択後に神社詳細へ進む行動は別行動として扱う。
+
+- Markerや地図内一覧を選んだだけでは`map_marker_select`のみを送信し、`shrine_card_click`は送らない
+- 選択カードの「詳細を見る」を押した時点で`shrine_card_click`(`position: "map"`)を送信する
+- 両者が同時に発火することはない(選択操作と遷移操作は別のUI操作である)
+
+## `route_open`のWeb契約との一致
+
+`apps/web/src/components/shrine/GoogleMapRouteLink.tsx`の`route_open`は`{source: "shrine_detail", routeTarget: "google_maps", shrineId, threadId, historyTheme, ctx}`を送信する。Mobileは`threadId`・`historyTheme`・`ctx`をWeb固有Payloadとして送信せず、`source`・`shrineId`・`routeTarget`のみをWebと同じ意味・同じ値で送信する。
+
+`apps/mobile/lib/shrineInteractions.ts`の`trackShrineRouteOpen`(Backend `/shrine-interactions/`へのPOST)は本契約と別系統であり、本書の対象外とする。両者は同じユーザー操作から呼ばれるが、送信先(PostHog系 / Backend保存系)が異なるため重複計測とはみなさない。
+
+## 神社詳細への入口source
+
+`apps/mobile/app/shrines/[id].tsx`の`trackShrineDetailView`は、入口(神社一覧/人気の神社/地図/コンシェルジュ等)によらず`source: "mobile_shrine_detail"`固定のままとする(変更しない)。入口の識別は、Search側で発火する`shrine_card_click`・`map_marker_select`の`position`で行う。神社詳細画面表示イベント自体の入口別source識別は、今回のスコープに含めない(`docs/audit/mobile-user-flow-inventory.md` 9節・14節、`docs/product/mobile-user-flow.md` 9節を参照)。
+
+## 禁止属性
+
+次の値はEvent名を問わず送信しない。
+
+- 相談文、検索語、自由入力条件
+- 住所、駅名、都道府県名、緯度・経度
+- 誕生日、参拝予定日
+- style URL、APIキー、MapTilerキー
+- Google MapsのURL全文
+- ユーザー名、メールアドレス、トークン、Cookie
+- APIレスポンス全文、Recommendation本文、`reasonFacts`全文
+
+`shrineId`・`source`・`position`・`routeTarget`・`platform`のみを許可する。
+
+## Payload型
+
+- primitive型(string/number/boolean)のみを許可する
+- nested object・配列を送らない
+- `null`/`undefined`は送信前に除外する(`apps/mobile/lib/analytics.ts`の`serializeAnalyticsPayload`が構造的に担う)
+
+## 重複防止
+
+- `search_screen_view`は画面マウント時の`useEffect`(空配列依存)でのみ発火し、再レンダーでは発火しない
+- `map_marker_select`と`shrine_card_click`(`position: "map"`)は別Event・別UI操作であり、同じ操作で二重発火しない
+- `shrine_card_click`は「一覧」「人気の神社」「選択カード」のいずれか1つのUI要素からのみ発火し、同一クリックで複数箇所から発火しない
+- `route_open`(本契約、PostHog系)と`trackShrineRouteOpen`(Backend `/shrine-interactions/`POST系)は送信先が異なる別系統として扱い、本書では重複とみなさない
+
+## 変更ルール
+
+- Event名またはPayloadを変更する場合は、`apps/mobile/lib/searchAnalytics.ts`と本書を同じPRで更新する
+- `position`に新しい値を追加する場合は、Web側の`SearchAnalyticsPayload`型と意味が衝突しないことを確認したうえで本書へ追記する
+- 本書はMobile Search導線のEvent契約のみを管理する。Web側の実装・契約(`apps/web/src/lib/analytics/searchEvents.ts`)は変更しない


### PR DESCRIPTION
## 目的

Mobile Search導線(Home入口〜Search画面〜神社詳細遷移〜外部経路CTA)にAnalytics計測が存在せず、どの入口(一覧/人気の神社/地図)から神社詳細へ遷移しているかを判別できない状態だった。既存のAnalytics契約・実装パターンに沿って最小限の計測を追加する。

## 参照したActive Analytics文書

- `docs/analytics/README.md`(Active/Reference/Archive分類の正本。Search導線を管轄するActive文書が存在しないことを確認)
- `docs/analytics/direction-events.md`(Event契約文書の構成テンプレートとして参照)

## Archive文書を使用していないこと

`docs/analytics/README.md`のArchiveテーブルに掲載された文書(`analytics-card-events.md`等)は現行契約として参照していない。現行の計測契約判断は実装コード・テスト・本PRで追加するActive文書のみを正本とした。

## Web Search Analyticsの確認結果

`apps/web/src/lib/analytics/searchEvents.ts`を確認し、以下を把握した。

- `SearchAnalyticsEventName`のうち`map_search`・`shrine_search`は型定義のみでgrep上どこからも呼び出されておらず、実質未使用(dead code)。再利用対象から除外した。
- `shrine_card_click`(`ShrineCard.tsx`、Link onClickで`{source, shrineId}`を送信)と`route_open`(`GoogleMapRouteLink.tsx`、`{source, routeTarget, shrineId, threadId, historyTheme, ctx}`を送信)は実際に発火している実装であり、Mobileから意味を合わせて再利用可能と判断した。
- `shrine_detail_transition`はConciergeの候補カードからのみ発火し、Payloadがresult set/rank等Concierge固有の構造であるため、Search画面のカードクリックへは転用しなかった。
- `SearchAnalyticsPayload`は`[key: string]: SearchAnalyticsPrimitive`という索引シグネチャを持ち、追加のprimitive値を許容する型のため、Mobile専用の`position: "popular"`追加はWeb契約を破壊しない。

## Mobile既存Analyticsの確認結果

- `apps/mobile/lib/analytics.ts`の`track()`パイプライン(dev: `ConsoleAnalyticsProvider`、prod: `PostHogAnalyticsProvider`)がPostHog系の計測の正本であることを確認した。
- `apps/mobile/lib/premiumAnalytics.ts`・`visitReflectionAnalytics.ts`が「固定`SOURCE`定数 + `track()`を呼ぶ薄い関数」という確立されたヘルパーパターンを持つことを確認し、同じパターンで`searchAnalytics.ts`を実装した。
- `apps/mobile/lib/shrineInteractions.ts`はBackend `/shrine-interactions/`へ直接POSTする別系統(PostHogには送られない)であり、`apps/mobile/app/shrines/[id].tsx`の`trackShrineRouteOpen`が既にこの系統でGoogleマップ起動を記録していることを確認した。今回追加する`route_open`(PostHog系)とは送信先が異なるため、二重計測とはみなさない。

## 再利用したEvent名

- `shrine_card_click`(Web`ShrineCard.tsx`と同一Event名。Payloadに`position: "popular"`をMobile専用値として追加)
- `route_open`(Web`GoogleMapRouteLink.tsx`と同一Event名・同一意味。`threadId`/`historyTheme`/`ctx`はWeb固有のため送信しない)

## 新規Event名がある場合の理由

- `search_entry_click`: HomeからSearchへのCTAクリックを表すEventがWeb側に存在しないため新規追加。
- `search_screen_view`: Search画面のマウントを表すEventがWeb側に存在しないため新規追加。
- `map_marker_select`: 地図上でのMarker選択(神社詳細への遷移ではない探索行動)を表すEventがWeb側に存在しないため新規追加。`shrine_card_click`と混同しないよう明確に分離した。

## Payload一覧

| Event | Payload |
| --- | --- |
| `search_entry_click` | `source: "home"`, `platform: "mobile"` |
| `search_screen_view` | `source: "mobile_search"`, `platform: "mobile"` |
| `shrine_card_click` | `source`, `shrineId`, `position`(`"list"` \| `"popular"` \| `"map"`), `platform: "mobile"` |
| `map_marker_select` | `source: "map"`, `shrineId`, `position: "map"`, `platform: "mobile"` |
| `route_open` | `source: "shrine_detail"`, `shrineId`, `routeTarget: "google_maps"`, `platform: "mobile"` |

## Payload禁止属性

相談文・検索語・自由入力条件・住所・駅名・都道府県名・緯度経度・誕生日・参拝予定日・style URL・APIキー・MapTilerキー・Google MapsのURL全文・ユーザー名・メールアドレス・トークン・Cookie・APIレスポンス全文・Recommendation本文・`reasonFacts`全文は一切送信していない。許可した属性は`shrineId`・`source`・`position`・`routeTarget`・`platform`のみ。テスト(`searchAnalytics.test.ts`)でこれらの禁止キーが含まれないことを網羅的に確認している。

## 各Eventの発火条件

- `search_entry_click`: Homeの「神社を地図・一覧から探す」CTA押下時
- `search_screen_view`: Search画面(`/search`)マウント時(`useEffect`空配列依存で1回のみ)
- `shrine_card_click`: 神社一覧・人気の神社・地図の選択カードのいずれかから神社詳細へ遷移する操作時(単なる表示では発火しない)
- `map_marker_select`: Marker(Native/Web)・Native座標欠損リスト・Web fallback一覧いずれかでの選択操作時
- `route_open`: 神社詳細画面の「地図で経路を確認する」CTA押下時

## 重複防止方法

- `search_screen_view`は`React.useEffect(() => {...}, [])`の空配列依存で1回のみ発火し、`selectedShrineId`等の状態変化による再レンダーでは発火しない。
- `map_marker_select`と`shrine_card_click`(`position: "map"`)は別UI操作(選択 vs 詳細遷移)から発火する別Eventであり、同一操作での二重発火はない。
- `route_open`(PostHog系)と既存の`trackShrineRouteOpen`(Backend POST系)は送信先が異なる別系統として扱い、同一クリックからの2系統発火は意図した設計であり重複ではない。
- React Strict Mode/Expo Web開発時の挙動をブラウザで実機確認した結果、コンソールに同一Eventが2行表示される事象を観測したが、他の既存ログ(`Running application "main"`等、本来1回しか呼ばれない起動ログ)にも同一パターンの2行表示が見られたため、これはブラウザ計測ツールのコンソールキャプチャがオブジェクト引数を2表現で記録する表示上のアーティファクトであり、`track()`自体の二重呼び出しではないと判断した。

## Home→Searchの計測

`apps/mobile/app/index.tsx`の`openSearch`内で`trackSearchEntryClick()`を呼び出し、`source: "home"`で送信する。

## 一覧／人気神社／地図の識別方法

`shrine_card_click`の`position`フィールドで区別する。`apps/mobile/app/search/index.tsx`内の3箇所の遷移操作(神社一覧カードの`onPress`は`position: "list"`、人気の神社カードの`onPress`は`position: "popular"`、選択中の地図カード(`SelectedShrineMapCard`)の`onDetail`は`position: "map"`)にそれぞれ異なる`position`を指定して呼び分けている。

## 神社詳細sourceの扱い

案A(Search側の遷移Eventのみで入口を識別し、`apps/mobile/app/shrines/[id].tsx`の`trackShrineDetailView`が送る`source: "mobile_shrine_detail"`固定値は変更しない)を採用した。入口ごとに神社詳細画面自体のsourceを可変にする案B(Route paramを経由した追加実装)は、既存の`returnTo`や画面遷移ロジックへの影響範囲が今回のスコープを超えるため採用しなかった。詳細は`docs/analytics/mobile-search-events.md`の「神社詳細への入口source」節に記載した。

## 外部経路CTAの扱い

`apps/mobile/app/shrines/[id].tsx`の`openDirections`内、既存の`trackShrineRouteOpen`(Backend POST系)呼び出しの直後に`trackRouteOpen({ shrineId })`(PostHog系、Web`route_open`と同一Event名・同一意味)を追加した。Web側の`threadId`/`historyTheme`/`ctx`はMobileには存在しない、または送信対象外のためPayloadに含めていない。

## 変更ファイル

- `apps/mobile/lib/searchAnalytics.ts`(新規)
- `apps/mobile/lib/__tests__/searchAnalytics.test.ts`(新規)
- `apps/mobile/app/index.tsx`
- `apps/mobile/app/search/index.tsx`
- `apps/mobile/app/shrines/[id].tsx`
- `apps/mobile/components/search/ShrineSearchMap.native.tsx`
- `apps/mobile/components/search/ShrineSearchMap.web.tsx`
- `docs/analytics/mobile-search-events.md`(新規、Active/Contract)
- `docs/analytics/README.md`(Activeテーブルに1行追加)

## 実行したテスト

- `apps/mobile/lib/__tests__/searchAnalytics.test.ts`: Event名・Payload型・禁止キー不在・primitive-onlyをユニットテストで検証(9 tests)
- `pnpm install --frozen-lockfile --ignore-workspace`(`apps/mobile`)
- `CI=1 pnpm exec expo install --check`(`apps/mobile`)
- `pnpm typecheck`(`apps/mobile`)
- `pnpm test`(`apps/mobile`、130/130 pass)
- `pnpm exec expo export -p web`(`apps/mobile`、export成功を確認後dist削除)
- `git diff --check && git status --short --branch`(差分の空白エラーなし、変更ファイルが想定の9件のみであることを確認)
- ブラウザでの実地確認(Expo Web dev server): `search_entry_click`・`search_screen_view`・`shrine_card_click`(list/popular/map全position)・`map_marker_select`・`route_open`の全5 Eventが実際に発火することをコンソールログで確認した。`map_marker_select`検証時のみ`.env`に`EXPO_PUBLIC_WEB_MAP_STYLE_URL`を一時設定し、確認後に元の内容(`EXPO_PUBLIC_API_BASE_URL`のみ)へ復元した。

## 今回変更していない範囲

Backend Recommendation実装・APIスキーマ・Billing/Premium導線・Search画面のUIレイアウト・人気神社の配置ロジック・Search Filter仕様・Native/Web地図の表示ポリシー・MapTiler設定・EAS Environment・実際の環境変数値・Home画面の文言・コンシェルジュUI・記録から再相談への導線・孤立画面・認証・`returnTo`挙動・`package.json`・ルート/Mobileの`pnpm-lock.yaml`・Archive文書・本PR対象外のAnalytics Event。`apps/web`配下のコードは変更していない。

## 残存リスク

- PostHog本番環境での実発火確認は未実施(dev環境の`ConsoleAnalyticsProvider`経由でのみ確認)。prod切り替え後の`PostHogAnalyticsProvider`側の実送信確認は別途必要。
- Native実機/シミュレータでの`map_marker_select`発火確認は未実施(本セッション全体を通じてNative Simulator検証が不安定なため、Web版での確認と静的コードレビューで代替した。Native側の`onSelect`呼び出し箇所は`ShrineSearchMap.native.tsx`の`handleSelect`に集約されており、Web版と同一ロジック構造であることをコード上で確認済み)。
- ブラウザコンソールでの2行表示アーティファクトについて、tooling起因と判断したが、100%排除しきれない可能性を考慮し、今後同種の疑義が出た場合は`track()`呼び出し箇所への直接ログ計測等での再検証を推奨する。

## Rollback方法

本PRの変更(`searchAnalytics.ts`の追加、各画面での発火コード追加、テスト追加、`docs/analytics/mobile-search-events.md`の追加とREADMEへの登録)を丸ごとrevertすることで、計測追加前の挙動(Home→Search遷移・Search画面表示・神社詳細遷移・外部経路CTAのいずれもAnalytics非計測)に完全に戻る。既存の`trackShrineRouteOpen`(Backend POST系)や神社詳細画面自体の`trackShrineDetailView`など、本PR対象外の計測ロジックには一切手を加えていないため、rollback時にそれらへの影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)