### PR TITLE
feat(mobile): 相談履歴の一覧・詳細画面を実装

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -95,6 +95,7 @@ export default function Root() {
       <Tabs.Screen name="visit-history/index" options={{ href: null }} />
       <Tabs.Screen name="reflection-history/index" options={{ href: null }} />
       <Tabs.Screen name="consultation-history/index" options={{ href: null }} />
+      <Tabs.Screen name="consultation-history/[id]" options={{ href: null }} />
       <Tabs.Screen name="recently-viewed/index" options={{ href: null }} />
       <Tabs.Screen name="profile/index" options={{ href: null }} />
       <Tabs.Screen name="search/index" options={{ href: null }} />

--- a/apps/mobile/app/consultation-history/[id].tsx
+++ b/apps/mobile/app/consultation-history/[id].tsx
@@ -1,0 +1,365 @@
+import * as React from "react";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+
+import {
+  getConciergeThread,
+  type ConciergeRecommendation,
+  type ConciergeThreadDetail,
+} from "../../lib/consultationHistory";
+import {
+  ACTION_STATE_LABEL,
+  classifyThreadDetailLoadError,
+  extractRecommendationShrineId,
+  formatThreadDateTime,
+} from "../../lib/consultationHistoryUi";
+import {
+  buildReasonV4Sections,
+  normalizeRecommendationReasonV4Detail,
+  serializeReasonV4Detail,
+} from "../../lib/recommendationReasonV4";
+import { StateCard } from "../../components/common/StateCard";
+import { AuthPrompt } from "../../components/common/AuthPrompt";
+import Button from "../../components/ui/Button";
+import { kamimusubiDark as theme } from "../../design/theme";
+import { spacing } from "../../design/spacing";
+import { cardSizes } from "../../design/cardSizes";
+import { radius } from "../../design/radius";
+
+function RecommendationCard({
+  rec,
+  onOpenShrineDetail,
+}: {
+  rec: ConciergeRecommendation;
+  onOpenShrineDetail: (shrineId: string) => void;
+}) {
+  const shrineId = extractRecommendationShrineId(rec);
+  const name = rec.display_name?.trim() || rec.name?.trim() || "名称未設定の神社";
+  const address = rec.address ?? rec.location ?? rec.formatted_address ?? null;
+  const reasonV4Detail = normalizeRecommendationReasonV4Detail(rec.recommendation_reason_v4_detail);
+  const sections = buildReasonV4Sections({ detail: reasonV4Detail, fallbackReason: null });
+  const factText = sections.factText ?? sections.fallbackText;
+  const actionLabel = rec.action_state ? ACTION_STATE_LABEL[rec.action_state] : undefined;
+
+  return (
+    <View style={styles.recommendationCard}>
+      <View style={styles.recommendationHeader}>
+        <Text style={styles.recommendationName}>{name}</Text>
+        {actionLabel ? (
+          <View style={styles.actionBadge}>
+            <Text style={styles.actionBadgeText}>{actionLabel}</Text>
+          </View>
+        ) : null}
+      </View>
+      {address ? <Text style={styles.recommendationAddress}>{address}</Text> : null}
+      {factText ? <Text style={styles.recommendationFact}>{factText}</Text> : null}
+      {shrineId ? (
+        <Pressable
+          onPress={() => onOpenShrineDetail(shrineId)}
+          accessibilityRole="button"
+          accessibilityLabel={`${name}の詳細を見る`}
+          style={styles.detailLink}
+        >
+          <Text style={styles.detailLinkText}>神社の詳細を見る</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+type DetailState =
+  | { kind: "loading" }
+  | { kind: "unauthenticated" }
+  | { kind: "not_found" }
+  | { kind: "error" }
+  | { kind: "ready"; thread: ConciergeThreadDetail };
+
+export default function ConsultationHistoryDetailScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const tid = React.useMemo(() => {
+    const raw = params.id;
+    return Array.isArray(raw) ? raw[0] : raw;
+  }, [params.id]);
+
+  const [state, setState] = React.useState<DetailState>({ kind: "loading" });
+  const [authPromptVisible, setAuthPromptVisible] = React.useState(false);
+
+  const load = React.useCallback(async () => {
+    if (!tid) {
+      setState({ kind: "not_found" });
+      return;
+    }
+
+    setState({ kind: "loading" });
+
+    try {
+      const thread = await getConciergeThread(tid);
+      setState({ kind: "ready", thread });
+    } catch (error) {
+      const kind = classifyThreadDetailLoadError(error);
+      if (kind === "error" && __DEV__) {
+        console.warn("[ConsultationHistoryDetailScreen] failed to load thread", error);
+      }
+      setState({ kind });
+    }
+  }, [tid]);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  React.useEffect(() => {
+    if (state.kind === "unauthenticated") setAuthPromptVisible(true);
+  }, [state.kind]);
+
+  const handleOpenShrineDetail = React.useCallback(
+    (shrineId: string, rec: ConciergeRecommendation) => {
+      const reasonV4Detail = normalizeRecommendationReasonV4Detail(rec.recommendation_reason_v4_detail);
+      router.push({
+        pathname: "/shrines/[id]",
+        params: {
+          id: shrineId,
+          recommendationReasonV4: rec.recommendation_reason_v4 ?? "",
+          reasonFacts: rec.reason_facts ? JSON.stringify(rec.reason_facts) : "",
+          recommendationReasonDetail: rec.recommendation_reason_detail
+            ? JSON.stringify(rec.recommendation_reason_detail)
+            : "",
+          actionSuggestionV4Preview: rec.action_suggestion_v4_preview
+            ? JSON.stringify(rec.action_suggestion_v4_preview)
+            : "",
+          recommendationReasonV4Detail: serializeReasonV4Detail(reasonV4Detail),
+        },
+      });
+    },
+    [router],
+  );
+
+  const recommendations =
+    state.kind === "ready" ? (state.thread.recommendations_v2 ?? state.thread.recommendations ?? []) : [];
+
+  return (
+    <>
+      <ScrollView style={styles.screen} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+        <View style={styles.header}>
+          <Pressable onPress={() => router.back()} style={styles.backButton}>
+            <Text style={styles.backText}>← 相談履歴へ戻る</Text>
+          </Pressable>
+          <Text style={styles.title}>
+            {state.kind === "ready" ? state.thread.title?.trim() || "相談タイトル未設定" : "相談履歴"}
+          </Text>
+          {state.kind === "ready" ? (
+            <Text style={styles.subtitle}>{formatThreadDateTime(state.thread.last_message_at)}</Text>
+          ) : null}
+        </View>
+
+        {state.kind === "loading" ? (
+          <StateCard title="相談履歴を読み込み中" description="保存された相談を確認しています。" />
+        ) : null}
+
+        {state.kind === "unauthenticated" ? (
+          <StateCard title="ログインが必要です" description="この相談履歴を見返すには、ログインしてください。" />
+        ) : null}
+
+        {state.kind === "not_found" ? (
+          <View style={styles.errorBlock}>
+            <StateCard
+              title="この相談は見つかりませんでした"
+              description="削除されたか、アクセスできない相談です。"
+            />
+            <Button
+              title="相談履歴の一覧へ戻る"
+              variant="outline"
+              size="compact"
+              onPress={() => router.replace("/consultation-history")}
+              accessibilityLabel="相談履歴の一覧へ戻る"
+            />
+          </View>
+        ) : null}
+
+        {state.kind === "error" ? (
+          <View style={styles.errorBlock}>
+            <StateCard
+              title="相談履歴を読み込めませんでした"
+              description="通信状況を確認して、もう一度お試しください。"
+            />
+            <Button
+              title="もう一度読み込む"
+              variant="outline"
+              size="compact"
+              onPress={() => void load()}
+              accessibilityLabel="相談履歴をもう一度読み込む"
+            />
+          </View>
+        ) : null}
+
+        {state.kind === "ready" ? (
+          <>
+            {recommendations.length > 0 ? (
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>当時推薦された神社</Text>
+                <View style={styles.list}>
+                  {recommendations.map((rec, idx) => (
+                    <RecommendationCard
+                      key={`${extractRecommendationShrineId(rec) ?? rec.name ?? "rec"}-${idx}`}
+                      rec={rec}
+                      onOpenShrineDetail={(shrineId) => handleOpenShrineDetail(shrineId, rec)}
+                    />
+                  ))}
+                </View>
+              </View>
+            ) : null}
+
+            <View style={styles.section}>
+              <Text style={styles.sectionTitle}>相談内容</Text>
+              <View style={styles.list}>
+                {state.thread.messages.map((message) => (
+                  <View
+                    key={message.id}
+                    style={[
+                      styles.messageBubble,
+                      message.role === "user" ? styles.messageBubbleUser : styles.messageBubbleAssistant,
+                    ]}
+                  >
+                    <Text style={styles.messageText}>{message.content}</Text>
+                    <Text style={styles.messageDate}>{formatThreadDateTime(message.created_at)}</Text>
+                  </View>
+                ))}
+              </View>
+            </View>
+          </>
+        ) : null}
+      </ScrollView>
+
+      <AuthPrompt
+        visible={authPromptVisible}
+        onClose={() => setAuthPromptVisible(false)}
+        description="この相談履歴を見返すには、ログインが必要です。"
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: theme.background,
+  },
+  content: {
+    padding: spacing.screenXWide,
+    paddingBottom: spacing.bottomSpace,
+    gap: spacing.lgGap,
+  },
+  header: {
+    gap: spacing.mdGap,
+  },
+  backButton: {
+    alignSelf: "flex-start",
+    marginBottom: spacing.smGap,
+  },
+  backText: {
+    color: theme.gold,
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  title: {
+    color: theme.gold,
+    fontSize: 22,
+    fontWeight: "900",
+  },
+  subtitle: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "700",
+  },
+  errorBlock: {
+    gap: spacing.smGap,
+  },
+  section: {
+    gap: spacing.smGap,
+  },
+  sectionTitle: {
+    color: theme.goldSoft,
+    fontSize: 13,
+    fontWeight: "900",
+    letterSpacing: 0.6,
+  },
+  list: {
+    gap: spacing.mdGap,
+  },
+  recommendationCard: {
+    backgroundColor: theme.surface,
+    borderColor: theme.borderGold,
+    borderRadius: radius.lg,
+    borderWidth: cardSizes.borderWidth,
+    padding: cardSizes.cardPaddingLg,
+    gap: spacing.tightGap,
+  },
+  recommendationHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: spacing.smGap,
+  },
+  recommendationName: {
+    flex: 1,
+    color: theme.gold,
+    fontSize: 16,
+    fontWeight: "900",
+  },
+  actionBadge: {
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderGold,
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  actionBadgeText: {
+    color: theme.gold,
+    fontSize: 11,
+    fontWeight: "800",
+  },
+  recommendationAddress: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  recommendationFact: {
+    color: theme.text,
+    fontSize: 14,
+    lineHeight: 21,
+    fontWeight: "600",
+  },
+  detailLink: {
+    marginTop: spacing.tightGap,
+    alignSelf: "flex-start",
+  },
+  detailLinkText: {
+    color: theme.gold,
+    fontSize: 13,
+    fontWeight: "800",
+    textDecorationLine: "underline",
+  },
+  messageBubble: {
+    borderRadius: radius.lg,
+    padding: cardSizes.cardPaddingLg,
+    gap: spacing.tightGap,
+  },
+  messageBubbleUser: {
+    backgroundColor: theme.surfaceSoft,
+  },
+  messageBubbleAssistant: {
+    backgroundColor: theme.surface,
+  },
+  messageText: {
+    color: theme.text,
+    fontSize: 14,
+    lineHeight: 22,
+    fontWeight: "600",
+  },
+  messageDate: {
+    color: theme.muted,
+    fontSize: 11,
+    fontWeight: "600",
+  },
+});

--- a/apps/mobile/app/consultation-history/index.tsx
+++ b/apps/mobile/app/consultation-history/index.tsx
@@ -2,71 +2,34 @@ import * as React from "react";
 import { Pressable, RefreshControl, ScrollView, StyleSheet, Text, View } from "react-native";
 import { useRouter } from "expo-router";
 
-import { listConciergeThreads, type ConciergeThreadListItem } from "../../lib/consultationHistory";
+import { fetchConciergeThreadsRaw, type ConciergeThreadListItem } from "../../lib/consultationHistory";
+import {
+  classifyThreadsLoadError,
+  formatThreadDate,
+  groupThreadsByDate,
+  normalizeThreadPreview,
+} from "../../lib/consultationHistoryUi";
 import { StateCard } from "../../components/common/StateCard";
+import { AuthPrompt } from "../../components/common/AuthPrompt";
+import Button from "../../components/ui/Button";
 import { kamimusubiDark as theme } from "../../design/theme";
 import { spacing } from "../../design/spacing";
 import { cardSizes } from "../../design/cardSizes";
 import { radius } from "../../design/radius";
 
-function formatDate(value: string | null | undefined): string {
-  if (!value) return "日付未記録";
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "日付未記録";
-
-  return date.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-}
-
-function formatDateGroupLabel(value: string | null | undefined): string {
-  if (!value) return "日付未記録";
-
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "日付未記録";
-
-  return date.toLocaleDateString("ja-JP", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    weekday: "short",
-  });
-}
-
-function normalizePreview(value: string | null | undefined): string {
-  const text = String(value ?? "").replace(/\s+/g, " ").trim();
-  return text || "相談内容はまだ記録されていません。";
-}
-
-type ConsultationGroup = {
-  label: string;
-  items: ConciergeThreadListItem[];
-};
-
-function groupThreadsByDate(threads: ConciergeThreadListItem[]): ConsultationGroup[] {
-  const groups = new Map<string, ConciergeThreadListItem[]>();
-
-  threads.forEach((thread) => {
-    const label = formatDateGroupLabel(thread.last_message_at);
-    const current = groups.get(label) ?? [];
-    current.push(thread);
-    groups.set(label, current);
-  });
-
-  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
-}
-
-function ConsultationCard({ thread }: { thread: ConciergeThreadListItem }) {
+function ConsultationCard({ thread, onPress }: { thread: ConciergeThreadListItem; onPress: () => void }) {
   const title = thread.title?.trim() || "相談タイトル未設定";
-  const preview = normalizePreview(thread.last_message);
-  const date = formatDate(thread.last_message_at);
+  const preview = normalizeThreadPreview(thread.last_message);
+  const date = formatThreadDate(thread.last_message_at);
   const messageCount = Number.isFinite(thread.message_count) ? thread.message_count : 0;
 
   return (
-    <View style={styles.consultationCard}>
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`${title}の相談履歴を開く`}
+      style={({ pressed }) => [styles.consultationCard, pressed && styles.consultationCardPressed]}
+    >
       <View style={styles.cardHeader}>
         <Text style={styles.threadTitle}>{title}</Text>
         <Text style={styles.createdAt}>{date}</Text>
@@ -81,98 +44,142 @@ function ConsultationCard({ thread }: { thread: ConciergeThreadListItem }) {
           <Text style={styles.messageCountText}>{messageCount}件のやりとり</Text>
         </View>
       </View>
-    </View>
+    </Pressable>
   );
 }
 
+type ListState =
+  | { kind: "loading" }
+  | { kind: "unauthenticated" }
+  | { kind: "error" }
+  | { kind: "ready"; threads: ConciergeThreadListItem[] };
+
 export default function ConsultationHistoryScreen() {
   const router = useRouter();
-  const [threads, setThreads] = React.useState<ConciergeThreadListItem[]>([]);
-  const [loading, setLoading] = React.useState(true);
-  const [error, setError] = React.useState(false);
+  const [state, setState] = React.useState<ListState>({ kind: "loading" });
   const [refreshing, setRefreshing] = React.useState(false);
+  const [authPromptVisible, setAuthPromptVisible] = React.useState(false);
 
-  const loadThreads = React.useCallback(async (options?: { showInitialLoading?: boolean; showRefreshing?: boolean }) => {
-    if (options?.showInitialLoading) setLoading(true);
-    if (options?.showRefreshing) setRefreshing(true);
+  const loadThreads = React.useCallback(async (options?: { showRefreshing?: boolean }) => {
+    if (options?.showRefreshing) {
+      setRefreshing(true);
+    } else {
+      setState({ kind: "loading" });
+    }
 
     try {
-      const items = await listConciergeThreads();
-      setThreads(items);
-      setError(false);
-    } catch {
-      setThreads([]);
-      setError(true);
+      const threads = await fetchConciergeThreadsRaw();
+      setState({ kind: "ready", threads });
+    } catch (error) {
+      const kind = classifyThreadsLoadError(error);
+      if (kind === "error" && __DEV__) {
+        console.warn("[ConsultationHistoryScreen] failed to load threads", error);
+      }
+      setState({ kind });
     } finally {
-      if (options?.showInitialLoading) setLoading(false);
       if (options?.showRefreshing) setRefreshing(false);
     }
   }, []);
 
   React.useEffect(() => {
-    void loadThreads({ showInitialLoading: true });
+    void loadThreads();
   }, [loadThreads]);
-
-  const groupedThreads = React.useMemo(() => groupThreadsByDate(threads), [threads]);
 
   const onRefresh = React.useCallback(() => {
     void loadThreads({ showRefreshing: true });
   }, [loadThreads]);
 
+  const threads = state.kind === "ready" ? state.threads : [];
+  const groupedThreads = React.useMemo(() => groupThreadsByDate(threads), [threads]);
+
+  React.useEffect(() => {
+    if (state.kind === "unauthenticated") setAuthPromptVisible(true);
+  }, [state.kind]);
+
   return (
-    <ScrollView
-      style={styles.screen}
-      contentContainerStyle={styles.content}
-      showsVerticalScrollIndicator={false}
-      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.gold} />}
-    >
-      <View style={styles.header}>
-        <Pressable onPress={() => router.replace("/records")} style={styles.backButton}>
-          <Text style={styles.backText}>← 記録へ戻る</Text>
-        </Pressable>
+    <>
+      <ScrollView
+        style={styles.screen}
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={theme.gold} />}
+      >
+        <View style={styles.header}>
+          <Pressable onPress={() => router.replace("/records")} style={styles.backButton}>
+            <Text style={styles.backText}>← 記録へ戻る</Text>
+          </Pressable>
 
-        <Text style={styles.title}>相談履歴</Text>
-        <Text style={styles.subtitle}>
-          これまでの相談を新しい順に見返せます。迷いや願いの変化を、次の相談につなげるための記録です。
-        </Text>
-      </View>
-
-      {loading ? (
-        <StateCard
-          title="相談履歴を読み込み中"
-          description="保存された相談を確認しています。"
-        />
-      ) : null}
-
-      {!loading && error ? (
-        <StateCard
-          title="相談履歴を読み込めませんでした"
-          description="通信状況を確認して、もう一度開き直してください。"
-        />
-      ) : null}
-
-      {!loading && !error && threads.length === 0 ? (
-        <StateCard
-          title="相談履歴はまだありません"
-          description="コンシェルジュで相談すると、ここに履歴として表示されます。"
-        />
-      ) : null}
-
-      {!loading && !error && groupedThreads.length > 0 ? (
-        <View style={styles.timeline}>
-          {groupedThreads.map((group) => (
-            <View key={group.label} style={styles.timelineGroup}>
-              <Text style={styles.groupLabel}>{group.label}</Text>
-              <View style={styles.list}>
-                {group.items.map((thread) => (
-                  <ConsultationCard key={thread.id} thread={thread} />
-                ))}
-              </View>
-            </View>
-          ))}
+          <Text style={styles.title}>相談履歴</Text>
+          <Text style={styles.subtitle}>
+            これまでの相談を新しい順に見返せます。迷いや願いの変化を、次の相談につなげるための記録です。
+          </Text>
         </View>
-      ) : null}
-    </ScrollView>
+
+        {state.kind === "loading" ? (
+          <StateCard title="相談履歴を読み込み中" description="保存された相談を確認しています。" />
+        ) : null}
+
+        {state.kind === "unauthenticated" ? (
+          <StateCard
+            title="ログインが必要です"
+            description="相談履歴を見返すには、ログインしてください。"
+          />
+        ) : null}
+
+        {state.kind === "error" ? (
+          <View style={styles.errorBlock}>
+            <StateCard
+              title="相談履歴を読み込めませんでした"
+              description="通信状況を確認して、もう一度お試しください。"
+            />
+            <Button
+              title="もう一度読み込む"
+              variant="outline"
+              size="compact"
+              onPress={() => void loadThreads()}
+              accessibilityLabel="相談履歴をもう一度読み込む"
+            />
+          </View>
+        ) : null}
+
+        {state.kind === "ready" && threads.length === 0 ? (
+          <StateCard
+            title="相談履歴はまだありません"
+            description="コンシェルジュで相談すると、ここに履歴として表示されます。"
+          />
+        ) : null}
+
+        {state.kind === "ready" && groupedThreads.length > 0 ? (
+          <View style={styles.timeline}>
+            {groupedThreads.map((group) => (
+              <View key={group.label} style={styles.timelineGroup}>
+                <Text style={styles.groupLabel}>{group.label}</Text>
+                <View style={styles.list}>
+                  {group.items.map((thread) => (
+                    <ConsultationCard
+                      key={thread.id}
+                      thread={thread}
+                      onPress={() =>
+                        router.push({
+                          pathname: "/consultation-history/[id]",
+                          params: { id: String(thread.id) },
+                        })
+                      }
+                    />
+                  ))}
+                </View>
+              </View>
+            ))}
+          </View>
+        ) : null}
+      </ScrollView>
+
+      <AuthPrompt
+        visible={authPromptVisible}
+        onClose={() => setAuthPromptVisible(false)}
+        description="相談履歴を見返すには、ログインが必要です。"
+      />
+    </>
   );
 }
 
@@ -209,6 +216,9 @@ const styles = StyleSheet.create({
     lineHeight: 23,
     fontWeight: "600",
   },
+  errorBlock: {
+    gap: spacing.smGap,
+  },
   timeline: {
     gap: spacing.lgGap,
   },
@@ -231,6 +241,9 @@ const styles = StyleSheet.create({
     borderWidth: cardSizes.borderWidth,
     padding: cardSizes.cardPaddingLg,
     gap: spacing.smGap,
+  },
+  consultationCardPressed: {
+    opacity: 0.72,
   },
   cardHeader: {
     gap: spacing.tightGap,

--- a/apps/mobile/app/mypage/index.tsx
+++ b/apps/mobile/app/mypage/index.tsx
@@ -181,6 +181,17 @@ export default function MyPageScreen() {
       </View>
 
       <View style={styles.section}>
+        <Text style={styles.sectionTitle}>相談</Text>
+        <MyPageCard
+          title="相談履歴"
+          description="これまでの相談と、当時推薦された神社を見返せます。"
+          iconText="談"
+          actionLabel="開く"
+          onPress={() => router.push("/consultation-history")}
+        />
+      </View>
+
+      <View style={styles.section}>
         <Text style={styles.sectionTitle}>Premium</Text>
         <MyPageCard
           title="Premium"

--- a/apps/mobile/lib/__tests__/consultationHistory.test.ts
+++ b/apps/mobile/lib/__tests__/consultationHistory.test.ts
@@ -14,8 +14,8 @@ vi.mock("../http", async (importOriginal) => {
   };
 });
 
-import { listConciergeThreads } from "../consultationHistory";
-import { UnauthenticatedError } from "../http";
+import { fetchConciergeThreadsRaw, getConciergeThread, listConciergeThreads } from "../consultationHistory";
+import { HttpError, UnauthenticatedError } from "../http";
 
 describe("listConciergeThreads", () => {
   beforeEach(() => {
@@ -73,5 +73,108 @@ describe("listConciergeThreads", () => {
     const result = await listConciergeThreads();
 
     expect(result).toEqual([]);
+  });
+});
+
+describe("fetchConciergeThreadsRaw", () => {
+  beforeEach(() => {
+    getAuthMock.mockReset();
+  });
+
+  it("正常系: results配列をそのまま返す", async () => {
+    getAuthMock.mockResolvedValueOnce({
+      results: [{ id: 1, title: "相談A", last_message: "本文", last_message_at: null, message_count: 1 }],
+    });
+
+    const result = await fetchConciergeThreadsRaw();
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("フラットレスポンス型との整合: 配列がそのまま返るレスポンス形状にも対応する", async () => {
+    getAuthMock.mockResolvedValueOnce([
+      { id: 2, title: "相談B", last_message: "本文2", last_message_at: null, message_count: 0 },
+    ]);
+
+    const result = await fetchConciergeThreadsRaw();
+
+    expect(result).toEqual([{ id: 2, title: "相談B", last_message: "本文2", last_message_at: null, message_count: 0 }]);
+  });
+
+  it("listConciergeThreadsとは異なり、401(UnauthenticatedError)を握りつぶさずそのまま投げる", async () => {
+    getAuthMock.mockRejectedValueOnce(new UnauthenticatedError());
+
+    await expect(fetchConciergeThreadsRaw()).rejects.toBeInstanceOf(UnauthenticatedError);
+  });
+
+  it("403(HttpError)も握りつぶさずそのまま投げる", async () => {
+    getAuthMock.mockRejectedValueOnce(new HttpError(403, "HTTP 403: Forbidden"));
+
+    await expect(fetchConciergeThreadsRaw()).rejects.toMatchObject({ status: 403 });
+  });
+
+  it("network errorも握りつぶさずそのまま投げる", async () => {
+    getAuthMock.mockRejectedValueOnce(new TypeError("Network request failed"));
+
+    await expect(fetchConciergeThreadsRaw()).rejects.toBeInstanceOf(TypeError);
+  });
+});
+
+describe("getConciergeThread", () => {
+  beforeEach(() => {
+    getAuthMock.mockReset();
+  });
+
+  it("正常系: フラット構造のThreadDetailをそのまま返す", async () => {
+    const detail = {
+      id: 42,
+      title: "縁結びの相談",
+      last_message: "ありがとうございました。",
+      last_message_at: "2026-01-01T00:00:00Z",
+      message_count: 2,
+      messages: [{ id: 1, role: "user", content: "こんにちは", created_at: "2026-01-01T00:00:00Z" }],
+      recommendations: [],
+    };
+    getAuthMock.mockResolvedValueOnce(detail);
+
+    const result = await getConciergeThread("42");
+
+    expect(result).toEqual(detail);
+    // thread という入れ子構造ではなく、id/title等がトップレベルにあることを確認する
+    expect((result as unknown as { thread?: unknown }).thread).toBeUndefined();
+    expect(getAuthMock).toHaveBeenCalledWith("/concierge-threads/42/");
+  });
+
+  it("401(UnauthenticatedError)を握りつぶさず投げる", async () => {
+    getAuthMock.mockRejectedValueOnce(new UnauthenticatedError());
+
+    await expect(getConciergeThread("42")).rejects.toBeInstanceOf(UnauthenticatedError);
+  });
+
+  it("404(HttpError)を握りつぶさず投げる(不正または存在しないtid)", async () => {
+    getAuthMock.mockRejectedValueOnce(new HttpError(404, "HTTP 404: Not Found"));
+
+    await expect(getConciergeThread("999")).rejects.toMatchObject({ status: 404 });
+  });
+
+  it("network errorを握りつぶさず投げる", async () => {
+    getAuthMock.mockRejectedValueOnce(new TypeError("Network request failed"));
+
+    await expect(getConciergeThread("42")).rejects.toBeInstanceOf(TypeError);
+  });
+
+  it("tidはencodeURIComponentされてpathへ渡される", async () => {
+    getAuthMock.mockResolvedValueOnce({
+      id: 1,
+      title: "t",
+      last_message: "",
+      last_message_at: null,
+      message_count: 0,
+      messages: [],
+    });
+
+    await getConciergeThread("abc/def");
+
+    expect(getAuthMock).toHaveBeenCalledWith("/concierge-threads/abc%2Fdef/");
   });
 });

--- a/apps/mobile/lib/__tests__/consultationHistoryUi.test.ts
+++ b/apps/mobile/lib/__tests__/consultationHistoryUi.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ACTION_STATE_LABEL,
+  classifyThreadDetailLoadError,
+  classifyThreadsLoadError,
+  extractRecommendationShrineId,
+  formatThreadDate,
+  formatThreadDateGroupLabel,
+  formatThreadDateTime,
+  groupThreadsByDate,
+  normalizeThreadPreview,
+} from "../consultationHistoryUi";
+import { HttpError, UnauthenticatedError } from "../http";
+import type { ConciergeThreadListItem } from "../consultationHistory";
+
+describe("classifyThreadsLoadError", () => {
+  it("UnauthenticatedErrorはunauthenticatedに分類する", () => {
+    expect(classifyThreadsLoadError(new UnauthenticatedError())).toBe("unauthenticated");
+  });
+
+  it("回帰テスト: 403(HttpError)はunauthenticatedではなくerrorに分類する(同一メッセージへ握り潰さない)", () => {
+    expect(classifyThreadsLoadError(new HttpError(403, "HTTP 403: Forbidden"))).toBe("error");
+  });
+
+  it("network error等はerrorに分類する", () => {
+    expect(classifyThreadsLoadError(new TypeError("Network request failed"))).toBe("error");
+  });
+});
+
+describe("classifyThreadDetailLoadError", () => {
+  it("UnauthenticatedErrorはunauthenticatedに分類する(401相当)", () => {
+    expect(classifyThreadDetailLoadError(new UnauthenticatedError())).toBe("unauthenticated");
+  });
+
+  it("status=404のHttpErrorはnot_foundに分類する(不正または存在しないtid)", () => {
+    expect(classifyThreadDetailLoadError(new HttpError(404, "HTTP 404: Not Found"))).toBe("not_found");
+  });
+
+  it("回帰テスト: status=403のHttpErrorはunauthenticated/not_foundどちらでもなくerrorに分類する", () => {
+    expect(classifyThreadDetailLoadError(new HttpError(403, "HTTP 403: Forbidden"))).toBe("error");
+  });
+
+  it("status=500等その他のHttpErrorはerrorに分類する", () => {
+    expect(classifyThreadDetailLoadError(new HttpError(500, "HTTP 500: Server Error"))).toBe("error");
+  });
+
+  it("network error等はerrorに分類する", () => {
+    expect(classifyThreadDetailLoadError(new TypeError("Network request failed"))).toBe("error");
+  });
+});
+
+describe("formatThreadDate / formatThreadDateTime / formatThreadDateGroupLabel", () => {
+  it("nullはすべて未記録文言を返す", () => {
+    expect(formatThreadDate(null)).toBe("日付未記録");
+    expect(formatThreadDateTime(null)).toBe("日時未記録");
+    expect(formatThreadDateGroupLabel(null)).toBe("日付未記録");
+  });
+
+  it("不正な日付文字列は未記録文言を返す", () => {
+    expect(formatThreadDate("not-a-date")).toBe("日付未記録");
+    expect(formatThreadDateTime("not-a-date")).toBe("日時未記録");
+  });
+
+  it("正しいISO日時は整形して返す", () => {
+    expect(formatThreadDate("2026-01-05T00:00:00Z")).toMatch(/2026/);
+    expect(formatThreadDateTime("2026-01-05T00:00:00Z")).toMatch(/2026/);
+  });
+});
+
+describe("normalizeThreadPreview", () => {
+  it("空・未記録は既定文言にfallbackする", () => {
+    expect(normalizeThreadPreview(null)).toBe("相談内容はまだ記録されていません。");
+    expect(normalizeThreadPreview("   ")).toBe("相談内容はまだ記録されていません。");
+  });
+
+  it("連続空白は1つに正規化する", () => {
+    expect(normalizeThreadPreview("こんにちは\n\n次の行")).toBe("こんにちは 次の行");
+  });
+});
+
+describe("groupThreadsByDate", () => {
+  it("同じ日付ラベルのスレッドをまとめる", () => {
+    const threads: ConciergeThreadListItem[] = [
+      { id: 1, title: "A", last_message: "", last_message_at: "2026-01-05T01:00:00Z", message_count: 1 },
+      { id: 2, title: "B", last_message: "", last_message_at: "2026-01-05T05:00:00Z", message_count: 1 },
+      { id: 3, title: "C", last_message: "", last_message_at: "2026-01-06T01:00:00Z", message_count: 1 },
+    ];
+
+    const groups = groupThreadsByDate(threads);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].items).toHaveLength(2);
+    expect(groups[1].items).toHaveLength(1);
+  });
+
+  it("空配列は空配列を返す", () => {
+    expect(groupThreadsByDate([])).toEqual([]);
+  });
+});
+
+describe("extractRecommendationShrineId", () => {
+  it("shrine_idを優先して数値文字列を返す", () => {
+    expect(extractRecommendationShrineId({ shrine_id: 5, id: 999 })).toBe("5");
+  });
+
+  it("shrine_idが無ければidを使う", () => {
+    expect(extractRecommendationShrineId({ id: 7 })).toBe("7");
+  });
+
+  it("どちらも無い/数値化できない場合はnullを返す", () => {
+    expect(extractRecommendationShrineId({})).toBeNull();
+    expect(extractRecommendationShrineId({ shrine_id: "abc" })).toBeNull();
+  });
+});
+
+describe("ACTION_STATE_LABEL", () => {
+  it("saved/visited/reflectedにラベルを持つ", () => {
+    expect(ACTION_STATE_LABEL.saved).toBe("気になる登録済み");
+    expect(ACTION_STATE_LABEL.visited).toBe("参拝済み");
+    expect(ACTION_STATE_LABEL.reflected).toBe("振り返り済み");
+  });
+
+  it("noneにはラベルを持たない(バッジを表示しない)", () => {
+    expect(ACTION_STATE_LABEL.none).toBeUndefined();
+  });
+});

--- a/apps/mobile/lib/__tests__/http.test.ts
+++ b/apps/mobile/lib/__tests__/http.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const getAccessTokenMock = vi.fn();
+const getRefreshTokenMock = vi.fn();
+const isExpiringSoonMock = vi.fn();
+const setAccessTokenMock = vi.fn();
+
+vi.mock("../authTokens", () => ({
+  getAccessToken: (...args: unknown[]) => getAccessTokenMock(...args),
+  getRefreshToken: (...args: unknown[]) => getRefreshTokenMock(...args),
+  isExpiringSoon: (...args: unknown[]) => isExpiringSoonMock(...args),
+  setAccessToken: (...args: unknown[]) => setAccessTokenMock(...args),
+}));
+
+import { HttpError, UnauthenticatedError, get, getAuth, isHttpError, isUnauthenticatedError } from "../http";
+
+describe("http", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("get", () => {
+    it("正常系: 200のときJSONを返す", async () => {
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+      const result = await get<{ ok: boolean }>("/ping/");
+
+      expect(result).toEqual({ ok: true });
+      fetchSpy.mockRestore();
+    });
+
+    it("異常系: 404のときstatus=404のHttpErrorを投げる", async () => {
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: async () => "not found",
+      } as Response);
+
+      await expect(get("/missing/")).rejects.toMatchObject({ name: "HttpError", status: 404 });
+
+      fetchSpy.mockRestore();
+    });
+
+    it("isHttpErrorはHttpErrorのみをtrueと判定する", async () => {
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        text: async () => "",
+      } as Response);
+
+      try {
+        await get("/broken/");
+        throw new Error("unreachable");
+      } catch (error) {
+        expect(isHttpError(error)).toBe(true);
+        expect(isUnauthenticatedError(error)).toBe(false);
+        expect(error).toBeInstanceOf(HttpError);
+        expect(error).toBeInstanceOf(Error);
+      }
+
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe("getAuth", () => {
+    it("正常系: 有効なaccess tokenがあればBearerを付けて取得する", async () => {
+      getAccessTokenMock.mockResolvedValue("valid-token");
+      isExpiringSoonMock.mockReturnValue(false);
+
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 1 }),
+      } as Response);
+
+      const result = await getAuth<{ id: number }>("/concierge-threads/1/");
+
+      expect(result).toEqual({ id: 1 });
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/concierge-threads/1/"),
+        expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer valid-token" }) }),
+      );
+      fetchSpy.mockRestore();
+    });
+
+    it("回帰テスト: access tokenもrefresh tokenも無い場合はUnauthenticatedErrorを投げる(fetchを呼ばない)", async () => {
+      getAccessTokenMock.mockResolvedValue(null);
+      getRefreshTokenMock.mockResolvedValue(null);
+
+      const fetchSpy = vi.spyOn(global, "fetch");
+
+      await expect(getAuth("/concierge-threads/")).rejects.toBeInstanceOf(UnauthenticatedError);
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      fetchSpy.mockRestore();
+    });
+
+    it("回帰テスト: 初回401後にrefresh成功したら新tokenで再試行する", async () => {
+      getAccessTokenMock.mockResolvedValue("expiring-token");
+      isExpiringSoonMock.mockReturnValue(false);
+      getRefreshTokenMock.mockResolvedValue("refresh-token");
+
+      const fetchSpy = vi
+        .spyOn(global, "fetch")
+        .mockResolvedValueOnce({ ok: false, status: 401, statusText: "Unauthorized", text: async () => "" } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ access: "new-token" }) } as Response)
+        .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: 2 }) } as Response);
+
+      const result = await getAuth<{ id: number }>("/concierge-threads/2/");
+
+      expect(result).toEqual({ id: 2 });
+      expect(setAccessTokenMock).toHaveBeenCalledWith("new-token");
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      fetchSpy.mockRestore();
+    });
+
+    it("回帰テスト: 初回401後にrefreshが失敗したらUnauthenticatedErrorを投げる", async () => {
+      getAccessTokenMock.mockResolvedValue("expired-token");
+      isExpiringSoonMock.mockReturnValue(false);
+      getRefreshTokenMock.mockResolvedValue("refresh-token");
+
+      const fetchSpy = vi
+        .spyOn(global, "fetch")
+        .mockResolvedValueOnce({ ok: false, status: 401, statusText: "Unauthorized", text: async () => "" } as Response)
+        .mockResolvedValueOnce({ ok: false, status: 401, statusText: "Unauthorized", text: async () => "" } as Response);
+
+      await expect(getAuth("/concierge-threads/")).rejects.toBeInstanceOf(UnauthenticatedError);
+      fetchSpy.mockRestore();
+    });
+
+    it("異常系: 401以外の異常応答(403)はstatus=403のHttpErrorを投げる", async () => {
+      getAccessTokenMock.mockResolvedValue("valid-token");
+      isExpiringSoonMock.mockReturnValue(false);
+
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        text: async () => "forbidden",
+      } as Response);
+
+      await expect(getAuth("/concierge-threads/")).rejects.toMatchObject({ name: "HttpError", status: 403 });
+      fetchSpy.mockRestore();
+    });
+
+    it("異常系: 404はstatus=404のHttpErrorを投げる", async () => {
+      getAccessTokenMock.mockResolvedValue("valid-token");
+      isExpiringSoonMock.mockReturnValue(false);
+
+      const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        text: async () => "not found",
+      } as Response);
+
+      await expect(getAuth("/concierge-threads/999/")).rejects.toMatchObject({ name: "HttpError", status: 404 });
+      fetchSpy.mockRestore();
+    });
+  });
+});

--- a/apps/mobile/lib/consultationHistory.ts
+++ b/apps/mobile/lib/consultationHistory.ts
@@ -11,21 +11,73 @@ export type ConciergeThreadListItem = {
   message_count: number;
 };
 
+// Backend契約(GET /concierge-threads/{id}/, ConciergeThreadDetailView)は
+// id/title/last_message/last_message_at/message_count/messages/recommendations/recommendations_v2を
+// トップレベルに持つフラットな構造で返す(`thread`という入れ子キーは存在しない)。
+export type ConciergeMessage = {
+  id: number;
+  role: "user" | "assistant" | "system";
+  content: string;
+  created_at: string | null;
+};
+
+// 推薦itemはConcierge Chat応答と同じ生のsnake_case構造(Snapshotとして保存されたもの)。
+// Fact/Interpretation/Action等の構造化fieldは既存の共通ロジック(recommendationReasonV4.ts)で正規化する。
+export type ConciergeRecommendation = {
+  id?: number | string | null;
+  shrine_id?: number | string | null;
+  name?: string | null;
+  display_name?: string | null;
+  address?: string | null;
+  location?: string | null;
+  formatted_address?: string | null;
+  action_state?: "reflected" | "visited" | "saved" | "detail_viewed" | "route_opened" | "none" | null;
+  recommendation_reason_v4?: string | null;
+  reason_facts?: unknown;
+  recommendation_reason_detail?: unknown;
+  recommendation_reason_v4_detail?: unknown;
+  action_suggestion_v4_preview?: unknown;
+};
+
+export type ConciergeThreadDetail = {
+  id: number;
+  title: string;
+  last_message: string;
+  last_message_at: string | null;
+  message_count: number;
+  messages: ConciergeMessage[];
+  recommendations?: ConciergeRecommendation[] | null;
+  recommendations_v2?: ConciergeRecommendation[] | null;
+};
+
 type PaginatedResponse<T> = {
   results: T[];
 };
 
+// 401(UnauthenticatedError)・404等を握りつぶさない生の取得関数。
+// History画面はこちらを使い、未ログインと0件を呼び出し側で区別すること。
+export async function fetchConciergeThreadsRaw(): Promise<ConciergeThreadListItem[]> {
+  const data = await getAuth<ConciergeThreadListItem[] | PaginatedResponse<ConciergeThreadListItem>>(
+    "/concierge-threads/",
+  );
+
+  return Array.isArray(data) ? data : (data.results ?? []);
+}
+
+// 既存呼び出し元向けの後方互換ラッパー。401/403/network error等はすべて空配列へfallbackする
+// (「0件」と「未認証」を区別できない既知の制約。区別が必要な場合はfetchConciergeThreadsRawを使うこと)。
 export async function listConciergeThreads(): Promise<ConciergeThreadListItem[]> {
   try {
-    const data = await getAuth<ConciergeThreadListItem[] | PaginatedResponse<ConciergeThreadListItem>>(
-      "/concierge-threads/",
-    );
-
-    return Array.isArray(data) ? data : (data.results ?? []);
+    return await fetchConciergeThreadsRaw();
   } catch (error) {
     if (__DEV__) {
       console.warn("[listConciergeThreads] failed", error);
     }
     return [];
   }
+}
+
+// 401(UnauthenticatedError)・404(HttpError)を握りつぶさない。呼び出し側で状態を区別すること。
+export async function getConciergeThread(tid: string): Promise<ConciergeThreadDetail> {
+  return getAuth<ConciergeThreadDetail>(`/concierge-threads/${encodeURIComponent(tid)}/`);
 }

--- a/apps/mobile/lib/consultationHistoryUi.ts
+++ b/apps/mobile/lib/consultationHistoryUi.ts
@@ -1,0 +1,99 @@
+// apps/mobile/lib/consultationHistoryUi.ts
+//
+// 相談履歴の一覧・詳細Screen(apps/mobile/app/consultation-history/)が使う表示用の純粋関数。
+// vitestのtest discovery(vitest.config.ts)はlib/__tests__/配下の.test.tsのみを対象とするため、
+// Screen(.tsx)側に置くとテスト対象外になってしまう。単体テスト可能にするためlib側へ切り出す。
+import { isHttpError, isUnauthenticatedError } from "./http";
+import type { ConciergeRecommendation, ConciergeThreadListItem } from "./consultationHistory";
+
+// 401(UnauthenticatedError)と、それ以外(403/404/network error等)を区別する。
+// 「未ログイン」と「取得失敗」を同じメッセージへ握り潰さないための分類関数。
+export function classifyThreadsLoadError(error: unknown): "unauthenticated" | "error" {
+  return isUnauthenticatedError(error) ? "unauthenticated" : "error";
+}
+
+// 401(UnauthenticatedError)・404(HttpError)・その他(network error等)を区別する。
+// 「未ログイン」「不正または存在しないtid」「取得失敗」を同じ状態へ握り潰さないための分類関数。
+export function classifyThreadDetailLoadError(error: unknown): "unauthenticated" | "not_found" | "error" {
+  if (isUnauthenticatedError(error)) return "unauthenticated";
+  if (isHttpError(error) && error.status === 404) return "not_found";
+  return "error";
+}
+
+export function formatThreadDate(value: string | null | undefined): string {
+  if (!value) return "日付未記録";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "日付未記録";
+
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+export function formatThreadDateTime(value: string | null | undefined): string {
+  if (!value) return "日時未記録";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "日時未記録";
+
+  return date.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export function formatThreadDateGroupLabel(value: string | null | undefined): string {
+  if (!value) return "日付未記録";
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "日付未記録";
+
+  return date.toLocaleDateString("ja-JP", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+  });
+}
+
+export function normalizeThreadPreview(value: string | null | undefined): string {
+  const text = String(value ?? "").replace(/\s+/g, " ").trim();
+  return text || "相談内容はまだ記録されていません。";
+}
+
+export type ConsultationGroup = {
+  label: string;
+  items: ConciergeThreadListItem[];
+};
+
+export function groupThreadsByDate(threads: ConciergeThreadListItem[]): ConsultationGroup[] {
+  const groups = new Map<string, ConciergeThreadListItem[]>();
+
+  threads.forEach((thread) => {
+    const label = formatThreadDateGroupLabel(thread.last_message_at);
+    const current = groups.get(label) ?? [];
+    current.push(thread);
+    groups.set(label, current);
+  });
+
+  return Array.from(groups.entries()).map(([label, items]) => ({ label, items }));
+}
+
+export const ACTION_STATE_LABEL: Partial<Record<NonNullable<ConciergeRecommendation["action_state"]>, string>> = {
+  saved: "気になる登録済み",
+  visited: "参拝済み",
+  reflected: "振り返り済み",
+};
+
+export function extractRecommendationShrineId(rec: ConciergeRecommendation): string | null {
+  const raw = rec.shrine_id ?? rec.id;
+  if (raw === null || raw === undefined) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? String(n) : null;
+}

--- a/apps/mobile/lib/http.ts
+++ b/apps/mobile/lib/http.ts
@@ -13,6 +13,22 @@ export function isUnauthenticatedError(error: unknown): error is Unauthenticated
   return error instanceof UnauthenticatedError;
 }
 
+// HTTPステータスを保持するエラー。401(UnauthenticatedError)以外の異常応答(403/404/500等)を
+// 呼び出し側がstatusで区別できるようにする(メッセージ文字列のparseに頼らない)。
+export class HttpError extends Error {
+  status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+export function isHttpError(error: unknown): error is HttpError {
+  return error instanceof HttpError;
+}
+
 type TokenRefreshResponse = {
   access: string;
 };
@@ -63,7 +79,7 @@ async function request<T>(path: string, init: RequestInit): Promise<T> {
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
+    throw new HttpError(res.status, `HTTP ${res.status}: ${text || res.statusText}`);
   }
 
   return (await res.json()) as T;
@@ -87,7 +103,7 @@ async function requestAuth<T>(path: string, init: RequestInit): Promise<T> {
   if (first.status !== 401) {
     if (!first.ok) {
       const text = await first.text().catch(() => "");
-      throw new Error(`HTTP ${first.status}: ${text || first.statusText}`);
+      throw new HttpError(first.status, `HTTP ${first.status}: ${text || first.statusText}`);
     }
     return (await first.json()) as T;
   }
@@ -112,7 +128,7 @@ async function requestAuth<T>(path: string, init: RequestInit): Promise<T> {
 
   if (!retry.ok) {
     const text = await retry.text().catch(() => "");
-    throw new Error(`HTTP ${retry.status}: ${text || retry.statusText}`);
+    throw new HttpError(retry.status, `HTTP ${retry.status}: ${text || retry.statusText}`);
   }
 
   return (await retry.json()) as T;


### PR DESCRIPTION
## 背景

`docs/product/history-recommendation-navigation-design.md`で設計済みのHistory Navigation機能のうち、Mobile側の一覧・詳細画面を実装する。Web側は[PR #2215](https://github.com/etsu33/jinja_app/pull/2215)で実装・マージ済み。

## 変更内容

### 新規・修正画面
- `apps/mobile/app/consultation-history/index.tsx`(既存、修正): カードタップで詳細画面へ遷移する導線を追加、Loading/未ログイン/Error+Retry/Empty/正常表示の状態を分離
- `apps/mobile/app/consultation-history/[id].tsx`(新規): 詳細画面。Consultation Snapshot(会話履歴)、Recommendation Snapshot(推薦神社カード、Fact要約、action_stateバッジ)、Shrine Detailへの導線を実装
- `apps/mobile/app/mypage/index.tsx`: 「相談」セクションに「相談履歴」カードを追加(既存はどこからも遷移できないデッドエンド画面だったため、MyPageからの導線を新設)
- `apps/mobile/app/_layout.tsx`: `consultation-history/[id]`を非表示Tabs.Screenとして登録

### 発見した既存バグの修正(実装の前提として必要だったため対応)
- `listConciergeThreads()`は401/403/network error等すべてを空配列へ握り潰す実装で、この関数だけに頼ると「未ログイン」を「履歴0件」と誤表示してしまう既知の制約があった(既存の回帰テストのコメントにも明記済み)。この関数自体の契約は変更せず、握り潰さない`fetchConciergeThreadsRaw()`を新設し、History画面はこちらを使うことで「未ログイン」と「0件」を区別する
- `apps/mobile/lib/http.ts`にstatusを保持する`HttpError`を追加(既存の`Error`は`HTTP {status}: ...`という文字列にstatusを埋め込むのみで、呼び出し側がstatusで分岐できなかった)。既存の`UnauthenticatedError`は変更なし、`HttpError`は`Error`のサブクラスのため既存の呼び出し元への影響はない

### API契約監査
- Django実装(`ConciergeThreadListView`/`ConciergeThreadDetailView`)を根拠に、Mobile側の型をフラット構造(`{id, title, last_message, last_message_at, message_count, messages, recommendations, recommendations_v2}`)に合わせて追加した(`ConciergeThreadDetail`/`ConciergeMessage`/`ConciergeRecommendation`)
- Web側の`.thread`参照を再監査した結果、`ConciergeThreadDetail`型としてのネスト参照は残っていないことを確認済み(PR #2215で修正済み)。Web側の追加修正は行っていない

### UI State / 認証エラー処理
- List: Loading/未ログイン/Error+Retry/Empty(0件)/正常表示を分離。未ログインは`AuthPrompt`(既存コンポーネント、`premium/index.tsx`と同じパターン)で表示し、「まだ相談履歴がありません」とは異なるメッセージにした
- Detail: Loading/未ログイン/不正または存在しないtid(404)/Error+Retry/正常表示を分離。Detail APIは`AllowAny`+所有者チェックのみで401/403を返さないため(Backend実装で確認済み)、未ログインは`getConciergeThread`が`UnauthenticatedError`を投げた時点(=有効なaccess/refresh tokenが無い)で判定している。403は理論上到達しないため専用状態は設けず、到達した場合もerrorとして扱う(母艦判断待ち項目として後述)
- 401(UnauthenticatedError)と403/404等(HttpError)を同一メッセージへ握り潰さないよう、`classifyThreadsLoadError`/`classifyThreadDetailLoadError`という分類関数に切り出した

### Shrine Detailへの遷移
- 既存のConcierge→Shrine Detail連携(`apps/mobile/app/concierge/index.tsx`の`handleDetail`)と全く同じroute paramsの構造(`recommendationReasonV4`/`reasonFacts`/`recommendationReasonDetail`/`actionSuggestionV4Preview`/`recommendationReasonV4Detail`)を再利用した。Shrine Detail側(`apps/mobile/app/shrines/[id].tsx`)は無改修
- Fact抽出は既存の共通ロジック(`recommendationReasonV4.ts`の`buildReasonV4Sections`/`normalizeRecommendationReasonV4Detail`/`serializeReasonV4Detail`)をそのまま再利用し、History専用の新しいロジックは追加していない

## テスト

- `lib/__tests__/http.test.ts`(新規): `HttpError`/`isHttpError`、`getAuth`のtoken無し/refresh成功/refresh失敗/401以外のstatus伝播を検証
- `lib/__tests__/consultationHistory.test.ts`(拡張): `fetchConciergeThreadsRaw`/`getConciergeThread`の正常系・401・403・404・network errorでの例外伝播、フラットレスポンス型との整合を検証
- `lib/__tests__/consultationHistoryUi.test.ts`(新規): List/Detail画面が使う分類関数・日付整形・グルーピング・Fact抽出等の純粋関数を検証
- vitest.config.tsの`include`が`lib/__tests__/**/*.test.ts`のみを対象とし、Screen(`.tsx`)配下は対象外のため、Screenの状態分岐ロジック(401/403/404の区別、日付整形等)は`apps/mobile/lib/consultationHistoryUi.ts`へ切り出してテスト可能にした
- `npm run typecheck`: エラーなし
- `npm run test`: 22 files / 235 tests 全通過(新規15件程度含む)
- pre-push hook: OpenAPI lint・Web契約テスト通過

## Mobile QA

iOS Simulatorでのbuild(`expo run:ios`)は、ホストのXcode SDK(iOS 26.5)とインストール済みシミュレータランタイム(iOS 26.0/26.1)の不一致により実行できない(Xcode Platform Componentの追加インストールが必要でパスワードが必要なため対応不可)。過去のセッションと同様にExpo Web(`npm run web`)へ切り替えてQAを実施した。

Backend + Expo Webを起動し、テストユーザー・テストスレッド(推薦神社1件付き)を作成して確認した。

- 未ログイン: MyPage→「相談履歴」カードで一覧へ遷移し、「ログインが必要です」(Emptyとは別メッセージ)+ `AuthPrompt`モーダルを確認
- ログイン後: 一覧にタイトル・日付・要約・件数を表示、カードタップで詳細画面へ遷移することを確認
- 詳細画面: 会話履歴、推薦神社カード(Fact優先順位どおり`deity`を表示、住所は別枠)を確認。`action_state`バッジは、Backendが読み取り時に実際のFavorite等の記録から都度再計算する仕様のため、QA用に該当レコードを作らなかった今回は正しく非表示だった(Snapshotの値をそのまま信用しない、という既存契約どおりの動作)
- 「神社の詳細を見る」から遷移し、Shrine Detail側が無改修でFact/Interpretation/Actionを表示することを確認
- 不正なtid(Direct Navigation)で「この相談は見つかりませんでした」を確認
- コンソール・サーバーログにエラーなし
- QA用データ・サーバーは作業後にクリーンアップ済み

## 対象外(本PRでは行っていない)

- Backend/Web/OpenAPI本体/CI workflowの変更
- History Analytics実装
- Premium導線の同時実装
- Reflection Timelineの同時改修
- 推薦神社カードでの現在Shrine API参照によるname/address上書き(Snapshot値をそのまま使用。Web側と同じ簡易実装)

## 母艦判断待ち項目

- Detail APIが403を返すことは現状のBackend実装(`AllowAny`+所有者チェックのみ、該当しなければ404)では構造的に発生しないが、チェックリストが401/403を明示的に要求していたため、403が発生した場合の扱い(現状はerrorとして扱う)がこのままでよいか
- `action_state`バッジのラベル(`saved`/`visited`/`reflected`のみ)を、Backendが実際に返しうる`detail_viewed`/`route_opened`まで拡張するかどうか(Web側の`ConciergeRecommendation.action_state`型も同様に未対応)

## マージについて

**本PRはマージせず、母艦判断待ちとします。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)