### PR TITLE
fix(mobile): Android地図の実行時設定と選択導線を修正

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -4,6 +4,17 @@ import type { ConfigContext, ExpoConfig } from "expo/config";
 // 使うためにはapp.config.ts(動的config)が必要で、静的なapp.jsonはprocess.envを解決できない
 // (app.json内の"process.env.X"はビルド時に置換されず、生成AndroidManifest.xmlへ
 // リテラル文字列のまま書き込まれてしまう)。
+// Android Maps APIキーは一度だけ読み取る。react-native-mapsプラグインへは
+// 従来通り実値を渡す(AndroidManifestへのネイティブ注入に必要)一方、
+// JavaScript側の表示判定(Search画面)へは実値を渡さず、extra.androidMapsEnabled
+// というbooleanのみを公開する。process.env.EXPO_PUBLIC_*はMetroバンドル生成時に
+// インライン化されるが、EAS BuildのGradle経由バンドル生成では確実に伝播しない
+// ことが確認されたため(READ_APP_CONFIG/AndroidManifestへは伝播するが、
+// Gradleが起動するJSバンドル生成には伝播しない場合がある)、JS側の判定は
+// ビルド時に確定済みのextra(Constants.expoConfig経由で実行時も安定して取得できる)
+// を参照する設計にしている。
+const androidGoogleMapsApiKey = process.env.EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY;
+
 export default ({ config }: ConfigContext): ExpoConfig => ({
   ...config,
   name: "KAMI MUSUBI",
@@ -24,7 +35,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
         // iosGoogleMapsApiKeyは意図的に渡さない。未指定の場合、react-native-mapsの
         // config pluginはiOS側にGoogle Maps SDKを組み込まず、既定のApple Mapsのままにする
         // (node_modules/react-native-maps/plugin/build/ios.jsのwithMapsIOSで確認済み)。
-        androidGoogleMapsApiKey: process.env.EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY,
+        androidGoogleMapsApiKey,
       },
     ],
   ],
@@ -45,6 +56,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     eas: {
       projectId: "a6cd458a-bdb6-4a5b-8b44-2939d4848b39",
     },
+    androidMapsEnabled: Boolean(androidGoogleMapsApiKey),
   },
   owner: "morietsu",
 });

--- a/apps/mobile/app/search/index.tsx
+++ b/apps/mobile/app/search/index.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import Constants from "expo-constants";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { View, Text, ScrollView, Pressable, Image, StyleSheet, Platform } from "react-native";
 import { SHRINES } from "../../data/shrines";
@@ -18,10 +19,16 @@ import { fetchPopularShrines, type PopularShrine } from "../../lib/popularShrine
 import { trackSearchScreenView, trackShrineCardClick } from "../../lib/searchAnalytics";
 import { filterShrines, parseSearchFilters } from "../../lib/searchFilters";
 
+// Androidの地図可否はAPIキー実値ではなく、app.config.tsが生成したbooleanを
+// Constants.expoConfig経由で参照する(process.env.EXPO_PUBLIC_*はEAS BuildのGradle
+// 経由JSバンドル生成では確実に伝播しないことが確認されたため、実行時に安定して
+// 取得できるexpo configのextraを使う。詳細はlib/shrineMap.tsのコメント参照)。
+const androidMapsEnabled = Constants.expoConfig?.extra?.androidMapsEnabled === true;
+
 const isMapSectionAvailable = isSearchMapSectionAvailable(
   Platform.OS,
   process.env.EXPO_PUBLIC_WEB_MAP_STYLE_URL,
-  process.env.EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY,
+  androidMapsEnabled,
 );
 
 export default function SearchPage() {
@@ -154,22 +161,24 @@ export default function SearchPage() {
                     </Text>
                   </Pressable>
 
-                  <View style={styles.cardMapActionRow}>
-                    <Button
-                      title={isSelectedOnMap ? "地図で選択中" : "地図で選択"}
-                      variant="outline"
-                      size="compact"
-                      disabled={!existsOnMap}
-                      onPress={() => setSelectedShrineId(s.id)}
-                      accessibilityLabel={
-                        !existsOnMap
-                          ? `${s.name}は地図に表示されていません`
-                          : isSelectedOnMap
-                            ? `${s.name}を地図で選択中`
-                            : `${s.name}を地図で選択`
-                      }
-                    />
-                  </View>
+                  {isMapSectionAvailable ? (
+                    <View style={styles.cardMapActionRow}>
+                      <Button
+                        title={isSelectedOnMap ? "地図で選択中" : "地図で選択"}
+                        variant="outline"
+                        size="compact"
+                        disabled={!existsOnMap}
+                        onPress={() => setSelectedShrineId(s.id)}
+                        accessibilityLabel={
+                          !existsOnMap
+                            ? `${s.name}は地図に表示されていません`
+                            : isSelectedOnMap
+                              ? `${s.name}を地図で選択中`
+                              : `${s.name}を地図で選択`
+                        }
+                      />
+                    </View>
+                  ) : null}
                 </View>
               );
             })}

--- a/apps/mobile/lib/__tests__/shrineMap.test.ts
+++ b/apps/mobile/lib/__tests__/shrineMap.test.ts
@@ -163,17 +163,19 @@ describe("isSearchMapSectionAvailable", () => {
     expect(isSearchMapSectionAvailable("ios", "https://example.com/style.json")).toBe(true);
   });
 
-  it("AndroidはGoogle Maps APIキー未設定の場合false(MapView初期化が安全でない、style URLの有無は無関係)", () => {
+  it("AndroidはandroidMapsEnabledがundefinedの場合false(MapView初期化が安全でない、style URLの有無は無関係)", () => {
     expect(isSearchMapSectionAvailable("android", undefined, undefined)).toBe(false);
-    expect(isSearchMapSectionAvailable("android", undefined, "")).toBe(false);
     expect(isSearchMapSectionAvailable("android", "https://example.com/style.json", undefined)).toBe(false);
   });
 
-  it("AndroidはGoogle Maps APIキー設定済みの場合true(style URLの有無は無関係)", () => {
-    expect(isSearchMapSectionAvailable("android", undefined, "test-android-maps-key")).toBe(true);
-    expect(isSearchMapSectionAvailable("android", "https://example.com/style.json", "test-android-maps-key")).toBe(
-      true,
-    );
+  it("AndroidはandroidMapsEnabled=falseの場合false(style URLの有無は無関係)", () => {
+    expect(isSearchMapSectionAvailable("android", undefined, false)).toBe(false);
+    expect(isSearchMapSectionAvailable("android", "https://example.com/style.json", false)).toBe(false);
+  });
+
+  it("AndroidはandroidMapsEnabled=trueの場合true(style URLの有無は無関係)", () => {
+    expect(isSearchMapSectionAvailable("android", undefined, true)).toBe(true);
+    expect(isSearchMapSectionAvailable("android", "https://example.com/style.json", true)).toBe(true);
   });
 });
 

--- a/apps/mobile/lib/shrineMap.ts
+++ b/apps/mobile/lib/shrineMap.ts
@@ -35,17 +35,20 @@ export function hasValidCoordinates(
  * Androidはreact-native-mapsが常にGoogle Mapsを使用しAPIキーが必須であり、
  * APIキー未設定のままMapViewを初期化すると例外で落ちる既知の不具合がある
  * (react-native-maps公式リポジトリのIssueで複数報告されているクラッシュパターン)。
- * androidGoogleMapsApiKeyは`EXPO_PUBLIC_ANDROID_GOOGLE_MAPS_API_KEY`(app.config.tsの
- * react-native-mapsプラグインへ渡す値と同じ変数)の有無を表す。EAS Environmentへ未登録の
- * ビルド(development/preview等)ではこの値が渡らず、Android地図は安全に非表示のままになる。
+ * androidMapsEnabledはapp.config.tsが生成したbooleanで、呼び出し側
+ * (Search画面)はConstants.expoConfig?.extra?.androidMapsEnabled経由で取得する。
+ * APIキー実値はJavaScript側の表示判定に一切渡さない(EAS BuildのGradle経由JS
+ * バンドル生成ではprocess.env.EXPO_PUBLIC_*が確実に伝播しない場合があり、実値を
+ * 直接参照するとビルドによって判定が不安定になるため)。値が未設定・undefinedの
+ * 場合はfail-safeとしてfalse(地図非表示)を返す。
  */
 export function isSearchMapSectionAvailable(
   platformOS: string,
   styleUrl: string | undefined,
-  androidGoogleMapsApiKey?: string,
+  androidMapsEnabled?: boolean,
 ): boolean {
   if (platformOS === "web") return Boolean(styleUrl);
-  if (platformOS === "android") return Boolean(androidGoogleMapsApiKey);
+  if (platformOS === "android") return androidMapsEnabled === true;
   return true;
 }
 


### PR DESCRIPTION
### 背景

Android QA APKでは、Google Maps APIキーがAndroidManifestには注入されていた一方、JavaScript bundle内では未解決となり、地図表示判定がfalseになっていた。

また、地図が利用不可でも「地図で選択」ボタンが表示され、無反応に見える状態だった。

### 変更内容

- app.config.tsでAPIキーの有無をboolean化
- extra.androidMapsEnabledとしてbooleanのみ公開
- Search画面からAPIキー実値の直接参照を削除
- expo-constants経由でbooleanを取得
- isSearchMapSectionAvailableの第3引数をbooleanへ変更
- 地図利用不可時は「地図で選択」を描画しない
- Android表示判定テストを更新

### セキュリティ

- APIキー実値をextraへ含めていない
- APIキー実値をJS表示判定へ渡していない
- SHA-1・Keystore情報を変更していない

### ローカル検査

- git diff --check: pass
- pnpm install --frozen-lockfile: pass
- Mobile typecheck: pass
- Mobile test: 167 tests pass
- Expo Web export: pass
- APIキー未設定時: androidMapsEnabled=false
- ダミーキー設定時: androidMapsEnabled=true
- ダミーキー文字列はextraへ含まれない

### 残作業

- EAS productionへEXPO_PUBLIC_API_BASE_URLを登録
- EAS QA Build
- Androidエミュレーター再QA
- Markerと一覧の双方向同期確認

### 既知の別件

expo install --checkでDependabot由来のSDK推奨バージョン警告が存在するが、本PRではpackage.json・pnpm-lock.yamlを変更しておらず、今回の修正範囲外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)