### PR TITLE
feat(backend): Chatへrecommendation_reason_v4_detail契約を追加

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -385,12 +385,14 @@ def _attach_recommendation_reason_quality(
     recs: dict[str, Any],
     interpretation_profile: dict[str, Any],
 ) -> None:
-    """Attach Recommendation Reason quality metrics to recommendation items.
+    """Attach Recommendation Reason quality metrics and display detail to recommendation items.
 
-    This keeps the lightweight quality payload on normal recommendations so API
-    response and thread storage do not depend on debug preview visibility.
+    This keeps the lightweight quality payload and the display-only
+    recommendation_reason_v4_detail on normal recommendations so API response and
+    thread storage do not depend on debug preview visibility.
     """
     quality_by_key: dict[Any, dict[str, Any]] = {}
+    detail_by_key: dict[Any, dict[str, Any]] = {}
 
     for rec in (r for r in (recs.get("recommendations") or []) if isinstance(r, dict)):
         meaning_payload = rec.get("meaning_payload") if isinstance(rec.get("meaning_payload"), dict) else {}
@@ -409,9 +411,21 @@ def _attach_recommendation_reason_quality(
         quality = preview.get("quality") or {}
         rec["recommendation_reason_quality"] = quality
 
+        # Display-only subset of the same preview: reason_text/fact/interpretation/action.
+        # used_fact/used_interpretation/used_action/source stay backend-internal (debug/audit only).
+        detail = {
+            "version": "v4",
+            "reason_text": str(preview.get("reason_text") or ""),
+            "fact": preview.get("fact") or {},
+            "interpretation": preview.get("interpretation") or {},
+            "action": preview.get("action") or {},
+        }
+        rec["recommendation_reason_v4_detail"] = detail
+
         key = rec.get("shrine_id") or rec.get("id") or rec.get("name")
         if key is not None:
             quality_by_key[key] = quality
+            detail_by_key[key] = detail
 
     recommendations_v2 = recs.get("recommendations_v2")
     if not isinstance(recommendations_v2, list):
@@ -421,6 +435,8 @@ def _attach_recommendation_reason_quality(
         key = rec.get("shrine_id") or rec.get("id") or rec.get("name")
         if key in quality_by_key:
             rec["recommendation_reason_quality"] = quality_by_key[key]
+        if key in detail_by_key:
+            rec["recommendation_reason_v4_detail"] = detail_by_key[key]
 
 
 def _build_score_v3_observer_items(score_v3_debug: dict[str, Any]) -> list[dict[str, Any]]:

--- a/backend/temples/tests/api/test_concierge_chat_response_body_contract.py
+++ b/backend/temples/tests/api/test_concierge_chat_response_body_contract.py
@@ -460,6 +460,142 @@ def test_chat_response_passes_recommendation_reason_quality_to_thread_storage(cl
     assert captured["recommendations_v2"][0]["recommendation_reason_quality"] == quality
 
 
+def _sample_recommendation_reason_v4_detail():
+    return {
+        "version": "v4",
+        "reason_text": "この神社は再出発の文脈を持ちます。",
+        "fact": {
+            "label": "根津神社",
+            "name": "根津神社",
+            "deity": None,
+            "shrine_history": None,
+            "place_context": None,
+            "history_theme": "再出発",
+            "goriyaku": "仕事運",
+            "visit_style_tags": [],
+            "evidence": ["history_theme:再出発", "goriyaku:仕事運"],
+        },
+        "interpretation": {
+            "theme": "再出発",
+            "text": "相談内容から、今扱いたいテーマを読み取っています。",
+        },
+        "action": {
+            "text": "参拝前に、問いを一つに絞ることを決めておきます。",
+            "source": "meaning_translation.action_context",
+        },
+    }
+
+
+@pytest.mark.django_db
+def test_chat_response_preserves_recommendation_reason_v4_detail_contract(client, monkeypatch):
+    _stub_candidates(monkeypatch)
+    _stub_recommendations(
+        monkeypatch,
+        [
+            {
+                "name": "神社A",
+                "reason": "ok-a",
+                "reason_source": "reason:test",
+                "recommendation_reason_v4": "この神社は再出発の文脈を持ちます。",
+                "recommendation_reason_quality": {
+                    "shrine_data_rate": 0.5,
+                    "consultation_reflection_rate": 0.0,
+                    "fallback_reason_rate": 0.0,
+                    "evidence_rate": 0.5,
+                    "action_grounding_rate": 0.3333,
+                    "is_ai_inference_only": False,
+                    "fallback_source": None,
+                },
+                "recommendation_reason_v4_detail": _sample_recommendation_reason_v4_detail(),
+            }
+        ],
+    )
+
+    r = client.post(
+        URL,
+        data=json.dumps({"query": "近場で参拝したい", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+
+    rec = r.json()["data"]["recommendations"][0]
+
+    assert "recommendation_reason_v4_detail" in rec
+    detail = rec["recommendation_reason_v4_detail"]
+    assert isinstance(detail, dict)
+    assert set(detail.keys()) == {"version", "reason_text", "fact", "interpretation", "action"}
+    assert detail["version"] == "v4"
+    assert isinstance(detail["reason_text"], str)
+    assert isinstance(detail["fact"], dict)
+    assert isinstance(detail["interpretation"], dict)
+    assert isinstance(detail["action"], dict)
+    assert "used_fact" not in detail
+    assert "used_interpretation" not in detail
+    assert "used_action" not in detail
+    assert "source" not in detail
+    assert "quality" not in detail
+
+    # 既存fieldは変更・破壊されない
+    assert isinstance(rec["recommendation_reason_v4"], str)
+    assert "recommendation_reason_quality" in rec
+    assert rec["reason"] == "ok-a"
+
+
+@pytest.mark.django_db
+def test_chat_response_passes_recommendation_reason_v4_detail_to_thread_storage(client, monkeypatch):
+    _stub_candidates(monkeypatch)
+    _stub_recommendations(
+        monkeypatch,
+        [
+            {
+                "id": 11,
+                "shrine_id": 11,
+                "name": "神社A",
+                "reason": "ok",
+                "reason_source": "reason:test",
+                "recommendation_reason_v4": "この神社は再出発の文脈を持ちます。",
+                "recommendation_reason_quality": {
+                    "shrine_data_rate": 0.5,
+                    "consultation_reflection_rate": 0.0,
+                    "fallback_reason_rate": 0.0,
+                    "evidence_rate": 0.5,
+                    "action_grounding_rate": 0.3333,
+                    "is_ai_inference_only": False,
+                    "fallback_source": None,
+                },
+                "recommendation_reason_v4_detail": _sample_recommendation_reason_v4_detail(),
+            }
+        ],
+    )
+
+    captured = {}
+
+    def _append_chat_stub(**kwargs):
+        captured["recommendations"] = kwargs.get("recommendations")
+        captured["recommendations_v2"] = kwargs.get("recommendations_v2")
+        return SimpleNamespace(thread=SimpleNamespace(id=322))
+
+    monkeypatch.setattr("temples.api_views_concierge.append_chat", _append_chat_stub)
+    monkeypatch.setattr(
+        "temples.services.concierge_observability.save_concierge_recommendation_log",
+        lambda **kwargs: None,
+    )
+
+    r = client.post(
+        URL,
+        data=json.dumps({"query": "仕事で迷っている", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+
+    recommendations = r.json()["data"]["recommendations"]
+    assert "recommendation_reason_v4_detail" in recommendations[0]
+
+    detail = recommendations[0]["recommendation_reason_v4_detail"]
+    assert captured["recommendations"][0]["recommendation_reason_v4_detail"] == detail
+    assert captured["recommendations_v2"][0]["recommendation_reason_v4_detail"] == detail
+
+
 @pytest.mark.django_db
 def test_chat_response_includes_debug_observation_contract_fields(client, monkeypatch):
     _stub_candidates(monkeypatch)

--- a/backend/temples/tests/services/test_concierge_chat_observation.py
+++ b/backend/temples/tests/services/test_concierge_chat_observation.py
@@ -1130,3 +1130,76 @@ def test_observe_ranking_breakdown_empty_contract_has_stable_schema():
             "reflection_hint_source_history_theme": [],
         },
     }
+
+
+def test_build_chat_recommendations_attaches_recommendation_reason_v4_detail(monkeypatch):
+    def fake_resolve_llm_route(*, query, valid_candidates, need_tags, llm_enabled, consultation_axis=None):
+        return {
+            "recs": {
+                "recommendations": [
+                    {
+                        "name": "根津神社",
+                        "shrine_id": 101,
+                        "history_theme": "再出発",
+                        "goriyaku": "縁結び・厄除け",
+                        "distance_m": 1200,
+                    },
+                ],
+                "_seed": True,
+            },
+            "requested_llm_enabled": False,
+            "effective_llm_enabled": False,
+            "llm_used": False,
+            "llm_error": None,
+        }
+
+    monkeypatch.setattr(
+        "temples.services.concierge_chat.resolve_llm_route",
+        fake_resolve_llm_route,
+    )
+    monkeypatch.setattr(
+        "temples.services.concierge_chat._backfill_location_from_name",
+        lambda recs, *, bias, language: None,
+    )
+
+    result = build_chat_recommendations(
+        query="仕事の再出発について相談したい",
+        language="ja",
+        candidates=[
+            {
+                "name": "根津神社",
+                "shrine_id": 101,
+                "history_theme": "再出発",
+                "goriyaku": "縁結び・厄除け",
+                "distance_m": 1200,
+            },
+        ],
+        bias=None,
+        birthdate=None,
+        goriyaku_tag_ids=None,
+        extra_condition=None,
+        public_mode="need",
+        flow="B",
+    )
+
+    rec = result["recommendations"][0]
+
+    # 既存fieldは壊れない
+    assert isinstance(rec["recommendation_reason_v4"], str)
+    assert "recommendation_reason_quality" in rec
+
+    # recommendation_reason_v4_detailが実際の計算結果として付与される
+    assert "recommendation_reason_v4_detail" in rec
+    detail = rec["recommendation_reason_v4_detail"]
+    assert isinstance(detail, dict)
+    assert set(detail.keys()) == {"version", "reason_text", "fact", "interpretation", "action"}
+    assert detail["version"] == "v4"
+    assert detail["reason_text"] == rec["recommendation_reason_v4"]
+    assert isinstance(detail["fact"], dict)
+    assert isinstance(detail["interpretation"], dict)
+    assert isinstance(detail["action"], dict)
+    assert "used_fact" not in detail
+    assert "used_interpretation" not in detail
+    assert "used_action" not in detail
+    assert "source" not in detail
+    assert "quality" not in detail


### PR DESCRIPTION
### 概要

Concierge Chatの通常recommendationレスポンスへ、構造化されたRecommendation Reason V4表示契約`recommendation_reason_v4_detail`を追加します。

### 実装方針

- 既に計算済みのReason V4 previewを再利用
- 新しいReason V4計算は追加しない
- 表示用途のreason_text / fact / interpretation / actionのみ公開
- 内部監査用のused_* / sourceは公開しない
- qualityは既存field(`recommendation_reason_quality`)を維持
- 既存fieldは変更しない
- thread保存時(`recommendations` / `recommendations_v2`)にも新fieldを保持

### 後方互換

以下を維持します。

- reason
- recommendation_reason_v4
- recommendation_reason_quality
- reason_facts
- explanation
- _explanation_payload

### 非対象

- Plan
- Web
- Mobile
- OpenAPI
- Analytics
- 二重生成解消
- fail-safe
- デッドコード削除