### PR TITLE
feat(web): 推薦HeroカードをReason V4構造化表示へ移行

### DIFF
--- a/apps/web/e2e/05_direction_flow.spec.ts
+++ b/apps/web/e2e/05_direction_flow.spec.ts
@@ -69,13 +69,14 @@ test.describe("方位条件のWeb E2E", () => {
 
     await expect(page.getByText("方位の参考情報")).toBeVisible();
     await expect(page.getByText("現在地から見た方角が、予定日の参考方位と一致しています。")).toBeVisible();
-    const displayOrder = await page.locator('[data-testid="recommendation-match-reason"], [data-testid="recommendation-standard-reason"], aside:has-text("方位の参考情報")').evaluateAll(
-      (nodes) => nodes.map((node) => node.textContent),
-    );
-    expect(displayOrder[0]).toContain("相談内容・ご利益との一致");
-    expect(displayOrder[1]).toContain("この神社を選んだ理由");
-    expect(displayOrder[2]).toContain("方位の参考情報");
-    expect(`${displayOrder[0]}${displayOrder[1]}`).not.toMatch(/方位|方角|吉方位/);
+    const displayOrder = await page.locator(
+      '[data-testid="recommendation-reason-v4-fact"], [data-testid="recommendation-reason-v4-interpretation"], [data-testid="recommendation-reason-v4-action"], aside:has-text("方位の参考情報")',
+    ).evaluateAll((nodes) => nodes.map((node) => node.textContent));
+    expect(displayOrder[0]).toContain("この神社について");
+    expect(displayOrder[1]).toContain("今の相談とのつながり");
+    expect(displayOrder[2]).toContain("参拝前にできること");
+    expect(displayOrder[3]).toContain("方位の参考情報");
+    expect(`${displayOrder[0]}${displayOrder[1]}${displayOrder[2]}`).not.toMatch(/方位|方角|吉方位/);
     await expect.poll(() => captured.analyticsEvents.filter((event) => event.eventName === "direction_match_impression").length).toBe(1);
     await page.waitForTimeout(250);
     expect(captured.analyticsEvents.filter((event) => event.eventName === "direction_match_impression")).toHaveLength(1);
@@ -169,7 +170,7 @@ test.describe("方位条件のWeb E2E", () => {
     await page.goto("/concierge");
     await fillAndSubmit(page);
     await expect(page.getByText("固定レスポンス神社511")).toBeVisible();
-    await expect(page.getByText("固定レスポンスによる推薦です。")).toBeVisible();
+    await expect(page.getByTestId("recommendation-reason-v4-fact")).toBeVisible();
     await expect(page.getByText("方位の参考情報")).toHaveCount(0);
   });
 

--- a/apps/web/e2e/fixtures/directionScenario.ts
+++ b/apps/web/e2e/fixtures/directionScenario.ts
@@ -1,5 +1,31 @@
 import type { Page, Request } from "@playwright/test";
 
+function buildReasonV4Detail(id: number) {
+  return {
+    version: "v4",
+    reason_text: "仕事運を整えるご利益を持つ神社です。相談内容から、今扱いたいテーマを読み取っています。参拝前に、次に確認したいことを一つだけ決めておきます。",
+    fact: {
+      label: "仕事運を整えるご利益",
+      name: `固定レスポンス神社${id}`,
+      deity: null,
+      shrine_history: null,
+      place_context: null,
+      history_theme: null,
+      goriyaku: "仕事運を整えるご利益",
+      visit_style_tags: [],
+      evidence: ["goriyaku:仕事運を整えるご利益"],
+    },
+    interpretation: {
+      theme: "仕事",
+      text: "相談内容から、今扱いたいテーマを読み取っています。",
+    },
+    action: {
+      text: "参拝前に、次に確認したいことを一つだけ決めておきます。",
+      source: "fallback",
+    },
+  };
+}
+
 export type CapturedDirectionScenario = {
   chatPayloads: Array<Record<string, unknown>>;
   analyticsEvents: Array<{ eventName: string; payload: Record<string, unknown> }>;
@@ -88,6 +114,8 @@ export async function installDirectionScenario(
       display_name: `固定レスポンス神社${options.recommendationId}`,
       display_address: "テスト用所在地",
       reason: "固定レスポンスによる推薦です。",
+      recommendation_reason_v4: "固定レスポンスによる推薦です。",
+      recommendation_reason_v4_detail: buildReasonV4Detail(options.recommendationId),
       breakdown: { matched_need_tags: ["career"] },
       reason_facts: { primary_axis: "benefit", shrine_benefit: "仕事運を整えるご利益" },
       ...(options.directionReference ? { direction_reference: options.directionReference } : {}),
@@ -99,6 +127,8 @@ export async function installDirectionScenario(
         display_name: `固定レスポンス神社${options.additionalRecommendation.id}`,
         display_address: "テスト用所在地",
         reason: "固定レスポンスによる推薦です。",
+        recommendation_reason_v4: "固定レスポンスによる推薦です。",
+        recommendation_reason_v4_detail: buildReasonV4Detail(options.additionalRecommendation.id),
         breakdown: { matched_need_tags: ["career"] },
         reason_facts: { primary_axis: "benefit", shrine_benefit: "仕事運を整えるご利益" },
         ...(options.additionalRecommendation.directionReference

--- a/apps/web/src/features/concierge/__tests__/buildHeroReasonV4Sections.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildHeroReasonV4Sections.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { buildHeroReasonV4Sections } from "../buildHeroReasonV4Sections";
+
+function makeDetail(overrides: Partial<{ reason_text: string; fact: any; interpretation: any; action: any }> = {}) {
+  return {
+    version: "v4" as const,
+    reason_text: overrides.reason_text ?? "根津神社には、縁結び・厄除けに関する情報があります。",
+    fact: {
+      label: "候補神社",
+      name: null,
+      deity: null,
+      shrine_history: null,
+      place_context: null,
+      history_theme: "再出発",
+      goriyaku: "縁結び・厄除け",
+      visit_style_tags: [],
+      evidence: [],
+      ...(overrides.fact ?? {}),
+    },
+    interpretation: {
+      theme: "再出発",
+      text: "相談内容から、今扱いたいテーマを読み取っています。",
+      ...(overrides.interpretation ?? {}),
+    },
+    action: {
+      text: "参拝前に、問いを一つに絞ることを決めておきます。",
+      source: "meaning_translation.action_context",
+      ...(overrides.action ?? {}),
+    },
+  };
+}
+
+describe("buildHeroReasonV4Sections", () => {
+  it("fact/interpretation/actionが構造化表示として返る", () => {
+    const result = buildHeroReasonV4Sections({ detail: makeDetail(), recommendationReasonV4: null, reason: null });
+
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBe("縁結び・厄除け");
+    expect(result.interpretationText).toBe("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(result.actionText).toBe("参拝前に、問いを一つに絞ることを決めておきます。");
+    expect(result.fallbackText).toBeNull();
+  });
+
+  it("factは優先順位(shrine_history > place_context > goriyaku > history_theme > label)で選ばれる", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { shrine_history: "由緒あり", place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発", label: "候補神社" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBe("由緒あり");
+  });
+
+  it("detailがまったく無い場合はrecommendation_reason_v4へfallbackする", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: null,
+      recommendationReasonV4: "根津神社は仕事運に関わる神社です。",
+      reason: "旧型の理由文",
+    });
+
+    expect(result.hasStructured).toBe(false);
+    expect(result.factText).toBeNull();
+    expect(result.interpretationText).toBeNull();
+    expect(result.actionText).toBeNull();
+    expect(result.fallbackText).toBe("根津神社は仕事運に関わる神社です。");
+  });
+
+  it("detailのreason_textが最優先のfallbackになる", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        reason_text: "reason_textの内容",
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+      recommendationReasonV4: "recommendation_reason_v4の内容",
+      reason: "旧型の理由文",
+    });
+
+    expect(result.hasStructured).toBe(false);
+    expect(result.fallbackText).toBe("reason_textの内容");
+  });
+
+  it("reason_textが無い場合はrecommendation_reason_v4へfallbackする", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        reason_text: "",
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+      recommendationReasonV4: "recommendation_reason_v4の内容",
+      reason: "旧型の理由文",
+    });
+
+    expect(result.fallbackText).toBe("recommendation_reason_v4の内容");
+  });
+
+  it("recommendation_reason_v4も無い場合は最終的にreasonへfallbackする", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        reason_text: "",
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+      recommendationReasonV4: null,
+      reason: "旧型の理由文",
+    });
+
+    expect(result.fallbackText).toBe("旧型の理由文");
+  });
+
+  it("すべて欠落していてもクラッシュせずnullを返す", () => {
+    const result = buildHeroReasonV4Sections({ detail: null, recommendationReasonV4: null, reason: null });
+
+    expect(result.hasStructured).toBe(false);
+    expect(result.factText).toBeNull();
+    expect(result.interpretationText).toBeNull();
+    expect(result.actionText).toBeNull();
+    expect(result.fallbackText).toBeNull();
+  });
+
+  it("方位・断定表現を含むテキストは表示から除外される", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: null,
+      recommendationReasonV4: "この方位は吉方位なので必ず良い結果になります。",
+      reason: null,
+    });
+
+    expect(result.fallbackText).toBeNull();
+  });
+
+  it("action.sourceはUIモデルに含まれない", () => {
+    const result = buildHeroReasonV4Sections({ detail: makeDetail(), recommendationReasonV4: null, reason: null });
+    expect(result).not.toHaveProperty("actionSource");
+    expect(result).not.toHaveProperty("source");
+  });
+});

--- a/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.payload.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.payload.test.ts
@@ -140,6 +140,64 @@ it("reason_facts を recommendation item に通す", () => {
   );
 });
 
+it("recommendation_reason_v4_detail と recommendation_reason_v4 を recommendation item に通す", () => {
+  const u: any = {
+    data: {
+      recommendations: [
+        {
+          shrine_id: 20,
+          display_name: "S2",
+          reason: "R2",
+          recommendation_reason_v4: "根津神社は仕事運に関わる神社です。",
+          recommendation_reason_v4_detail: {
+            version: "v4",
+            reason_text: "根津神社は仕事運に関わる神社です。",
+            fact: {
+              label: "根津神社",
+              name: "根津神社",
+              deity: null,
+              shrine_history: null,
+              place_context: null,
+              history_theme: "再出発",
+              goriyaku: "仕事運",
+              visit_style_tags: [],
+              evidence: ["history_theme:再出発"],
+            },
+            interpretation: { theme: "再出発", text: "相談内容から今のテーマを読み取っています。" },
+            action: { text: "参拝前に問いを一つに絞ります。", source: "meaning_translation.action_context" },
+          },
+        },
+      ],
+    },
+    thread: { id: 1 },
+  };
+
+  const p = buildPayloadFromUnified(u, baseFilterState);
+  const recSec = p?.sections.find((s: any) => s.type === "recommendations") as any;
+  expect(recSec.items[0].recommendationReasonV4).toBe("根津神社は仕事運に関わる神社です。");
+  expect(recSec.items[0].reasonV4Detail).toEqual(
+    expect.objectContaining({
+      version: "v4",
+      reason_text: "根津神社は仕事運に関わる神社です。",
+    }),
+  );
+  expect(recSec.items[0].reasonV4Detail.fact.goriyaku).toBe("仕事運");
+});
+
+it("recommendation_reason_v4_detail が無くてもクラッシュせずnullのまま通す", () => {
+  const u: any = {
+    data: {
+      recommendations: [{ shrine_id: 21, display_name: "S3", reason: "R3" }],
+    },
+    thread: { id: 1 },
+  };
+
+  const p = buildPayloadFromUnified(u, baseFilterState);
+  const recSec = p?.sections.find((s: any) => s.type === "recommendations") as any;
+  expect(recSec.items[0].reasonV4Detail ?? null).toBeNull();
+  expect(recSec.items[0].recommendationReasonV4 ?? null).toBeNull();
+});
+
 it("consultation_axis を meta と recommendation item に通す", () => {
   const u: any = {
     data: {

--- a/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
+++ b/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
@@ -1,0 +1,73 @@
+// apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
+import type { RecommendationReasonV4Detail } from "@/lib/api/concierge";
+import { buildRecommendationReasonDisplay } from "../../../../../packages/shared/recommendationReasonDisplay";
+
+export type HeroReasonV4Sections = {
+  factText: string | null;
+  interpretationText: string | null;
+  actionText: string | null;
+  hasStructured: boolean;
+  fallbackText: string | null;
+};
+
+function clean(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  return s.length ? s : null;
+}
+
+function pickFirst(...values: unknown[]): string | null {
+  for (const v of values) {
+    const s = clean(v);
+    if (s) return s;
+  }
+  return null;
+}
+
+// 方位・断定表現の除外は既存のbuildRecommendationReasonDisplayに委譲する(Frontendで新規フィルタを作らない)
+function safeText(value: string | null): string | null {
+  if (!value) return null;
+  return buildRecommendationReasonDisplay({ matchReason: null, reason: value, directionReference: null }).reason;
+}
+
+/**
+ * Backendのrecommendation_reason_v4_detail(fact/interpretation/action)から
+ * Hero Recommendation Card表示用の最小モデルを組み立てる。
+ *
+ * 優先順位:
+ * 1. 構造化fact / interpretation / action
+ * 2. recommendation_reason_v4_detail.reason_text
+ * 3. recommendation_reason_v4(文字列)
+ * 4. reason(旧文字列)
+ *
+ * 構造化セクションが1つ以上表示できる場合はfallbackTextを返さない(重複表示防止)。
+ */
+export function buildHeroReasonV4Sections(params: {
+  detail?: RecommendationReasonV4Detail | null;
+  recommendationReasonV4?: string | null;
+  reason?: string | null;
+}): HeroReasonV4Sections {
+  const detail = params.detail ?? null;
+
+  const factText = safeText(
+    detail
+      ? pickFirst(
+          detail.fact?.shrine_history,
+          detail.fact?.place_context,
+          detail.fact?.goriyaku,
+          detail.fact?.history_theme,
+          detail.fact?.label,
+        )
+      : null,
+  );
+  const interpretationText = safeText(detail ? clean(detail.interpretation?.text) : null);
+  const actionText = safeText(detail ? clean(detail.action?.text) : null);
+
+  const hasStructured = Boolean(factText || interpretationText || actionText);
+
+  const fallbackText = hasStructured
+    ? null
+    : safeText(pickFirst(detail?.reason_text, params.recommendationReasonV4, params.reason));
+
+  return { factText, interpretationText, actionText, hasStructured, fallbackText };
+}

--- a/apps/web/src/features/concierge/buildPayloadFromUnified.ts
+++ b/apps/web/src/features/concierge/buildPayloadFromUnified.ts
@@ -5,7 +5,7 @@ import type {
   ConciergeSection,
   ConciergeFilterState,
 } from "@/features/concierge/sections/types";
-import type { ConciergeReasonFacts } from "@/lib/api/concierge";
+import type { ConciergeReasonFacts, RecommendationReasonV4Detail } from "@/lib/api/concierge";
 import { validDirectionReferenceOrNull, type DirectionReference } from "../../../../../packages/shared/directionReference";
 
 
@@ -20,6 +20,8 @@ type NormalizedItemBase = {
   breakdown: any | null;
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
+  reasonV4Detail?: RecommendationReasonV4Detail | null;
+  recommendationReasonV4?: string | null;
   trustMetadata?: any | null;
   historyTheme?: string | null;
   historyContext?: string | null;
@@ -141,6 +143,8 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
   const breakdown = r?.breakdown ?? null;
   const breakdownDetail = r?.breakdown_detail ?? r?.breakdownDetail ?? null;
   const reasonFacts = r?.reason_facts ?? r?.reasonFacts ?? null;
+  const reasonV4Detail = r?.recommendation_reason_v4_detail ?? r?.recommendationReasonV4Detail ?? null;
+  const recommendationReasonV4 = asTrimmedString(r?.recommendation_reason_v4 ?? r?.recommendationReasonV4);
   const trustMetadata = r?.trust_metadata ?? r?.trustMetadata ?? null;
   const historyTheme = pickFirstString(r?.history_theme, r?.historyTheme);
   const historyContext = pickFirstString(r?.history_context, r?.historyContext);
@@ -164,6 +168,8 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
       breakdown,
       breakdown_detail: breakdownDetail,
       reasonFacts,
+      reasonV4Detail,
+      recommendationReasonV4,
       trustMetadata,
       historyTheme,
       historyContext,
@@ -188,6 +194,8 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
       breakdown,
       breakdown_detail: breakdownDetail,
       reasonFacts,
+      reasonV4Detail,
+      recommendationReasonV4,
       trustMetadata,
       historyTheme,
       historyContext,
@@ -276,6 +284,12 @@ function dedupeItems(items: NormalizedItem[]): NormalizedItem[] {
         }
         if (reg?.kind === "registered" && !reg.consultationAxis && item.consultationAxis) {
           out[idx] = { ...out[idx], consultationAxis: item.consultationAxis };
+        }
+        if (reg?.kind === "registered" && !reg.reasonV4Detail && item.reasonV4Detail) {
+          out[idx] = { ...out[idx], reasonV4Detail: item.reasonV4Detail };
+        }
+        if (reg?.kind === "registered" && !reg.recommendationReasonV4 && item.recommendationReasonV4) {
+          out[idx] = { ...out[idx], recommendationReasonV4: item.recommendationReasonV4 };
         }
       }
       continue;

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -8,6 +8,7 @@ import ShrineSaveButton from "@/components/shrine/ShrineSaveButton";
 import ConciergeFilterPanel from "@/features/concierge/components/ConciergeFilterPanel";
 import ModeBadge from "@/features/concierge/components/ModeBadge";
 import { buildRecommendationReasonViewModel } from "@/lib/concierge/buildRecommendationReasonViewModel";
+import { buildHeroReasonV4Sections } from "@/features/concierge/buildHeroReasonV4Sections";
 import ConciergeTopRecommendationHero from "@/features/concierge/components/ConciergeTopRecommendationHero";
 import ShrineCardCompact from "@/components/shrines/ShrineCardCompact";
 
@@ -812,6 +813,16 @@ export default function ConciergeSectionsRenderer({
                           reason: heroItem.description,
                           directionReference: heroItem.directionReference,
                         });
+                        // Reason V4構造化契約(fact/interpretation/action)を優先し、
+                        // needTagsベースの独自テンプレート(reasonDisplay)は新fieldが無い場合のfallbackとしてのみ使う
+                        const heroReasonV4 = buildHeroReasonV4Sections({
+                          detail: (heroItem as any).reasonV4Detail ?? null,
+                          recommendationReasonV4: (heroItem as any).recommendationReasonV4 ?? null,
+                          reason: heroItem.description ?? null,
+                        });
+                        // primaryReason(相談内容・ご利益との一致)は新設のinterpretation/fact表示と役割が重なるため
+                        // Hero通常経路では使用しない(reasonVm.hero.*等の見出し系は変更しない)
+                        const heroSecondaryReason = heroReasonV4.hasStructured ? null : heroReasonV4.fallbackText;
                         const trustMetadata = (heroItem as any).trustMetadata ?? null;
                         const trustLabels = [
                           trustMetadata?.rank_class ?? trustMetadata?.rankClass,
@@ -850,8 +861,11 @@ export default function ConciergeSectionsRenderer({
                               subtitle={reasonVm.hero.subtitle ?? null}
                               catchCopy={reasonVm.hero.catchCopy}
                               whyTop={null}
-                              primaryReason={reasonDisplay.matchReason}
-                              secondaryReason={reasonDisplay.reason}
+                              primaryReason={null}
+                              secondaryReason={heroSecondaryReason}
+                              factReason={heroReasonV4.factText}
+                              interpretationReason={heroReasonV4.interpretationText}
+                              actionReason={heroReasonV4.actionText}
                               differenceFromOthers={null}
                               tags={matchedNeedTags.map(labelNeedDisplayTag).slice(0, 3)}
                               actionSuggestions={(heroItem as any).actionSuggestions ?? []}

--- a/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
@@ -23,6 +23,9 @@ type Props = {
   whyTop?: string | null;
   primaryReason?: string | null;
   secondaryReason?: string | null;
+  factReason?: string | null;
+  interpretationReason?: string | null;
+  actionReason?: string | null;
   differenceFromOthers?: string | null;
   nextActionHint?: string | null;
   tags?: string[];
@@ -61,6 +64,9 @@ export default function ConciergeTopRecommendationHero({
   whyTop: _whyTop = null,
   primaryReason = null,
   secondaryReason = null,
+  factReason = null,
+  interpretationReason = null,
+  actionReason = null,
   differenceFromOthers: _differenceFromOthers = null,
   nextActionHint: _nextActionHint = null,
   tags: _tags = [],
@@ -178,6 +184,36 @@ export default function ConciergeTopRecommendationHero({
           >
             <p className="text-[11px] font-semibold tracking-[0.14em] text-slate-600">この神社を選んだ理由</p>
             <p className="mt-1 text-sm leading-6 text-slate-700">{secondaryReason}</p>
+          </div>
+        ) : null}
+
+        {factReason ? (
+          <div
+            className="rounded-[var(--kt-radius-card)] border border-emerald-100 bg-white/70 px-4 py-3 shadow-sm shadow-emerald-900/5"
+            data-testid="recommendation-reason-v4-fact"
+          >
+            <p className="text-[11px] font-semibold tracking-[0.14em] text-emerald-700">この神社について</p>
+            <p className="mt-1 text-sm leading-6 text-slate-800">{factReason}</p>
+          </div>
+        ) : null}
+
+        {interpretationReason ? (
+          <div
+            className="rounded-[var(--kt-radius-card)] border border-slate-100 bg-slate-50/70 px-4 py-3"
+            data-testid="recommendation-reason-v4-interpretation"
+          >
+            <p className="text-[11px] font-semibold tracking-[0.14em] text-slate-600">今の相談とのつながり</p>
+            <p className="mt-1 text-sm leading-6 text-slate-700">{interpretationReason}</p>
+          </div>
+        ) : null}
+
+        {actionReason ? (
+          <div
+            className="rounded-[var(--kt-radius-card)] border border-teal-100 bg-teal-50/70 px-4 py-3 shadow-sm shadow-teal-900/5"
+            data-testid="recommendation-reason-v4-action"
+          >
+            <p className="text-[11px] font-semibold tracking-[0.14em] text-teal-700">参拝前にできること</p>
+            <p className="mt-1 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{actionReason}</p>
           </div>
         ) : null}
 

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonV4Detail.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonV4Detail.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const analyticsMocks = vi.hoisted(() => ({
+  trackSearchEvent: vi.fn(),
+  trackCardEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/searchEvents", () => ({
+  trackSearchEvent: analyticsMocks.trackSearchEvent,
+}));
+
+vi.mock("@/lib/analytics/cardEvents", () => ({
+  trackCardEvent: analyticsMocks.trackCardEvent,
+}));
+
+const authMock = vi.hoisted(() => ({
+  useAuth: vi.fn(() => ({ isLoggedIn: false, loading: false })),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: authMock.useAuth,
+}));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[]) {
+  const u: any = {
+    data: { recommendations },
+    thread: { id: 900 },
+  };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+function detailFixture(overrides: Partial<{ fact: any; interpretation: any; action: any; reason_text: string }> = {}) {
+  return {
+    version: "v4",
+    reason_text: overrides.reason_text ?? "根津神社は仕事運に関わる神社です。",
+    fact: {
+      label: "根津神社",
+      name: "根津神社",
+      deity: null,
+      shrine_history: null,
+      place_context: null,
+      history_theme: "再出発",
+      goriyaku: "仕事運",
+      visit_style_tags: [],
+      evidence: ["history_theme:再出発"],
+      ...(overrides.fact ?? {}),
+    },
+    interpretation: {
+      theme: "再出発",
+      text: "相談内容から、今扱いたいテーマを読み取っています。",
+      ...(overrides.interpretation ?? {}),
+    },
+    action: {
+      text: "参拝前に、問いを一つに絞ることを決めておきます。",
+      source: "meaning_translation.action_context",
+      ...(overrides.action ?? {}),
+    },
+  };
+}
+
+const heroRecWithDetail = {
+  shrine_id: 1,
+  display_name: "根津神社",
+  reason: "旧型の理由文",
+  address: "東京都文京区1-1-1",
+  recommendation_reason_v4: "根津神社は仕事運に関わる神社です。",
+  recommendation_reason_v4_detail: detailFixture(),
+};
+
+describe("ConciergeSectionsRenderer - Reason V4構造化表示", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    authMock.useAuth.mockReturnValue({ isLoggedIn: false, loading: false });
+    window.localStorage.clear();
+  });
+
+  it("Heroでfact/interpretation/actionの3セクションが表示される", () => {
+    const payload = buildTestPayload([heroRecWithDetail]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
+
+    expect(screen.getByTestId("recommendation-reason-v4-fact")).toHaveTextContent("仕事運");
+    expect(screen.getByTestId("recommendation-reason-v4-interpretation")).toHaveTextContent(
+      "相談内容から、今扱いたいテーマを読み取っています。",
+    );
+    expect(screen.getByTestId("recommendation-reason-v4-action")).toHaveTextContent(
+      "参拝前に、問いを一つに絞ることを決めておきます。",
+    );
+  });
+
+  it("action.sourceは表示されない", () => {
+    const payload = buildTestPayload([heroRecWithDetail]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
+
+    expect(screen.queryByText("meaning_translation.action_context")).not.toBeInTheDocument();
+  });
+
+  it("構造化セクションが表示できる場合、reason_textと同内容を重複表示しない", () => {
+    const payload = buildTestPayload([heroRecWithDetail]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
+
+    expect(screen.queryByTestId("recommendation-standard-reason")).not.toBeInTheDocument();
+    expect(screen.queryByText("根津神社は仕事運に関わる神社です。")).not.toBeInTheDocument();
+  });
+
+  it("構造化fieldがすべて空の場合、reason_textへfallbackする", () => {
+    const rec = {
+      ...heroRecWithDetail,
+      recommendation_reason_v4_detail: detailFixture({
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+        action: { text: "" },
+        reason_text: "reason_textのfallback文言",
+      }),
+    };
+    const payload = buildTestPayload([rec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
+
+    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-reason-v4-interpretation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-reason-v4-action")).not.toBeInTheDocument();
+    expect(screen.getByTestId("recommendation-standard-reason")).toHaveTextContent("reason_textのfallback文言");
+  });
+
+  it("recommendation_reason_v4_detailが無くてもクラッシュせず表示される", () => {
+    const rec = {
+      shrine_id: 2,
+      display_name: "小網神社",
+      reason: "旧型の理由文のみの候補",
+    };
+    const payload = buildTestPayload([rec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
+
+    expect(screen.getByText("小網神社")).toBeInTheDocument();
+    expect(screen.getByTestId("recommendation-standard-reason")).toHaveTextContent("旧型の理由文のみの候補");
+    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
+  });
+
+  it("Heroのcard_view analyticsイベントの内容は変化しない", () => {
+    const payload = buildTestPayload([heroRecWithDetail]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
+
+    expect(analyticsMocks.trackCardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "card_view",
+        cardId: "shrine_hero",
+        source: "concierge_result",
+        shrineId: 1,
+        recommendationRank: 1,
+      }),
+    );
+  });
+});

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
@@ -54,6 +54,39 @@ describe("ConciergeTopRecommendationHero", () => {
     expect(match.compareDocumentPosition(reason) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
+  it("fact/interpretation/actionをこの順序で表示し、action.sourceは表示しない", () => {
+    render(
+      <ConciergeTopRecommendationHero
+        name="検証神社"
+        catchCopy="入口コピー"
+        factReason="仕事運に関わる神社です。"
+        interpretationReason="相談内容から、今扱いたいテーマを読み取っています。"
+        actionReason="参拝前に、問いを一つに絞ることを決めておきます。"
+      />,
+    );
+
+    const fact = screen.getByTestId("recommendation-reason-v4-fact");
+    const interpretation = screen.getByTestId("recommendation-reason-v4-interpretation");
+    const action = screen.getByTestId("recommendation-reason-v4-action");
+
+    expect(fact).toHaveTextContent("仕事運に関わる神社です。");
+    expect(interpretation).toHaveTextContent("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(action).toHaveTextContent("参拝前に、問いを一つに絞ることを決めておきます。");
+
+    expect(fact.compareDocumentPosition(interpretation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(interpretation.compareDocumentPosition(action) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    expect(screen.queryByText("meaning_translation.action_context")).not.toBeInTheDocument();
+  });
+
+  it("factReason等が無い場合は各セクションを表示しない", () => {
+    render(<ConciergeTopRecommendationHero name="検証神社" catchCopy="入口コピー" />);
+
+    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-reason-v4-interpretation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-reason-v4-action")).not.toBeInTheDocument();
+  });
+
 
   it("does not render legacy action suggestions on the hero card", () => {
     render(

--- a/apps/web/src/lib/api/concierge.ts
+++ b/apps/web/src/lib/api/concierge.ts
@@ -15,6 +15,10 @@ export type {
   ConciergeBreakdown,
   ConciergeReasonFactAxis,
   ConciergeReasonFacts,
+  RecommendationReasonV4Detail,
+  RecommendationReasonV4Fact,
+  RecommendationReasonV4Interpretation,
+  RecommendationReasonV4Action,
 } from "./concierge/types";
 
 import type {

--- a/apps/web/src/lib/api/concierge/types.ts
+++ b/apps/web/src/lib/api/concierge/types.ts
@@ -89,6 +89,36 @@ export type ConciergeReasonFactAxis =
   | "popularity"
   | "fallback";
 
+export type RecommendationReasonV4Fact = {
+  label: string;
+  name: string | null;
+  deity: string | null;
+  shrine_history: string | null;
+  place_context: string | null;
+  history_theme: string | null;
+  goriyaku: string | null;
+  visit_style_tags: string[];
+  evidence: string[];
+};
+
+export type RecommendationReasonV4Interpretation = {
+  theme: string;
+  text: string;
+};
+
+export type RecommendationReasonV4Action = {
+  text: string;
+  source: string;
+};
+
+export type RecommendationReasonV4Detail = {
+  version: "v4";
+  reason_text: string;
+  fact: RecommendationReasonV4Fact;
+  interpretation: RecommendationReasonV4Interpretation;
+  action: RecommendationReasonV4Action;
+};
+
 export type ConciergeReasonFacts = {
   version?: 1;
   primary_axis?: ConciergeReasonFactAxis | null;
@@ -150,6 +180,7 @@ export type ConciergeRecommendation = {
   reason_source?: string | null;
   recommendation_reason_v4?: string | null;
   recommendation_reason_quality?: RecommendationReasonQuality | null;
+  recommendation_reason_v4_detail?: RecommendationReasonV4Detail | null;
 
   bullets?: string[] | null;
   explanation?: {


### PR DESCRIPTION
### 概要

WebのConcierge Hero Recommendation Cardを、Backendの`recommendation_reason_v4_detail`構造化表示契約(#2191で追加)へ移行します。

### 現行表示経路の確認結果

- 本番実装は`ConciergeSectionsRenderer.tsx`のHeroブロック(`PrimaryRecommendationCard.tsx`は未使用)
- 従来は`rec.reason`(旧文字列)+ `needTags`ベースの独自テンプレート(`buildRecommendationReasonViewModel`/`buildRecommendationReasonDisplay`)で理由文を構成

### 実装した型

`apps/web/src/lib/api/concierge/types.ts`に`RecommendationReasonV4Detail`(`fact`/`interpretation`/`action`)を追加し、`ConciergeRecommendation.recommendation_reason_v4_detail`として公開。既存の`reason` / `recommendation_reason_v4` / `reason_facts`は変更していません。

### UIモデルの変更

新規`buildHeroReasonV4Sections.ts`でBackendのsnake_case fieldを表示コンポーネントへ直接渡さず、`{factText, interpretationText, actionText, hasStructured, fallbackText}`へ変換。方位・断定表現の除外は既存の`buildRecommendationReasonDisplay`に委譲し、新規フィルタは作っていません。

### 表示優先順位

1. 構造化fact / interpretation / action(この神社について / 今の相談とのつながり / 参拝前にできること)
2. `recommendation_reason_v4_detail.reason_text`
3. `recommendation_reason_v4`(文字列)
4. `reason`(旧文字列)

構造化セクションが1つ以上表示できる場合はreason_textを重複表示しません。`action.source`は通常UIに表示しません。

### 独自テンプレートの扱い

`needTags`ベースの独自テンプレートは、新fieldが無い場合のfallback表示にのみ使用します。`reasonVm.hero.*`(見出し・タグ表示等)は変更していません。デッドコードの大規模削除は行っていません(別PR)。

### 追加・更新したテスト

- `buildHeroReasonV4Sections.test.ts`(新規): fallback優先順位・方位表現除外・構造化判定
- `buildPayloadFromUnified.payload.test.ts`: `recommendation_reason_v4_detail`/`recommendation_reason_v4`の伝播、欠落時の安全性
- `ConciergeTopRecommendationHero.test.tsx`: fact/interpretation/actionの表示順序、action.source非表示、未指定時の非表示
- `ConciergeSectionsRenderer.reasonV4Detail.test.tsx`(新規): Hero3セクション表示、重複防止、fallback、クラッシュ耐性、Analytics内容不変

### 実行したテストと結果

`pnpm test:run`: 104 test files / 626 tests すべて成功(既存fixtureが古いレスポンス形状でも回帰なし)。`pnpm typecheck`・`eslint`ともにエラーなし。

### Responsive確認結果

Storybookで一時story(検証後削除)を使い375px/390px/430pxで確認。横スクロールなし、ラベル・本文の欠けなし、セクション間余白は適正、空セクション時の余白残留なし、CTA位置は押し下げられすぎない。

### Analytics非変更確認

`apps/web/src/lib/analytics`・`apps/mobile`への変更は0件。Hero `card_view`イベント(`shrineId`/`recommendationRank`/`mode`等)の内容が変わらないことをテストで確認済み。

### 非対象(変更していないもの)

- Backend / Mobile / concierge_plan.py / OpenAPI / Analytics定義
- Shrine Detail画面 / Compact候補カード
- reason_facts型ドリフト / デッドコードの大規模削除