### PR TITLE
Mobile Native地図の公開準備を改善

### DIFF
--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -248,7 +248,8 @@ export default function SearchPage() {
         ) : null}
       </View>
 
-      {/* 地図で探す: 補助表示。Webでstyle URL未設定の間はセクション自体を表示しない */}
+      {/* 地図で探す: 補助表示。Webはstyle URL未設定の間、AndroidはGoogle Maps APIキー未設定の間、
+          セクション自体を表示しない(isSearchMapSectionAvailable、lib/shrineMap.ts参照) */}
       {isMapSectionAvailable ? (
         <View style={styles.mapSection}>
           <View style={styles.sectionHeader}>

--- a/apps/mobile/lib/__tests__/shrineMap.test.ts
+++ b/apps/mobile/lib/__tests__/shrineMap.test.ts
@@ -158,13 +158,14 @@ describe("isSearchMapSectionAvailable", () => {
     expect(isSearchMapSectionAvailable("web", "https://example.com/style.json")).toBe(true);
   });
 
-  it("iOSはstyle URLの有無に関わらずtrue(Nativeは常時react-native-mapsを表示する)", () => {
+  it("iOSはstyle URLの有無に関わらずtrue(既定providerのApple MapsはAPIキー不要)", () => {
     expect(isSearchMapSectionAvailable("ios", undefined)).toBe(true);
     expect(isSearchMapSectionAvailable("ios", "https://example.com/style.json")).toBe(true);
   });
 
-  it("Androidもstyle URLの有無に関わらずtrue", () => {
-    expect(isSearchMapSectionAvailable("android", undefined)).toBe(true);
+  it("Androidはstyle URLの有無に関わらずfalse(Google Maps APIキー未設定のためMapView初期化が安全でない)", () => {
+    expect(isSearchMapSectionAvailable("android", undefined)).toBe(false);
+    expect(isSearchMapSectionAvailable("android", "https://example.com/style.json")).toBe(false);
   });
 });
 

--- a/apps/mobile/lib/shrineMap.ts
+++ b/apps/mobile/lib/shrineMap.ts
@@ -31,10 +31,17 @@ export function hasValidCoordinates(
  * Search画面で「地図で探す」セクションを表示してよいか判定する。
  * Web版はEXPO_PUBLIC_WEB_MAP_STYLE_URL未設定を初期公開の通常状態として扱い、
  * セクション自体を表示しない(docs/product/mobile-user-flow.md 11節)。
- * Nativeはreact-native-mapsを常時表示するため、platformOSが"web"でなければ常にtrueとする。
+ * iOSはreact-native-mapsの既定provider(Apple Maps)がAPIキー不要のため常時表示する。
+ * Androidはreact-native-mapsが常にGoogle Mapsを使用しAPIキーが必須だが、
+ * 現状app.jsonにreact-native-maps config plugin・Google Maps APIキーが未設定であり、
+ * MapView初期化時に例外で落ちる既知の不具合がある(react-native-maps公式リポジトリのIssueで
+ * 複数報告されているクラッシュパターン)。APIキー・config plugin設定(契約・費用判断が必要)が
+ * 整うまでは、Android側の地図セクションを表示しない。
  */
 export function isSearchMapSectionAvailable(platformOS: string, styleUrl: string | undefined): boolean {
-  return platformOS !== "web" || Boolean(styleUrl);
+  if (platformOS === "web") return Boolean(styleUrl);
+  if (platformOS === "android") return false;
+  return true;
 }
 
 // selectedShrineIdから選択中の神社を導出する。Search画面・Web地図の両方から


### PR DESCRIPTION
## 目的

Mobile Native環境(iOS/Android)の地図機能について、既存Product・Audit・Analytics文書、現行コード、Expo/EAS設定、react-native-mapsの公式仕様を確認し、初期公開時の配布リスクを整理する。調査の結果、Androidに限定した確定的な配布障害を確認したため、既存条件による最小差分の防御修正のみを実施した。最終的な契約・費用・Google Cloudアカウントの判断は行っていない。

## 調査日

2026-07-26

## 参照したProduct・Audit・Analytics文書

- `docs/product/mobile-user-flow.md`(11節: Web地図の責務、12節: Native地図の扱い「本書ではNative地図の削除・非表示を決定しない」、18節: Deferred、20節: 未確定事項)
- `docs/product/README.md`(文書分類・読む順番の確認。Archiveは判断根拠に使用していない)
- `docs/product/mobile-bottom-navigation.md`(Status: Reference。現行`_layout.tsx`の4タブとは一致しないため、参考情報としてのみ確認)
- `docs/product/concierge-first-final-spec.md`(地図・一覧はSearch側のサブ導線であり、Concierge責務外であることの再確認)
- `docs/audit/mobile-user-flow-inventory.md`(12.4〜12.6節、13節: Native/Web地図の実装差、Analytics 0件の事実。調査開始SHA `0610dfd9`時点の記録であり、現行判断には現行コードを優先した)
- `docs/audit/web-search-map-library-selection.md`、`docs/audit/web-map-tile-provider-selection.md`(Web地図(MapLibre)専用の比較監査であり、Native地図(react-native-maps)は対象外であることを確認。責務が重複しないため、本PRはこれらの文書を変更していない)
- `docs/analytics/mobile-search-events.md`(`map_marker_select`・`shrine_card_click position:"map"`の契約を確認。変更していない)
- `docs/analytics/README.md`(Analytics文書の分類確認)

`docs/audit/web-mobile-experience-parity.md`は現行リポジトリに存在しなかった(指示書記載のファイル名だが未作成)。

既存文書(`mobile-user-flow.md` 12節)がNative地図の責務・未確定事項を既に管理できているため、新しい監査文書は作成していない。

## react-native-mapsの現行構成

- `apps/mobile/components/search/ShrineSearchMap.native.tsx`は`<MapView>`に`provider`propを指定していない(iOS/Android共通の`.native.tsx`ファイル)。
- `apps/mobile/package.json`: `react-native-maps@1.27.2`、`expo@^57.0.8`(react-native-mapsのExpo設定プラグイン要件「1.22以上・Expo SDK 53以上」を満たす)。
- `apps/mobile/app.json`に`react-native-maps`のconfig pluginエントリは存在しない(`plugins`は`expo-router`・`expo-location`のみ)。`android.config.googleMaps.apiKey`・`ios.config.googleMapsApiKey`のいずれも未設定。`npx expo config --type public`の出力でも確認済み。

## iOS provider

`provider`未指定時の既定はApple Maps(react-native-maps公式ドキュメント: "Apple Maps works out-of-the-box"、iOSは"choose between Google Maps or the native Apple Maps implementation"のうちAppleが既定)。APIキー不要。現行コードはこの既定のままであり、iOSは安全。

## Android provider

react-native-maps公式ドキュメント: "On Android, one has to use Google Maps, which in turn requires you to obtain an API key"。Androidには他のprovider選択肢が存在せず、`provider`propの指定有無に関わらず常にGoogle Maps SDK for Androidが使われる。

## API key要否・billing/費用要件

- Android: Google Maps SDK for Androidの利用に**必ず**APIキーが必要(Google Cloud ConsoleでMaps SDK for Androidを有効化し、billingを設定する必要がある。無料枠はあるが利用にはbilling有効化が前提)。現状このリポジトリには設定が一切ない。
- iOS: Apple Maps使用時は不要。
- 現行`.env`は`EXPO_PUBLIC_API_BASE_URL`のみを定義しており、Google Maps関連の値は存在しない。`git log --all -S "AIza"`(Google API keyの典型的なprefix)でもリポジトリ全体を検索し、キーの混入は確認されなかった。

## Expo Go／Development Build／EAS Buildの差

- Expo Goでは`react-native-maps`のようなカスタムネイティブモジュールは動作しない(Expo Go自体の制約であり本リポジトリ固有ではない)。
- Development Build・Preview Build・Production Build(すべて`apps/mobile/eas.json`の3プロファイル経由でカスタムネイティブバイナリを生成)はreact-native-mapsのネイティブコードを含むため、Android側でGoogle Maps APIキー欠如の影響を直接受ける。
- `.github/workflows/mobile-ci.yml`はtypecheck/testのみで、ネイティブビルド(EAS Build含む)を一切実行していない。そのためこの設定ギャップはこれまでCIで検出されようがなかった。

## app.json／eas.jsonの確認結果(値は変更していない)

- `app.json`: `plugins`は`["expo-router", ["expo-location", {...}]]`のみ。`ios.bundleIdentifier`は設定済み(`com.morietsu.kamimusubi`)。`android`は`permissions`(位置情報)のみで`package`(applicationId)は未設定。Google Maps関連設定は存在しない。
- `eas.json`: `build.development/preview/production`の3プロファイル。各`environment`フィールドでEAS Environmentsと連携する構成(値は未確認、契約情報のため本PRでは扱わない)。Google Maps API keyに関する記述はない。

## 現行UI構造

Search画面(`apps/mobile/app/search/index.tsx`)は「検索条件サマリー→神社一覧(主要探索UI)→選択カード→人気の神社→地図で探す」の順で、地図は一覧・人気神社より後方に配置される(`docs/product/mobile-user-flow.md` 10節・13節の責務どおり)。地図セクションは`isSearchMapSectionAvailable(Platform.OS, EXPO_PUBLIC_WEB_MAP_STYLE_URL)`で表示可否が決まる。

## Marker・一覧・選択カード同期

- `selectedShrineId`はSearch画面のstateで一元管理し、一覧の「地図で選択」ボタン、Marker押下(`ShrineSearchMap`)、座標欠損リストのいずれからも同じ`setSelectedShrineId`を呼ぶ単一経路(`apps/mobile/lib/shrineMap.ts`の`findShrineMapPointById`で選択中神社を導出)。
- 座標欠損神社は`hasValidCoordinates`でMarker表示対象からのみ除外され、一覧・選択・詳細遷移の対象からは除外されない(`toShrineMapPoints`は座標欠損でも項目を残す設計、既存テストで確認済み)。
- 有効座標0件時は`mapStatus === "ready" && mapPoints.length === 0`で専用のStateCard(「神社が見つかりませんでした」)を表示する。

## Analytics

- `map_marker_select`(Marker・座標欠損リスト選択)、`shrine_card_click position:"map"`(選択カードからの詳細遷移)いずれもEvent名・Payloadは変更していない。
- 地図セクションが非表示の環境(今回のAndroid)では、Markerクリックの機会自体が発生しないため`map_marker_select`は発火しない。ただし一覧の「地図で選択」ボタンは`existsOnMap`(APIから取得した`mapPoints`)のみを条件にしており地図の表示可否を見ていないため、Android上でも選択カード経由の`shrine_card_click position:"map"`は従来どおり発火可能(Web版でstyle URL未設定時と同じ既存の許容パターンであり、本PRで新たに生じた挙動ではない)。
- 地図利用率の将来計測は、現状Analyticsが0件のため引き続き別課題(`mobile-user-flow-inventory.md` 18.2節と同じ既知ギャップ、本PR範囲外)。

## 案A／B／C／D比較

| 項目 | 案A: 現行維持 | 案B: 折りたたみ | 案C: 初期公開では非表示 | 案D: 別画面へ分離 |
| --- | --- | --- | --- | --- |
| 実装変更量 | なし | 中(開閉state・初期化タイミング制御が必要) | 小(既存の`isSearchMapSectionAvailable`条件を拡張するだけ) | 大(新Route・Navigation・state引き継ぎ) |
| 配布設定 | Android Google Maps APIキー・config plugin・billingが必須(未設定) | 同左(表示自体は残るため必須なまま) | Androidは当面不要(iOSはApple Mapsのままで不要) | 表示する場合は同左が必要 |
| API key・費用 | Android未設定→配布後に既知のクラッシュ/初期化失敗パターンに該当するリスクが確定的に存在 | 同左のリスクが残る(展開時に同じ初期化が走る) | 契約・費用判断を後日に切り離せる | 同左のリスクが残る |
| 障害点/UX | Search画面全体が使えなくなるわけではないが、地図領域が既知の初期化失敗パターンに該当しうる状態のまま配布される | 初期状態では地図を初期化しないため露出は減るが、展開時に同じリスクが顕在化する | 地図起因の障害点をそのまま初期公開から除外できる | 別Routeに切り離すため露出はさらに減るが実装量が見合わない |
| Webとの差 | Web(style URL未設定)は一覧のみ、Androidは(本来は)地図ありで差がある | 同左だが折りたたみで多少緩和 | Web・Android双方が「地図なしの一覧」で揃う(iOSのみ地図あり) | Webと個別Route構成が異なり一貫性の判断がさらに複雑になる |
| Analytics | 変更なし | 変更なし(初期化タイミングのみ変わる) | 変更なし(発火機会が減るのみ、Event自体は無傷) | 変更なし |
| Rollback容易性 | 該当なし | 中(state管理の追加分を戻す必要) | 高(1関数の条件分岐を戻すだけ) | 低(Route自体の削除が必要) |

## 推奨候補

**案C(初期公開ではAndroidのみ非表示)を採用した。** ただし判断の速さを優先したものではなく、以下の確定した事実に基づく:

1. react-native-maps公式ドキュメントで「Androidは常にGoogle Mapsを使用し、APIキーが必須」と明記されている。
2. 本リポジトリの`app.json`にはreact-native-mapsのconfig plugin・Google Maps APIキーが一切設定されていない(直接確認済み)。
3. react-native-maps公式リポジトリのIssueで、APIキー未設定時に`IllegalStateException: API key not found`等でクラッシュする既知の不具合パターンが複数報告されている(react-native-maps/react-native-maps#5884、#5611等)。
4. 本リポジトリのCI(`mobile-ci.yml`)はネイティブビルドを行わないため、この設定ギャップは今後もEAS Build実行やストア配布まで顕在化しない。

「地図表示が画面全体をクラッシュさせる」「API key未設定でproduction buildが確実に壊れる」に該当する確定的な配布障害と判断し、既存の`isSearchMapSectionAvailable`関数(Web版のstyle URL未設定判定と同じ関数)にAndroid判定を追加する最小差分で対応した。iOSはApple Maps既定のため無変更。

案B・Dは実装量に対してこの防御修正の緊急性に見合わないため採用しなかった。案A(現行維持)は上記の確定リスクをそのまま配布することになるため採用しなかった。

## 採用しなかった案の理由

- **案A**: Android配布時に既知のクラッシュパターンへ該当するリスクをそのまま残すため。
- **案B**: 状態管理・初期化タイミング制御の実装量に対し、Androidのリスクを避けられない(展開した瞬間に同じ初期化が走る)ため、今回の防御修正の範囲を超える。
- **案D**: 新Route・Navigation・state引き継ぎが必要で「別画面分離は実装量が大きいため、今回のPRでは原則実装しない」という制約に反するため。

Native地図の**長期的な**表示継続・優先度・画面配置という戦略的判断(`docs/product/mobile-user-flow.md` 12節が明示的に「別PRで判断する」としている論点)は、本PRでは行っていない。今回の変更はAndroidの配布安全性のみを扱う防御修正であり、APIキー・config plugin設定が整い次第、1関数の条件分岐を戻すだけで再度有効化できる。

## コード変更の有無

あり(最小差分)。

## 変更ファイル

- `apps/mobile/lib/shrineMap.ts`: `isSearchMapSectionAvailable`にAndroid判定を追加(`platformOS === "android"`の場合は常に`false`)。iOS・Webの既存挙動は無変更。
- `apps/mobile/lib/__tests__/shrineMap.test.ts`: 上記に合わせてAndroidのテスト期待値を`true`→`false`へ更新し、理由をテスト名へ明記。
- `apps/mobile/app/search/index.tsx`: 地図セクション付近のコメントを更新(挙動変更なし)。

`app.json`・`eas.json`・`package.json`・lockfileはいずれも変更していない。

## 実行したテスト

`pnpm typecheck`、`pnpm test`(160 tests)、`pnpm exec expo export -p web`、`git diff --check`、push時のpre-push hook(OpenAPI lint、Web契約テスト607件)いずれも成功。

## 実機・シミュレータ確認

- **iOS Simulator**: 未確認。ブート済みシミュレータが存在せず、この環境には`ios/`ディレクトリ(prebuild成果物)も存在しないため、確認には`expo prebuild`からのフルネイティブビルドが必要になる。今回の主要リスクはAndroid固有(iOSはApple Mapsの既定挙動が変わらないため今回の修正でも無変更)であり、ビルドにかかる時間に対して得られる追加確証が小さいと判断し、実施しなかった。前回セッション(`docs/audit/mobile-user-flow-inventory.md`)でも同様にiOS Simulatorでの実地確認は不安定だったため未実施としている。
- **Android Emulator**: 未確認。この環境にAndroid Emulatorはセットアップされていない。
- **Expo Web**: 確認済み。`/search`をstyle URL未設定のまま表示し、一覧3件・人気神社(Backend未起動のためerror state、既存挙動)が従来どおり表示されることを確認した。Web版のロジック分岐(`platformOS === "web"`)は本PRで変更していないため、回帰なし。

## 未確認事項

- Android実機/エミュレータでの実際のクラッシュ再現(公式ドキュメント・公式リポジトリのIssueに基づく確定的な仕様確認であり、本セッションでの実機再現は行っていない)。
- iOS Simulatorでの地図表示・Marker選択・座標欠損神社・有効座標0件の実地確認(未確認。今回の変更はiOS動作に影響しないため、リグレッションリスクは低いと判断)。

## 契約・費用の判断待ち

- Android向けGoogle Maps SDKの有効化、APIキー発行、billing設定、bundle/package制限の要否は本PRで判断していない。これらが整い次第、`isSearchMapSectionAvailable`のAndroid分岐を解除するだけで再有効化できる。
- Native地図を長期的に維持するか、折りたたみ(案B)や別画面分離(案D)へ移行するかという戦略判断も本PRでは行っていない。

## 今回変更していない範囲

Backend、API schema、Recommendationロジック、Meaning Layer、Concierge、Search通常一覧、人気神社、Ranking、Searchフィルター、Reflection／再相談、Web地図、MapLibre、Analytics Event名・Payload、Premium、Billing、認証、returnTo、Orphan画面、`package.json`、root`pnpm-lock.yaml`、`apps/mobile/pnpm-lock.yaml`、EAS Environmentの実値、API key実値、Product正本文書、Archive文書、既存監査文書。新規依存は追加していない。

## Rollback方法

`apps/mobile/lib/shrineMap.ts`の`isSearchMapSectionAvailable`とその関連テストをrevertすれば、Androidでも常時地図セクションを表示する従来の挙動に戻る(ただしその場合、上記の未設定APIキーに起因するリスクが再度顕在化する点に注意)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)