### PR TITLE
Mobile人気神社を既存APIへ接続

### DIFF
--- a/apps/mobile/app/ranking/index.tsx
+++ b/apps/mobile/app/ranking/index.tsx
@@ -1,9 +1,10 @@
 // apps/mobile/app/ranking/index.tsx
 import * as React from "react";
-import { Animated, ScrollView, View, Text, Image, Pressable, StyleSheet } from "react-native";
+import { Animated, ScrollView, View, Text, Pressable, StyleSheet } from "react-native";
 import { useRouter, useFocusEffect } from "expo-router";
-import { SHRINES } from "../../data/shrines";
+import { fetchPopularShrines, type PopularShrine } from "../../lib/popularShrines";
 import { getFavorites, toggleFavorite } from "../../lib/storage";
+import { StateCard } from "../../components/common/StateCard";
 import Button from "../../components/ui/Button";
 import { kamimusubiDark } from "../../design/theme";
 import { spacing } from "../../design/spacing";
@@ -54,8 +55,26 @@ function FavoriteHeartButton({ favored, onPress }: FavoriteHeartButtonProps) {
 export default function RankingPage() {
   const router = useRouter();
 
-  // お気に入り数の多い順で表示
-  const items = React.useMemo(() => [...SHRINES].sort((a, b) => (b.favorites ?? 0) - (a.favorites ?? 0)), []);
+  const [items, setItems] = React.useState<PopularShrine[]>([]);
+  const [status, setStatus] = React.useState<"loading" | "ready" | "error">("loading");
+
+  // Backend(/populars/)が返す順序(popular_score降順)をそのまま維持し、Mobile側で再ソートしない。
+  // 画面マウント時に1回だけ取得する(Search画面のloadPopularShrinesと同じ契約)。
+  const loadItems = React.useCallback(async () => {
+    setStatus("loading");
+    try {
+      const shrines = await fetchPopularShrines();
+      setItems(shrines);
+      setStatus("ready");
+    } catch {
+      setItems([]);
+      setStatus("error");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void loadItems();
+  }, [loadItems]);
 
   // お気に入り集合（ハイライト判定用）
   const [favSet, setFavSet] = React.useState<Set<string>>(new Set());
@@ -105,7 +124,7 @@ export default function RankingPage() {
           marginBottom: spacing.xlGap,
         }}
       >
-        保存数の多い神社を、参拝先選びの補助として見られます。
+        人気の神社を、参拝先選びの補助として見られます。
       </Text>
 
       <View style={{ flexDirection: "row", alignItems: "center", marginBottom: spacing.lgGap }}>
@@ -127,29 +146,50 @@ export default function RankingPage() {
         </Text>
       </View>
 
-      {list.map((s, idx) => {
-        const favored = favSet.has(s.id);
-        return (
-          <Pressable
-            key={s.id}
-            onPress={() => router.push(`/shrines/${s.id}`)}
-            style={[styles.card, favored && styles.cardFav]}
-          >
-            <Text style={styles.rank}>{idx + 1}</Text>
-            <Image source={{ uri: s.imageUrl }} style={styles.thumb} />
-            <View style={{ flex: 1 }}>
-              <Text style={styles.name}>{s.name}</Text>
-              <Text style={styles.sub}>{s.prefecture}</Text>
-              <Text style={styles.meta}>
-                ★ {(s.rating ?? 4.6).toFixed(1)}　♡ {s.favorites ?? 0}
-              </Text>
-              {favored && <Text style={styles.savedHint}>記録タブで確認できます</Text>}
-            </View>
+      {status === "loading" ? <StateCard title="読み込み中" description="人気の神社を確認しています。" /> : null}
 
-            <FavoriteHeartButton favored={favored} onPress={() => onToggleFav(s.id)} />
-          </Pressable>
-        );
-      })}
+      {status === "error" ? (
+        <View style={{ gap: spacing.mdGap, alignItems: "flex-start" }}>
+          <StateCard title="読み込めませんでした" description="通信状況を確認して、もう一度お試しください。" />
+          <Button
+            title="もう一度試す"
+            variant="outline"
+            size="compact"
+            onPress={() => void loadItems()}
+            accessibilityLabel="人気の神社をもう一度読み込む"
+          />
+        </View>
+      ) : null}
+
+      {status === "ready" && list.length === 0 ? (
+        <StateCard title="現在表示できる人気の神社がありません" description="条件を変えて、もう一度お試しください。" />
+      ) : null}
+
+      {status === "ready"
+        ? list.map((s, idx) => {
+            const favored = favSet.has(s.id);
+            return (
+              <Pressable
+                key={s.id}
+                onPress={() => router.push(`/shrines/${s.id}`)}
+                style={[styles.card, favored && styles.cardFav]}
+              >
+                <Text style={styles.rank}>{idx + 1}</Text>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.name}>{s.name}</Text>
+                  {s.address ? (
+                    <Text style={styles.sub} numberOfLines={1}>
+                      {s.address}
+                    </Text>
+                  ) : null}
+                  {favored && <Text style={styles.savedHint}>記録タブで確認できます</Text>}
+                </View>
+
+                <FavoriteHeartButton favored={favored} onPress={() => onToggleFav(s.id)} />
+              </Pressable>
+            );
+          })
+        : null}
     </ScrollView>
   );
 }
@@ -180,13 +220,6 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     marginRight: spacing.mdGap,
   },
-  thumb: {
-    width: 68,
-    height: 52,
-    borderRadius: radius.xs,
-    marginRight: spacing.lgGap,
-    backgroundColor: kamimusubiDark.surfaceSoft,
-  },
   name: {
     color: kamimusubiDark.text,
     fontWeight: "700",
@@ -196,11 +229,6 @@ const styles = StyleSheet.create({
     color: kamimusubiDark.muted,
     fontSize: 12,
     marginTop: 3,
-  },
-  meta: {
-    color: kamimusubiDark.goldSoft,
-    fontSize: 12,
-    marginTop: 5,
   },
   savedHint: {
     color: kamimusubiDark.mutedSoft,

--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -14,6 +14,7 @@ import {
   isSearchMapSectionAvailable,
   type ShrineMapPoint,
 } from "../../lib/shrineMap";
+import { fetchPopularShrines, type PopularShrine } from "../../lib/popularShrines";
 import { trackSearchScreenView, trackShrineCardClick } from "../../lib/searchAnalytics";
 
 const isMapSectionAvailable = isSearchMapSectionAvailable(Platform.OS, process.env.EXPO_PUBLIC_WEB_MAP_STYLE_URL);
@@ -27,6 +28,8 @@ export default function SearchPage() {
   const [mapPoints, setMapPoints] = React.useState<ShrineMapPoint[]>([]);
   const [mapStatus, setMapStatus] = React.useState<"loading" | "ready" | "error">("loading");
   const [selectedShrineId, setSelectedShrineId] = React.useState<string | null>(null);
+  const [popularShrines, setPopularShrines] = React.useState<PopularShrine[]>([]);
+  const [popularStatus, setPopularStatus] = React.useState<"loading" | "ready" | "error">("loading");
 
   // 画面マウント中は1回だけ送る(依存配列を空にして再レンダーでの重複発火を避ける)。
   React.useEffect(() => {
@@ -49,6 +52,24 @@ export default function SearchPage() {
     void loadMapPoints();
   }, [loadMapPoints]);
 
+  // 「人気の神社」だけをloading/error対象にし、通常一覧・地図には影響させない。
+  // loadMapPointsと同じ「マウント時に1回取得、再レンダーでは取得し直さない」契約に揃える。
+  const loadPopularShrines = React.useCallback(async () => {
+    setPopularStatus("loading");
+    try {
+      const shrines = await fetchPopularShrines();
+      setPopularShrines(shrines.slice(0, 3));
+      setPopularStatus("ready");
+    } catch {
+      setPopularShrines([]);
+      setPopularStatus("error");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void loadPopularShrines();
+  }, [loadPopularShrines]);
+
   React.useEffect(() => {
     if (selectedShrineId && !mapPoints.some((point) => point.id === selectedShrineId)) {
       setSelectedShrineId(null);
@@ -69,12 +90,9 @@ export default function SearchPage() {
     return textHit && tagsHit;
   });
 
-  const popularShrines = [...SHRINES]
-    .sort((a, b) => (b.favorites ?? 0) - (a.favorites ?? 0) || (b.rating ?? 0) - (a.rating ?? 0))
-    .slice(0, 3);
-
-  const popularShrineIds = new Set(popularShrines.map((s) => String(s.id)));
-  const visibleShrines = filtered.filter((s) => !popularShrineIds.has(String(s.id)));
+  // 人気の神社は実API(/populars/)由来のため、静的SHRINESとのID空間が重ならず
+  // 重複除外の必要がない。神社一覧のフィルタ・ソート結果(filtered)はそのまま表示する。
+  const visibleShrines = filtered;
 
   return (
     <ScrollView style={styles.screen} contentContainerStyle={styles.content}>
@@ -180,34 +198,57 @@ export default function SearchPage() {
       <View style={styles.popularSection}>
         <View style={styles.sectionHeader}>
           <Text style={styles.sectionTitle}>人気の神社</Text>
-          <Text style={styles.sectionCount}>3件</Text>
+          <Text style={styles.sectionCount}>{popularStatus === "ready" ? `${popularShrines.length}件` : ""}</Text>
         </View>
 
-        <View style={styles.popularList}>
-          {popularShrines.map((s, index) => (
-            <Pressable
-              key={s.id}
-              onPress={() => {
-                trackShrineCardClick({ shrineId: s.id, position: "popular" });
-                router.push(`/shrines/${s.id}`);
-              }}
-              style={({ pressed }) => [styles.popularCard, pressed && styles.cardPressed]}
-            >
-              <Text style={styles.popularRank}>{index + 1}</Text>
-              <Image source={{ uri: s.imageUrl }} style={styles.popularImage} />
-              <View style={styles.cardBody}>
-                <Text style={styles.cardName}>{s.name}</Text>
-                <Text style={styles.cardArea}>{s.prefecture}</Text>
-                <Text style={styles.popularMeta}>
-                  ★ {(s.rating ?? 4.6).toFixed(1)}　♡ {s.favorites ?? 0}
+        {popularStatus === "loading" ? (
+          <StateCard title="人気の神社を読み込み中" description="しばらくお待ちください。" />
+        ) : null}
+
+        {popularStatus === "error" ? (
+          <View style={styles.mapErrorWrap}>
+            <StateCard title="人気の神社を読み込めませんでした" description="通信状況を確認して、もう一度お試しください。" />
+            <Button
+              title="もう一度試す"
+              variant="outline"
+              size="compact"
+              onPress={() => void loadPopularShrines()}
+              accessibilityLabel="人気の神社をもう一度読み込む"
+            />
+          </View>
+        ) : null}
+
+        {popularStatus === "ready" && popularShrines.length === 0 ? (
+          <StateCard title="人気の神社がまだありません" description="通常の一覧からも神社を探せます。" />
+        ) : null}
+
+        {popularStatus === "ready" && popularShrines.length > 0 ? (
+          <View style={styles.popularList}>
+            {popularShrines.map((s, index) => (
+              <Pressable
+                key={s.id}
+                onPress={() => {
+                  trackShrineCardClick({ shrineId: s.id, position: "popular" });
+                  router.push(`/shrines/${s.id}`);
+                }}
+                style={({ pressed }) => [styles.popularCard, pressed && styles.cardPressed]}
+              >
+                <Text style={styles.popularRank}>{index + 1}</Text>
+                <View style={styles.cardBody}>
+                  <Text style={styles.cardName}>{s.name}</Text>
+                  {s.address ? (
+                    <Text style={styles.cardArea} numberOfLines={1}>
+                      {s.address}
+                    </Text>
+                  ) : null}
+                </View>
+                <Text accessibilityElementsHidden style={styles.chevron}>
+                  ›
                 </Text>
-              </View>
-              <Text accessibilityElementsHidden style={styles.chevron}>
-                ›
-              </Text>
-            </Pressable>
-          ))}
-        </View>
+              </Pressable>
+            ))}
+          </View>
+        ) : null}
       </View>
 
       {/* 地図で探す: 補助表示。Webでstyle URL未設定の間はセクション自体を表示しない */}
@@ -395,18 +436,6 @@ const styles = StyleSheet.create({
     fontWeight: "900",
     lineHeight: 28,
     textAlign: "center",
-  },
-  popularImage: {
-    width: 62,
-    height: 54,
-    borderRadius: 13,
-    backgroundColor: theme.surfaceSoft,
-  },
-  popularMeta: {
-    color: theme.goldSoft,
-    fontSize: 12,
-    fontWeight: "700",
-    marginTop: 2,
   },
   list: {
     gap: 12,

--- a/apps/mobile/lib/__tests__/popularShrines.test.ts
+++ b/apps/mobile/lib/__tests__/popularShrines.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMock = vi.fn();
+vi.mock("../http", () => ({
+  get: (...args: unknown[]) => getMock(...args),
+}));
+
+import { __internal, fetchPopularShrines } from "../popularShrines";
+
+const { toPopularShrines } = __internal;
+
+describe("toPopularShrines", () => {
+  it("Backendのresults順を維持したまま変換する", () => {
+    const shrines = toPopularShrines({
+      count: 2,
+      next: null,
+      previous: null,
+      results: [
+        { id: 105, kind: "shrine", name_jp: "重複検証神社（別宮）", address: "東京都港区重複3-3-3", latitude: 35.6, longitude: 139.7 },
+        { id: 104, kind: "shrine", name_jp: "重複検証神社", address: "東京都中央区重複2-2-2", latitude: 35.68, longitude: 139.76 },
+      ],
+    });
+    expect(shrines).toEqual([
+      { id: "105", name: "重複検証神社（別宮）", address: "東京都港区重複3-3-3" },
+      { id: "104", name: "重複検証神社", address: "東京都中央区重複2-2-2" },
+    ]);
+  });
+
+  it("配列を直接渡してもitemsキーでも受け取れる", () => {
+    const arrayInput = toPopularShrines([{ id: 1, name_jp: "配列直接" }]);
+    expect(arrayInput).toEqual([{ id: "1", name: "配列直接", address: undefined }]);
+
+    const itemsInput = toPopularShrines({ items: [{ id: 2, name_jp: "itemsキー" }] });
+    expect(itemsInput).toEqual([{ id: "2", name: "itemsキー", address: undefined }]);
+  });
+
+  it("画像・評価値・お気に入り数などAPIに存在しないfieldを推測で補わない", () => {
+    const shrines = toPopularShrines({
+      results: [{ id: 1, name_jp: "テスト神社", address: "テスト住所", rating: 4.8, favorites: 540, imageUrl: "https://example.com/x.jpg" }],
+    });
+    expect(shrines).toEqual([{ id: "1", name: "テスト神社", address: "テスト住所" }]);
+    expect(shrines[0]).not.toHaveProperty("rating");
+    expect(shrines[0]).not.toHaveProperty("favorites");
+    expect(shrines[0]).not.toHaveProperty("imageUrl");
+  });
+
+  it("空配列を正常な結果として扱う", () => {
+    expect(toPopularShrines({ count: 0, next: null, previous: null, results: [] })).toEqual([]);
+  });
+
+  it("id欠損を安全に扱う", () => {
+    const shrines = toPopularShrines({
+      results: [
+        { name_jp: "id無し" },
+        { id: null, name_jp: "id null" },
+        { id: "", name_jp: "id空文字" },
+      ],
+    });
+    expect(shrines).toEqual([]);
+  });
+
+  it("name欠損を安全に扱う", () => {
+    expect(toPopularShrines({ results: [{ id: 1 }] })).toEqual([]);
+  });
+
+  it("addressが文字列でない場合はundefinedにする", () => {
+    const shrines = toPopularShrines({ results: [{ id: 1, name_jp: "住所なし", address: null }] });
+    expect(shrines).toEqual([{ id: "1", name: "住所なし", address: undefined }]);
+  });
+
+  it("不正な入力全体(null・非配列)でも例外を投げない", () => {
+    expect(toPopularShrines(null)).toEqual([]);
+    expect(toPopularShrines(undefined)).toEqual([]);
+    expect(toPopularShrines("not an object")).toEqual([]);
+    expect(toPopularShrines({})).toEqual([]);
+  });
+});
+
+describe("fetchPopularShrines", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正しいURL(/populars/)をGETで呼び出す", async () => {
+    getMock.mockResolvedValueOnce({ count: 0, next: null, previous: null, results: [] });
+    await fetchPopularShrines();
+    expect(getMock).toHaveBeenCalledWith("/populars/");
+  });
+
+  it("正常Responseを変換して返す", async () => {
+    getMock.mockResolvedValueOnce({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [{ id: 1, name_jp: "明治神宮", address: "東京都渋谷区" }],
+    });
+    const result = await fetchPopularShrines();
+    expect(result).toEqual([{ id: "1", name: "明治神宮", address: "東京都渋谷区" }]);
+  });
+
+  it("空配列レスポンスは空配列として返す(errorにしない)", async () => {
+    getMock.mockResolvedValueOnce({ count: 0, next: null, previous: null, results: [] });
+    await expect(fetchPopularShrines()).resolves.toEqual([]);
+  });
+
+  it("非2xx等の取得失敗はhttp helper側の例外をそのまま呼び出し元へ伝える", async () => {
+    getMock.mockRejectedValueOnce(new Error("HTTP 500: Internal Server Error"));
+    await expect(fetchPopularShrines()).rejects.toThrow("HTTP 500");
+  });
+
+  it("不正なResponse(objectだがresults/items/配列のいずれでもない)は空配列として安全に扱う", async () => {
+    getMock.mockResolvedValueOnce({ unexpected: "shape" });
+    await expect(fetchPopularShrines()).resolves.toEqual([]);
+  });
+});

--- a/apps/mobile/lib/popularShrines.ts
+++ b/apps/mobile/lib/popularShrines.ts
@@ -1,0 +1,64 @@
+// apps/mobile/lib/popularShrines.ts
+//
+// Search画面「人気の神社」・Ranking画面が共通で利用する、Backend正本API
+// (`GET /api/populars/`, `temples.api.views.shrine.PopularShrineListView`)の
+// 取得・変換のみを責務とするhelper。
+//
+// 実際のResponseは`{count, next, previous, results: [...]}`(DRF PageNumberPagination、
+// page_size=10固定・`limit`クエリは無視される)であり、各項目は`ShrineListSerializer`の
+// フィールド(id, kind, name_jp, address, latitude, longitude, goriyaku_tags, distance,
+// distance_text, location, kyusei)のみを持つ。画像・評価値・お気に入り数は含まれないため、
+// このhelperではそれらを推測で補わず、実在するフィールドのみをMobile表示用の形へ変換する。
+//
+// 並び順はBackendの`results`配列順(popular_score降順)をそのまま維持し、Mobile側で
+// 再ソート・再計算は行わない。
+import { get } from "./http";
+
+export type PopularShrine = {
+  id: string;
+  name: string;
+  address?: string;
+};
+
+function toPopularShrines(raw: unknown): PopularShrine[] {
+  const items: unknown[] = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { results?: unknown } | null)?.results)
+      ? ((raw as { results: unknown[] }).results)
+      : Array.isArray((raw as { items?: unknown } | null)?.items)
+        ? ((raw as { items: unknown[] }).items)
+        : [];
+
+  const shrines: PopularShrine[] = [];
+
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+
+    const idRaw = record.id;
+    if (idRaw === null || idRaw === undefined || idRaw === "") continue;
+    const id = String(idRaw);
+
+    const name = String(record.name_jp ?? record.name ?? "").trim();
+    if (!name) continue;
+
+    const address = typeof record.address === "string" && record.address.trim() ? record.address.trim() : undefined;
+
+    shrines.push({ id, name, address });
+  }
+
+  return shrines;
+}
+
+/**
+ * `/populars/`から人気神社一覧を取得する。Backendが既に並び替え済みの順序を
+ * そのまま維持し、Mobile側での再ソートは行わない。
+ * 失敗時は例外を投げ、呼び出し側でloading/error/emptyを制御できるようにする
+ * (`fetchShrineMapPoints`と同じ契約)。空配列は正常な結果として扱う。
+ */
+export async function fetchPopularShrines(): Promise<PopularShrine[]> {
+  const raw = await get<unknown>("/populars/");
+  return toPopularShrines(raw);
+}
+
+export const __internal = { toPopularShrines };


### PR DESCRIPTION
## 目的

Mobile Search画面「人気の神社」・Ranking画面が静的モック(`data/shrines.ts`)に依存していた問題を、既存Backend API `GET /api/populars/` へ接続することで解消する。新しい人気ランキングロジックは作成せず、既存契約の確認・Mobile側の取得/変換/状態表示の統一のみを行った。

## 参照した監査・Product正本

- `docs/audit/popular-shrines-responsibility-audit.md`(PR #2179) — Search内人気神社の責務・`WM-RANK-103`との対応関係
- `docs/audit/web-mobile-experience-parity.md` — `WM-RANK-103`(P1、データ契約)・`WM-RANK-102`/`WM-SEARCH-202`(導線、本セッション内で解消済み)
- `docs/product/mobile-user-flow.md` 13節 — 人気神社はSecondary/発見導線、削除は決定しない
- `docs/analytics/mobile-search-events.md` — `shrine_card_click`の`position: "popular"`契約
- `docs/analytics/README.md` — Archive文書は現行契約に使用しないルール

Archive文書は参照していない。新規Analytics契約文書は作成していない(既存契約を変更していないため)。

## `/api/populars/`の確認結果

URL定義(`backend/temples/api/urls.py:132`)・View(`PopularShrineListView`, `backend/temples/api/views/shrine.py:153`)・Serializer(`ShrineListSerializer`)・テスト(`backend/temples/tests/test_ranking_api.py`)を追跡し、実際に稼働中のバックエンドへ`curl`で直接確認した。

- `GET /api/populars/`(trailing slash必須)、`AllowAny`(認証不要)
- Response実体: `{count, next, previous, results: [...]}`(DRF `PageNumberPagination`、`page_size=10`固定)
- 各要素のfield: `id, kind, name_jp, address, latitude, longitude, goriyaku_tags, distance, distance_text, location, kyusei`。画像・評価値・お気に入り数は**含まれない**
- `limit`クエリは`PopularShrineListView`側で未対応のため無視される(ページサイズは常に10)
- 並び順はBackendが`popular_score`降順で既にソート済み
- **`docs/openapi.yaml`の`/api/populars/`記載(`PopularsResponse`/`PopularItem`、`items`/`shrine.name`/`shrine.lat`/`shrine.lng`/`score`)は実装と一致しない**。これは`backend/temples/api/views/ranking.py`の`RankingAPIView`(どのurls.pyにも未登録の未使用コード)の戻り値形状であり、実際にルーティングされている`PopularShrineListView`とは異なる。Backend側のドキュメント修正は本PRのスコープ外のため実施していない(別PR候補として記録するのみ)
- 別途`RankingAPIView`(`backend/temples/api/views/shrine.py:204`)というBackend側の重複実装も発見したが、どちらも未ルーティングのため実質的な「Ranking専用API」は存在しない。Mobile Ranking画面もSearchの人気神社と同じ`/api/populars/`を利用する設計とした

## Web側populars利用の確認結果

`apps/web/src/lib/api/popular.ts`・`apps/web/src/app/api/populars/route.ts`(BFF)・`apps/web/src/lib/api/ranking.ts`を確認した。

- Web `/populars`ページ・`/ranking`ページはいずれもこの同じ`/api/populars/`をBFF経由で呼び出している(`ranking.ts`のコメント「✅ populars BFFを使う(直backend撤去)」)
- Web側の型(`ShrineBase`)は`name_jp`/`latitude`/`longitude`を使用し、`lat`/`lng`直参照をコンパイルエラーにする設計(`lat?: never; lng?: never;`)になっており、実際のfield名が`name_jp`/`latitude`/`longitude`であることをWeb側の型からも裏付けられた
- `RankingItem`型は`score`/`visit_count`/`favorite_count`を持つが、`normalizeRankingItems`は`s.score ?? 0`等でフォールバックしており、実際のBackend Response(該当fieldなし)では常に0になる。Web側もこれらの値を推測で補っていない
- Web実装はコピーせず、契約理解の参考としてのみ利用した

## Mobileの変更前データソース

- Search「人気の神社」: `apps/mobile/data/shrines.ts`(静的モック、3件、`favorites`/`rating`をハードコード)を`favorites`降順でソートし上位3件
- Ranking画面: 同じ静的モックを`favorites`降順で全件表示

## Mobileの変更後データソース

- Search「人気の神社」・Ranking画面ともに`GET /api/populars/`(共通helper`fetchPopularShrines()`経由)
- Backendの`results`配列順をそのまま使用し、Mobile側での再ソート・重み付け・固定順位付けは行っていない
- Search側は取得結果の先頭3件を表示(`slice(0, 3)`、UI表示件数の絞り込みであり再ランキングではない)

## 共通API helperの責務

`apps/mobile/lib/popularShrines.ts`(新規)。既存の`fetchShrineMapPoints`(`lib/shrineMap.ts`)と同じ「配列/`.results`/`.items`のいずれでも受け取り、id/name欠損を安全に除外し、失敗時は例外を投げて呼び出し側にloading/error/emptyを委ねる」という契約パターンに揃えた。既存の`get()`(`lib/http.ts`、認証ヘッダを付けない公開API向けGETラッパー)をそのまま利用し、新規のfetch wrapperは作らなかった。

`PopularShrine`型は`{id: string, name: string, address?: string}`のみを持つ最小型とした。`ShrineMapPoint`(緯度経度前提)を流用せず、`any`も使用していない。APIに存在しない`imageUrl`/`rating`/`favorites`は型に含めていない(推測で補っていない)。

## Searchでのloading/error/empty

- loading: 「人気の神社を読み込み中」の`StateCard`を人気セクション内にのみ表示。通常一覧・地図には影響しない
- error: 人気セクション内に最小限のエラー表示+「もう一度試す」ボタン。神社一覧・地図・画面全体は操作可能なまま
- empty(空配列): 「人気の神社がまだありません」を表示し、errorとして扱わない

## Rankingでのloading/error/empty

- loading: 既存の`StateCard`共通コンポーネントで表示
- error: 「読み込めませんでした」+「もう一度試す」ボタン。戻る操作は既存のまま維持(画面ヘッダ・Route構造は変更していない)
- empty: 「現在表示できる人気の神社がありません」と断定しすぎない文言で表示

## fallback方針

API失敗時に静的`SHRINES`へ黙ってfallbackする既存契約は存在しなかったため、fallbackは実装していない。失敗時はerror状態を明示し、Search側は通常一覧(静的データ、今回変更なし)のみ引き続き利用可能とした。

## 静的SHRINES依存を除去した範囲

- Search「人気の神社」: 静的`SHRINES`からの算出(`sort().slice(0,3)`)を削除し、`fetchPopularShrines()`に置き換えた
- Ranking画面: 静的`SHRINES`からの算出を削除し、同じく`fetchPopularShrines()`に置き換えた
- `apps/mobile/data/shrines.ts`自体、およびSearch「神社一覧」・タグ/キーワードフィルタ・地図表示が使う`SHRINES`参照は削除していない(神社一覧・地図はスコープ外、変更禁止事項のため)

**副次的な事実**: Search「人気の神社」が静的モックの3件のうち全件を占めていたため、従来「神社一覧」は常に0件で非表示だった。人気の神社が実APIに切り替わったことで両者のID空間が重ならなくなり、静的モックの重複除外ロジック(`popularShrineIds`によるフィルタ)が意味を失ったため削除した。結果として「神社一覧」セクションは静的モック3件を表示するようになった(`filtered`自体のフィルタ・ソートロジックは一切変更していない)。神社一覧の表示件数が0→3件に変わった点は、人気神社のデータソース分離に伴う必然的な副作用であり、意図的なUI変更ではない。

## Backend順序を維持していること

`popularShrines.ts`の`toPopularShrines`はBackendが返した`results`配列の順序をそのまま`PopularShrine[]`へ変換するのみで、`.sort()`等の再整列は一切行っていない(単体テストで確認済み)。Search側の`.slice(0, 3)`は表示件数の絞り込みであり、順序自体は変更しない。

## Analytics `position: "popular"`を維持していること

`apps/mobile/lib/searchAnalytics.ts`・`docs/analytics/mobile-search-events.md`は変更していない。人気カードクリック時は引き続き`trackShrineCardClick({ shrineId, position: "popular" })`を呼び出し、`shrineId`には実APIの数値IDを文字列化した値を渡す(Marker選択等、既存の`ShrineMapPoint.id`と同じ「数値IDを文字列化する」規約に揃えた)。

## 変更ファイル

- `apps/mobile/lib/popularShrines.ts`(新規)
- `apps/mobile/lib/__tests__/popularShrines.test.ts`(新規)
- `apps/mobile/app/search/index.tsx`
- `apps/mobile/app/ranking/index.tsx`

Backend・Web・`docs/openapi.yaml`・Analytics契約文書・Product文書はいずれも変更していない。

## 実行したテスト

- `apps/mobile/lib/__tests__/popularShrines.test.ts`: 正常変換・Backend順序維持・空配列の正常扱い・非2xxのエラー伝播・不正Response・id/name欠損・画像やrating等の未定義フィールドを補わないことを確認(13 tests)
- `pnpm install --frozen-lockfile --ignore-workspace`(`apps/mobile`)
- `CI=1 pnpm exec expo install --check`(`apps/mobile`)
- `pnpm typecheck`(`apps/mobile`)
- `pnpm test`(`apps/mobile`、143/143 pass)
- `pnpm exec expo export -p web`(`apps/mobile`、export成功を確認後dist削除)
- `git diff --check && git status --short --branch`(変更ファイルが想定の4件のみ、lockfile変更なしを確認)

なお、このリポジトリのVitest構成(`vitest.config.ts`)は`lib/__tests__/**/*.test.ts`のみを対象としたNode環境(jsdom/React Testing Libraryなし)のため、`app/search/index.tsx`・`app/ranking/index.tsx`自体のコンポーネントレンダリングテストは追加できない。画面レベルのloading/error/empty/遷移の検証は下記の実ブラウザ確認で代替した。

## 実ブラウザ確認

Expo Web dev server(`localhost:8081`)+ローカルBackend(`localhost:8000`、シードデータ)で確認した。

- Backend起動時: Search「人気の神社」が実API由来のデータ(重複検証神社等、シード投入されたテスト神社)で表示され、順位番号・住所が正しく表示されることを確認。人気カードから神社詳細へ遷移できることを確認。コンソールで`shrine_card_click`(position: popular)の発火を確認。Ranking画面(`/ranking`)へ直接遷移し、実APIの10件がBackend順序のまま表示され、カードから神社詳細へ遷移できることを確認
- API失敗時(`EXPO_PUBLIC_API_BASE_URL`を一時的に到達不能なポートへ変更): Search側は「人気の神社を読み込めませんでした」+再試行ボタンを人気セクション内にのみ表示し、神社一覧(3件)は影響を受けず利用可能なままであることを確認。Ranking側は「読み込めませんでした」+再試行ボタンを表示することを確認。確認後`.env`を`EXPO_PUBLIC_API_BASE_URL=http://localhost:8000/api`(元の値)へ復元し、再度Backend正常時の表示に戻ることを確認した
- empty状態は、確認可能な安全なfixture操作が本セッションの制約内になかったため、コードレビューと単体テスト(空配列を正常として扱う)で担保した。本番コードへの一時的なempty hackは残していない

## 今回変更していない範囲

Backendの人気順位算出ロジック・API schema・Recommendationロジック・Meaning Layer・Concierge・Search通常一覧のデータ取得元(`SHRINES`)・Searchフィルター・地図(MapLibre/react-native-maps)・Analytics Event名/Payload/契約文書・Product文書・Premium・Billing・記録→再相談・Orphan画面への導線追加・Ranking画面への入口追加・認証・returnTo・EAS Environment・環境変数実値・`package.json`・lockfile・Archive文書・既存監査文書・`docs/openapi.yaml`。新規依存も追加していない。

## 残存リスク

- `docs/openapi.yaml`の`/api/populars/`記載が実装と一致していない(未使用の`RankingAPIView`の形状を記載している)。Backend側のドキュメント修正は別PR候補として記録するのみに留めた
- 画像・評価値・お気に入り数がAPIに存在しないため、Search人気カード・Rankingカードの見た目から★評価・♡お気に入り数・サムネイル画像を削除した。これは実データに存在しない値を表示しないための必然的な調整であり、UIの全面改修ではない
- Native実機での動作確認は未実施(本セッション全体を通じてNative Simulator検証が不安定なため、Web版での確認と、Native/Web共通の`fetchPopularShrines()`helperを両画面が呼び出す構造であることの静的確認で代替した)
- 空配列(0件)状態はブラウザでの実地確認ではなく、単体テストとコードレビューのみで確認した

## Rollback方法

`apps/mobile/lib/popularShrines.ts`・`apps/mobile/lib/__tests__/popularShrines.test.ts`の追加、および`apps/mobile/app/search/index.tsx`・`apps/mobile/app/ranking/index.tsx`への変更をまとめてrevertすれば、Search「人気の神社」・Ranking画面はいずれも静的`SHRINES`モックに基づく従来の表示へ完全に戻る。Backend・Web・Analytics契約・Product文書には一切手を加えていないため、rollback時にそれらへの影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)