### PR TITLE
Mobile Reflection保存後に再相談導線を追加

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -16,7 +16,12 @@ import { ctaSizes } from "../../design/ctaSizes";
 import { createFavoriteByShrineId } from "../../lib/favorites";
 import { createVisitByShrineId } from "../../lib/visits";
 import { createShrineReflection } from "../../lib/reflections";
-import { trackVisitDone, trackReflectionPromptView, trackReflectionSaved } from "../../lib/visitReflectionAnalytics";
+import {
+  trackVisitDone,
+  trackReflectionPromptView,
+  trackReflectionSaved,
+  trackReflectionToConsultationClick,
+} from "../../lib/visitReflectionAnalytics";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 import Button from "../../components/ui/Button";
 
@@ -539,6 +544,29 @@ export default function ShrineDetail() {
     }
   }, [apiShrineId, contextReasonFacts, reflectionAnswer, reflectionPrompt, reflectionSaving, shrine, shrineId]);
 
+  // 保存成功直後のCTAからのみ呼ばれる(reflectionSaved===trueの間だけボタンが描画される)。
+  // 自動遷移は行わず、ユーザーがCTAを押した場合のみConciergeへ進む。
+  const consultationNavigatingRef = React.useRef(false);
+  const onGoToConsultation = React.useCallback(() => {
+    if (consultationNavigatingRef.current) return;
+    consultationNavigatingRef.current = true;
+    // 連打時の重複遷移・重複Analyticsのみを防ぐための短時間ガード。
+    // 画面へ戻ってきた後は再びCTAを押せるよう、一定時間で解除する。
+    setTimeout(() => {
+      consultationNavigatingRef.current = false;
+    }, 1000);
+
+    const targetShrineId = apiShrineId ?? shrineId;
+    trackReflectionToConsultationClick({
+      shrineId: targetShrineId ?? "",
+      historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+    });
+
+    // Reflection本文・相談文等の自由入力は一切引き継がず、Conciergeを通常状態で開く
+    // (安全に本文を引き継げる既存契約が無いため。docs/product/visit-reflection-flow.md「次回相談との接続」参照)。
+    router.push("/concierge");
+  }, [apiShrineId, contextReasonFacts, router, shrine, shrineId]);
+
   const openDirections = React.useCallback(() => {
     if (!shrine) return;
     const shrineIdNumber = apiShrineId != null ? Number(apiShrineId) : null;
@@ -780,6 +808,17 @@ export default function ShrineDetail() {
               loading={reflectionSaving}
               accessibilityLabel={reflectionSaved ? "振り返りを保存しました" : "振り返りを保存する"}
             />
+
+            {reflectionSaved ? (
+              <View style={styles.nextConsultationWrap}>
+                <Button
+                  title="この体験をもとに、もう一度相談する"
+                  variant="outline"
+                  onPress={onGoToConsultation}
+                  accessibilityLabel="この体験をもとに、もう一度相談する"
+                />
+              </View>
+            ) : null}
           </View>
         ) : null}
       </ScrollView>
@@ -1102,6 +1141,9 @@ const styles = StyleSheet.create({
     borderColor: theme.borderGold,
     padding: cardSizes.cardPaddingLg,
     gap: spacing.mdGap,
+  },
+  nextConsultationWrap: {
+    marginTop: spacing.smGap,
   },
   reflectionInput: {
     minHeight: 96,

--- a/apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts
+++ b/apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts
@@ -4,7 +4,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 (globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
 
 import { setAnalyticsProvider, type AnalyticsProvider } from "../analytics";
-import { trackReflectionPromptView, trackReflectionSaved, trackVisitDone } from "../visitReflectionAnalytics";
+import {
+  trackReflectionPromptView,
+  trackReflectionSaved,
+  trackReflectionToConsultationClick,
+  trackVisitDone,
+} from "../visitReflectionAnalytics";
 
 describe("visitReflectionAnalytics", () => {
   const trackSpy = vi.fn();
@@ -89,6 +94,72 @@ describe("visitReflectionAnalytics", () => {
       shrineId: 17,
       threadId: 42,
       historyTheme: "静寂",
+    });
+  });
+
+  describe("trackReflectionToConsultationClick", () => {
+    it("source/platform/shrineId/reflectionSaved(true固定)を送る", () => {
+      trackReflectionToConsultationClick({ shrineId: 17, historyTheme: "静寂" });
+
+      expect(trackSpy).toHaveBeenCalledWith("reflection_to_consultation_click", {
+        source: "shrine_detail",
+        platform: "mobile",
+        shrineId: 17,
+        historyTheme: "静寂",
+        reflectionSaved: true,
+      });
+    });
+
+    it("reflectionSavedは呼び出し元の値に関わらず常にtrueで送る", () => {
+      // BasePayloadParamsにreflectionSavedというfieldは存在しないため、
+      // 呼び出し元が誤った値を渡す余地がなく、関数内部で固定される。
+      trackReflectionToConsultationClick({ shrineId: 1 });
+
+      const payload = trackSpy.mock.calls[0][1] as Record<string, unknown>;
+      expect(payload.reflectionSaved).toBe(true);
+    });
+
+    it("historyTheme/threadIdが未取得の場合キー自体を送らない", () => {
+      trackReflectionToConsultationClick({ shrineId: 17 });
+
+      expect(trackSpy).toHaveBeenCalledWith("reflection_to_consultation_click", {
+        source: "shrine_detail",
+        platform: "mobile",
+        shrineId: 17,
+        reflectionSaved: true,
+      });
+    });
+
+    it("Reflection本文・相談文・住所・緯度経度等の禁止属性を含まない", () => {
+      trackReflectionToConsultationClick({ shrineId: 17, threadId: 42, historyTheme: "静寂" });
+
+      const payload = trackSpy.mock.calls[0][1] as Record<string, unknown>;
+      const forbiddenKeys = [
+        "answer",
+        "query",
+        "consultation",
+        "address",
+        "latitude",
+        "longitude",
+        "birthdate",
+        "moodBefore",
+        "moodAfter",
+        "reasonFacts",
+        "email",
+        "token",
+      ];
+      for (const key of forbiddenKeys) {
+        expect(payload).not.toHaveProperty(key);
+      }
+    });
+
+    it("payloadはprimitive値のみで構成される", () => {
+      trackReflectionToConsultationClick({ shrineId: 17, threadId: 42, historyTheme: "静寂" });
+
+      const payload = trackSpy.mock.calls[0][1] as Record<string, unknown>;
+      for (const value of Object.values(payload)) {
+        expect(["string", "number", "boolean"]).toContain(typeof value);
+      }
     });
   });
 });

--- a/apps/mobile/lib/visitReflectionAnalytics.ts
+++ b/apps/mobile/lib/visitReflectionAnalytics.ts
@@ -61,3 +61,13 @@ export function trackReflectionSaved(params: ReflectionSavedParams): void {
     moodAfter: params.moodAfter || undefined,
   });
 }
+
+// Reflection保存成功後に表示される再相談CTAのクリックのみを計測する(表示は
+// reflection_savedと1:1で連動するため、別途の表示Eventは追加しない)。
+// reflectionSavedは常にtrueのため呼び出し元から受け取らず固定値として送る。
+export function trackReflectionToConsultationClick(params: BasePayloadParams): void {
+  track("reflection_to_consultation_click", {
+    ...buildBasePayload(params),
+    reflectionSaved: true,
+  });
+}

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -18,6 +18,7 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 | --- | --- |
 | `direction-events.md` | Web／Mobile共通の方位分析Event名・Payload・禁止属性契約を管理する |
 | `mobile-search-events.md` | Mobile Search導線(Home入口・画面表示・一覧/人気神社/地図からの詳細遷移・外部経路CTA)のEvent名・Payload・禁止属性契約を管理する |
+| `mobile-reflection-to-consultation.md` | Mobile Reflection保存後に表示される再相談CTAのEvent名・Payload・禁止属性契約を管理する |
 | `direction-analytics-dashboard.md` | 方位利用ファネル、KPI、PostHog設定案、異常値・日盤検討基準を管理する |
 | `direction-analytics-data-quality.md` | 方位Eventの機械可読品質契約、重複・欠損・禁止属性、障害調査手順を管理する |
 | `action-suggestion-funnel.md` | Action Suggestion関連Event（PostHog view計測 / Backend `ActionEvent`）の現状を管理する |

--- a/docs/analytics/mobile-reflection-to-consultation.md
+++ b/docs/analytics/mobile-reflection-to-consultation.md
@@ -1,0 +1,52 @@
+> **Status: Active / Contract**
+
+# Mobile Reflection保存後の再相談導線イベント契約
+
+神社詳細画面(`apps/mobile/app/shrines/[id].tsx`)でReflection保存が成功した直後に表示される、任意の再相談CTA(「この体験をもとに、もう一度相談する」)のEvent契約を管理する。実装は`apps/mobile/lib/visitReflectionAnalytics.ts`を正本とし、送信はMobile既存の`track()`パイプライン(`apps/mobile/lib/analytics.ts`)へ委譲する。
+
+体験責務(CTAを表示する条件、自動遷移しない方針、Conciergeへ本文を引き継がない方針)は`docs/product/visit-reflection-flow.md`「次回相談との接続」節を正本とする。本書はEvent名・Payload・禁止属性のみを規定する。
+
+| Event | 発火条件 | Payload | 重複の単位 |
+| --- | --- | --- | --- |
+| `reflection_to_consultation_click` | Reflection保存成功後に表示されるCTA「この体験をもとに、もう一度相談する」を押した操作 | `source: "shrine_detail"`, `platform: "mobile"`, `shrineId`, `threadId`(取得できた場合のみ), `historyTheme`(取得できた場合のみ), `reflectionSaved: true` | クリックごと |
+
+## 表示Eventを追加しない理由
+
+CTAの表示条件は`reflectionSaved`(Reflection保存成功)のみであり、これは既存の`reflection_saved`(`docs/analytics/reflection-funnel-dashboard.md`が定義するFunnelの一部)と1:1で連動する。CTA表示だけを対象にした新規Eventは`reflection_saved`と完全に重複するため追加しない。CTAが実際にクリックされたかどうかのみを本書のEventで計測する。
+
+## Conciergeへ渡す情報
+
+CTA押下時、`router.push("/concierge")`をparamsなしで呼び出し、Conciergeを通常状態(未入力)で開く。Reflection本文・相談文・住所・緯度経度・誕生日等の自由入力・個人情報はURL・Payloadいずれにも含めない。
+
+Concierge側の`theme`/`q`クエリは`docs/product/concierge-first-final-spec.md`が「相談本文の自然文として扱う」と定義しており、ここへReflection由来の文字列を渡すと自由入力本文をURLへ含めることになるため使用しない。`threadId`等の安全な参照契約は今回時点でConcierge画面側に存在しないため、本文・スレッドいずれも引き継がない。
+
+## 禁止属性
+
+次の値はEvent名を問わず送信しない。
+
+- Reflection本文(`answer`)、相談文、自由入力条件
+- 住所、駅名、都道府県名、緯度・経度
+- 誕生日、参拝予定日
+- mood_before / mood_after の自由記述値
+- ユーザー名、メールアドレス、トークン、Cookie
+- APIレスポンス全文、推薦理由本文、`reasonFacts`全文
+
+`shrineId`・`source`・`platform`・`threadId`・`historyTheme`・`reflectionSaved`のみを許可する。
+
+## Payload型
+
+- primitive型(string/number/boolean)のみを許可する
+- nested object・配列を送らない
+- `null`/`undefined`は送信前に除外する(`apps/mobile/lib/analytics.ts`の`serializeAnalyticsPayload`が構造的に担う)
+
+## 重複防止
+
+- CTAは`reflectionSaved === true`の間のみ描画され、保存前・保存中・保存失敗時には描画されない
+- CTA押下時に短時間の重複防止ガード(`consultationNavigatingRef`)を設け、連打による多重発火・多重遷移を防ぐ
+- `reflection_saved`(保存成功)と`reflection_to_consultation_click`(CTAクリック)は別Eventであり、混同しない
+
+## 変更ルール
+
+- Event名またはPayloadを変更する場合は、`apps/mobile/lib/visitReflectionAnalytics.ts`と本書を同じPRで更新する
+- CTAの表示条件・配置画面が変更された場合は、`docs/product/visit-reflection-flow.md`との整合を確認したうえで本書を更新する
+- 本書はMobile Reflection保存後の再相談導線のEvent契約のみを管理する。Visit/Reflection保存自体のEvent契約(`visit_done`/`reflection_prompt_view`/`reflection_saved`)は本書で重複管理しない


### PR DESCRIPTION
## 目的

Mobile／Expo Webにおいて、参拝・振り返り体験の後にユーザーが任意で次の相談へ進める導線を追加した。新しい相談機能・自動推薦・推薦ロジック変更は行っていない。既存Product方針(`相談→神社詳細→参拝→記録・振り返り→必要に応じて再相談`)を、現行コード・Route・保存処理・Analytics契約に沿って最小差分で接続した。

## 参照したProduct・Analytics文書

- `docs/product/visit-reflection-flow.md`(Active) — 「次回相談との接続」節が、過去の記録を結論として使わず補助文脈として扱う方針、Reflection本文をAIが断定材料にしない方針を規定。14節の分類(Visit/Reflection入口・保存・履歴・次回相談の責務境界)を踏襲した
- `docs/product/mobile-user-flow.md` 14節・18節・20節 — 「記録から再相談への実装は別PRとする」と明記されており、本PRがその別PRに該当する
- `docs/product/concierge-first-final-spec.md` — `theme`クエリは「相談本文の自然文として扱う」と定義されていることを確認し、Reflection由来の文字列をこの経路へ渡すことを避ける根拠とした
- `docs/product/premium-experience.md` — 「継続利用に基づく振り返り・傾向分析」はPremiumの長期比較機能であり、単発の再相談CTA(Free機能)とは別物であることを確認。本CTAをPremium限定にしない根拠とした
- `docs/analytics/reflection-funnel-dashboard.md`(Reference)・`docs/analytics/reflection-next-recommendation-design.md`(Reference) — 既存Funnel(`visit_done`→`reflection_prompt_view`→`reflection_saved`)を確認。後者はBackend側のスコアリング活用設計であり、本PRのUI導線とは別軸であることを確認
- `docs/analytics/mobile-search-events.md`(Active) — 責務範囲がSearch導線のみであることを確認し、新規Eventの追加先として不適切と判断
- `docs/analytics/README.md` — Archive文書は参照せず、Active文書のみを現行契約として扱った

Archive文書は参照していない。新しい監査文書は作成していない(既存の`docs/audit/mobile-user-flow-inventory.md`・`docs/audit/visit-reflection-implementation-consistency.md`を確認し、いずれも本PRが扱う再相談CTA自体を対象にしていないことを確認したのみで、新規Audit文書は不要と判断した)。

## 現行保存後挙動(調査結果)

`apps/mobile/app/shrines/[id].tsx`を確認した。

- 参拝完了(`onVisitDone`)は`createVisitByShrineId`(`lib/visits.ts`)で保存し、成功時に`visited`をtrueにして`trackVisitDone`を発火する。未ログイン時は`AuthPrompt`を表示する
- `visited`がtrueになると、Reflection入力カード(`reflectionCard`)が表示され、表示時に`trackReflectionPromptView`が発火する
- Reflection保存(`onSaveReflection`)は`createShrineReflection`(`lib/reflections.ts`、`postAuth`)で保存し、成功時に`reflectionSaved`をtrueにして`trackReflectionSaved`を発火する。この処理も未ログイン時は`AuthPrompt`を表示する
- 保存成功後にConciergeへ進むCTA・自動遷移は存在しなかった(`grep`で`"concierge"`という文字列がこのファイルに1件も存在しないことを確認)
- Concierge(`apps/mobile/app/concierge/index.tsx`)は`q`/`theme`/`birthdate`/`plannedVisitDate`/`visitStyle`/`goriyaku`/`support`/`originLat`/`originLng`のみを`useLocalSearchParams`で受け取り、`threadId`/`reflectionId`のような保存データ参照用paramsは存在しない
- `q`/`theme`が渡された場合、`initialQuery`として相談文入力欄に反映されるのみで、自動送信はされない(`concierge-first-final-spec.md`「相談内容の確認画面として扱う」と一致)

## CTA配置の判断理由

**第一候補(Reflection保存成功後の完了状態)を採用した。** `apps/mobile/app/shrines/[id].tsx`の`reflectionCard`内、「振り返りを保存する」ボタンの直後、`reflectionSaved === true`の場合にのみ描画する1箇所のみに配置した。

理由:

- Reflection保存の完了は`visit-reflection-flow.md`が定義する体験フローの最終段階であり、「次回相談」への自然な接続点である
- 複数画面への同時追加(Records/Journey/履歴画面等)は今回のスコープ外であり、`mobile-user-flow.md`が既に「Journey全体の再設計」「履歴画面統合」等をDeferredとしていることとも整合する
- Records/Journey/履歴画面への追加は、保存直後だけでは継続体験として不足する明確な理由がなかったため見送った

## 自動遷移を採用しなかった理由

保存完了の確認を妨げないこと、ユーザーの意図なく次の相談を開始しないこと、相談を強制する体験にしないことを優先し、`Button`によるユーザー操作を必須とした。CTAは`reflectionSaved`が`false`の間(保存前・保存中・保存失敗時)は描画されない。

## Conciergeへ引き継ぐ情報・引き継がない情報

**案A(Conciergeを通常状態で開く)を採用した。** `router.push("/concierge")`をqueryなしで呼び出す。

- 引き継ぐ情報: なし(URLにparamsを一切含めない)
- 引き継がない情報: Reflection本文(`answer`)、相談文、住所、緯度経度、誕生日、推薦理由、`reasonFacts`全文、その他の自由入力

案B(`theme=...`で固定テーマを渡す)は、Concierge側の`theme`が「相談本文の自然文」として扱われる契約であり、Reflection由来の文字列(たとえ短い固定フレーズでも)を渡すと自由入力本文をURLへ含めることに近づくリスクがあるため採用しなかった。案C(`reflectionId`等を渡す)は、Concierge側に該当paramsを受け取る既存契約が存在せず、新しいAPI・保存参照機構が必要になるため、今回のPRでは採用しなかった。最小構成である案Aで、Product方針が求める「循環の接続」自体は達成できると判断した。

## URL・Analyticsの禁止属性

以下はURL・Analytics Payloadいずれにも含めていない。

- Reflection本文、相談文、自由入力条件
- 住所、緯度経度、誕生日、参拝予定日
- mood_before/mood_after等の自由記述値
- ユーザー名、メールアドレス、トークン、Cookie
- APIレスポンス全文、推薦理由本文、`reasonFacts`全文

許可した属性は`shrineId`・`source`・`platform`・`threadId`・`historyTheme`・`reflectionSaved`のみ(`historyTheme`は既存の`trackReflectionSaved`等と同じ、`contextReasonFacts?.primary_axis`由来の値を再利用しており、新たな個人情報の追加はない)。

## Analytics Eventの扱い

既存Event(`visit_done`/`reflection_prompt_view`/`reflection_saved`)は変更していない。CTAクリックを表す新規Event`reflection_to_consultation_click`を`apps/mobile/lib/visitReflectionAnalytics.ts`へ追加し、対応するActive契約文書`docs/analytics/mobile-reflection-to-consultation.md`を同じPRで新規作成、`docs/analytics/README.md`のActiveテーブルへ登録した。

表示Eventは追加していない。CTAの表示条件は`reflectionSaved`(=`reflection_saved`発火と1:1で連動)のみであり、別途の表示Eventは`reflection_saved`と完全に重複するため不要と判断した(この判断根拠は契約文書にも明記した)。

## 未ログイン時の挙動

CTAは`reflectionSaved === true`の場合のみ表示され、Reflection保存(`postAuth`)は認証必須のため、CTAが表示される時点でユーザーは必ずログイン済みである。Concierge自体は認証不要画面(`mobile-user-flow.md` 16節「コンシェルジュ推薦フロー自体は認証不要」)であるため、CTA押下後の遷移先でも新たな認証は発生しない。新しいログインフロー・`returnTo`機構は追加していない。

## 変更ファイル

- `apps/mobile/app/shrines/[id].tsx`
- `apps/mobile/lib/visitReflectionAnalytics.ts`
- `apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts`
- `docs/analytics/mobile-reflection-to-consultation.md`(新規、Active/Contract)
- `docs/analytics/README.md`

Records/Journey/履歴画面、Concierge画面自体、Backend、Analytics既存Event、Product文書は変更していない。

## 実行したテスト

- `apps/mobile/lib/__tests__/visitReflectionAnalytics.test.ts`: `trackReflectionToConsultationClick`のPayload(source/platform/shrineId/threadId/historyTheme)、`reflectionSaved`が呼び出し元の値に関わらず常に`true`固定であること、禁止属性(answer/query/address/moodBefore等)が含まれないこと、primitive値のみで構成されることを検証(既存4件+新規6件、計10 tests)
- `pnpm install --frozen-lockfile --ignore-workspace`(`apps/mobile`)
- `CI=1 pnpm exec expo install --check`(`apps/mobile`)
- `pnpm typecheck`(`apps/mobile`)
- `pnpm test`(`apps/mobile`、148/148 pass)
- `pnpm exec expo export -p web`(`apps/mobile`、export成功を確認後dist削除)
- `git diff --check && git status --short --branch`(変更ファイルが想定の5件のみ、lockfile変更なしを確認)
- `npx markdownlint-cli`で新規・変更したAnalytics文書のlintを確認(pass)

なお、`app/shrines/[id].tsx`自体のコンポーネントレンダリングテストは、このリポジトリのVitest構成(`lib/__tests__/**/*.test.ts`のみが対象、jsdom/React Testing Libraryなし)では追加できないため、画面レベルの表示条件・遷移・Analytics発火は下記の実ブラウザ確認で検証した。

## 実ブラウザ確認

Expo Web dev server(`localhost:8081`)+ローカルBackend(`localhost:8000`)で確認した。検証用に一時的なテストユーザー(`e2e_reflection_test`)をローカルDjango shellで作成し、確認完了後に削除した(本番・共有データへの影響なし)。

- 未保存(参拝未記録)の神社詳細を開いた状態では、再相談CTAが表示されないことを確認
- 「参拝したことを記録する」を押下 → `visit_done`・`reflection_prompt_view`が発火し、Reflection入力欄が表示されることを確認。この時点では再相談CTAは未表示
- Reflectionを入力し「振り返りを保存する」を押下 → `reflection_saved`が発火し、「この体験をもとに、もう一度相談する」CTAが表示されることを確認
- CTA押下 → `reflection_to_consultation_click`が1回発火し、`/concierge`(クエリなし)へ遷移することを`window.location.href`/`window.location.search`で確認。Concierge画面は相談内容「未入力」の通常状態で操作可能であることを確認

## 今回変更していない範囲

Recommendationロジック・Score計算・Meaning Layer・Concierge API schema・Conciergeの推薦件数・Search・人気神社・Ranking・Searchフィルター・地図(MapLibre/react-native-maps)・Premium・Billing・Orphan画面への導線追加・認証方式・ログイン後returnTo・Backend保存schema・新しいReflection/Consultation API・既存Analytics Event(`visit_done`/`reflection_prompt_view`/`reflection_saved`)・Records/Journey/履歴画面・package.json・lockfile・Archive文書・既存監査文書。

## 残存リスク

- Native実機での動作確認は未実施(本セッション全体を通じてNative Simulator検証が不安定なため、Web版での確認と、Native/Web共通のコード経路(`shrines/[id].tsx`はplatform分岐なし)であることの静的確認で代替した)
- 保存失敗時のCTA非表示は、コードレビュー(`onSaveReflection`のcatchブロックが`reflectionSaved`をtrueにしないことを確認)で担保し、実ブラウザでの意図的な保存失敗再現は行っていない(既存の保存失敗ハンドリング自体を変更していないため、既存の信頼性の範囲内とした)
- 「この体験をもとに、もう一度相談する」という文言は今回新規に定めたものであり、A/Bテスト等による文言検証は行っていない

## Rollback方法

`apps/mobile/app/shrines/[id].tsx`のCTA追加部分、`apps/mobile/lib/visitReflectionAnalytics.ts`の`trackReflectionToConsultationClick`追加、対応するテスト、および`docs/analytics/mobile-reflection-to-consultation.md`とREADMEの登録をまとめてrevertすれば、Reflection保存後に画面へ留まる従来挙動(再相談CTAなし)へ完全に戻る。既存の`visit_done`/`reflection_prompt_view`/`reflection_saved`Event、Visit/Reflection保存処理自体には一切手を加えていないため、rollback時にそれらへの影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)