### PR TITLE
fix(backend): 推薦理由をFact種別ごとの文型へ修正

### DIFF
--- a/backend/temples/services/recommendation_reason_v4.py
+++ b/backend/temples/services/recommendation_reason_v4.py
@@ -140,6 +140,10 @@ def _build_fact(candidate_profile: dict[str, Any], meaning_translation: dict[str
     visit_style_tags = _as_list(candidate_profile.get("visit_style_tags"))
     name = _first_string(candidate_profile.get("name"))
 
+    # label は互換目的の補助フィールド（既存テスト・evidence表示のみで参照）。
+    # _build_reason_text の主判定には使用しない。place_context(住所)を含む算出方法は
+    # 従来のまま維持し、reason_text生成側でplace_contextを除外することで
+    # 「住所が神社の特徴として表示される」不具合のみを止める。
     label = _first_string(deity, shrine_history, place_context, history_theme, goriyaku, name, "候補神社") or "候補神社"
     evidence: list[str] = []
 
@@ -164,6 +168,7 @@ def _build_fact(candidate_profile: dict[str, Any], meaning_translation: dict[str
         "deity": deity,
         "shrine_history": shrine_history,
         "place_context": place_context,
+        "history_theme": history_theme,
         "goriyaku": goriyaku,
         "visit_style_tags": visit_style_tags,
         "evidence": evidence,
@@ -177,7 +182,7 @@ def _build_used_fact(fact: dict[str, Any]) -> dict[str, Any]:
         "shrine_history": fact.get("shrine_history"),
         "place_context": fact.get("place_context"),
         "goriyaku": fact.get("goriyaku"),
-        "history_theme": fact.get("label") if fact.get("label") not in {fact.get("deity"), fact.get("shrine_history"), fact.get("place_context"), fact.get("goriyaku"), "候補神社"} else None,
+        "history_theme": fact.get("history_theme"),
         "evidence": fact.get("evidence") or [],
     }
 
@@ -386,44 +391,61 @@ def build_recommendation_reason_quality_audit(reason: dict[str, Any]) -> dict[st
     }
 
 
+def _build_fact_text(fact: dict[str, Any]) -> str:
+    """Compose the Fact sentence by branching on Fact type.
+
+    Each Fact type (deity / shrine_history / goriyaku / history_theme) has its own
+    sentence form instead of being flattened into a single "label" template.
+    place_context (raw address) is never used as the sentence subject: an address is
+    not a shrine-specific feature, and stating "shrine X has the feature of <address>"
+    reads as broken Japanese and misrepresents empty Fact data as grounded content.
+    """
+    fact_name = _first_string(fact.get("name"))
+    fact_deity = _first_string(fact.get("deity"))
+    fact_shrine_history = _first_string(fact.get("shrine_history"))
+    fact_goriyaku = _first_string(fact.get("goriyaku"))
+    fact_history_theme = _first_string(fact.get("history_theme"))
+    visit_style_copies = _copy_visit_style_tags(_as_list(fact.get("visit_style_tags")))
+
+    subject = fact_name or "この神社"
+    fact_details: list[str] = []
+
+    if fact_deity:
+        fact_text = f"{subject}では、{fact_deity}が祀られています。"
+        if fact_goriyaku:
+            fact_details.append(f"{fact_goriyaku}の要素")
+    elif fact_shrine_history:
+        history_text = fact_shrine_history.rstrip("。")
+        fact_text = f"{subject}には、{history_text}という背景があります。"
+        if fact_goriyaku:
+            fact_details.append(f"{fact_goriyaku}の要素")
+    elif fact_goriyaku:
+        fact_text = f"{subject}には、{fact_goriyaku}に関する情報があります。"
+    elif fact_history_theme:
+        fact_text = f"{subject}は、{fact_history_theme}という文脈で整理されています。"
+    else:
+        # deity / shrine_history / goriyaku / history_theme が一つもない場合。
+        # place_context(住所)や神社名だけでは神社固有Factがあるとは表現しない。
+        fact_text = "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
+
+    if visit_style_copies:
+        fact_details.extend(visit_style_copies[:2])
+
+    if fact_details:
+        detail_text = "、".join(fact_details)
+        fact_text = f"{fact_text.rstrip('。')}。{detail_text}も確認材料になります。"
+
+    return fact_text
+
+
 def _build_reason_text(fact: dict[str, Any], interpretation: dict[str, Any], action: dict[str, Any]) -> str:
     """Compose reason_text as Fact -> Interpretation -> Action.
 
     Keep each sentence responsible for one layer only.
     """
-    fact_label = _first_string(fact.get("label")) or "候補神社"
-    fact_name = _first_string(fact.get("name"))
-    fact_goriyaku = _first_string(fact.get("goriyaku"))
-    visit_style_copies = _copy_visit_style_tags(_as_list(fact.get("visit_style_tags")))
+    fact_text = _build_fact_text(fact)
     interpretation_text = _first_string(interpretation.get("text")) or "相談内容から、今扱いたいテーマを読み取っています。"
     action_text = _first_string(action.get("text")) or "次に確認したいことを一つだけ決めます。"
-
-    if fact_name and fact_label != "候補神社":
-        fact_text = f"{fact_name}には、{fact_label}の特徴があります。"
-    elif fact_name:
-        fact_text = f"{fact_name}は、相談内容と神社側の情報を重ねて見ています。"
-    elif fact_label == "候補神社":
-        fact_text = "この神社は、相談内容と神社側の情報を重ねて見ています。"
-    else:
-        fact_text = f"この神社には、{fact_label}の特徴があります。"
-
-    fact_details: list[str] = []
-    if fact_goriyaku and fact_goriyaku != fact_label:
-        fact_details.append(f"{fact_goriyaku}の要素")
-    if visit_style_copies:
-        fact_details.extend(visit_style_copies[:2])
-    if fact_details:
-        detail_text = "、".join(fact_details)
-        if fact_text.endswith("の特徴があります。"):
-            fact_text = fact_text.replace(
-                "の特徴があります。",
-                f"の特徴があり、{detail_text}も材料になります。",
-            )
-        else:
-            fact_text = f"{fact_text.rstrip('。')}。{detail_text}も確認材料になります。"
-
-    if fact_label == "候補神社" and interpretation_text == "相談内容から、今扱いたいテーマを読み取っています。":
-        interpretation_text = "相談内容から、今扱いたいテーマを読み取っています。"
 
     reason_parts = [fact_text, interpretation_text, action_text]
     return "".join(reason_parts[:3])

--- a/backend/temples/tests/services/test_recommendation_reason_v4.py
+++ b/backend/temples/tests/services/test_recommendation_reason_v4.py
@@ -72,7 +72,7 @@ def test_build_recommendation_reason_v4_returns_stable_schema():
     assert isinstance(result["used_interpretation"], dict)
     assert isinstance(result["used_action"], dict)
     assert isinstance(result["quality"], dict)
-    assert set(result["fact"].keys()) == {"label", "name", "deity", "shrine_history", "place_context", "goriyaku", "visit_style_tags", "evidence"}
+    assert set(result["fact"].keys()) == {"label", "name", "deity", "shrine_history", "place_context", "history_theme", "goriyaku", "visit_style_tags", "evidence"}
     assert set(result["interpretation"].keys()) == {"theme", "text"}
     assert set(result["action"].keys()) == {"text", "source"}
     assert set(result["used_fact"].keys()) == {"deity", "shrine_history", "place_context", "goriyaku", "history_theme", "evidence"}
@@ -102,6 +102,7 @@ def test_build_recommendation_reason_v4_builds_fact_layer_from_candidate_and_mea
         "deity": "武神",
         "shrine_history": "古くから勝負の祈願で知られる",
         "place_context": "静かな丘の上",
+        "history_theme": "再出発",
         "goriyaku": "仕事運",
         "visit_style_tags": ["quiet", "nature"],
         "evidence": [
@@ -120,7 +121,7 @@ def test_build_recommendation_reason_v4_builds_fact_layer_from_candidate_and_mea
         "shrine_history": "古くから勝負の祈願で知られる",
         "place_context": "静かな丘の上",
         "goriyaku": "仕事運",
-        "history_theme": None,
+        "history_theme": "再出発",
         "evidence": [
             "deity:武神",
             "shrine_history:古くから勝負の祈願で知られる",
@@ -149,7 +150,7 @@ def test_build_recommendation_reason_v4_includes_shrine_name_in_reason_text():
         },
     )
 
-    assert "神社Aには、再出発の特徴があり、仕事運の要素も材料になります。" in result["reason_text"]
+    assert "神社Aには、仕事運に関する情報があります。" in result["reason_text"]
 
 
 def test_build_recommendation_reason_v4_keeps_goriyaku_and_visit_style_in_fact():
@@ -177,7 +178,7 @@ def test_build_recommendation_reason_v4_reflects_goriyaku_and_visit_style_in_fac
         },
     )
 
-    assert "神社Eには、再出発の特徴があり、仕事運の要素、静かに参拝しやすい、自然を感じながら過ごしやすいも材料になります。" in result["reason_text"]
+    assert "神社Eには、仕事運に関する情報があります。静かに参拝しやすい、自然を感じながら過ごしやすいも確認材料になります。" in result["reason_text"]
 
 
 def test_build_recommendation_reason_v4_prioritizes_shrine_specific_fact_fields():
@@ -422,13 +423,14 @@ def test_build_recommendation_reason_v4_handles_missing_inputs_safely():
     result = build_recommendation_reason_v4()
 
     assert result == {
-        "reason_text": "この神社は、相談内容と神社側の情報を重ねて見ています。相談内容から、今扱いたいテーマを読み取っています。参拝前に、次に確認したいことを一つだけ決めておきます。",
+        "reason_text": "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。相談内容から、今扱いたいテーマを読み取っています。参拝前に、次に確認したいことを一つだけ決めておきます。",
         "fact": {
             "label": "候補神社",
             "name": None,
             "deity": None,
             "shrine_history": None,
             "place_context": None,
+            "history_theme": None,
             "goriyaku": None,
             "visit_style_tags": [],
             "evidence": [],
@@ -562,3 +564,133 @@ def test_build_recommendation_reason_v4_uses_state_direction_and_emotion_profile
         "text": "気持ちを落ち着け、今の状態を整理したい相談として受け取れます。不安や心配を中心に、要素が強めに出ています。",
     }
     assert "あなたは" not in result["reason_text"]
+
+
+# --- Fact種別別コピー修正: place_context誤用防止・種別別文型のテスト ---
+
+
+def test_build_recommendation_reason_v4_place_context_only_does_not_state_address_as_feature():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "place_context": "東京都渋谷区代々木神園町1-1",
+        },
+    )
+
+    assert "東京都渋谷区代々木神園町1-1" not in result["reason_text"]
+    assert "の特徴があります" not in result["reason_text"]
+    assert (
+        "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
+        in result["reason_text"]
+    )
+
+
+def test_build_recommendation_reason_v4_name_and_address_only_does_not_assert_unique_feature():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "place_context": "東京都渋谷区代々木神園町1-1",
+        },
+    )
+
+    assert "東京都渋谷区代々木神園町1-1" not in result["reason_text"]
+    assert "テスト神社には、東京都渋谷区代々木神園町1-1" not in result["reason_text"]
+
+
+def test_build_recommendation_reason_v4_history_theme_only_is_prioritized_over_address():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "history_theme": "縁",
+        },
+    )
+
+    assert "テスト神社は、縁という文脈で整理されています。" in result["reason_text"]
+
+    result_with_address = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "history_theme": "縁",
+            "place_context": "東京都渋谷区代々木神園町1-1",
+        },
+    )
+    assert "テスト神社は、縁という文脈で整理されています。" in result_with_address["reason_text"]
+    assert "東京都渋谷区代々木神園町1-1" not in result_with_address["reason_text"]
+
+
+def test_build_recommendation_reason_v4_goriyaku_only_is_not_labeled_as_history_or_deity():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "goriyaku": "縁結び・厄除け",
+        },
+    )
+
+    assert "テスト神社には、縁結び・厄除けに関する情報があります。" in result["reason_text"]
+    assert "の特徴があります" not in result["reason_text"]
+    assert "祀られています" not in result["reason_text"]
+    assert "由緒" not in result["reason_text"]
+
+
+def test_build_recommendation_reason_v4_deity_uses_enshrined_copy_not_feature_copy():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "deity": "テスト祭神",
+        },
+    )
+
+    assert "テスト神社では、テスト祭神が祀られています。" in result["reason_text"]
+    assert "テスト祭神の特徴があります" not in result["reason_text"]
+
+
+def test_build_recommendation_reason_v4_shrine_history_uses_background_copy_without_broken_grammar():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+        },
+    )
+
+    assert (
+        "テスト神社には、戦災で焼失した後、氏子により再建されたという背景があります。"
+        in result["reason_text"]
+    )
+    assert "の特徴があります" not in result["reason_text"]
+    # 日本語として破綻する二重句点・不自然な接続がないことを確認する
+    assert "。。" not in result["reason_text"]
+    assert "たの特徴" not in result["reason_text"]
+
+
+def test_build_recommendation_reason_v4_all_facts_present_prioritizes_deity_and_excludes_place_context():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "deity": "テスト祭神",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "place_context": "東京都渋谷区代々木神園町1-1",
+            "history_theme": "縁",
+            "goriyaku": "縁結び・厄除け",
+            "visit_style_tags": ["quiet", "nature"],
+        },
+    )
+
+    assert result["reason_text"].startswith("テスト神社では、テスト祭神が祀られています。")
+    assert "縁結び・厄除けの要素" in result["reason_text"]
+    assert "静かに参拝しやすい" in result["reason_text"]
+    assert "自然を感じながら過ごしやすい" in result["reason_text"]
+    assert "東京都渋谷区代々木神園町1-1" not in result["reason_text"]
+
+
+def test_build_recommendation_reason_v4_no_facts_falls_back_without_fabricating_specificity():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+        },
+    )
+
+    assert (
+        "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
+        in result["reason_text"]
+    )
+    assert result["quality"]["fallback_source"] == "fallback"


### PR DESCRIPTION
### 背景

実データ100件をRecommendation Reason V4へ通した結果、deityとshrine_historyが全件空であるため、place_contextに入った住所が100/100件でFact文の主語として採用されていた。

例:

`明治神宮には、東京都渋谷区代々木神園町1-1の特徴があります。`

また、shrine_historyを追加した場合も、長文が単一label文型へ入り、日本語が破綻する構造だった。

### 変更内容

- history_themeをFact dictへ明示的に保持
- used_fact.history_themeをlabel逆算から直接参照へ変更
- Fact本文をdeity / shrine_history / goriyaku / history_theme / fallbackの種別別文型へ変更
- place_contextはFactとevidenceには保持するが、推薦理由本文には使用しない
- labelは互換目的で維持
- Interpretation / Action / ranking / Score / UIは変更しない

### 100件再監査

- 住所混入: 100/100 → 0/100
- 旧「特徴があります」文型: 100/100 → 0/100
- 生成例外: 0件
- Fact主文:
  - goriyaku: 98件
  - fallback: 2件

### テスト

- Recommendation Reason V4: 24件pass
- Backend temples: 770 passed / 9 skipped / 0 failed
- git diff --check: pass

### 対象外

- is_ai_inference_only
- evidence_rate
- shrine_data_rate
- _take3
- shrine seedデータ
- concierge_explanations.py
- UI

これらは後続PRへ分離する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)