### PR TITLE
feat(web): Concierge相談履歴の一覧・詳細画面を追加

### DIFF
--- a/apps/web/src/app/mypage/history/[tid]/__tests__/page.test.tsx
+++ b/apps/web/src/app/mypage/history/[tid]/__tests__/page.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getConciergeThreadServerMock = vi.fn();
+
+vi.mock("@/lib/api/concierge.server", () => ({
+  getConciergeThreadServer: getConciergeThreadServerMock,
+}));
+
+vi.mock("@/components/views/ConsultationHistoryDetailView", () => ({
+  default: ({ tid, thread, fetchFailed }: { tid: string; thread: unknown; fetchFailed: boolean }) => (
+    <div
+      data-testid="view"
+      data-tid={tid}
+      data-has-thread={String(thread != null)}
+      data-fetch-failed={String(fetchFailed)}
+    />
+  ),
+}));
+
+describe("ConsultationHistoryDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常系: 取得したthreadをそのままViewへ渡す", async () => {
+    getConciergeThreadServerMock.mockResolvedValue({
+      id: 42,
+      title: "相談A",
+      last_message: "",
+      last_message_at: null,
+      message_count: 0,
+      messages: [],
+    });
+
+    const { default: Page } = await import("../page");
+    const element = await Page({ params: Promise.resolve({ tid: "42" }) });
+    render(element);
+
+    const view = screen.getByTestId("view");
+    expect(view).toHaveAttribute("data-tid", "42");
+    expect(view).toHaveAttribute("data-has-thread", "true");
+    expect(view).toHaveAttribute("data-fetch-failed", "false");
+  });
+
+  it("Direct Navigation: 不正または存在しないtidはthread=nullをViewへ渡す", async () => {
+    getConciergeThreadServerMock.mockResolvedValue(null);
+
+    const { default: Page } = await import("../page");
+    const element = await Page({ params: Promise.resolve({ tid: "999" }) });
+    render(element);
+
+    const view = screen.getByTestId("view");
+    expect(view).toHaveAttribute("data-has-thread", "false");
+    expect(view).toHaveAttribute("data-fetch-failed", "false");
+  });
+
+  it("Error: getConciergeThreadServerが例外を投げたときfetchFailed=trueをViewへ渡す", async () => {
+    getConciergeThreadServerMock.mockRejectedValue(new Error("getConciergeThreadServer failed: 500"));
+
+    const { default: Page } = await import("../page");
+    const element = await Page({ params: Promise.resolve({ tid: "42" }) });
+    render(element);
+
+    const view = screen.getByTestId("view");
+    expect(view).toHaveAttribute("data-fetch-failed", "true");
+  });
+});

--- a/apps/web/src/app/mypage/history/[tid]/page.tsx
+++ b/apps/web/src/app/mypage/history/[tid]/page.tsx
@@ -1,0 +1,26 @@
+// apps/web/src/app/mypage/history/[tid]/page.tsx
+import ConsultationHistoryDetailView from "@/components/views/ConsultationHistoryDetailView";
+import { getConciergeThreadServer } from "@/lib/api/concierge.server";
+import type { ConciergeThreadDetail } from "@/lib/api/concierge/types";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ConsultationHistoryDetailPage({
+  params,
+}: {
+  params: Promise<{ tid: string }>;
+}) {
+  const { tid } = await params;
+
+  let thread: ConciergeThreadDetail | null = null;
+  let fetchFailed = false;
+
+  try {
+    thread = await getConciergeThreadServer(tid);
+  } catch {
+    fetchFailed = true;
+  }
+
+  return <ConsultationHistoryDetailView tid={tid} thread={thread} fetchFailed={fetchFailed} />;
+}

--- a/apps/web/src/app/mypage/history/__tests__/page.test.tsx
+++ b/apps/web/src/app/mypage/history/__tests__/page.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getConciergeThreadsServerMock = vi.fn();
+
+vi.mock("@/lib/api/concierge.server", () => ({
+  getConciergeThreadsServer: getConciergeThreadsServerMock,
+}));
+
+vi.mock("@/components/views/ConsultationHistoryListView", () => ({
+  default: ({ initialThreads, fetchFailed }: { initialThreads: unknown[]; fetchFailed: boolean }) => (
+    <div data-testid="view" data-fetch-failed={String(fetchFailed)} data-count={initialThreads.length} />
+  ),
+}));
+
+describe("ConsultationHistoryListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("正常系: 取得したthreadsをそのままViewへ渡す", async () => {
+    getConciergeThreadsServerMock.mockResolvedValue([
+      { id: 1, title: "相談A", last_message: "", last_message_at: null, message_count: 1 },
+    ]);
+
+    const { default: Page } = await import("../page");
+    const element = await Page();
+    render(element);
+
+    const view = screen.getByTestId("view");
+    expect(view).toHaveAttribute("data-fetch-failed", "false");
+    expect(view).toHaveAttribute("data-count", "1");
+  });
+
+  it("Error: getConciergeThreadsServerが例外を投げたときfetchFailed=trueをViewへ渡す", async () => {
+    getConciergeThreadsServerMock.mockRejectedValue(new Error("getConciergeThreadsServer failed: 500"));
+
+    const { default: Page } = await import("../page");
+    const element = await Page();
+    render(element);
+
+    const view = screen.getByTestId("view");
+    expect(view).toHaveAttribute("data-fetch-failed", "true");
+    expect(view).toHaveAttribute("data-count", "0");
+  });
+});

--- a/apps/web/src/app/mypage/history/page.tsx
+++ b/apps/web/src/app/mypage/history/page.tsx
@@ -1,0 +1,20 @@
+// apps/web/src/app/mypage/history/page.tsx
+import ConsultationHistoryListView from "@/components/views/ConsultationHistoryListView";
+import { getConciergeThreadsServer } from "@/lib/api/concierge.server";
+import type { ConciergeThread } from "@/lib/api/concierge/types";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export default async function ConsultationHistoryListPage() {
+  let threads: ConciergeThread[] = [];
+  let fetchFailed = false;
+
+  try {
+    threads = await getConciergeThreadsServer();
+  } catch {
+    fetchFailed = true;
+  }
+
+  return <ConsultationHistoryListView initialThreads={threads} fetchFailed={fetchFailed} />;
+}

--- a/apps/web/src/components/views/ConsultationHistoryDetailView.tsx
+++ b/apps/web/src/components/views/ConsultationHistoryDetailView.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { buildLoginHref } from "@/lib/nav/login";
+import { pickReasonV4FactText } from "@/features/concierge/reasonV4FactPriority";
+import type { ConciergeThreadDetail, ConciergeRecommendation } from "@/lib/api/concierge/types";
+
+type Props = {
+  tid: string;
+  thread: ConciergeThreadDetail | null;
+  fetchFailed: boolean;
+};
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return "日時未記録";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "日時未記録";
+  return date.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+const ACTION_STATE_LABEL: Record<string, string> = {
+  saved: "気になる登録済み",
+  visited: "参拝済み",
+  reflected: "振り返り済み",
+};
+
+function extractShrineId(rec: ConciergeRecommendation): number | null {
+  const raw = rec.shrine_id ?? rec.id;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+function RecommendationCard({ rec, tid }: { rec: ConciergeRecommendation; tid: string }) {
+  const shrineId = extractShrineId(rec);
+  const factText = pickReasonV4FactText(rec.recommendation_reason_v4_detail?.fact);
+  const actionLabel = rec.action_state ? ACTION_STATE_LABEL[rec.action_state] : null;
+
+  return (
+    <li className="rounded-2xl border border-stone-200/20 bg-stone-50/30 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="font-semibold text-stone-900">{rec.name}</p>
+        {actionLabel ? (
+          <span className="shrink-0 rounded-full border border-emerald-700/20 bg-emerald-50 px-2 py-0.5 text-xs text-emerald-800">
+            {actionLabel}
+          </span>
+        ) : null}
+      </div>
+      {rec.address ? <p className="mt-1 text-xs text-stone-500">{rec.address}</p> : null}
+      {factText ? <p className="mt-2 text-sm text-stone-700">{factText}</p> : null}
+      {shrineId != null ? (
+        <Link
+          href={`/shrines/${shrineId}?ctx=concierge&tid=${encodeURIComponent(tid)}`}
+          className="mt-3 inline-block text-xs font-semibold text-emerald-800 underline"
+        >
+          神社の詳細を見る
+        </Link>
+      ) : null}
+    </li>
+  );
+}
+
+export default function ConsultationHistoryDetailView({ tid, thread, fetchFailed }: Props) {
+  const { loading, isLoggedIn } = useAuth();
+  const router = useRouter();
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <p className="text-sm text-stone-500">読み込み中…</p>
+      </main>
+    );
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
+        <div className="rounded-2xl border border-stone-200/20 bg-stone-50/30 p-6">
+          <p className="mb-3 text-sm text-stone-600">ログインすると、この相談履歴を見返せます。</p>
+          <Link
+            href={buildLoginHref(`/mypage/history/${tid}`)}
+            className="inline-block rounded-full border border-emerald-700/20 bg-emerald-800 px-4 py-2 text-sm text-white transition hover:bg-emerald-900"
+          >
+            ログインへ
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (fetchFailed) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <div className="rounded-2xl border border-rose-200/40 bg-rose-50/40 p-6">
+          <p className="mb-3 text-sm text-rose-700">相談履歴を読み込めませんでした。</p>
+          <button
+            type="button"
+            onClick={() => router.refresh()}
+            className="inline-block rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50"
+          >
+            もう一度読み込む
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  if (!thread) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <div className="rounded-2xl border border-stone-200/20 bg-stone-50/30 p-6">
+          <p className="text-sm text-stone-600">この相談は見つかりませんでした。</p>
+          <Link href="/mypage/history" className="mt-3 inline-block text-sm text-emerald-800 underline">
+            相談履歴の一覧へ戻る
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const recommendations = thread.recommendations_v2 ?? thread.recommendations ?? [];
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 p-6 text-stone-800">
+      <div>
+        <Link href="/mypage/history" className="text-xs text-stone-500 underline">
+          ← 相談履歴の一覧へ
+        </Link>
+        <h1 className="mt-2 text-xl font-semibold">{thread.title?.trim() || "相談タイトル未設定"}</h1>
+        <p className="mt-1 text-xs text-stone-500">{formatDateTime(thread.last_message_at)}</p>
+      </div>
+
+      {recommendations.length > 0 ? (
+        <section>
+          <h2 className="mb-2 text-sm font-semibold text-stone-700">当時推薦された神社</h2>
+          <ul className="space-y-3">
+            {recommendations.map((rec, idx) => (
+              <RecommendationCard key={`${extractShrineId(rec) ?? rec.name}-${idx}`} rec={rec} tid={tid} />
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-stone-700">相談内容</h2>
+        <ul className="space-y-2">
+          {thread.messages.map((message) => (
+            <li
+              key={message.id}
+              className={
+                message.role === "user"
+                  ? "rounded-2xl bg-emerald-50 p-3 text-sm text-stone-800"
+                  : "rounded-2xl bg-stone-100 p-3 text-sm text-stone-800"
+              }
+            >
+              <p className="whitespace-pre-wrap">{message.content}</p>
+              <p className="mt-1 text-xs text-stone-400">{formatDateTime(message.created_at)}</p>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/components/views/ConsultationHistoryListView.tsx
+++ b/apps/web/src/components/views/ConsultationHistoryListView.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth/AuthProvider";
+import { buildLoginHref } from "@/lib/nav/login";
+import type { ConciergeThread } from "@/lib/api/concierge/types";
+
+type Props = {
+  initialThreads: ConciergeThread[];
+  fetchFailed: boolean;
+};
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "日付未記録";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "日付未記録";
+  return date.toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+function normalizePreview(value: string | null | undefined): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text || "相談内容はまだ記録されていません。";
+}
+
+export default function ConsultationHistoryListView({ initialThreads, fetchFailed }: Props) {
+  const { loading, isLoggedIn } = useAuth();
+  const router = useRouter();
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
+        <p className="text-sm text-stone-500">読み込み中…</p>
+      </main>
+    );
+  }
+
+  if (!isLoggedIn) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
+        <div className="rounded-2xl border border-stone-200/20 bg-stone-50/30 p-6">
+          <p className="mb-3 text-sm text-stone-600">ログインすると、これまでの相談履歴を見返せます。</p>
+          <Link
+            href={buildLoginHref("/mypage/history")}
+            className="inline-block rounded-full border border-emerald-700/20 bg-emerald-800 px-4 py-2 text-sm text-white transition hover:bg-emerald-900"
+          >
+            ログインへ
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  if (fetchFailed) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
+        <div className="rounded-2xl border border-rose-200/40 bg-rose-50/40 p-6">
+          <p className="mb-3 text-sm text-rose-700">相談履歴を読み込めませんでした。</p>
+          <button
+            type="button"
+            onClick={() => router.refresh()}
+            className="inline-block rounded-full border border-stone-300 bg-white px-4 py-2 text-sm text-stone-700 transition hover:bg-stone-50"
+          >
+            もう一度読み込む
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  if (initialThreads.length === 0) {
+    return (
+      <main className="mx-auto max-w-3xl p-6 text-stone-800">
+        <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
+        <div className="rounded-2xl border border-stone-200/20 bg-stone-50/30 p-6">
+          <p className="mb-3 text-sm text-stone-600">まだ相談履歴がありません。</p>
+          <Link
+            href="/concierge"
+            className="inline-block rounded-full border border-emerald-700/20 bg-emerald-800 px-4 py-2 text-sm text-white transition hover:bg-emerald-900"
+          >
+            コンシェルジュに相談する
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl p-6 text-stone-800">
+      <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
+      <ul className="space-y-3">
+        {initialThreads.map((thread) => (
+          <li key={thread.id}>
+            <Link
+              href={`/mypage/history/${thread.id}`}
+              className="block rounded-2xl border border-stone-200/20 bg-stone-50/30 p-4 transition hover:bg-stone-50/60"
+            >
+              <div className="flex items-center justify-between gap-3">
+                <p className="font-semibold text-stone-900">{thread.title?.trim() || "相談タイトル未設定"}</p>
+                <p className="shrink-0 text-xs text-stone-500">{formatDate(thread.last_message_at)}</p>
+              </div>
+              <p className="mt-1 line-clamp-2 text-sm text-stone-600">{normalizePreview(thread.last_message)}</p>
+              <p className="mt-2 text-xs text-stone-400">{thread.message_count}件のやりとり</p>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/src/components/views/__tests__/ConsultationHistoryDetailView.test.tsx
+++ b/apps/web/src/components/views/__tests__/ConsultationHistoryDetailView.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import ConsultationHistoryDetailView from "../ConsultationHistoryDetailView";
+import type { ConciergeThreadDetail } from "@/lib/api/concierge/types";
+
+const refreshMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock, push: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+const THREAD: ConciergeThreadDetail = {
+  id: 42,
+  title: "縁結びの相談",
+  last_message: "ありがとうございました。",
+  last_message_at: "2026-07-20T10:00:00Z",
+  message_count: 2,
+  messages: [
+    { id: 1, thread_id: 42, role: "user", content: "良い神社を探しています。", created_at: "2026-07-20T09:00:00Z" },
+    { id: 2, thread_id: 42, role: "assistant", content: "こちらはいかがでしょうか。", created_at: "2026-07-20T09:05:00Z" },
+  ],
+  recommendations_v2: [
+    {
+      shrine_id: 5,
+      name: "根津神社",
+      address: "東京都文京区根津1-28-9",
+      action_state: "saved",
+      recommendation_reason_v4_detail: {
+        version: "v4",
+        reason_text: "縁結びの神として知られています。",
+        fact: {
+          label: "根津神社",
+          name: "根津神社",
+          deity: "須佐之男命",
+          shrine_history: null,
+          place_context: "東京都文京区根津1-28-9",
+          history_theme: null,
+          goriyaku: null,
+          visit_style_tags: [],
+          evidence: [],
+        },
+        interpretation: { theme: "縁結び", text: "新しい縁が結ばれる時期です。" },
+        action: { text: "静かに参拝してみましょう。", source: "template" },
+      },
+    },
+  ],
+};
+
+describe("ConsultationHistoryDetailView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("認証状態読み込み中はLoading状態を表示する", () => {
+    useAuthMock.mockReturnValue({ loading: true, isLoggedIn: false });
+    render(<ConsultationHistoryDetailView tid="42" thread={null} fetchFailed={false} />);
+
+    expect(screen.getByText("読み込み中…")).toBeInTheDocument();
+  });
+
+  it("未ログイン(401/403相当)のときログイン導線を表示し、returnToにtidを含む", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: false });
+    render(<ConsultationHistoryDetailView tid="42" thread={null} fetchFailed={false} />);
+
+    expect(screen.getByRole("link", { name: "ログインへ" })).toHaveAttribute(
+      "href",
+      "/auth/login?returnTo=%2Fmypage%2Fhistory%2F42",
+    );
+  });
+
+  it("取得失敗時はError状態とRetry導線を表示し、クリックでrouter.refreshが呼ばれる", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="42" thread={null} fetchFailed={true} />);
+
+    expect(screen.getByText("相談履歴を読み込めませんでした。")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "もう一度読み込む" }));
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("Direct Navigation: 不正または存在しないtid(thread=null)のとき見つからない旨を表示する", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="999" thread={null} fetchFailed={false} />);
+
+    expect(screen.getByText("この相談は見つかりませんでした。")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "相談履歴の一覧へ戻る" })).toHaveAttribute("href", "/mypage/history");
+  });
+
+  it("正常系: 会話履歴と推薦神社カード、Fact要約、action_stateバッジを表示する", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
+
+    expect(screen.getByRole("heading", { name: "縁結びの相談" })).toBeInTheDocument();
+    expect(screen.getByText("良い神社を探しています。")).toBeInTheDocument();
+    expect(screen.getByText("こちらはいかがでしょうか。")).toBeInTheDocument();
+
+    expect(screen.getByText("根津神社")).toBeInTheDocument();
+    expect(screen.getByText("気になる登録済み")).toBeInTheDocument();
+    // Fact優先順位: deityが最優先。place_context(住所)はFact本文として使われない。
+    expect(screen.getByText("須佐之男命")).toBeInTheDocument();
+  });
+
+  it("Shrine Detail遷移: 推薦神社カードのリンクがctx=concierge&tidを維持する", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
+
+    expect(screen.getByRole("link", { name: "神社の詳細を見る" })).toHaveAttribute(
+      "href",
+      "/shrines/5?ctx=concierge&tid=42",
+    );
+  });
+});

--- a/apps/web/src/components/views/__tests__/ConsultationHistoryListView.test.tsx
+++ b/apps/web/src/components/views/__tests__/ConsultationHistoryListView.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import ConsultationHistoryListView from "../ConsultationHistoryListView";
+import type { ConciergeThread } from "@/lib/api/concierge/types";
+
+const refreshMock = vi.fn();
+const useAuthMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: refreshMock, push: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+const THREADS: ConciergeThread[] = [
+  { id: 1, title: "縁結びの相談", last_message: "ありがとうございました。", last_message_at: "2026-07-20T10:00:00Z", message_count: 4 },
+  { id: 2, title: "仕事運の相談", last_message: "参考になりました。", last_message_at: "2026-07-10T10:00:00Z", message_count: 2 },
+];
+
+describe("ConsultationHistoryListView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("認証状態読み込み中はLoading状態を表示する", () => {
+    useAuthMock.mockReturnValue({ loading: true, isLoggedIn: false });
+    render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={false} />);
+
+    expect(screen.getByText("読み込み中…")).toBeInTheDocument();
+  });
+
+  it("未ログイン(401/403相当)のときEmptyとは別のログイン導線を表示する", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: false });
+    render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={false} />);
+
+    expect(screen.getByText("ログインすると、これまでの相談履歴を見返せます。")).toBeInTheDocument();
+    expect(screen.queryByText("まだ相談履歴がありません。")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "ログインへ" })).toHaveAttribute(
+      "href",
+      "/auth/login?returnTo=%2Fmypage%2Fhistory",
+    );
+  });
+
+  it("取得失敗時はError状態とRetry導線を表示し、クリックでrouter.refreshが呼ばれる", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={true} />);
+
+    expect(screen.getByText("相談履歴を読み込めませんでした。")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "もう一度読み込む" }));
+    expect(refreshMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ログイン済みで0件のときEmpty状態を表示する", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={false} />);
+
+    expect(screen.getByText("まだ相談履歴がありません。")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "コンシェルジュに相談する" })).toHaveAttribute("href", "/concierge");
+  });
+
+  it("正常系: 相談履歴一覧を表示し、詳細画面へのリンクを持つ", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryListView initialThreads={THREADS} fetchFailed={false} />);
+
+    expect(screen.getByText("縁結びの相談")).toBeInTheDocument();
+    expect(screen.getByText("仕事運の相談")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /縁結びの相談/ })).toHaveAttribute("href", "/mypage/history/1");
+    expect(screen.getByRole("link", { name: /仕事運の相談/ })).toHaveAttribute("href", "/mypage/history/2");
+  });
+});

--- a/apps/web/src/lib/api/concierge/types.ts
+++ b/apps/web/src/lib/api/concierge/types.ts
@@ -45,8 +45,15 @@ export type ConciergeChatResponse = {
   limitReached?: boolean;
 };
 
+// Backend契約(GET /api/concierge-threads/{pk}/, ConciergeThreadDetailView)は
+// id/title/last_message/last_message_at/message_countをトップレベルに返す
+// フラットな構造であり、`thread`というネストしたキーは存在しない。
 export type ConciergeThreadDetail = {
-  thread: ConciergeThread;
+  id: number;
+  title: string;
+  last_message: string;
+  last_message_at: string | null;
+  message_count: number;
   messages: ConciergeMessage[];
   recommendations?: ConciergeRecommendation[];
   recommendations_v2?: ConciergeRecommendation[];

--- a/apps/web/src/lib/concierge/buildPreviousConsultationSummary.ts
+++ b/apps/web/src/lib/concierge/buildPreviousConsultationSummary.ts
@@ -11,12 +11,6 @@ export function buildPreviousConsultationSummary(
     return null;
   }
 
-  const root = thread as ConciergeThreadDetail & {
-    id?: number | null;
-    last_message_at?: string | null;
-  };
-  const threadLike = thread.thread ?? root;
-
   const recs = thread.recommendations_v2 ?? thread.recommendations ?? [];
   const first = recs[0];
   const shrineId = Number(first?.shrine_id ?? first?.id);
@@ -36,8 +30,8 @@ export function buildPreviousConsultationSummary(
   const combination = resolveNeedCombinationNarrative(matchedNeedTags as NeedTag[]);
 
   return {
-    threadId: typeof threadLike.id === "number" ? threadLike.id : null,
-    createdAt: threadLike.last_message_at ?? null,
+    threadId: typeof thread.id === "number" ? thread.id : null,
+    createdAt: thread.last_message_at ?? null,
     consultationSummary: payload?.original_reason ?? null,
     matchedNeedTags,
     combination: combination


### PR DESCRIPTION
## 背景

`docs/product/history-recommendation-navigation-design.md`（PR #2211、PR #2214でOpenAPI governance明記を追記）で設計済みのHistory Navigation機能のうち、Web側の一覧・詳細画面を実装する。Mobile側は既に一覧表示を実装済み（遷移導線は別PRで対応予定）。

## 変更内容

### 新規画面
- `apps/web/src/app/mypage/history/page.tsx`（一覧、Server Component）
- `apps/web/src/app/mypage/history/[tid]/page.tsx`（詳細、Server Component）
- `apps/web/src/components/views/ConsultationHistoryListView.tsx`（Client Component）
- `apps/web/src/components/views/ConsultationHistoryDetailView.tsx`（Client Component）

### ルート設計
- `/mypage/history`, `/mypage/history/[tid]`。`sanitizeNext`の`/mypage`許可プレフィックスに合致するためログイン後returnToが無改修で機能する
- 既存`mypage/loading.tsx`/`error.tsx`をそのまま継承（汎用文言のため上書き不要）
- 神社詳細への遷移は既存の`/shrines/{id}?ctx=concierge&tid={thread_id}`パターンを再利用（Shrine Detail側は無改修）

### UI状態
Loading / 未ログイン（Emptyとは別導線、`buildLoginHref`でreturnTo付与） / API取得失敗（Retry導線、`router.refresh()`） / 履歴0件Empty / 不正・存在しないtid（見つかりませんでした） / 正常表示、の6状態を一覧・詳細それぞれで分離実装した。

一覧・詳細取得APIは401/403/404をいずれも空配列/nullへ丸めるため（既存のfallback仕様）、未ログイン判定は`useAuth()`のクライアント側認証状態で別途行い、「未ログイン」と「0件」を区別している（設計文書で指摘済みの既知の制約への対応）。

### Fact表示
推薦神社カードのFact要約は既存の共通関数`pickReasonV4FactText`（`deity > shrine_history > goriyaku > history_theme`優先、`place_context`/`label`除外）をそのまま再利用した。History専用の新しい優先順位ロジックは追加していない。

### 発見した型不整合の修正（実装の前提として必要だったため対応）
`ConciergeThreadDetail`型（`apps/web/src/lib/api/concierge/types.ts`）が実在しない`thread`ネストフィールドを宣言しており、実際のBackendレスポンス（`GET /api/concierge-threads/{pk}/`）はid/title/last_message/last_message_at/message_countをトップレベルに持つフラット構造だった。既存コード（`shrines/[id]/page.tsx`、`buildPreviousConsultationSummary.ts`）は`thread.thread ?? root`のような防御的回避で対応していたが、今回新設するDetail画面で型安全に`title`/`last_message_at`等を参照するために、型定義を実態に合わせて修正し、不要になった回避コードを削除した。Backend/Web他機能への挙動変更はない。

## テスト

- `ConsultationHistoryListView.test.tsx` / `ConsultationHistoryDetailView.test.tsx`: Loading・未ログイン・Error+Retry・Empty・正常系・Shrine Detail遷移リンクを検証
- 各`page.tsx`のtest: 正常系・Direct Navigation（不正tid→thread=null）・Error（例外→fetchFailed=true）を検証
- `npx tsc --noEmit`: エラーなし
- `npx eslint .`: 変更ファイルにエラー・警告なし
- Web test: 110 files / 675 tests 全通過（新規16件含む）
- pre-push hook: OpenAPI lint・Web契約テスト通過

## ブラウザQA

Backend + Web devサーバーを起動し、テストユーザー・テストスレッド（推薦神社1件付き）を作成して実施。
- 未ログイン時: 「ログインすると、これまでの相談履歴を見返せます。」+ ログインリンク（`returnTo=/mypage/history`）を確認、Empty文言とは別表示であることを確認
- ログイン後: 一覧に相談タイトル・日付・要約・件数を表示、詳細画面へのリンクが`/mypage/history/{id}`であることを確認
- 詳細画面: 会話履歴、推薦神社カード（Fact優先順位どおりdeityを表示、住所はFactと別枠で表示）、action_stateバッジを確認
- 「神社の詳細を見る」リンク（`/shrines/{id}?ctx=concierge&tid={id}`）から遷移し、Shrine Detail側が無改修で相談文脈（①今回の相談の整理等）を表示することを確認
- 不正なtid（Direct Navigation）で「この相談は見つかりませんでした。」を確認
- コンソール・サーバーログにエラーなし
- QA用データ・サーバーは作業後にクリーンアップ済み

## 対象外（本PRでは行っていない）

- Mobile側のThread詳細画面・遷移導線（設計文書のPR分割案どおり別PR）
- Analytics実装（`history_list_view`等、別PR予定）
- 推薦神社カードでの現在Shrine API参照によるname/address上書き（Snapshot値をそのまま使用。設計文書が許容するfallback相当の簡易実装）
- Backend実装の変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)