### PR TITLE
fix(backend): 推薦理由のFact品質指標を修正

### DIFF
--- a/backend/temples/services/recommendation_reason_v4.py
+++ b/backend/temples/services/recommendation_reason_v4.py
@@ -350,22 +350,56 @@ def _rate(count: int, total: int) -> float:
     return round(count / total, 4)
 
 
+# 品質指標(shrine_data_rate / evidence_rate / is_ai_inference_only)がFact根拠として
+# 数えるキー集合。神社固有の由緒・祭神・意味的根拠のみを対象とする。
+#
+# place_context(住所)とname(神社名)は意図的に含めない。
+# - place_contextの実体は生の郵便住所であり、神社固有の由緒・祭神・意味的根拠ではない
+#   (PR1で推薦理由本文のFact候補からも除外済み)。
+# - nameは常に存在しうる識別子であり、Fact根拠の有無を判定する材料にならない。
+# visit_style_tagsも今回は品質指標へ含めない。参拝体験の補助属性であり、
+# 神社固有の由緒・祭神・意味的根拠とは性質が異なるため。
+QUALITY_FACT_KEYS: tuple[str, ...] = ("deity", "shrine_history", "goriyaku", "history_theme")
+
+
+def _is_present_fact_value(value: Any) -> bool:
+    """Return True only for a non-empty string. Guards against None/int/list/dict noise."""
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _evidence_key(entry: Any) -> str | None:
+    if not isinstance(entry, str) or ":" not in entry:
+        return None
+    key, _, _ = entry.partition(":")
+    return key
+
+
 def build_recommendation_reason_quality_audit(reason: dict[str, Any]) -> dict[str, Any]:
     """Calculate lightweight quality metrics for Recommendation Reason v4.
 
     This audit is deterministic and only evaluates the generated payload.
     It does not change recommendation ranking or copy generation.
+
+    shrine_data_rate / evidence_rate / is_ai_inference_only are all derived from the
+    same QUALITY_FACT_KEYS set so a shrine name or a raw address is never counted as
+    shrine-specific Fact grounding.
     """
     used_fact = _as_dict(reason.get("used_fact"))
     used_interpretation = _as_dict(reason.get("used_interpretation"))
     used_action = _as_dict(reason.get("used_action"))
 
-    shrine_fact_keys = ["deity", "shrine_history", "place_context", "goriyaku", "history_theme"]
     consultation_keys = ["consultation_axis", "need_profile", "state_profile", "historical_interpretation"]
     action_keys = ["action_context", "reflection_question_seed", "action_intent"]
 
-    shrine_data_count = sum(1 for key in shrine_fact_keys if used_fact.get(key))
-    evidence_count = len(_as_list(used_fact.get("evidence")))
+    shrine_data_count = sum(
+        1 for key in QUALITY_FACT_KEYS if _is_present_fact_value(used_fact.get(key))
+    )
+
+    evidence_keys_present = {
+        _evidence_key(entry) for entry in _as_list(used_fact.get("evidence"))
+    }
+    evidence_count = sum(1 for key in QUALITY_FACT_KEYS if key in evidence_keys_present)
+
     consultation_count = 0
     for key in consultation_keys:
         value = used_interpretation.get(key)
@@ -378,13 +412,13 @@ def build_recommendation_reason_quality_audit(reason: dict[str, Any]) -> dict[st
 
     source = _first_string(used_action.get("source")) or "fallback"
     is_fallback = source == "fallback"
-    is_ai_inference_only = shrine_data_count == 0 and evidence_count == 0
+    is_ai_inference_only = shrine_data_count == 0
 
     return {
-        "shrine_data_rate": _rate(shrine_data_count, len(shrine_fact_keys)),
+        "shrine_data_rate": _rate(shrine_data_count, len(QUALITY_FACT_KEYS)),
         "consultation_reflection_rate": _rate(consultation_count, len(consultation_keys)),
         "fallback_reason_rate": 1.0 if is_fallback else 0.0,
-        "evidence_rate": _rate(evidence_count, len(shrine_fact_keys)),
+        "evidence_rate": _rate(evidence_count, len(QUALITY_FACT_KEYS)),
         "action_grounding_rate": _rate(action_count, len(action_keys)),
         "is_ai_inference_only": is_ai_inference_only,
         "fallback_source": source if is_fallback else None,

--- a/backend/temples/tests/services/test_recommendation_reason_v4.py
+++ b/backend/temples/tests/services/test_recommendation_reason_v4.py
@@ -373,11 +373,15 @@ def test_build_recommendation_reason_quality_audit_calculates_rates_from_used_pa
         },
     }
 
+    # QUALITY_FACT_KEYS = (deity, shrine_history, goriyaku, history_theme) の4キーのみが
+    # Fact根拠として数えられる。history_theme は None のため 3/4 = 0.75。
+    # evidence も同じ4キーでフィルタするため、place_context の evidence エントリは
+    # 分子から除外され、deity + shrine_history の 2/4 = 0.5 になる。
     assert build_recommendation_reason_quality_audit(reason) == {
-        "shrine_data_rate": 0.8,
+        "shrine_data_rate": 0.75,
         "consultation_reflection_rate": 1.0,
         "fallback_reason_rate": 0.0,
-        "evidence_rate": 0.6,
+        "evidence_rate": 0.5,
         "action_grounding_rate": 0.6667,
         "is_ai_inference_only": False,
         "fallback_source": None,
@@ -694,3 +698,130 @@ def test_build_recommendation_reason_v4_no_facts_falls_back_without_fabricating_
         in result["reason_text"]
     )
     assert result["quality"]["fallback_source"] == "fallback"
+
+
+# --- 品質指標修正: QUALITY_FACT_KEYS(deity/shrine_history/goriyaku/history_theme)基準のテスト ---
+
+
+def test_quality_name_only_has_no_shrine_grounding():
+    result = build_recommendation_reason_v4(candidate_profile={"name": "候補神社"})
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.0
+    assert quality["evidence_rate"] == 0.0
+    assert quality["is_ai_inference_only"] is True
+
+
+def test_quality_address_only_has_no_shrine_grounding():
+    result = build_recommendation_reason_v4(
+        candidate_profile={"place_context": "東京都渋谷区代々木神園町1-1"}
+    )
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.0
+    assert quality["evidence_rate"] == 0.0
+    assert quality["is_ai_inference_only"] is True
+
+
+def test_quality_name_and_address_only_has_no_shrine_grounding():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "候補神社",
+            "place_context": "東京都渋谷区代々木神園町1-1",
+        }
+    )
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.0
+    assert quality["evidence_rate"] == 0.0
+    assert quality["is_ai_inference_only"] is True
+
+
+def test_quality_history_theme_only_is_grounded():
+    result = build_recommendation_reason_v4(candidate_profile={"history_theme": "縁"})
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.25
+    assert quality["evidence_rate"] == 0.25
+    assert quality["is_ai_inference_only"] is False
+
+
+def test_quality_goriyaku_only_is_grounded():
+    result = build_recommendation_reason_v4(candidate_profile={"goriyaku": "縁結び"})
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.25
+    assert quality["evidence_rate"] == 0.25
+    assert quality["is_ai_inference_only"] is False
+
+
+def test_quality_deity_only_is_grounded():
+    result = build_recommendation_reason_v4(candidate_profile={"deity": "テスト祭神"})
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.25
+    assert quality["is_ai_inference_only"] is False
+
+
+def test_quality_shrine_history_only_is_grounded():
+    result = build_recommendation_reason_v4(
+        candidate_profile={"shrine_history": "戦災で焼失した後、氏子により再建された"}
+    )
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.25
+    assert quality["is_ai_inference_only"] is False
+
+
+def test_quality_all_facts_present_reaches_full_rate_without_exceeding_one():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "deity": "テスト祭神",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "place_context": "東京都渋谷区代々木神園町1-1",
+            "history_theme": "縁",
+            "goriyaku": "縁結び・厄除け",
+            "visit_style_tags": ["quiet", "nature"],
+        }
+    )
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 1.0
+    assert quality["evidence_rate"] == 1.0
+    assert quality["evidence_rate"] <= 1.0
+    assert quality["is_ai_inference_only"] is False
+
+
+def test_quality_visit_style_tags_alone_do_not_count_as_shrine_grounding():
+    # visit_style_tagsは参拝体験の補助属性として扱い、
+    # 神社固有Factの品質指標(QUALITY_FACT_KEYS)には含めない契約を固定する。
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "候補神社",
+            "visit_style_tags": ["quiet", "nature"],
+        }
+    )
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.0
+    assert quality["evidence_rate"] == 0.0
+    assert quality["is_ai_inference_only"] is True
+
+
+def test_quality_does_not_miscount_invalid_or_empty_fact_values():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "候補神社",
+            "deity": "",
+            "shrine_history": None,
+            "goriyaku": [],
+            "history_theme": {"unexpected": "shape"},
+            "place_context": 12345,
+        }
+    )
+    quality = result["quality"]
+
+    assert quality["shrine_data_rate"] == 0.0
+    assert quality["evidence_rate"] == 0.0
+    assert quality["is_ai_inference_only"] is True

--- a/docs/audit/recommendation-reason-v4-quality-report.md
+++ b/docs/audit/recommendation-reason-v4-quality-report.md
@@ -115,3 +115,98 @@ Recommendation Reason v4 では利用可能だが、
 - Recommendation Reason v4 のコピー品質改善
 - deity / shrine_history のデータ拡充
 - 神社データ補完後に再監査を実施
+
+---
+
+> 以降は旧指標の問題点を修正した後の追記節である。上記の本文（対象105件、旧`shrine_fact_keys`基準）は
+> 監査当時の記録として削除せず残す。Archive化は行わず、本文書は引き続きActiveな監査記録として扱う。
+
+---
+
+# 追記: 新指標による再監査（PR2: 品質指標修正）
+
+## 旧指標の問題点
+
+上記の監査（Coverage Rate表、shrine_data_count分布、「93%は十分」という結論）は、
+以下の理由で神社固有Factの充足状況を実態より高く見積もっていた。
+
+- 旧`shrine_fact_keys`は`["deity", "shrine_history", "place_context", "goriyaku", "history_theme"]`の5キーで構成されており、
+  **`place_context`（生の郵便住所文字列）を神社固有Factの一項目として算入していた**。
+- 実データでは`place_context`（住所）が100%充足していたため、`deity`・`shrine_history`が0%であっても
+  `shrine_data_count`は最低1（住所分）を確保でき、「1件も根拠なし」という判定にはなりにくい構造だった。
+- 旧`shrine_data_count`分布（対象105件）: `1件=7社`, `3件=98社`。この「3件」は
+  `place_context + goriyaku + history_theme`の組み合わせで達成されており、**祭神・由緒という神社固有の意味的根拠は1件も含まれていない**。
+- Recommendation Reason V4 PR1（`fix/recommendation-reason-v4-fact-type-copy`）で、推薦理由本文からは
+  `place_context`を除外済みだが、品質指標側はPR1時点では未修正のまま残っていた。
+- 加えて、`evidence_rate`は`evidence`配列の生の要素数（`name`・`visit_style_tags`を含み最大7種）を、
+  `shrine_fact_keys`（5種）で割っていたため、**理論上0.0〜1.4の範囲を取りうる不整合**があった（全Fact充足時に実測で1.4を確認済み）。
+- `is_ai_inference_only`は`shrine_data_count == 0 and evidence_count == 0`で判定していたが、
+  `evidence`には常に`name:{name}`が含まれうるため、**神社名しか情報がない場合でも`False`（=AI推論のみではない）と誤判定される**構造だった。
+
+結論として、「Recommendation Reason v4 は約93%の神社で十分な神社固有情報を利用できている」という
+旧結論は、**住所とご利益タグの充足率を神社固有Factの充足率と混同していた**ため成立しない。
+祭神（deity）・由緒（shrine_history）という意味での神社固有Fact充足率は、新旧いずれの指標でも実質0%のままである。
+
+## 新指標の定義
+
+品質指標が神社固有Fact根拠として数えるキー集合を、コード上に明示的に定義した。
+
+```python
+QUALITY_FACT_KEYS: tuple[str, ...] = ("deity", "shrine_history", "goriyaku", "history_theme")
+```
+
+- `place_context`（住所）と`name`（神社名）はFact根拠として数えない。住所・神社名は常に存在しうる識別情報であり、
+  神社固有の由緒・祭神・意味的根拠ではないため。
+- `visit_style_tags`も今回は含めない。参拝体験の補助属性であり、由緒・祭神とは性質が異なるため（既存契約と矛盾しないことを確認済み。今回のPRで初めて品質指標の対象に加えるかどうかを判断した結果、除外を選択）。
+- `shrine_data_rate`と`evidence_rate`はいずれもこの4キー集合を分子・分母双方の基準として使うため、**設計上ほぼ同じ値になる**（`evidence_rate`は`evidence`配列を同じ4キーでフィルタして算出するため、値の由来が異なる独立した検証経路として残している）。
+- `is_ai_inference_only`は`shrine_data_count == 0`のみで判定する（旧来の`evidence_count == 0`条件は、name evidenceの存在により実質機能していなかったため削除）。
+
+## 対象件数についての注記
+
+今回の再監査は`backend/temples/data/shrines_seed_clean.json`（100件、PR1と同一データセット）を対象とした。
+上記の旧監査記録は105件（本番DB相当）を対象としており、**追加5件の内訳・データ品質は本文書からは確認できない**。
+100件と105件の差分は未確認のまま残る。本番DBに対する新指標再監査は別途実施が必要。
+
+## Coverage Rate（新指標、対象100件）
+
+| 項目 | 充足件数 | 備考 |
+|------|-------:|------|
+| deity | 0/100 | Fact根拠に算入 |
+| shrine_history | 0/100 | Fact根拠に算入 |
+| goriyaku | 98/100 | Fact根拠に算入 |
+| history_theme | 98/100 | Fact根拠に算入 |
+| place_context | 100/100 | **Fact根拠に算入しない**（住所） |
+| visit_style_tags | 51/100 | Fact根拠に算入しない（補助属性） |
+
+## shrine_data_rate / evidence_rate（新指標、対象100件）
+
+| metric | 旧指標 | 新指標 |
+|---|---:|---:|
+| shrine_data_rate 平均 | 0.396 | 0.490 |
+| shrine_data_rate 分布 | 0.2×2件, 0.4×98件 | 0.0×2件, 0.5×98件 |
+| evidence_rate 平均 | 0.894 | 0.490 |
+| evidence_rate 分布 | 0.4×2, 0.8×47, 1.0×51 | 0.0×2件, 0.5×98件 |
+| evidence_rate > 1.0 の件数 | 0/100（全Fact充足パターンが実データに存在しないため未発生。理論値としては1.4を実測確認済み） | 0/100（構造的に1.0を超えない） |
+| is_ai_inference_only=true | 0/100 | **2/100** |
+| name/addressのみでFactあり判定された件数 | 集計対象外（旧定義では機構上不可避に発生） | **0/100** |
+
+`is_ai_inference_only=true`が0件から2件に増えたのは指標の後退ではなく、
+`history_theme`・`goriyaku`のどちらも持たない2件（旧監査の「長太稲荷神社」「給田六所神社」に相当する可能性が高いが、
+本文書からは100件データと実運用105件データの対応関係を確定できないため断定はしない）が、
+新指標で初めて正しく「Fact根拠なし」として検出されるようになったことを意味する。
+
+## 「93%は十分」という旧結論の再評価
+
+旧結論は撤回する。新指標での実態は以下の通り。
+
+- 祭神（deity）・由緒（shrine_history）という神社固有の一次情報は、100件中0件で利用可能。これはPR1・PR2いずれでも変わらない（データそのものが存在しないため）。
+- 98件は`goriyaku`と`history_theme`により`shrine_data_rate=0.5`（4項目中2項目）を得ており、「情報が全くない」わけではないが、「十分」と呼べる水準（1.0に近い）には遠い。
+- 2件（`shrine_data_rate=0.0`）は新指標で正しく`is_ai_inference_only=true`と判定され、最優先のデータ整備対象として識別できるようになった。
+- 「93%は十分、2件だけ直せば良い」という優先順位づけは誤りで、**実態は100件全件が祭神・由緒データ不足という同じ課題を共有しており、その中でも該当2件はさらにご利益・分類テーマも欠けているため最優先**、という位置づけが正しい。
+
+## 今後のデータ整備優先度（更新）
+
+1. **最優先**: `shrine_data_rate=0.0`の2件（history_theme・goriyakuの補完。旧監査の優先度A相当）
+2. **優先度高（全件共通）**: `deity`（祭神）・`shrine_history`（由緒）データの投入。現状100件中0件のため、投入した分だけ`shrine_data_rate`が直接改善する
+3. `place_context`（住所）のデータ品質改善は、品質指標上は効果がない（Fact根拠に算入されないため）。ただし経路案内・地図表示など他機能では引き続き必要
+4. 本番DB（105件相当）に対する新指標再監査を別途実施し、100件との差分5件の状態を確認する


### PR DESCRIPTION
### 背景

旧品質指標では、place_contextに入った生住所を神社Factとして算入し、evidence配列ではname・place_context・visit_style_tagsを含む最大7種類を、5種類のFactキーで割っていた。

その結果、次の誤判定が発生していた。

- 神社名や住所だけでもFactあり扱いになる
- nameのみでもis_ai_inference_only=falseになる
- 全Fact充足時にevidence_rate=1.4となる
- 旧監査の「93%は十分」という結論が住所による水増しを含んでいた

### 変更内容

品質指標で使用するFactキーを次の4項目へ統一した。

- deity
- shrine_history
- goriyaku
- history_theme

次は品質根拠から除外した。

- name
- place_context
- visit_style_tags

変更した指標:

- shrine_data_rate
- evidence_rate
- is_ai_inference_only

### 新しい契約

- nameのみ: shrine_data_rate=0.0 / evidence_rate=0.0 / is_ai_inference_only=true
- addressのみ: shrine_data_rate=0.0 / evidence_rate=0.0 / is_ai_inference_only=true
- history_themeまたはgoriyakuのみ: 0.25
- 4項目すべて: 1.0
- evidence_rateは構造上0.0〜1.0に収まる

### 100件再監査

| metric | 旧指標 | 新指標 |
|---|---:|---:|
| shrine_data_rate平均 | 0.396 | 0.490 |
| evidence_rate平均 | 0.894 | 0.490 |
| is_ai_inference_only=true | 0/100 | 2/100 |
| evidence_rate > 1.0 | 理論上発生 | 構造上発生しない |
| name/addressのみでFactあり | 誤判定あり | 0/100 |

注意:
shrine_data_rate平均の上昇はデータ品質改善ではなく、住所を除外して分母を5から4へ変更した定義変更によるもの。deityとshrine_historyは現在も0/100で、データ自体は追加していない。

### 監査文書

`docs/audit/recommendation-reason-v4-quality-report.md`へ新指標による再監査節を追記した。

- 旧105件監査は履歴として保持
- 今回はseed100件を対象
- 旧「93%は十分」という結論を撤回
- deity 0% / shrine_history 0%を明記
- 住所をFact groundingへ数えないことを明記

### テスト

- Recommendation Reason V4: 34 passed
- 関連サービステスト: 21 passed
- Backend temples: 780 passed / 9 skipped / 0 failed
- git diff --check: pass

### 対象外

- Recommendation Reasonの文言
- _take3
- concierge_explanations.py
- ranking / Score
- UI
- seed data
- sajin / description投入
- 出典管理
- 本番DB105件の再監査

🤖 Generated with [Claude Code](https://claude.com/claude-code)