### PR TITLE
fix(web): Hero Reason V4のFact表示優先順位をBackend契約に合わせて修正

### DIFF
--- a/apps/web/src/features/concierge/__tests__/buildHeroReasonV4Sections.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildHeroReasonV4Sections.test.ts
@@ -41,16 +41,121 @@ describe("buildHeroReasonV4Sections", () => {
     expect(result.fallbackText).toBeNull();
   });
 
-  it("factは優先順位(shrine_history > place_context > goriyaku > history_theme > label)で選ばれる", () => {
+  it("factは優先順位(deity > shrine_history > goriyaku > history_theme)で選ばれる(place_context/labelは候補にしない)", () => {
     const result = buildHeroReasonV4Sections({
       detail: makeDetail({
-        fact: { shrine_history: "由緒あり", place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発", label: "候補神社" },
+        fact: { deity: "武神", shrine_history: "由緒あり", place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発", label: "候補神社" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBe("武神");
+  });
+
+  it("deityが選ばれるケース", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { deity: "武神", shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "武神" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBe("武神");
+  });
+
+  it("shrine_historyが選ばれるケース(deityが無い場合)", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { deity: null, shrine_history: "由緒あり", place_context: null, goriyaku: null, history_theme: null, label: "由緒あり" },
       }),
       recommendationReasonV4: null,
       reason: null,
     });
 
     expect(result.factText).toBe("由緒あり");
+  });
+
+  it("goriyakuが選ばれるケース(deity/shrine_historyが無い場合)", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { deity: null, shrine_history: null, place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発", label: "住所情報" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBe("縁結び");
+    expect(result.factText).not.toBe("住所情報");
+  });
+
+  it("history_themeが選ばれるケース(deity/shrine_history/goriyakuが無い場合)", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { deity: null, shrine_history: null, place_context: "住所情報", goriyaku: null, history_theme: "再出発", label: "住所情報" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBe("再出発");
+  });
+
+  it("place_contextだけではFactを生成しない(住所を神社の特徴として表示しない)", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: {
+          deity: null,
+          shrine_history: null,
+          place_context: "東京都渋谷区代々木神園町1-1",
+          goriyaku: null,
+          history_theme: null,
+          label: "東京都渋谷区代々木神園町1-1",
+        },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBeNull();
+  });
+
+  it("labelだけではFactを生成しない", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: {
+          deity: null,
+          shrine_history: null,
+          place_context: null,
+          goriyaku: null,
+          history_theme: null,
+          label: "候補神社",
+        },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+      recommendationReasonV4: null,
+      reason: null,
+    });
+
+    expect(result.factText).toBeNull();
+  });
+
+  it("BackendのFact本文(deity)が独自fallbackより優先される", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { deity: "武神", shrine_history: null, place_context: "住所情報", goriyaku: null, history_theme: null, label: "住所情報" },
+      }),
+      recommendationReasonV4: "recommendation_reason_v4の内容",
+      reason: "旧型の理由文",
+    });
+
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBe("武神");
+    expect(result.fallbackText).toBeNull();
   });
 
   it("detailがまったく無い場合はrecommendation_reason_v4へfallbackする", () => {

--- a/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
+++ b/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
@@ -49,14 +49,16 @@ export function buildHeroReasonV4Sections(params: {
 }): HeroReasonV4Sections {
   const detail = params.detail ?? null;
 
+  // 優先順位はBackend契約(deity > shrine_history > goriyaku > history_theme)およびMobile実装に合わせる。
+  // place_context(住所)とlabel(place_contextへ落ちうる互換field)はFact本文の候補にしない。
+  // 住所を「選ばれた背景」として表示すると、神社固有の意味がないまま具体性があるように見えてしまう。
   const factText = safeText(
     detail
       ? pickFirst(
+          detail.fact?.deity,
           detail.fact?.shrine_history,
-          detail.fact?.place_context,
           detail.fact?.goriyaku,
           detail.fact?.history_theme,
-          detail.fact?.label,
         )
       : null,
   );


### PR DESCRIPTION
### 背景

`apps/web/src/features/concierge/buildHeroReasonV4Sections.ts`のFact本文組み立てが、`shrine_history > place_context > goriyaku > history_theme > label`という古い優先順位のままだった。これはMobile側で #2207 にて修正済みの不具合と同一系統で、deity/shrine_historyが空の神社ではHero card（コンシェルジュ結果1位）の「この神社について」に住所がそのまま表示されていた。

### 変更内容

Fact本文の優先順位をBackend契約およびMobile実装(#2207)に合わせて統一した。

- 新: `deity > shrine_history > goriyaku > history_theme`
- `place_context`（住所）と`label`（place_contextへ落ちうる互換field）はFact本文の候補から除外

interpretation/actionのロジックは無変更。Candidate/Compact Card（2位以下）は`buildHeroReasonV4Sections`を呼び出さない別経路のため影響なし。

### テスト

- `buildHeroReasonV4Sections.test.ts`へdeity/shrine_history/goriyaku/history_themeそれぞれが選ばれるケース、place_context/labelのみではFactを生成しないケース、BackendのFact本文がfallbackより優先されることを確認するケースを追加（16 passed）
- 関連テスト（buildPayloadFromUnified、ConciergeSectionsRenderer.reasonV4Detail）: 20 passed
- concierge配下: 93 passed
- Web全体: 104 test files / 633 passed
- typecheck: エラーなし
- lint: エラーなし

### QA

ローカルでbackend+Next.js devサーバーを起動し、コンシェルジュへ実際に相談して椿大神社（deity/shrine_history空、goriyaku="導き・仕事運・開運"）がHeroとして表示されるケースを確認。

- 「この神社について」に住所ではなく「導き・仕事運・開運」が表示されることを確認
- 「今の相談とのつながり」（interpretation）が表示されることを確認
- 「参拝前にできること」（action）が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)