### PR TITLE
Mobile HomeからSearchフィルターへ条件を接続

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -10,6 +10,7 @@ import * as Location from "expo-location";
 import type { UserOrigin } from "../../../packages/shared/userOrigin";
 import { setOriginSession } from "../lib/originSession";
 import { trackSearchEntryClick } from "../lib/searchAnalytics";
+import { buildSearchFilters } from "../lib/searchFilters";
 
 const THEMES = [
   "疲れを整えたい",
@@ -51,7 +52,17 @@ export default function Home() {
 
   const openSearch = () => {
     trackSearchEntryClick();
-    router.push("/search");
+    // Searchへ渡してよいのは、Search側の既存フィルター処理(SHRINES.tags)と
+    // 意味が一致する固定ラベル(ご利益)のみ。相談文・誕生日・参拝予定日・出発地点・
+    // 参拝スタイル・補助条件は渡さない(docs/product/mobile-user-flow.md 8節・10節)。
+    const filters = buildSearchFilters([selectedGoriyaku]);
+    if (!filters) {
+      router.push("/search");
+      return;
+    }
+    const params = new URLSearchParams();
+    params.set("filters", filters);
+    router.push(`/search?${params.toString()}`);
   };
 
   const openConcierge = () => {

--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -16,14 +16,14 @@ import {
 } from "../../lib/shrineMap";
 import { fetchPopularShrines, type PopularShrine } from "../../lib/popularShrines";
 import { trackSearchScreenView, trackShrineCardClick } from "../../lib/searchAnalytics";
+import { filterShrines, parseSearchFilters } from "../../lib/searchFilters";
 
 const isMapSectionAvailable = isSearchMapSectionAvailable(Platform.OS, process.env.EXPO_PUBLIC_WEB_MAP_STYLE_URL);
 
 export default function SearchPage() {
   const router = useRouter();
   const { q, filters } = useLocalSearchParams<{ q?: string; filters?: string }>();
-  const query = (q ?? "").toLowerCase();
-  const selected = (filters ?? "").split(",").filter(Boolean);
+  const selected = parseSearchFilters(filters);
 
   const [mapPoints, setMapPoints] = React.useState<ShrineMapPoint[]>([]);
   const [mapStatus, setMapStatus] = React.useState<"loading" | "ready" | "error">("loading");
@@ -78,17 +78,7 @@ export default function SearchPage() {
 
   const selectedMapShrine = findShrineMapPointById(mapPoints, selectedShrineId);
 
-  const filtered = SHRINES.filter((s) => {
-    const textHit =
-      !query ||
-      s.name.toLowerCase().includes(query) ||
-      s.tags.some((t) => t.toLowerCase().includes(query)) ||
-      (s.prefecture ?? "").toLowerCase().includes(query);
-
-    const tagsHit = selected.length === 0 || selected.every((sel) => s.tags.includes(sel) || s.prefecture === sel);
-
-    return textHit && tagsHit;
-  });
+  const filtered = filterShrines(SHRINES, { query: q, filters });
 
   // 人気の神社は実API(/populars/)由来のため、静的SHRINESとのID空間が重ならず
   // 重複除外の必要がない。神社一覧のフィルタ・ソート結果(filtered)はそのまま表示する。
@@ -181,7 +171,14 @@ export default function SearchPage() {
             })}
           </View>
         </>
-      ) : null}
+      ) : (
+        <View style={styles.list}>
+          <StateCard
+            title="条件に一致する神社が見つかりませんでした"
+            description="条件を変えると、他の神社が見つかる場合があります。"
+          />
+        </View>
+      )}
 
       {selectedMapShrine ? (
         <View style={styles.selectedShrineWrap}>

--- a/apps/mobile/lib/__tests__/searchFilters.test.ts
+++ b/apps/mobile/lib/__tests__/searchFilters.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { buildSearchFilters, filterShrines, parseSearchFilters } from "../searchFilters";
+import type { Shrine } from "../../data/shrines";
+
+const SAMPLE_SHRINES: Shrine[] = [
+  { id: "meiji", name: "明治神宮", imageUrl: "", tags: ["縁結び", "厄除け"], prefecture: "東京都" },
+  { id: "fushimi", name: "伏見稲荷大社", imageUrl: "", tags: ["商売繁盛", "金運"], prefecture: "京都府" },
+  { id: "kanda", name: "神田明神", imageUrl: "", tags: ["商売繁盛", "厄除け", "IT守護"], prefecture: "東京都" },
+];
+
+describe("buildSearchFilters", () => {
+  it("選択済みの安全な条件からfilters文字列を組み立てる", () => {
+    expect(buildSearchFilters(["縁結び"])).toBe("縁結び");
+  });
+
+  it("未選択(undefined)や空文字は除外し、対象が0件ならundefinedを返す", () => {
+    expect(buildSearchFilters([undefined])).toBeUndefined();
+    expect(buildSearchFilters([""])).toBeUndefined();
+    expect(buildSearchFilters([undefined, ""])).toBeUndefined();
+  });
+
+  it("重複した値は1つにまとめる", () => {
+    expect(buildSearchFilters(["縁結び", "縁結び"])).toBe("縁結び");
+  });
+
+  it("自由入力・住所・緯度経度・誕生日のような値を渡しても、そのまま素通りする(呼び出し側の責務)", () => {
+    // buildSearchFiltersは受け取った値をそのまま整形するだけであり、
+    // どの値を渡すかはHome側(呼び出し側)の責務。ここでは値の整形のみを確認する。
+    expect(buildSearchFilters(["静かに整えたい"])).toBe("静かに整えたい");
+  });
+});
+
+describe("parseSearchFilters", () => {
+  it("カンマ区切りの正常な値を配列へ解析する", () => {
+    expect(parseSearchFilters("縁結び,金運")).toEqual(["縁結び", "金運"]);
+  });
+
+  it("未指定(undefined/null)や空文字は未指定として扱う", () => {
+    expect(parseSearchFilters(undefined)).toEqual([]);
+    expect(parseSearchFilters(null)).toEqual([]);
+    expect(parseSearchFilters("")).toEqual([]);
+  });
+
+  it("空要素・前後の空白を無視する", () => {
+    expect(parseSearchFilters("縁結び,,  金運  ,")).toEqual(["縁結び", "金運"]);
+  });
+
+  it("重複値を除去する", () => {
+    expect(parseSearchFilters("縁結び,縁結び,金運")).toEqual(["縁結び", "金運"]);
+  });
+
+  it("未知の値でもクラッシュせず、そのまま候補として返す(一致判定はfilterShrines側の責務)", () => {
+    expect(parseSearchFilters("未知のタグ")).toEqual(["未知のタグ"]);
+  });
+
+  it("巨大な入力でもクラッシュせず、件数・値の長さの両方を上限で切り詰める", () => {
+    const manyValues = Array.from({ length: 50 }, (_, i) => `tag${i}`).join(",");
+    const result = parseSearchFilters(manyValues);
+    expect(result.length).toBeLessThanOrEqual(10);
+
+    const hugeValue = "a".repeat(500);
+    expect(parseSearchFilters(hugeValue)).toEqual([]);
+    expect(parseSearchFilters(`縁結び,${hugeValue}`)).toEqual(["縁結び"]);
+  });
+});
+
+describe("filterShrines", () => {
+  it("paramsなし(query/filtersともに未指定)では全件を返す", () => {
+    expect(filterShrines(SAMPLE_SHRINES, {})).toHaveLength(SAMPLE_SHRINES.length);
+  });
+
+  it("1つのfilters条件で該当する神社だけを残す", () => {
+    const result = filterShrines(SAMPLE_SHRINES, { filters: "縁結び" });
+    expect(result.map((s) => s.id)).toEqual(["meiji"]);
+  });
+
+  it("複数filters条件はAND(すべてに一致する神社だけを残す)", () => {
+    const result = filterShrines(SAMPLE_SHRINES, { filters: "商売繁盛,厄除け" });
+    expect(result.map((s) => s.id)).toEqual(["kanda"]);
+  });
+
+  it("都道府県名もfiltersの一致対象になる(既存仕様)", () => {
+    const result = filterShrines(SAMPLE_SHRINES, { filters: "京都府" });
+    expect(result.map((s) => s.id)).toEqual(["fushimi"]);
+  });
+
+  it("queryは神社名・タグ・都道府県への部分一致(大文字小文字を無視)", () => {
+    expect(filterShrines(SAMPLE_SHRINES, { query: "神宮" }).map((s) => s.id)).toEqual(["meiji"]);
+    expect(filterShrines(SAMPLE_SHRINES, { query: "金運" }).map((s) => s.id)).toEqual(["fushimi"]);
+  });
+
+  it("一致する神社がない場合は空配列を返す(呼び出し側でempty stateを出す)", () => {
+    expect(filterShrines(SAMPLE_SHRINES, { filters: "存在しないタグ" })).toEqual([]);
+    expect(filterShrines(SAMPLE_SHRINES, { query: "存在しない神社名" })).toEqual([]);
+  });
+
+  it("未知のfilters値は無視した扱いになり、クラッシュせず空配列を返す", () => {
+    expect(() => filterShrines(SAMPLE_SHRINES, { filters: "未知の値,未知の値2" })).not.toThrow();
+    expect(filterShrines(SAMPLE_SHRINES, { filters: "未知の値,未知の値2" })).toEqual([]);
+  });
+});

--- a/apps/mobile/lib/searchFilters.ts
+++ b/apps/mobile/lib/searchFilters.ts
@@ -1,0 +1,65 @@
+// apps/mobile/lib/searchFilters.ts
+// Home→Search間で受け渡す`filters`クエリパラメータの構築・解析と、
+// Search画面の神社一覧フィルタリングを担う純粋関数。
+//
+// Homeから渡してよい値は、Search側の既存フィルター処理(SHRINES.tags / prefecture)と
+// 意味が一致する既存の固定ラベル(ご利益)のみに限定する。自由入力・個人情報はここでは扱わない
+// (docs/product/mobile-user-flow.md 8節・10節、docs/audit/mobile-user-flow-inventory.md 12.8節)。
+import type { Shrine } from "../data/shrines";
+
+const MAX_FILTER_VALUES = 10;
+const MAX_FILTER_VALUE_LENGTH = 50;
+
+// Home側で選択された安全な固定値から、`filters`クエリパラメータの値を組み立てる。
+// 未選択(undefined)・空文字は除外し、有効な値が1件もなければundefinedを返す
+// (Search側は`filters`パラメータなしを「条件なし」として扱う)。
+export function buildSearchFilters(values: Array<string | undefined>): string | undefined {
+  const normalized = parseSearchFilters(values.filter((value): value is string => Boolean(value)).join(","));
+  return normalized.length > 0 ? normalized.join(",") : undefined;
+}
+
+// Search画面が受け取る`filters`クエリパラメータ(カンマ区切り文字列)を解析する。
+// Search画面はURLから直接開かれる可能性があるため、空値・重複値を除去し、
+// 想定外に大きい入力(値の件数・値自体の長さ)を無視することで安全に扱う。
+export function parseSearchFilters(filters?: string | null): string[] {
+  if (!filters) return [];
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const raw of filters.split(",")) {
+    const value = raw.trim();
+    if (!value || value.length > MAX_FILTER_VALUE_LENGTH || seen.has(value)) continue;
+
+    seen.add(value);
+    result.push(value);
+    if (result.length >= MAX_FILTER_VALUES) break;
+  }
+
+  return result;
+}
+
+export type ShrineListFilter = {
+  query?: string;
+  filters?: string;
+};
+
+// Search画面の神社一覧フィルタリング(既存ロジックをそのまま踏襲)。
+// query: 神社名・タグ・都道府県への部分一致(大文字小文字を区別しない)。
+// filters: 選択された値すべてが、タグまたは都道府県のいずれかに一致すること(AND)。
+export function filterShrines(shrines: Shrine[], { query, filters }: ShrineListFilter): Shrine[] {
+  const normalizedQuery = (query ?? "").toLowerCase();
+  const selected = parseSearchFilters(filters);
+
+  return shrines.filter((shrine) => {
+    const textHit =
+      !normalizedQuery ||
+      shrine.name.toLowerCase().includes(normalizedQuery) ||
+      shrine.tags.some((tag) => tag.toLowerCase().includes(normalizedQuery)) ||
+      (shrine.prefecture ?? "").toLowerCase().includes(normalizedQuery);
+
+    const tagsHit = selected.length === 0 || selected.every((sel) => shrine.tags.includes(sel) || shrine.prefecture === sel);
+
+    return textHit && tagsHit;
+  });
+}


### PR DESCRIPTION
## 目的

Mobile／Expo WebのSearch画面に実装済みだが、現行導線から到達不能だった`q`/`filters`フィルター処理を、Home側の安全な既存条件のみで接続する。新しい検索API・検索UI・推薦ロジックは追加しない。

## 参照したProduct・Audit文書

- `docs/product/mobile-user-flow.md`(8節: サブ導線、10節: 一覧の責務、19節: 現行実装との差分、18節: Deferred「Searchフィルターの接続、または削除判断」)
- `docs/audit/mobile-user-flow-inventory.md`(12.8節: フィルター機能はHome側`openSearch`がparamsを渡していないため事実上デッドコード化)
- `docs/product/concierge-first-final-spec.md`(HomeHero/Filterの責務境界。Searchへ渡す情報がConcierge payloadと同一である必要はないことを確認)
- `docs/analytics/mobile-search-events.md`(Event名・Payload契約。変更していない)

## Homeの現行条件一覧

`consultation`(自由入力相談文)、`selectedTheme`(相談テーマチップ、6種の固定文言だがSHRINESのtag/prefectureとは無関係な相談意図フレーズ)、`birthdate`、`plannedVisitDate`、`origin`(現在地・住所・都道府県)、`selectedVisitStyle`(参拝スタイル、backendキーへ変換される)、`selectedGoriyaku`(ご利益、6種の固定ラベル)、`supportText`(自由入力補助条件)。

## Searchの現行q/filters契約

`q`: `SHRINES`の`name`/`tags`/`prefecture`への部分一致(大文字小文字を無視)。
`filters`: カンマ区切り文字列。各値が`tags`または`prefecture`のいずれかに一致することを全値に要求(AND)。

## 接続した条件

`selectedGoriyaku`(ご利益)のみを`filters`として接続した。`GORIYAKU_OPTIONS`(`apps/mobile/lib/conditionPayload.ts`)の値は、`SHRINES`の`tags`に実際に使われているラベル(例:「縁結び」「厄除け」「金運」)と同じ語彙であり、Searchの既存フィルター処理がそのまま解釈できる唯一の安全な固定値だったため。

## 接続しなかった条件

- `q`(自由入力相談文): 原則禁止。相談文をそのままSearchへ渡すとConciergeとSearchの責務が混ざるため。
- `selectedTheme`: 6種の固定チップだが、値がSHRINESのtags/prefectureと語彙的に一致せず、接続すると常に0件になるため。またConciergeのNeed Mode領域の概念であり、Search(一覧探索)の語彙ではない。
- `selectedVisitStyle`: `VISIT_STYLE_TAG_BY_LABEL`でbackend向けキー(`quiet`等)に変換される値であり、SHRINESのtags/prefectureとは別の語彙。接続すると0件になる。
- `birthdate`/`plannedVisitDate`/`origin`(現在地・住所・都道府県)/`supportText`: 個人情報・自由入力のため。

未使用のまま残した`q`処理の接続要否・削除判断は、本PRのスコープ外として次に送る(`docs/product/mobile-user-flow.md` 18節の既存Deferred項目)。

## URLへ含めない情報

自由入力相談文、住所、駅名、都道府県名(現在地由来)、緯度・経度、誕生日、参拝予定日、ユーザー名、メールアドレス。

## filtersの形式

既存形式(カンマ区切り文字列)をそのまま踏襲した。新しいJSON文字列・配列URL encode・Base64は導入していない。複数条件はAND(既存仕様のまま)。Home側は現状`selectedGoriyaku`が単一選択のため、実際に渡る値は0件または1件。

## 未知値・不正paramsの扱い

`apps/mobile/lib/searchFilters.ts`の`parseSearchFilters`で、空値除去・前後空白除去・重複値除去・件数上限(10件)・値の長さ上限(50文字)を行う。未知の値は既存仕様どおり「一致する神社が0件」という形で安全に無視される(クラッシュしない)。

## Search一覧への影響

`filterShrines`(新規の純粋関数)へフィルタリングロジックを抽出し、Home/Search双方から同じ既存仕様のロジックを参照するようにした。挙動は既存と同一。0件時のみ、既存の`StateCard`を再利用したempty state(「条件に一致する神社が見つかりませんでした」)を追加した(これまでフィルターが実質デッドコードだったため0件到達経路自体がなかった)。

## 人気神社への影響

なし。人気神社は`/populars/`という別APIから独立して取得しており、`filters`は一切渡していない(既存実装のまま変更なし)。

## 地図への影響

なし。地図(`fetchShrineMapPoints`)は`q`のみを使用しており、Home側は`q`を渡さないため地図の挙動は変わらない。座標欠損神社の扱い、`selectedShrineId`同期、Marker選択もコード変更なし。

## Analyticsへの影響

なし。Event名・Payloadは変更していない。`search_entry_click`はfilters生成後も同じ呼び出し(`trackSearchEntryClick()`)のまま。filters利用に関する新規Eventは追加していない(必要性があれば別PR候補とする)。

## 変更ファイル

- `apps/mobile/app/index.tsx`: `openSearch`が`selectedGoriyaku`から安全な`filters`を組み立ててSearchへ渡すよう変更。未選択時は従来どおりparamsなしで遷移。
- `apps/mobile/app/search/index.tsx`: フィルタリングロジックを`lib/searchFilters.ts`の`filterShrines`/`parseSearchFilters`へ委譲。0件時のempty stateを追加(既存`StateCard`を再利用)。
- `apps/mobile/lib/searchFilters.ts`(新規): `buildSearchFilters`/`parseSearchFilters`/`filterShrines`の純粋関数。
- `apps/mobile/lib/__tests__/searchFilters.test.ts`(新規): 上記のユニットテスト。

## 実行したテスト

`pnpm typecheck`、`pnpm test`(160 tests, 新規17件含む)、`pnpm exec expo export -p web`、`git diff --check`、push時のpre-push hook(OpenAPI lint、Web契約テスト607件)いずれも成功。

## 実ブラウザ確認(Expo Web)

- 条件なし: Homeから無条件で`/search`へparamsなしで遷移し、従来どおり神社一覧3件・人気神社(Backend未起動のためerror state表示、既存挙動)を確認。
- 条件あり: Homeでご利益「縁結び」を選択してSearchへ進むと、URLは`/search?filters=%E7%B8%81%E7%B5%90%E3%81%B3`(=「縁結び」のみ)になり、自由入力・住所・緯度経度・誕生日は含まれないことを確認。一覧が「明治神宮」1件に絞り込まれ、検索条件サマリーにも「縁結び」タグが表示されることを確認。Backendへの実際のリクエスト(`/api/shrines/?limit=50`)にも`filters`が含まれず、ローカル一覧処理の範囲に閉じていることをネットワークログで確認。
- 0件: `filters=健康`(SHRINESのどのtagにも一致しない値)で直接アクセスし、新しいempty state「条件に一致する神社が見つかりませんでした」が表示され、画面全体はエラーにならず、人気神社セクションも壊れないことを確認。

戻る操作でのfilter維持は、Search側が`useLocalSearchParams`でURLから直接読み取る既存の仕組みをそのまま使っており(新しいstateストアを追加していない)、構造的にExpo Routerの既存スタック挙動に従う。プレビュー環境(headlessブラウザ)でのクリック経由のback往復確認は、複数スタック画面が同時にDOMへ残る挙動と噛み合わずクリックが安定しなかったため、コードレベルの確認(新規storeなし・URL直読み)にとどめている。

## 変更していない範囲

Backend、API schema、Recommendationロジック、Conciergeの推薦ロジック、Concierge payload、Popular API、Analytics Event名・Payload・契約文書、Premium、Billing、認証、package.json、lockfile、環境変数実値、Product正本文書、Archive文書、既存監査文書。

## 残存リスク

- `q`の未接続状態は今回も維持しており、別PRでの接続・削除判断が引き続き必要(`docs/product/mobile-user-flow.md` 18節)。
- Search画面の0件到達経路が今回のPRで初めて実際に到達可能になった。empty stateの文言・デザインは既存`StateCard`の再利用にとどめており、UIレビューの余地がある。

## Rollback方法

`apps/mobile/app/index.tsx`のfilters生成部分、`apps/mobile/app/search/index.tsx`のfilterShrines/parseSearchFilters利用部分、`apps/mobile/lib/searchFilters.ts`、関連テストをrevertすれば、従来の「Home→Searchはparamsなしで固定」という導線に戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)