### PR TITLE
feat(mobile): Concierge推薦カードをReason V4構造化表示へ移行

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -35,6 +35,11 @@ import { toOriginPayload, type UserOrigin } from "../../../../packages/shared/us
 import { buildRecommendationReasonDisplay } from "../../../../packages/shared/recommendationReasonDisplay";
 import { getOriginSession } from "../../lib/originSession";
 import { trackMobileDirection } from "../../lib/directionEvents";
+import {
+  buildReasonV4Sections,
+  normalizeRecommendationReasonV4Detail,
+  type RecommendationReasonV4Detail,
+} from "../../lib/recommendationReasonV4";
 
 // ────────────────────────────────────────────
 // 型
@@ -91,6 +96,7 @@ type RecommendationCard = {
   reasonFacts?: RecommendationReasonFacts | null;
   recommendationReasonQuality?: RecommendationReasonQuality | null;
   recommendationReasonDetail?: RecommendationReasonDetail | null;
+  reasonV4Detail?: RecommendationReasonV4Detail | null;
   tags: string[];
   shrineId?: string;
   actionSuggestionV4Preview?: ActionSuggestionV4Preview | null;
@@ -151,6 +157,8 @@ type RecommendationApiCard = {
   recommendationReasonDetail?: RecommendationReasonDetail | null;
   reason_detail?: RecommendationReasonDetail | null;
   reasonDetail?: RecommendationReasonDetail | null;
+  recommendation_reason_v4_detail?: unknown;
+  recommendationReasonV4Detail?: unknown;
   tags?: string[];
   shrineId?: string | number;
   shrine_id?: string | number;
@@ -373,6 +381,9 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
   const recommendationReasonDetail = normalizeRecommendationReasonDetail(
     item.recommendation_reason_detail ?? item.recommendationReasonDetail ?? item.reason_detail ?? item.reasonDetail,
   );
+  const reasonV4Detail = normalizeRecommendationReasonV4Detail(
+    item.recommendation_reason_v4_detail ?? item.recommendationReasonV4Detail,
+  );
   const reasonFactsRaw = item.reason_facts ?? item.reasonFacts ?? null;
   const reasonFacts = Array.isArray(reasonFactsRaw) ? (reasonFactsRaw[0] ?? null) : reasonFactsRaw;
   const reason = resolveRecommendationReason({
@@ -391,6 +402,7 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
     reasonFacts,
     recommendationReasonQuality,
     recommendationReasonDetail,
+    reasonV4Detail,
     tags: item.tags ?? [],
     shrineId: shrineId !== undefined && shrineId !== null ? String(shrineId) : undefined,
     actionSuggestionV4Preview,
@@ -481,6 +493,10 @@ function ResultCard({
     reason: card.reason,
     directionReference: card.directionReference,
   });
+  const reasonV4Sections = buildReasonV4Sections({
+    detail: card.reasonV4Detail,
+    fallbackReason: card.reason,
+  });
   React.useEffect(() => { if (!card.directionReference || directionImpressed.current) return; directionImpressed.current = true; trackMobileDirection("direction_match_impression", { matched: card.directionReference.matched, recommendation_rank: rank }); }, [card.directionReference, rank]);
   return (
     <View style={styles.card}>
@@ -499,21 +515,51 @@ function ResultCard({
         <Text style={styles.cardArea}>{card.area}</Text>
       </View>
 
-      {/* 相談内容・ご利益との一致 */}
-      {reasonDisplay.matchReason ? (
-        <View style={styles.connectionBlock}>
-          <Text style={styles.connectionLabel}>相談内容・ご利益との一致</Text>
-          <Text style={styles.connectionText}>{reasonDisplay.matchReason}</Text>
-        </View>
-      ) : null}
+      {reasonV4Sections.hasStructured ? (
+        <>
+          {/* この神社について */}
+          {reasonV4Sections.factText ? (
+            <View style={styles.reasonBlock}>
+              <Text style={styles.reasonLabel}>この神社について</Text>
+              <Text style={styles.cardReason} numberOfLines={3}>{reasonV4Sections.factText}</Text>
+            </View>
+          ) : null}
 
-      {/* 推薦理由 */}
-      {reasonDisplay.reason ? (
-        <View style={styles.reasonBlock}>
-          <Text style={styles.reasonLabel}>この神社を選んだ理由</Text>
-          <Text style={styles.cardReason} numberOfLines={3}>{reasonDisplay.reason}</Text>
-        </View>
-      ) : null}
+          {/* 今の相談とのつながり */}
+          {reasonV4Sections.interpretationText ? (
+            <View style={styles.reasonBlock}>
+              <Text style={styles.reasonLabel}>今の相談とのつながり</Text>
+              <Text style={styles.cardReason} numberOfLines={3}>{reasonV4Sections.interpretationText}</Text>
+            </View>
+          ) : null}
+
+          {/* 参拝前にできること */}
+          {reasonV4Sections.actionText ? (
+            <View style={styles.reasonBlock}>
+              <Text style={styles.reasonLabel}>参拝前にできること</Text>
+              <Text style={styles.cardReason} numberOfLines={3}>{reasonV4Sections.actionText}</Text>
+            </View>
+          ) : null}
+        </>
+      ) : (
+        <>
+          {/* 相談内容・ご利益との一致 */}
+          {reasonDisplay.matchReason ? (
+            <View style={styles.connectionBlock}>
+              <Text style={styles.connectionLabel}>相談内容・ご利益との一致</Text>
+              <Text style={styles.connectionText}>{reasonDisplay.matchReason}</Text>
+            </View>
+          ) : null}
+
+          {/* 推薦理由 */}
+          {reasonV4Sections.fallbackText ? (
+            <View style={styles.reasonBlock}>
+              <Text style={styles.reasonLabel}>この神社を選んだ理由</Text>
+              <Text style={styles.cardReason} numberOfLines={3}>{reasonV4Sections.fallbackText}</Text>
+            </View>
+          ) : null}
+        </>
+      )}
 
       {reasonFactItems.length > 0 ? (
         <View style={styles.reasonFactsCard}>

--- a/apps/mobile/lib/__tests__/recommendationReasonV4.test.ts
+++ b/apps/mobile/lib/__tests__/recommendationReasonV4.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReasonV4Sections,
+  normalizeRecommendationReasonV4Detail,
+  type RecommendationReasonV4Detail,
+} from "../recommendationReasonV4";
+
+function makeDetail(
+  overrides: Partial<{
+    reason_text: string;
+    fact: Partial<RecommendationReasonV4Detail["fact"]>;
+    interpretation: Partial<RecommendationReasonV4Detail["interpretation"]>;
+    action: Partial<RecommendationReasonV4Detail["action"]>;
+  }> = {},
+): RecommendationReasonV4Detail {
+  return {
+    version: "v4",
+    reason_text: overrides.reason_text ?? "根津神社は仕事運に関わる神社です。",
+    fact: {
+      label: "根津神社",
+      name: "根津神社",
+      deity: null,
+      shrine_history: null,
+      place_context: null,
+      history_theme: "再出発",
+      goriyaku: "仕事運",
+      visit_style_tags: [],
+      evidence: ["history_theme:再出発"],
+      ...(overrides.fact ?? {}),
+    },
+    interpretation: {
+      theme: "再出発",
+      text: "相談内容から、今扱いたいテーマを読み取っています。",
+      ...(overrides.interpretation ?? {}),
+    },
+    action: {
+      text: "参拝前に、問いを一つに絞ることを決めておきます。",
+      source: "meaning_translation.action_context",
+      ...(overrides.action ?? {}),
+    },
+  };
+}
+
+describe("normalizeRecommendationReasonV4Detail", () => {
+  it("正しいobjectを欠損なく正規化する", () => {
+    const raw = makeDetail();
+    const result = normalizeRecommendationReasonV4Detail(raw);
+    expect(result).toEqual(raw);
+  });
+
+  it("object以外(null/undefined/文字列/配列)はnullを返す", () => {
+    expect(normalizeRecommendationReasonV4Detail(null)).toBeNull();
+    expect(normalizeRecommendationReasonV4Detail(undefined)).toBeNull();
+    expect(normalizeRecommendationReasonV4Detail("not-an-object")).toBeNull();
+    expect(normalizeRecommendationReasonV4Detail([])).toBeNull();
+  });
+
+  it("空objectでもクラッシュせず空値で埋めたobjectを返す", () => {
+    const result = normalizeRecommendationReasonV4Detail({});
+    expect(result).toEqual({
+      version: "v4",
+      reason_text: "",
+      fact: {
+        label: "",
+        name: null,
+        deity: null,
+        shrine_history: null,
+        place_context: null,
+        history_theme: null,
+        goriyaku: null,
+        visit_style_tags: [],
+        evidence: [],
+      },
+      interpretation: { theme: "", text: "" },
+      action: { text: "", source: "" },
+    });
+  });
+
+  it("fact/interpretation/actionが欠落していてもクラッシュしない", () => {
+    const result = normalizeRecommendationReasonV4Detail({ reason_text: "本文のみ" });
+    expect(result?.reason_text).toBe("本文のみ");
+    expect(result?.fact.label).toBe("");
+    expect(result?.interpretation.text).toBe("");
+    expect(result?.action.text).toBe("");
+  });
+
+  it("空白のみの文字列は空文字として扱う", () => {
+    const result = normalizeRecommendationReasonV4Detail({
+      reason_text: "   ",
+      fact: { label: "  ", history_theme: "   " },
+    });
+    expect(result?.reason_text).toBe("");
+    expect(result?.fact.label).toBe("");
+    expect(result?.fact.history_theme).toBeNull();
+  });
+
+  it("visit_style_tags/evidenceが配列以外の場合は空配列にする", () => {
+    const result = normalizeRecommendationReasonV4Detail({
+      fact: { visit_style_tags: "not-an-array", evidence: null },
+    });
+    expect(result?.fact.visit_style_tags).toEqual([]);
+    expect(result?.fact.evidence).toEqual([]);
+  });
+});
+
+describe("buildReasonV4Sections", () => {
+  it("fact/interpretation/actionすべて存在する場合は構造化表示になる", () => {
+    const result = buildReasonV4Sections({ detail: makeDetail(), fallbackReason: null });
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBe("仕事運");
+    expect(result.interpretationText).toBe("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(result.actionText).toBe("参拝前に、問いを一つに絞ることを決めておきます。");
+    expect(result.fallbackText).toBeNull();
+  });
+
+  it("factのみ存在する場合もhasStructured=trueになる", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({ interpretation: { text: "" }, action: { text: "" } }),
+      fallbackReason: null,
+    });
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBe("仕事運");
+    expect(result.interpretationText).toBeNull();
+    expect(result.actionText).toBeNull();
+  });
+
+  it("interpretationのみ存在する場合もhasStructured=trueになる", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        action: { text: "" },
+      }),
+      fallbackReason: null,
+    });
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBeNull();
+    expect(result.interpretationText).toBe("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(result.actionText).toBeNull();
+  });
+
+  it("actionのみ存在する場合もhasStructured=trueになる", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+      }),
+      fallbackReason: null,
+    });
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBeNull();
+    expect(result.interpretationText).toBeNull();
+    expect(result.actionText).toBe("参拝前に、問いを一つに絞ることを決めておきます。");
+  });
+
+  it("fact優先順位はshrine_history > place_context > goriyaku > history_theme > label", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({
+        fact: { shrine_history: "由緒あり", place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発", label: "候補神社" },
+      }),
+      fallbackReason: null,
+    });
+    expect(result.factText).toBe("由緒あり");
+  });
+
+  it("空objectのdetail(全field空)はhasStructured=falseになりreason_textへfallbackする", () => {
+    const result = buildReasonV4Sections({
+      detail: normalizeRecommendationReasonV4Detail({}),
+      fallbackReason: "旧型の理由文",
+    });
+    expect(result.hasStructured).toBe(false);
+    expect(result.fallbackText).toBe("旧型の理由文");
+  });
+
+  it("構造化fieldがすべて空でもreason_textがあればreason_textへfallbackする", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+        action: { text: "" },
+        reason_text: "reason_textの内容",
+      }),
+      fallbackReason: "recommendation_reason_v4等の解決済み理由",
+    });
+    expect(result.hasStructured).toBe(false);
+    expect(result.fallbackText).toBe("reason_textの内容");
+  });
+
+  it("reason_textが無い場合はfallbackReason(recommendation_reason_v4/reasonFacts/reason解決済み)を使う", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({
+        fact: { shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "" },
+        interpretation: { text: "" },
+        action: { text: "" },
+        reason_text: "",
+      }),
+      fallbackReason: "recommendation_reason_v4等の解決済み理由",
+    });
+    expect(result.fallbackText).toBe("recommendation_reason_v4等の解決済み理由");
+  });
+
+  it("detailがnullでもfallbackReasonへ安全にfallbackする(reasonFacts/reason解決済み想定)", () => {
+    const result = buildReasonV4Sections({ detail: null, fallbackReason: "相談内容と神社情報をもとに選ばれた神社です。" });
+    expect(result.hasStructured).toBe(false);
+    expect(result.fallbackText).toBe("相談内容と神社情報をもとに選ばれた神社です。");
+  });
+
+  it("detail・fallbackReasonとも欠落してもクラッシュせずnullを返す", () => {
+    const result = buildReasonV4Sections({ detail: null, fallbackReason: null });
+    expect(result.hasStructured).toBe(false);
+    expect(result.factText).toBeNull();
+    expect(result.interpretationText).toBeNull();
+    expect(result.actionText).toBeNull();
+    expect(result.fallbackText).toBeNull();
+  });
+
+  it("action.sourceは戻り値に含まれない", () => {
+    const result = buildReasonV4Sections({ detail: makeDetail(), fallbackReason: null });
+    expect(result).not.toHaveProperty("actionSource");
+    expect(result).not.toHaveProperty("source");
+    expect(Object.keys(result)).toEqual(["factText", "interpretationText", "actionText", "hasStructured", "fallbackText"]);
+  });
+
+  it("構造化表示が可能な場合、fallbackTextと重複しない(fallbackTextはnull)", () => {
+    const result = buildReasonV4Sections({
+      detail: makeDetail({ reason_text: "reason_textの内容" }),
+      fallbackReason: "旧型の理由文",
+    });
+    expect(result.hasStructured).toBe(true);
+    expect(result.fallbackText).toBeNull();
+  });
+
+  it("方位・断定表現を含むテキストは表示から除外される", () => {
+    const result = buildReasonV4Sections({
+      detail: null,
+      fallbackReason: "この方位は吉方位なので必ず良い結果になります。",
+    });
+    expect(result.fallbackText).toBeNull();
+  });
+});

--- a/apps/mobile/lib/recommendationReasonV4.ts
+++ b/apps/mobile/lib/recommendationReasonV4.ts
@@ -1,0 +1,146 @@
+// apps/mobile/lib/recommendationReasonV4.ts
+import { buildRecommendationReasonDisplay } from "../../../packages/shared/recommendationReasonDisplay";
+
+export type RecommendationReasonV4Fact = {
+  label: string;
+  name: string | null;
+  deity: string | null;
+  shrine_history: string | null;
+  place_context: string | null;
+  history_theme: string | null;
+  goriyaku: string | null;
+  visit_style_tags: string[];
+  evidence: string[];
+};
+
+export type RecommendationReasonV4Interpretation = {
+  theme: string;
+  text: string;
+};
+
+export type RecommendationReasonV4Action = {
+  text: string;
+  source: string;
+};
+
+export type RecommendationReasonV4Detail = {
+  version: "v4";
+  reason_text: string;
+  fact: RecommendationReasonV4Fact;
+  interpretation: RecommendationReasonV4Interpretation;
+  action: RecommendationReasonV4Action;
+};
+
+export type ReasonV4Sections = {
+  factText: string | null;
+  interpretationText: string | null;
+  actionText: string | null;
+  hasStructured: boolean;
+  fallbackText: string | null;
+};
+
+function clean(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  return s.length ? s : null;
+}
+
+function cleanArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+}
+
+function pickFirst(...values: unknown[]): string | null {
+  for (const v of values) {
+    const s = clean(v);
+    if (s) return s;
+  }
+  return null;
+}
+
+// 方位・断定表現の除外は既存のbuildRecommendationReasonDisplayに委譲する(Mobileで新規フィルタを作らない)
+function safeText(value: string | null): string | null {
+  if (!value) return null;
+  return buildRecommendationReasonDisplay({ matchReason: null, reason: value, directionReference: null }).reason;
+}
+
+/**
+ * Backendの`recommendation_reason_v4_detail`を欠損に強い形へ正規化する。
+ * `raw`がobjectでない場合(field欠落・古いAPIレスポンス)はnullを返す。
+ * object内の各fieldは欠落・空文字・不正型でもクラッシュしない。
+ */
+export function normalizeRecommendationReasonV4Detail(raw: unknown): RecommendationReasonV4Detail | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const value = raw as Record<string, unknown>;
+  const factRaw = (value.fact && typeof value.fact === "object" ? value.fact : {}) as Record<string, unknown>;
+  const interpretationRaw = (value.interpretation && typeof value.interpretation === "object" ? value.interpretation : {}) as Record<string, unknown>;
+  const actionRaw = (value.action && typeof value.action === "object" ? value.action : {}) as Record<string, unknown>;
+
+  return {
+    version: "v4",
+    reason_text: clean(value.reason_text) ?? "",
+    fact: {
+      label: clean(factRaw.label) ?? "",
+      name: clean(factRaw.name),
+      deity: clean(factRaw.deity),
+      shrine_history: clean(factRaw.shrine_history),
+      place_context: clean(factRaw.place_context),
+      history_theme: clean(factRaw.history_theme),
+      goriyaku: clean(factRaw.goriyaku),
+      visit_style_tags: cleanArray(factRaw.visit_style_tags),
+      evidence: cleanArray(factRaw.evidence),
+    },
+    interpretation: {
+      theme: clean(interpretationRaw.theme) ?? "",
+      text: clean(interpretationRaw.text) ?? "",
+    },
+    action: {
+      text: clean(actionRaw.text) ?? "",
+      source: clean(actionRaw.source) ?? "",
+    },
+  };
+}
+
+/**
+ * Hero/その他候補を問わず、推薦カード表示用のReason V4セクションを組み立てる。
+ *
+ * 優先順位:
+ * 1. 構造化fact / interpretation / action
+ * 2. recommendation_reason_v4_detail.reason_text
+ * 3. recommendation_reason_v4(文字列) ※ fallbackReasonに事前解決済みとして渡す
+ * 4. reasonFacts由来の既存理由 ※ fallbackReasonに事前解決済みとして渡す
+ * 5. reason(旧文字列) ※ fallbackReasonに事前解決済みとして渡す
+ * 6. 既存固定fallback ※ fallbackReasonに事前解決済みとして渡す
+ *
+ * fallbackReasonには、呼び出し側で既に解決済みの理由文字列(3〜6段階を内包する値)を渡す。
+ * 構造化セクションが1つ以上表示できる場合はfallbackTextを返さない(重複表示防止)。
+ */
+export function buildReasonV4Sections(params: {
+  detail?: RecommendationReasonV4Detail | null;
+  fallbackReason?: string | null;
+}): ReasonV4Sections {
+  const detail = params.detail ?? null;
+
+  const factText = safeText(
+    detail
+      ? pickFirst(
+          detail.fact.shrine_history,
+          detail.fact.place_context,
+          detail.fact.goriyaku,
+          detail.fact.history_theme,
+          detail.fact.label,
+        )
+      : null,
+  );
+  const interpretationText = safeText(detail ? clean(detail.interpretation.text) : null);
+  const actionText = safeText(detail ? clean(detail.action.text) : null);
+
+  const hasStructured = Boolean(factText || interpretationText || actionText);
+
+  const fallbackText = hasStructured
+    ? null
+    : safeText(pickFirst(detail?.reason_text, params.fallbackReason));
+
+  return { factText, interpretationText, actionText, hasStructured, fallbackText };
+}


### PR DESCRIPTION
### 概要

Mobile Conciergeの推薦結果表示を、Backendの`recommendation_reason_v4_detail`構造化表示契約(#2191)へ移行します。

### 監査結果(実装前に確認)

- Mobileには**Hero/その他候補の分離コンポーネントが存在しない**。全候補が`results.map()`経由で共通の`ResultCard`を使用(`rank`のみ異なる)
- `resolveRecommendationReason()`が既にrecommendation_reason_v4文字列→reasonFacts由来→旧reason→固定fallbackの優先順位を実装済み
- `apps/mobile/app/shrines/[id].tsx`は独自の`resolveRecommendationReason()`を持ち、concierge画面とコード共有なし(今回変更不要)
- Analytics(`trackMobileDirection`/`trackActionEvent`)はreason本文に依存していない
- Mobile Concierge画面に対する自動テストは存在せず、vitest対象も`lib/__tests__/**`のみ。React Native Testing Library等のコンポーネントテスト基盤は未導入

### 確定方針(母艦判断)

全候補が同一`ResultCard`を使う既存構造に合わせ、rank分岐・Hero専用コンポーネントを追加せず、Reason V4構造化表示を全候補へ一律適用しました。

### 表示優先順位

1. `recommendation_reason_v4_detail`のfact/interpretation/action(構造化)
2. `recommendation_reason_v4_detail.reason_text`
3. `recommendation_reason_v4` / reasonFacts由来 / 旧`reason`(既存`resolveRecommendationReason`が解決済みの値を利用)
4. 既存固定fallback

構造化セクションが1件以上存在する場合は、旧2ブロック(相談内容・ご利益との一致/この神社を選んだ理由)を重複表示しません。

### factの生成ルール

`shrine_history > place_context > goriyaku > history_theme > label`の優先順位で最初に非空の値を採用(Web版と同一ルール、Frontendで新規文章生成はしない)。

### 変更ファイル

- `apps/mobile/app/concierge/index.tsx`: 型追加・`toRecommendationCard`での正規化・`ResultCard`のセクション分岐
- `apps/mobile/lib/recommendationReasonV4.ts`(新規): 型(`RecommendationReasonV4Detail`等)と純粋関数(`normalizeRecommendationReasonV4Detail`/`buildReasonV4Sections`)
- `apps/mobile/lib/__tests__/recommendationReasonV4.test.ts`(新規): 19ケース

### 維持したもの

根拠として見ている情報・方位カード・ActionSuggestion・詳細CTA・rank表示・Analyticsイベント/payloadは無変更。`action.source`/`used_*`/detail直下の`source`・`quality`はUIへ使用していません。

### 検証結果

- Mobile typecheck: エラーなし
- Mobile lint: **スクリプト自体が存在しない**(package.jsonにlint未定義、既存の制約でありこのPRでは追加していません)
- 対象テスト(`recommendationReasonV4.test.ts`): 19 passed
- Mobile全テスト: 19 test files / 186 tests すべて成功
- `git diff --check`: エラーなし
- pre-push Web契約テスト: 626 tests すべて成功

### 実機QA

ローカルにbootedなiOS Simulatorが無く、また本画面には既存の自動UIテスト基盤・fixtureが無いため、フル実機QAは実施していません。代わりに以下で検証しています。

- typecheckによる型・JSX構造の健全性確認
- 正規化ロジックのユニットテスト19件(空値・空文字・欠落・fallback連鎖・重複防止・action.source非表示を網羅)
- 新規3セクションは既存の`reasonBlock`/`reasonLabel`/`cardReason`スタイル(既に本番で使用中)をそのまま再利用し、`numberOfLines={3}`で長文対策済み

### 非対象

- Backend / Web / Analytics定義 / 推薦アルゴリズム / OpenAPI
- `apps/mobile/app/shrines/[id].tsx`(神社詳細画面)
- Journey Timeline
- package依存追加 / React Native Testing Library導入
- デッドコード削除