### PR TITLE
Mobile神社詳細へRecommendation Reason V4の相談文脈を統合

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -38,6 +38,7 @@ import { trackMobileDirection } from "../../lib/directionEvents";
 import {
   buildReasonV4Sections,
   normalizeRecommendationReasonV4Detail,
+  serializeReasonV4Detail,
   type RecommendationReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
 
@@ -842,6 +843,7 @@ export default function ConciergeScreen() {
           ? JSON.stringify(card.recommendationReasonDetail)
           : "",
         actionSuggestionV4Preview: card.actionSuggestionV4Preview ? JSON.stringify(card.actionSuggestionV4Preview) : "",
+        recommendationReasonV4Detail: serializeReasonV4Detail(card.reasonV4Detail),
       },
     });
   };

--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -24,6 +24,11 @@ import {
 } from "../../lib/visitReflectionAnalytics";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 import Button from "../../components/ui/Button";
+import {
+  buildReasonV4Sections,
+  normalizeRecommendationReasonV4Detail,
+  type RecommendationReasonV4Detail,
+} from "../../lib/recommendationReasonV4";
 
 type RecommendationReasonFactAxis =
   | "need"
@@ -251,6 +256,7 @@ export default function ShrineDetail() {
     reasonFacts?: string | string[];
     recommendationReasonDetail?: string | string[];
     actionSuggestionV4Preview?: string | string[];
+    recommendationReasonV4Detail?: string | string[];
   }>();
   const shrineId = React.useMemo(() => {
     const raw = params.id;
@@ -316,6 +322,19 @@ export default function ShrineDetail() {
     }
   }, [params.actionSuggestionV4Preview]);
 
+  const contextReasonV4Detail = React.useMemo<RecommendationReasonV4Detail | null>(() => {
+    const raw = params.recommendationReasonV4Detail;
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    if (!value) return null;
+
+    try {
+      const parsed = JSON.parse(value);
+      return normalizeRecommendationReasonV4Detail(parsed);
+    } catch {
+      return null;
+    }
+  }, [params.recommendationReasonV4Detail]);
+
   const apiShrineId = React.useMemo(() => {
     if (!shrineId) return undefined;
     return SHRINE_API_ID_BY_LOCAL_ID[shrineId] ?? shrineId;
@@ -354,6 +373,15 @@ export default function ShrineDetail() {
       reasonFacts: contextReasonFacts ?? shrine.reasonFacts,
     });
   }, [contextReasonFacts, contextRecommendationReasonV4, shrine]);
+
+  // Concierge以外の遷移ではcontextReasonV4Detailがnullのため常にhasStructured=falseとなり、
+  // 神社APIの値から相談文脈を推測することはない(v4 detailはroute params専用でShrine型に持たせていない)
+  const reasonV4Sections = buildReasonV4Sections({
+    detail: contextReasonV4Detail,
+    fallbackReason: recommendationReason ?? null,
+  });
+  const hasStructuredReasonV4 = reasonV4Sections.hasStructured;
+  const hideReasonFactsCard = Boolean(reasonV4Sections.factText);
 
   const explanation = React.useMemo(() => {
     if (!shrine) return undefined;
@@ -676,13 +704,22 @@ export default function ShrineDetail() {
           </View>
         ) : null}
 
-        {/* 推薦理由 */}
-        <View style={styles.recommendationCard}>
-          <Text style={styles.cardTitle}>② 選ばれた理由</Text>
-          <Text style={styles.cardBody}>{recommendationReason}</Text>
-        </View>
+        {/* 推薦理由(構造化Reason V4がある場合はfactを、無ければ旧recommendationReasonを表示) */}
+        {hasStructuredReasonV4 ? (
+          reasonV4Sections.factText ? (
+            <View style={styles.recommendationCard}>
+              <Text style={styles.cardTitle}>② 選ばれた背景</Text>
+              <Text style={styles.cardBody}>{reasonV4Sections.factText}</Text>
+            </View>
+          ) : null
+        ) : (
+          <View style={styles.recommendationCard}>
+            <Text style={styles.cardTitle}>② 選ばれた理由</Text>
+            <Text style={styles.cardBody}>{recommendationReason}</Text>
+          </View>
+        )}
 
-        {reasonFactItems.length > 0 ? (
+        {!hideReasonFactsCard && reasonFactItems.length > 0 ? (
           <View style={styles.reasonFactsCard}>
             <Text style={styles.reasonFactsLabel}>選定のポイント</Text>
             {reasonFactItems.map((item) => (
@@ -694,14 +731,28 @@ export default function ShrineDetail() {
           </View>
         ) : null}
 
-        {hasShrineMeaning ? (
+        {hasStructuredReasonV4 ? (
+          reasonV4Sections.interpretationText ? (
+            <View style={styles.meaningCard}>
+              <Text style={styles.cardTitle}>③ 今回の相談との意味</Text>
+              <Text style={styles.cardBody}>{reasonV4Sections.interpretationText}</Text>
+            </View>
+          ) : null
+        ) : hasShrineMeaning ? (
           <View style={styles.meaningCard}>
             <Text style={styles.cardTitle}>③ この神社で受け取る意味</Text>
             <Text style={styles.cardBody}>{contextRecommendationReasonDetail?.shrineMeaning}</Text>
           </View>
         ) : null}
 
-        {hasActionMeaning ? (
+        {hasStructuredReasonV4 ? (
+          reasonV4Sections.actionText ? (
+            <View style={styles.actionCard}>
+              <Text style={styles.cardTitle}>④ 参拝するときの視点</Text>
+              <Text style={styles.cardBody}>{reasonV4Sections.actionText}</Text>
+            </View>
+          ) : null
+        ) : hasActionMeaning ? (
           <View style={styles.actionCard}>
             <Text style={styles.cardTitle}>④ 参拝するときの視点</Text>
             <Text style={styles.cardBody}>{contextRecommendationReasonDetail?.actionMeaning}</Text>

--- a/apps/mobile/lib/__tests__/recommendationReasonV4.test.ts
+++ b/apps/mobile/lib/__tests__/recommendationReasonV4.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildReasonV4Sections,
   normalizeRecommendationReasonV4Detail,
+  serializeReasonV4Detail,
   type RecommendationReasonV4Detail,
 } from "../recommendationReasonV4";
 
@@ -235,5 +236,20 @@ describe("buildReasonV4Sections", () => {
       fallbackReason: "この方位は吉方位なので必ず良い結果になります。",
     });
     expect(result.fallbackText).toBeNull();
+  });
+});
+
+describe("serializeReasonV4Detail", () => {
+  it("detailが存在する場合はJSON文字列化する", () => {
+    const detail = makeDetail();
+    expect(serializeReasonV4Detail(detail)).toBe(JSON.stringify(detail));
+  });
+
+  it("detailがnullの場合は空文字を返す(不要なJSON文字列を生成しない)", () => {
+    expect(serializeReasonV4Detail(null)).toBe("");
+  });
+
+  it("detailがundefinedの場合は空文字を返す", () => {
+    expect(serializeReasonV4Detail(undefined)).toBe("");
   });
 });

--- a/apps/mobile/lib/recommendationReasonV4.ts
+++ b/apps/mobile/lib/recommendationReasonV4.ts
@@ -144,3 +144,11 @@ export function buildReasonV4Sections(params: {
 
   return { factText, interpretationText, actionText, hasStructured, fallbackText };
 }
+
+/**
+ * Concierge→Shrine Detailのroute paramsへ渡すJSON文字列を組み立てる。
+ * 既存のreasonFacts/recommendationReasonDetail等と同じ「値が無ければ空文字」規約に合わせる。
+ */
+export function serializeReasonV4Detail(detail: RecommendationReasonV4Detail | null | undefined): string {
+  return detail ? JSON.stringify(detail) : "";
+}


### PR DESCRIPTION
### 目的

Mobile Conciergeで保持している`recommendationReasonV4Detail`をShrine Detailへ引き継ぎ、`fact`・`interpretation`・`action`を構造化表示します。新V4がない場合(直接遷移・一覧・お気に入り等)は既存の旧契約表示を維持します。

### 実装内容

**Concierge**(`apps/mobile/app/concierge/index.tsx`):
- `handleDetail()`のroute paramsへ`recommendationReasonV4Detail`を追加。`card.reasonV4Detail`が存在する場合のみ`JSON.stringify()`、無ければ既存3fieldと同じ空文字fallback規約
- 既存の`recommendationReasonV4`/`reasonFacts`/`recommendationReasonDetail`/`actionSuggestionV4Preview`は無変更

**Shrine Detail**(`apps/mobile/app/shrines/[id].tsx`):
- `useLocalSearchParams`型へ`recommendationReasonV4Detail`を追加、`JSON.parse`失敗時は`null`へfallback、`normalizeRecommendationReasonV4Detail()`で正規化
- 既存helper`buildReasonV4Sections()`をそのまま再利用して表示用sectionを生成
- `hasStructured`を基準に新V4表示モード/旧表示モードを切り替え
  - ②`fact`→見出し「選ばれた背景」、③`interpretation`→見出し「今回の相談との意味」、④`action`→見出し「参拝するときの視点」(旧④と同一文言)
  - 値が空のsectionは個別に非表示
  - structured存在時は旧②〜④を非表示、structured `fact`存在時は旧`reasonFacts`カード(選定のポイント)を非表示
- ①「今回の相談の整理」(`consultationSummary`)・explanation・ActionSuggestion・神社profile表示は無変更
- V4 `action`と`ActionSuggestionV4Preview`は別セクションとして併存(変更なし)

**新規helper**(`apps/mobile/lib/recommendationReasonV4.ts`):
- `serializeReasonV4Detail()`を追加(既存の空文字fallback規約に合わせたJSON文字列化)。`normalizeRecommendationReasonV4Detail`/`buildReasonV4Sections`自体は無変更で再利用

### 変更していないもの

Backend / Web / `ConciergeThreadSerializer` / 旧契約の型・field / 神社profile由来の表示 / Concierge以外の遷移での相談文脈生成・補完

### テスト

`recommendationReasonV4.test.ts`へ`serializeReasonV4Detail`のテスト3件を追加(detail存在時のJSON化、null/undefined時の空文字返却)。既存の`buildReasonV4Sections`/`normalizeRecommendationReasonV4Detail`のテスト19件が構造化判定・fallback・malformed入力耐性を既にカバーしているため、Shrine Detail側のモード切替ロジック自体は既存helperのテストで裏付けられています。

Mobile画面コンポーネント(`app/`配下)に対する自動UIテスト基盤(RNTL等)は本リポジトリに存在しないため、表示切り替え自体はExpo web(`http://localhost:8081`)でURL直接操作によるQAで確認しました(下記)。

### 検証結果

- Mobile typecheck: エラーなし
- Mobile lint: **スクリプト自体が存在しない**(package.jsonに未定義、既存の制約でありこのPRでは追加していません)
- 対象テスト(`recommendationReasonV4.test.ts`): 22 passed
- Mobile全テスト: 19 test files / 189 tests すべて成功
- `git diff --check`: エラーなし
- pre-push Web契約テスト: 626 tests すべて成功

### Expo Web QA(実施済み)

`expo start --web`をローカル起動し、`/shrines/meiji`へ以下のクエリパラメータを付与して直接アクセスし確認:

1. **構造化V4あり**: 「② 選ばれた背景」「③ 今回の相談との意味」「④ 参拝するときの視点」が表示され、旧②〜④・consultationSummary(無し)は非表示。ActionSuggestion(「参拝前にできること」)は別セクションとして併存。
2. **v4 detail無し(直接表示相当)**: 「② 選ばれた理由」(固定fallback文言)のみ表示、①③④・選定のポイントは非表示。神社名・タグ・説明・ActionSuggestion等の神社profile表示は従来通り。
3. **malformed JSON**: クラッシュせず、v4 detail無し時と同じ表示へfallback(コンソールエラーなし)。
4. **factのみ空・interpretationのみ構造化 + reasonFacts共存**: 「② 選ばれた背景」は非表示(fact空のため)、「選定のポイント」(reasonFacts)は表示(fact不在のため非表示条件に該当せず)、「③ 今回の相談との意味」は表示。
5. **factが存在 + reasonFacts両方渡す**: 「② 選ばれた背景」表示、「選定のポイント」は非表示(fact優先で重複回避)。

全シナリオで意図した表示切り替え・fallback・重複回避が確認できました。