### PR TITLE
feat(web): Shrine DetailへRecommendation Reason V4のFact/Interpretation/Action表示を統合

### DIFF
--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -46,6 +46,7 @@ import { buildPreviousConsultationSummary } from "@/lib/concierge/buildPreviousC
 import { compareState } from "@/lib/concierge/compareState";
 import type { StateDelta } from "@/lib/concierge/stateComparison";
 import { parseDirectionRouteContext } from "@/lib/analytics/directionRouteContext";
+import { normalizeRecommendationReasonV4Detail } from "@/lib/shrine/buildShrineDetailReasonV4Sections";
 
 function normalizeCtx(v?: string | null): "map" | "concierge" | null {
   return v === "map" || v === "concierge" ? v : null;
@@ -408,6 +409,13 @@ export default async function Page({ params, searchParams }: Props) {
     conciergeDeepReason = builtReasonDetail.conciergeDeepReason;
   }
 
+  // recommendation_reason_v4_detailはURL queryへ載せず、tidから再取得したselectedRecommendation
+  // (Backend Runtime Snapshotに永続化済み)からそのまま読む。旧Threadにはfieldが存在しないため、
+  // normalizeRecommendationReasonV4Detailが欠損・不正型を吸収してnullへfallbackする。
+  const recommendationReasonV4Detail = normalizeRecommendationReasonV4Detail(
+    selectedRecommendation?.recommendation_reason_v4_detail ?? null,
+  );
+
   const model = buildShrineDetailModel({
     shrine: s,
     shrineMeaningPayloadV2,
@@ -418,6 +426,7 @@ export default async function Page({ params, searchParams }: Props) {
     conciergeExplanationPayload,
     conciergeMode,
     recommendationReasonDetail,
+    recommendationReasonV4Detail,
     recommendationRankExplanation,
     recommendationRankComparison,
     actionState,

--- a/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
+++ b/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
@@ -1,6 +1,7 @@
 // apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
 import type { RecommendationReasonV4Detail } from "@/lib/api/concierge";
 import { buildRecommendationReasonDisplay } from "../../../../../packages/shared/recommendationReasonDisplay";
+import { pickReasonV4FactText } from "./reasonV4FactPriority";
 
 export type HeroReasonV4Sections = {
   factText: string | null;
@@ -49,19 +50,8 @@ export function buildHeroReasonV4Sections(params: {
 }): HeroReasonV4Sections {
   const detail = params.detail ?? null;
 
-  // 優先順位はBackend契約(deity > shrine_history > goriyaku > history_theme)およびMobile実装に合わせる。
-  // place_context(住所)とlabel(place_contextへ落ちうる互換field)はFact本文の候補にしない。
-  // 住所を「選ばれた背景」として表示すると、神社固有の意味がないまま具体性があるように見えてしまう。
-  const factText = safeText(
-    detail
-      ? pickFirst(
-          detail.fact?.deity,
-          detail.fact?.shrine_history,
-          detail.fact?.goriyaku,
-          detail.fact?.history_theme,
-        )
-      : null,
-  );
+  // 優先順位の実体はreasonV4FactPriority.tsに集約する(Hero/Shrine Detailで共通)。
+  const factText = safeText(detail ? pickReasonV4FactText(detail.fact) : null);
   const interpretationText = safeText(detail ? clean(detail.interpretation?.text) : null);
   const actionText = safeText(detail ? clean(detail.action?.text) : null);
 

--- a/apps/web/src/features/concierge/reasonV4FactPriority.ts
+++ b/apps/web/src/features/concierge/reasonV4FactPriority.ts
@@ -1,0 +1,32 @@
+// apps/web/src/features/concierge/reasonV4FactPriority.ts
+//
+// Recommendation Reason V4のfactからFact本文用テキストを選ぶ、低レベルの共通変換関数。
+// Hero Adapter(buildHeroReasonV4Sections)とShrine Detail Adapter(buildShrineDetailReasonV4Sections)の
+// 両方から利用する。優先順位の実体をここ一箇所に集約し、画面ごとの独自実装による優先順位の乖離を防ぐ。
+//
+// 優先順位: deity > shrine_history > goriyaku > history_theme
+// place_context(住所)とlabel(place_contextへ落ちうる互換field)はFact本文の候補にしない。
+// 理由は docs/product/recommendation-v4-frontend-adapter-contract.md を参照。
+
+export type ReasonV4FactLike = {
+  deity?: string | null;
+  shrine_history?: string | null;
+  goriyaku?: string | null;
+  history_theme?: string | null;
+} | null | undefined;
+
+function clean(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  return s.length ? s : null;
+}
+
+export function pickReasonV4FactText(fact: ReasonV4FactLike): string | null {
+  if (!fact) return null;
+  return (
+    clean(fact.deity) ??
+    clean(fact.shrine_history) ??
+    clean(fact.goriyaku) ??
+    clean(fact.history_theme)
+  );
+}

--- a/apps/web/src/lib/shrine/__tests__/buildShrineDetailModel.test.ts
+++ b/apps/web/src/lib/shrine/__tests__/buildShrineDetailModel.test.ts
@@ -494,6 +494,164 @@ describe("buildShrineDetailModel", () => {
     expect(result.heroImageUrl).toBe("https://example.com/card.jpg");
   });
 
+  describe("recommendationReasonV4Detail(Fact/Interpretation/Action)", () => {
+    it("structured Factありの場合、旧reasonSection/meaningSection/actionSectionを重複させずV4のsectionに置き換える", () => {
+      const result = buildShrineDetailModel({
+        shrine: shrineStub,
+        publicGoshuins: publicGoshuinsStub,
+        conciergeBreakdown: conciergeBreakdownStub,
+        conciergeDeepReason: {
+          interpretation: "旧型の相談との一致文",
+          shrineMeaning: "旧型のこの神社で受け取る意味",
+          action: "旧型の参拝するときの視点",
+          short: "短句",
+        },
+        conciergeMode: "need",
+        ctx: "concierge",
+        tid: "thread-1",
+        recommendationReasonV4Detail: {
+          reason_text: "reason_text",
+          fact: { deity: "武神", shrine_history: null, place_context: "住所情報", goriyaku: null, history_theme: null },
+          interpretation: { text: "今回の相談との意味(V4)" },
+          action: { text: "参拝するときの視点(V4)" },
+        },
+      });
+
+      const premiumSections = result.premiumDisplaySections.map((item: { section: any }) => item.section);
+      const kinds = premiumSections.map((section: any) => section.kind);
+      expect(kinds).toEqual(["proposal", "reason", "meaning", "action"]);
+
+      const reasonSection = premiumSections.find((section: any) => section.kind === "reason");
+      expect(reasonSection.heading).toBe("② 選ばれた背景");
+      expect(reasonSection.groups[0].items).toEqual(["武神"]);
+      expect(JSON.stringify(reasonSection)).not.toContain("住所情報");
+      expect(JSON.stringify(reasonSection)).not.toContain("旧型");
+
+      const meaningSection = premiumSections.find((section: any) => section.kind === "meaning");
+      expect(meaningSection.heading).toBe("③ 今回の相談との意味");
+      expect(meaningSection.items[0].body).toBe("今回の相談との意味(V4)");
+      expect(JSON.stringify(meaningSection)).not.toContain("旧型");
+
+      const actionSection = premiumSections.find((section: any) => section.kind === "action");
+      expect(actionSection.heading).toBe("④ 参拝するときの視点");
+      expect(actionSection.items[0].body).toBe("参拝するときの視点(V4)");
+      expect(JSON.stringify(actionSection)).not.toContain("旧型");
+    });
+
+    it("Interpretationのみ存在する場合、meaning sectionのみV4に置き換わりreason/actionは欠落する", () => {
+      const result = buildShrineDetailModel({
+        shrine: shrineStub,
+        publicGoshuins: publicGoshuinsStub,
+        conciergeBreakdown: conciergeBreakdownStub,
+        conciergeMode: "need",
+        ctx: "concierge",
+        tid: "thread-1",
+        recommendationReasonV4Detail: {
+          reason_text: "reason_text",
+          fact: { deity: null, shrine_history: null, place_context: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "今回の相談との意味(V4)" },
+          action: { text: "" },
+        },
+      });
+
+      const premiumSections = result.premiumDisplaySections.map((item: { section: any }) => item.section);
+      const kinds = premiumSections.map((section: any) => section.kind);
+      expect(kinds).toContain("meaning");
+      expect(kinds).not.toContain("reason");
+      expect(kinds).not.toContain("action");
+
+      const meaningSection = premiumSections.find((section: any) => section.kind === "meaning");
+      expect(meaningSection.items[0].body).toBe("今回の相談との意味(V4)");
+    });
+
+    it("Actionのみ存在する場合、action sectionのみV4に置き換わる", () => {
+      const result = buildShrineDetailModel({
+        shrine: shrineStub,
+        publicGoshuins: publicGoshuinsStub,
+        conciergeBreakdown: conciergeBreakdownStub,
+        conciergeMode: "need",
+        ctx: "concierge",
+        tid: "thread-1",
+        recommendationReasonV4Detail: {
+          reason_text: "reason_text",
+          fact: { deity: null, shrine_history: null, place_context: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "" },
+          action: { text: "参拝するときの視点(V4)" },
+        },
+      });
+
+      const premiumSections = result.premiumDisplaySections.map((item: { section: any }) => item.section);
+      const kinds = premiumSections.map((section: any) => section.kind);
+      expect(kinds).toContain("action");
+      expect(kinds).not.toContain("reason");
+      expect(kinds).not.toContain("meaning");
+    });
+
+    it("structured Factが全欠落している場合は旧表示(reasonSection/meaningSection/actionSection)へfallbackする", () => {
+      const result = buildShrineDetailModel({
+        shrine: shrineStub,
+        publicGoshuins: publicGoshuinsStub,
+        conciergeBreakdown: conciergeBreakdownStub,
+        conciergeDeepReason: {
+          interpretation: "旧型の相談との一致文",
+          shrineMeaning: "旧型のこの神社で受け取る意味",
+          action: "旧型の参拝するときの視点",
+          short: "短句",
+        },
+        conciergeMode: "need",
+        ctx: "concierge",
+        tid: "thread-1",
+        recommendationReasonV4Detail: {
+          reason_text: "",
+          fact: { deity: null, shrine_history: null, place_context: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "" },
+          action: { text: "" },
+        },
+      });
+
+      expect(result.meaningSection.items[0].body).toBe("旧型のこの神社で受け取る意味");
+      expect(result.actionSection.items[0].body).toBe("旧型の参拝するときの視点");
+    });
+
+    it("旧Thread互換: recommendationReasonV4Detailが未指定でも従来どおり動作する", () => {
+      const result = buildShrineDetailModel({
+        shrine: shrineStub,
+        publicGoshuins: publicGoshuinsStub,
+        conciergeBreakdown: conciergeBreakdownStub,
+        conciergeDeepReason: {
+          interpretation: "旧型の相談との一致文",
+          shrineMeaning: "旧型のこの神社で受け取る意味",
+          action: "旧型の参拝するときの視点",
+          short: "短句",
+        },
+        conciergeMode: "need",
+        ctx: "concierge",
+        tid: "thread-1",
+      });
+
+      expect(result.meaningSection.items[0].body).toBe("旧型のこの神社で受け取る意味");
+      expect(result.actionSection.items[0].body).toBe("旧型の参拝するときの視点");
+    });
+
+    it("Direct Navigation(ctx!=='concierge')ではrecommendationReasonV4Detailが渡っても表示しない", () => {
+      const result = buildShrineDetailModel({
+        shrine: shrineStub,
+        publicGoshuins: publicGoshuinsStub,
+        conciergeBreakdown: conciergeBreakdownStub,
+        ctx: "map",
+        recommendationReasonV4Detail: {
+          reason_text: "reason_text",
+          fact: { deity: "武神", shrine_history: null, place_context: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "今回の相談との意味(V4)" },
+          action: { text: "参拝するときの視点(V4)" },
+        },
+      });
+
+      expect(JSON.stringify(result.sections)).not.toContain("武神");
+      expect(JSON.stringify(result.sections)).not.toContain("(V4)");
+    });
+  });
+
   it("public goshuin も cardProps.imageUrl も無いときは heroImageUrl が null", async () => {
     const { buildShrineCardProps } = await import("@/components/shrine/buildShrineCardProps");
     vi.mocked(buildShrineCardProps).mockReturnValueOnce({

--- a/apps/web/src/lib/shrine/__tests__/buildShrineDetailReasonV4Sections.test.ts
+++ b/apps/web/src/lib/shrine/__tests__/buildShrineDetailReasonV4Sections.test.ts
@@ -1,0 +1,145 @@
+// apps/web/src/lib/shrine/__tests__/buildShrineDetailReasonV4Sections.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  buildShrineDetailReasonV4Sections,
+  normalizeRecommendationReasonV4Detail,
+} from "../buildShrineDetailReasonV4Sections";
+
+function makeDetail(overrides: Partial<{ fact: any; interpretation: any; action: any }> = {}) {
+  return {
+    version: "v4" as const,
+    reason_text: "根津神社には、縁結び・厄除けに関する情報があります。",
+    fact: {
+      label: "候補神社",
+      name: "根津神社",
+      deity: null,
+      shrine_history: null,
+      place_context: null,
+      history_theme: "再出発",
+      goriyaku: "縁結び・厄除け",
+      ...(overrides.fact ?? {}),
+    },
+    interpretation: {
+      theme: "再出発",
+      text: "相談内容から、今扱いたいテーマを読み取っています。",
+      ...(overrides.interpretation ?? {}),
+    },
+    action: {
+      text: "参拝前に、問いを一つに絞ることを決めておきます。",
+      source: "meaning_translation.action_context",
+      ...(overrides.action ?? {}),
+    },
+  };
+}
+
+describe("buildShrineDetailReasonV4Sections", () => {
+  it("fact/interpretation/actionが構造化表示として返る", () => {
+    const result = buildShrineDetailReasonV4Sections(makeDetail());
+
+    expect(result.hasStructured).toBe(true);
+    expect(result.factText).toBe("縁結び・厄除け");
+    expect(result.interpretationText).toBe("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(result.actionText).toBe("参拝前に、問いを一つに絞ることを決めておきます。");
+  });
+
+  it("factは優先順位(deity > shrine_history > goriyaku > history_theme)で選ばれる", () => {
+    const result = buildShrineDetailReasonV4Sections(
+      makeDetail({
+        fact: { deity: "武神", shrine_history: "由緒あり", place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発" },
+      }),
+    );
+
+    expect(result.factText).toBe("武神");
+  });
+
+  it("deity/shrine_history/goriyakuが無い場合はhistory_themeを使う", () => {
+    const result = buildShrineDetailReasonV4Sections(
+      makeDetail({
+        fact: { deity: null, shrine_history: null, place_context: "住所情報", goriyaku: null, history_theme: "再出発" },
+      }),
+    );
+
+    expect(result.factText).toBe("再出発");
+  });
+
+  it("place_contextだけではFactを生成しない(住所を神社の特徴として表示しない)", () => {
+    const result = buildShrineDetailReasonV4Sections(
+      makeDetail({
+        fact: {
+          deity: null,
+          shrine_history: null,
+          place_context: "東京都渋谷区代々木神園町1-1",
+          goriyaku: null,
+          history_theme: null,
+        },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+    );
+
+    expect(result.factText).toBeNull();
+    expect(result.hasStructured).toBe(false);
+  });
+
+  it("labelだけではFactを生成しない", () => {
+    const result = buildShrineDetailReasonV4Sections(
+      makeDetail({
+        fact: {
+          label: "候補神社",
+          deity: null,
+          shrine_history: null,
+          place_context: null,
+          goriyaku: null,
+          history_theme: null,
+        },
+        interpretation: { text: "" },
+        action: { text: "" },
+      }),
+    );
+
+    expect(result.factText).toBeNull();
+  });
+
+  it("detailがnullの場合はすべてnull/falseを返す", () => {
+    const result = buildShrineDetailReasonV4Sections(null);
+
+    expect(result).toEqual({
+      factText: null,
+      interpretationText: null,
+      actionText: null,
+      hasStructured: false,
+    });
+  });
+});
+
+describe("normalizeRecommendationReasonV4Detail", () => {
+  it("正しいobjectを正規化する", () => {
+    const raw = makeDetail();
+    const result = normalizeRecommendationReasonV4Detail(raw);
+    expect(result?.fact?.goriyaku).toBe("縁結び・厄除け");
+    expect(result?.interpretation?.text).toBe("相談内容から、今扱いたいテーマを読み取っています。");
+  });
+
+  it("object以外(null/undefined/文字列/配列)はnullを返す(旧Thread互換)", () => {
+    expect(normalizeRecommendationReasonV4Detail(null)).toBeNull();
+    expect(normalizeRecommendationReasonV4Detail(undefined)).toBeNull();
+    expect(normalizeRecommendationReasonV4Detail("not-an-object")).toBeNull();
+    expect(normalizeRecommendationReasonV4Detail([])).toBeNull();
+  });
+
+  it("fact/interpretation/actionが欠落していてもクラッシュしない(空値で埋める)", () => {
+    const result = normalizeRecommendationReasonV4Detail({ reason_text: "本文のみ" });
+    expect(result?.reason_text).toBe("本文のみ");
+    expect(result?.fact?.deity).toBeNull();
+    expect(result?.interpretation?.text).toBeNull();
+    expect(result?.action?.text).toBeNull();
+  });
+
+  it("空white文字列は空値として扱う", () => {
+    const result = normalizeRecommendationReasonV4Detail({
+      fact: { deity: "   ", goriyaku: "縁結び" },
+    });
+    expect(result?.fact?.deity).toBeNull();
+    expect(result?.fact?.goriyaku).toBe("縁結び");
+  });
+});

--- a/apps/web/src/lib/shrine/buildShrineDetailModel.ts
+++ b/apps/web/src/lib/shrine/buildShrineDetailModel.ts
@@ -32,6 +32,10 @@ import { buildComparisonText } from "@/lib/concierge/narrative/buildComparisonTe
 import { buildPsychologicalTags } from "@/lib/concierge/narrative/buildPsychologicalTags";
 import { buildSymbolTags } from "@/lib/concierge/narrative/buildSymbolTags";
 import { resolveNeedCombinationNarrative } from "@/lib/concierge/narrative/needCombinationMap";
+import {
+  buildShrineDetailReasonV4Sections,
+  type RecommendationReasonV4DetailShape,
+} from "@/lib/shrine/buildShrineDetailReasonV4Sections";
 
 type ShrineActionState = "none" | "detail_viewed" | "saved" | "route_opened" | "visited" | "reflected";
 
@@ -54,6 +58,9 @@ type Args = {
     shrineMeaning?: string | null;
     actionMeaning?: string | null;
   } | null;
+  // Concierge経由(ctx === "concierge")の場合のみBackendから渡される。
+  // Direct Navigationでは常にnullのため、相談文脈からFact/Interpretation/Actionを推測しない。
+  recommendationReasonV4Detail?: RecommendationReasonV4DetailShape | null;
   signals?: {
     publicGoshuinsCount?: number;
     views30d?: number;
@@ -1337,6 +1344,7 @@ export function buildShrineDetailModel({
   recommendationRankExplanation = null,
   recommendationRankComparison = null,
   recommendationReasonDetail = null,
+  recommendationReasonV4Detail = null,
   ctx = null,
   tid = null,
   signals,
@@ -1598,7 +1606,7 @@ export function buildShrineDetailModel({
       supplementSection,
     });
 
-  const premiumDisplaySections =
+  const premiumDisplaySectionsBeforeReasonV4 =
     payloadV2DisplaySections?.premiumDisplaySections ??
     buildPremiumDisplaySections({
       isConciergeContext,
@@ -1607,6 +1615,61 @@ export function buildShrineDetailModel({
       meaningSection,
       actionSection,
     });
+
+  // Recommendation Reason V4(fact/interpretation/action)は、V1(reasonSection等)・V2(shrineMeaningPayloadV2)
+  // いずれが元になったsectionsであっても、構造化データが存在する場合は最終的にこちらを優先する。
+  // Direct Navigation(isConciergeContext=false)ではrecommendationReasonV4Detailは常にnullのため、
+  // 相談文脈をShrine APIの値から推測することはない。
+  const reasonV4 = isConciergeContext
+    ? buildShrineDetailReasonV4Sections(recommendationReasonV4Detail)
+    : { factText: null, interpretationText: null, actionText: null, hasStructured: false };
+
+  const premiumDisplaySections = reasonV4.hasStructured
+    ? [
+        ...premiumDisplaySectionsBeforeReasonV4.filter(
+          (item) => item.section.kind !== "reason" && item.section.kind !== "meaning" && item.section.kind !== "action",
+        ),
+        ...(reasonV4.factText
+          ? [
+              {
+                tier: "premium" as const,
+                layer: "context" as const,
+                section: {
+                  kind: "reason" as const,
+                  heading: "② 選ばれた背景",
+                  groups: [{ title: "神社の背景", items: [reasonV4.factText] }],
+                },
+              },
+            ]
+          : []),
+        ...(reasonV4.interpretationText
+          ? [
+              {
+                tier: "premium" as const,
+                layer: "context" as const,
+                section: {
+                  kind: "meaning" as const,
+                  heading: "③ 今回の相談との意味",
+                  items: [{ key: "reason_v4_interpretation", title: "今回の相談との意味", body: reasonV4.interpretationText }],
+                },
+              },
+            ]
+          : []),
+        ...(reasonV4.actionText
+          ? [
+              {
+                tier: "premium" as const,
+                layer: "context" as const,
+                section: {
+                  kind: "action" as const,
+                  heading: "④ 参拝するときの視点",
+                  items: [{ key: "reason_v4_action", title: "参拝するときの視点", body: reasonV4.actionText }],
+                },
+              },
+            ]
+          : []),
+      ]
+    : premiumDisplaySectionsBeforeReasonV4;
 
   const sections: ShrineDetailSectionModel[] = [
     ...freeDisplaySections.map((item) => item.section),

--- a/apps/web/src/lib/shrine/buildShrineDetailReasonV4Sections.ts
+++ b/apps/web/src/lib/shrine/buildShrineDetailReasonV4Sections.ts
@@ -1,0 +1,103 @@
+// apps/web/src/lib/shrine/buildShrineDetailReasonV4Sections.ts
+//
+// Backendのrecommendation_reason_v4_detailを、Shrine Detail画面表示用の
+// Fact/Interpretation/Actionセクションへ変換する低レベルAdapter。
+//
+// Hero Adapter(buildHeroReasonV4Sections)とFact優先順位ロジックを共有するが、
+// Hero(要約向け)とDetail(詳細向け)は表示量・画面構造が異なるため、
+// 画面用のAdapter自体は別ファイルとして分離する。
+import { buildRecommendationReasonDisplay } from "../../../../../packages/shared/recommendationReasonDisplay";
+import { pickReasonV4FactText } from "@/features/concierge/reasonV4FactPriority";
+
+export type RecommendationReasonV4DetailFact = {
+  label?: string | null;
+  name?: string | null;
+  deity?: string | null;
+  shrine_history?: string | null;
+  place_context?: string | null;
+  history_theme?: string | null;
+  goriyaku?: string | null;
+};
+
+export type RecommendationReasonV4DetailShape = {
+  version?: "v4";
+  reason_text?: string | null;
+  fact?: RecommendationReasonV4DetailFact | null;
+  interpretation?: { theme?: string | null; text?: string | null } | null;
+  action?: { text?: string | null; source?: string | null } | null;
+};
+
+export type ShrineDetailReasonV4Sections = {
+  factText: string | null;
+  interpretationText: string | null;
+  actionText: string | null;
+  hasStructured: boolean;
+};
+
+function clean(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const s = value.trim();
+  return s.length ? s : null;
+}
+
+// 方位・断定表現の除外は既存のbuildRecommendationReasonDisplayに委譲する(新規フィルタを作らない)
+function safeText(value: string | null): string | null {
+  if (!value) return null;
+  return buildRecommendationReasonDisplay({ matchReason: null, reason: value, directionReference: null }).reason;
+}
+
+/**
+ * Backendから受け取った値をもとに、欠損・不正型に強い形へ正規化する。
+ * `raw`がobjectでない場合(field欠落・旧Thread互換)はnullを返す。
+ */
+export function normalizeRecommendationReasonV4Detail(raw: unknown): RecommendationReasonV4DetailShape | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+  const value = raw as Record<string, unknown>;
+  const factRaw = value.fact && typeof value.fact === "object" ? (value.fact as Record<string, unknown>) : {};
+  const interpretationRaw =
+    value.interpretation && typeof value.interpretation === "object"
+      ? (value.interpretation as Record<string, unknown>)
+      : {};
+  const actionRaw = value.action && typeof value.action === "object" ? (value.action as Record<string, unknown>) : {};
+
+  return {
+    version: "v4",
+    reason_text: clean(value.reason_text),
+    fact: {
+      label: clean(factRaw.label),
+      name: clean(factRaw.name),
+      deity: clean(factRaw.deity),
+      shrine_history: clean(factRaw.shrine_history),
+      place_context: clean(factRaw.place_context),
+      history_theme: clean(factRaw.history_theme),
+      goriyaku: clean(factRaw.goriyaku),
+    },
+    interpretation: {
+      theme: clean(interpretationRaw.theme),
+      text: clean(interpretationRaw.text),
+    },
+    action: {
+      text: clean(actionRaw.text),
+      source: clean(actionRaw.source),
+    },
+  };
+}
+
+/**
+ * Shrine Detail画面表示用のFact/Interpretation/Actionセクションを組み立てる。
+ *
+ * place_context(住所)とlabelはFact本文の候補にしない(優先順位の実体はreasonV4FactPriority.ts)。
+ * いずれか1つ以上のセクションが表示できる場合にhasStructured=trueとする。
+ */
+export function buildShrineDetailReasonV4Sections(
+  detail: RecommendationReasonV4DetailShape | null | undefined,
+): ShrineDetailReasonV4Sections {
+  const factText = safeText(detail ? pickReasonV4FactText(detail.fact) : null);
+  const interpretationText = safeText(detail ? clean(detail.interpretation?.text) : null);
+  const actionText = safeText(detail ? clean(detail.action?.text) : null);
+
+  const hasStructured = Boolean(factText || interpretationText || actionText);
+
+  return { factText, interpretationText, actionText, hasStructured };
+}


### PR DESCRIPTION
### 背景

Web版のShrine Detailページは`recommendation_reason_v4_detail`を未使用のまま、旧`recommendationReasonDetail`(consultationSummary/shrineMeaning/actionMeaning)のみで構成されていた(監査で確認済み、Mobile Shrine Detailとの機能差分)。Hero card(#2208)に続き、Shrine DetailへもFact/Interpretation/Action構造化表示を統合する。

### 設計方針

1. **Backendを意味判定の正本にする**: Frontend側でFactの意味・採用候補を独自判定しない。優先順位ロジックは`deity > shrine_history > goriyaku > history_theme`のみ(Backend契約・Mobile実装と同一)。
2. **低レベル変換関数のみ共通化**: `apps/web/src/features/concierge/reasonV4FactPriority.ts`にFact優先順位ロジックを1箇所へ集約し、Hero Adapter(`buildHeroReasonV4Sections`)とDetail Adapter(`buildShrineDetailReasonV4Sections`)の両方から利用する。画面用ViewModelはHero/Detailで別々のまま維持。
3. **URLへ長いJSONを載せない**: `recommendation_reason_v4_detail`はURL queryへ含めない。既存の`tid`(Thread ID)からBackend再取得する仕組み(`getConciergeThreadServer`)がShrine Detailページに既に存在していたため、そこで取得した`selectedRecommendation.recommendation_reason_v4_detail`をそのまま利用する。

### 変更内容

- `apps/web/src/features/concierge/reasonV4FactPriority.ts`(新規): Fact優先順位ロジックの共通関数
- `apps/web/src/features/concierge/buildHeroReasonV4Sections.ts`: 共通関数を使うようリファクタ(出力は不変)
- `apps/web/src/lib/shrine/buildShrineDetailReasonV4Sections.ts`(新規): Shrine Detail用Adapter。`normalizeRecommendationReasonV4Detail`で旧Thread(fieldなし)・不正型を安全にnullへfallback
- `apps/web/src/lib/shrine/buildShrineDetailModel.ts`: `recommendationReasonV4Detail`を新規引数として受け取り、structured表示が可能な場合はV1(reasonSection等)・V2(shrineMeaningPayloadV2)いずれが元でも、最終的な`sections`配列でFact/Interpretation/Actionセクションへ置き換える。Direct Navigation(`ctx !== "concierge"`)では常に無効
- `apps/web/src/app/shrines/[id]/page.tsx`: `selectedRecommendation`から`recommendation_reason_v4_detail`を取り出し正規化して渡す

ActionSuggestion V4(primaryAction/secondaryAction等)はWeb Shrine Detailに現状表示されておらず、今回追加もしていないため責務の衝突なし。

### テスト

- `buildShrineDetailReasonV4Sections.test.ts`(新規): Fact優先順位、place_context/labelのみでは生成しないケース、normalize関数のクラッシュ耐性(10 passed)
- `buildShrineDetailModel.test.ts`: structured Factあり/Interpretationのみ/Actionのみ/全欠落fallback/旧Thread互換/Direct Navigation非表示のケースを追加(22 passed)
- `buildHeroReasonV4Sections.test.ts`: リファクタ後も16 passed(既存)
- Web全体: 105 test files / 649 passed
- typecheck: エラーなし
- lint: エラーなし

### QA(ローカルでbackend+Next.js dev起動して確認)

- コンシェルジュ→Hero→神社詳細で「② 選ばれた背景: 導き・仕事運・開運」(住所ではない)を確認
- 「③ 今回の相談との意味」「④ 参拝するときの視点」が表示され、旧②③④との重複表示がないことを確認
- `/shrines/33`への直接アクセス(ctx/tidなし)で①〜④が表示されないことを確認(神社名・住所・ご利益タグ等のprofile情報は従来どおり表示)
- Mobile Shrine Detail(#2194, #2207)と同一の見出し・優先順位ロジックであることを確認

### 対象外

- History画面からのV4 Detail再表示導線(別PRで対応予定)
- Analytics契約(別PRで対応予定)
- ActionSuggestion V4のWeb Shrine Detailへの新規追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)