### PR TITLE
feat(analytics): 相談履歴導線にAnalytics Eventを実装

### DIFF
--- a/apps/mobile/app/consultation-history/[id].tsx
+++ b/apps/mobile/app/consultation-history/[id].tsx
@@ -18,6 +18,11 @@ import {
   normalizeRecommendationReasonV4Detail,
   serializeReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
+import {
+  shouldTrackConsultationHistoryViewEvent,
+  trackConsultationHistoryDetailViewed,
+  trackConsultationHistoryShrineOpened,
+} from "../../lib/consultationHistoryAnalytics";
 import { StateCard } from "../../components/common/StateCard";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 import Button from "../../components/ui/Button";
@@ -28,10 +33,12 @@ import { radius } from "../../design/radius";
 
 function RecommendationCard({
   rec,
+  rank,
   onOpenShrineDetail,
 }: {
   rec: ConciergeRecommendation;
-  onOpenShrineDetail: (shrineId: string) => void;
+  rank: number;
+  onOpenShrineDetail: (shrineId: string, rank: number) => void;
 }) {
   const shrineId = extractRecommendationShrineId(rec);
   const name = rec.display_name?.trim() || rec.name?.trim() || "名称未設定の神社";
@@ -55,7 +62,7 @@ function RecommendationCard({
       {factText ? <Text style={styles.recommendationFact}>{factText}</Text> : null}
       {shrineId ? (
         <Pressable
-          onPress={() => onOpenShrineDetail(shrineId)}
+          onPress={() => onOpenShrineDetail(shrineId, rank)}
           accessibilityRole="button"
           accessibilityLabel={`${name}の詳細を見る`}
           style={styles.detailLink}
@@ -114,7 +121,11 @@ export default function ConsultationHistoryDetailScreen() {
   }, [state.kind]);
 
   const handleOpenShrineDetail = React.useCallback(
-    (shrineId: string, rec: ConciergeRecommendation) => {
+    (shrineId: string, rec: ConciergeRecommendation, recommendationRank: number) => {
+      if (tid) {
+        trackConsultationHistoryShrineOpened({ threadId: tid, shrineId, recommendationRank });
+      }
+
       const reasonV4Detail = normalizeRecommendationReasonV4Detail(rec.recommendation_reason_v4_detail);
       router.push({
         pathname: "/shrines/[id]",
@@ -132,8 +143,27 @@ export default function ConsultationHistoryDetailScreen() {
         },
       });
     },
-    [router],
+    [router, tid],
   );
+
+  // 認証済みかつ取得成功でthreadが正常表示された時点で、同一tidの同一マウント中に1回だけ発火する。
+  const trackedDetailViewTidRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    const isReady = state.kind === "ready" && tid != null;
+    const alreadyTracked = trackedDetailViewTidRef.current === tid;
+
+    if (!shouldTrackConsultationHistoryViewEvent({ isReady, alreadyTracked })) return;
+    if (state.kind !== "ready") return;
+
+    trackedDetailViewTidRef.current = tid ?? null;
+
+    const recommendations = state.thread.recommendations_v2 ?? state.thread.recommendations ?? [];
+    trackConsultationHistoryDetailViewed({
+      threadId: state.thread.id,
+      recommendationCount: recommendations.length,
+      messageCount: state.thread.messages.length,
+    });
+  }, [state, tid]);
 
   const recommendations =
     state.kind === "ready" ? (state.thread.recommendations_v2 ?? state.thread.recommendations ?? []) : [];
@@ -203,7 +233,8 @@ export default function ConsultationHistoryDetailScreen() {
                     <RecommendationCard
                       key={`${extractRecommendationShrineId(rec) ?? rec.name ?? "rec"}-${idx}`}
                       rec={rec}
-                      onOpenShrineDetail={(shrineId) => handleOpenShrineDetail(shrineId, rec)}
+                      rank={idx + 1}
+                      onOpenShrineDetail={(shrineId, rank) => handleOpenShrineDetail(shrineId, rec, rank)}
                     />
                   ))}
                 </View>

--- a/apps/mobile/app/consultation-history/index.tsx
+++ b/apps/mobile/app/consultation-history/index.tsx
@@ -9,6 +9,11 @@ import {
   groupThreadsByDate,
   normalizeThreadPreview,
 } from "../../lib/consultationHistoryUi";
+import {
+  shouldTrackConsultationHistoryViewEvent,
+  trackConsultationHistoryDetailOpened,
+  trackConsultationHistoryListViewed,
+} from "../../lib/consultationHistoryAnalytics";
 import { StateCard } from "../../components/common/StateCard";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 import Button from "../../components/ui/Button";
@@ -96,6 +101,23 @@ export default function ConsultationHistoryScreen() {
     if (state.kind === "unauthenticated") setAuthPromptVisible(true);
   }, [state.kind]);
 
+  // 認証済みかつ取得成功で一覧が表示可能になった時点で1回だけ発火する(0件でも発火する)。
+  // Pull to Refresh・Retryによる再取得やその他の再レンダーでは再発火しない。
+  const hasTrackedListViewRef = React.useRef(false);
+  React.useEffect(() => {
+    if (
+      !shouldTrackConsultationHistoryViewEvent({
+        isReady: state.kind === "ready",
+        alreadyTracked: hasTrackedListViewRef.current,
+      })
+    ) {
+      return;
+    }
+
+    hasTrackedListViewRef.current = true;
+    trackConsultationHistoryListViewed({ historyCount: threads.length });
+  }, [state.kind, threads.length]);
+
   return (
     <>
       <ScrollView
@@ -159,12 +181,15 @@ export default function ConsultationHistoryScreen() {
                     <ConsultationCard
                       key={thread.id}
                       thread={thread}
-                      onPress={() =>
+                      onPress={() => {
+                        // 日付グループごとの添字ではなく、一覧全体(threads)内での1始まりpositionを送る。
+                        const position = threads.findIndex((t) => t.id === thread.id) + 1;
+                        trackConsultationHistoryDetailOpened({ threadId: thread.id, position });
                         router.push({
                           pathname: "/consultation-history/[id]",
                           params: { id: String(thread.id) },
-                        })
-                      }
+                        });
+                      }}
                     />
                   ))}
                 </View>

--- a/apps/mobile/app/mypage/index.tsx
+++ b/apps/mobile/app/mypage/index.tsx
@@ -6,6 +6,7 @@ import { getFavoriteShrines, getRecentViewed } from "../../lib/shrineStorage";
 import { getCounts } from "../../lib/storage";
 import { getAuthenticatedBillingStatus, isPremiumStatus, type BillingStatus } from "../../lib/billing";
 import { isUnauthenticatedError } from "../../lib/http";
+import { trackConsultationHistoryEntryClicked } from "../../lib/consultationHistoryAnalytics";
 
 type PremiumMetaState =
   | { kind: "loading" }
@@ -187,7 +188,10 @@ export default function MyPageScreen() {
           description="これまでの相談と、当時推薦された神社を見返せます。"
           iconText="談"
           actionLabel="開く"
-          onPress={() => router.push("/consultation-history")}
+          onPress={() => {
+            trackConsultationHistoryEntryClicked();
+            router.push("/consultation-history");
+          }}
         />
       </View>
 

--- a/apps/mobile/lib/__tests__/consultationHistoryAnalytics.test.ts
+++ b/apps/mobile/lib/__tests__/consultationHistoryAnalytics.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// __DEV__ は Metro/React Native が注入するグローバルで、vitest実行環境には存在しないため定義する。
+(globalThis as unknown as { __DEV__: boolean }).__DEV__ = false;
+
+import { setAnalyticsProvider, type AnalyticsProvider } from "../analytics";
+import {
+  shouldTrackConsultationHistoryViewEvent,
+  trackConsultationHistoryDetailOpened,
+  trackConsultationHistoryDetailViewed,
+  trackConsultationHistoryEntryClicked,
+  trackConsultationHistoryListViewed,
+  trackConsultationHistoryShrineOpened,
+} from "../consultationHistoryAnalytics";
+
+describe("consultationHistoryAnalytics", () => {
+  const trackSpy = vi.fn();
+
+  beforeEach(() => {
+    const customProvider: AnalyticsProvider = { track: trackSpy };
+    setAnalyticsProvider(customProvider);
+  });
+
+  afterEach(() => {
+    trackSpy.mockClear();
+    setAnalyticsProvider(null);
+  });
+
+  it("trackConsultationHistoryEntryClicked: platform:mobile/source:mypageを送る", () => {
+    trackConsultationHistoryEntryClicked();
+
+    expect(trackSpy).toHaveBeenCalledWith("consultation_history_entry_clicked", {
+      platform: "mobile",
+      source: "mypage",
+    });
+  });
+
+  it("trackConsultationHistoryListViewed: historyCountを送る", () => {
+    trackConsultationHistoryListViewed({ historyCount: 3 });
+
+    expect(trackSpy).toHaveBeenCalledWith("consultation_history_list_viewed", {
+      platform: "mobile",
+      source: "consultation_history",
+      historyCount: 3,
+    });
+  });
+
+  it("trackConsultationHistoryListViewed: 0件でもhistoryCount:0を送る", () => {
+    trackConsultationHistoryListViewed({ historyCount: 0 });
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      "consultation_history_list_viewed",
+      expect.objectContaining({ historyCount: 0 }),
+    );
+  });
+
+  it("trackConsultationHistoryDetailOpened: threadId・positionを送る", () => {
+    trackConsultationHistoryDetailOpened({ threadId: 42, position: 1 });
+
+    expect(trackSpy).toHaveBeenCalledWith("consultation_history_detail_opened", {
+      platform: "mobile",
+      source: "consultation_history_list",
+      threadId: 42,
+      position: 1,
+    });
+  });
+
+  it("trackConsultationHistoryDetailViewed: threadId・recommendationCount・messageCountを送る", () => {
+    trackConsultationHistoryDetailViewed({ threadId: "42", recommendationCount: 2, messageCount: 5 });
+
+    expect(trackSpy).toHaveBeenCalledWith("consultation_history_detail_viewed", {
+      platform: "mobile",
+      source: "consultation_history_detail",
+      threadId: "42",
+      recommendationCount: 2,
+      messageCount: 5,
+    });
+  });
+
+  it("trackConsultationHistoryShrineOpened: threadId・shrineId・recommendationRankを送る", () => {
+    trackConsultationHistoryShrineOpened({ threadId: 42, shrineId: 5, recommendationRank: 2 });
+
+    expect(trackSpy).toHaveBeenCalledWith("consultation_history_shrine_opened", {
+      platform: "mobile",
+      source: "consultation_history_detail",
+      threadId: 42,
+      shrineId: 5,
+      recommendationRank: 2,
+    });
+  });
+
+  it("全EventのPayloadはprimitive値のみで構成される(nested object・配列を含まない)", () => {
+    trackConsultationHistoryEntryClicked();
+    trackConsultationHistoryListViewed({ historyCount: 1 });
+    trackConsultationHistoryDetailOpened({ threadId: 1, position: 1 });
+    trackConsultationHistoryDetailViewed({ threadId: 1, recommendationCount: 1, messageCount: 1 });
+    trackConsultationHistoryShrineOpened({ threadId: 1, shrineId: 1, recommendationRank: 1 });
+
+    for (const call of trackSpy.mock.calls) {
+      const payload = call[1] as Record<string, unknown>;
+      for (const value of Object.values(payload)) {
+        expect(["string", "number", "boolean"].includes(typeof value)).toBe(true);
+      }
+    }
+  });
+
+  it("禁止Payload: 相談本文・タイトル・住所・緯度経度等を一切含まない", () => {
+    trackConsultationHistoryEntryClicked();
+    trackConsultationHistoryListViewed({ historyCount: 1 });
+    trackConsultationHistoryDetailOpened({ threadId: 1, position: 1 });
+    trackConsultationHistoryDetailViewed({ threadId: 1, recommendationCount: 1, messageCount: 1 });
+    trackConsultationHistoryShrineOpened({ threadId: 1, shrineId: 1, recommendationRank: 1 });
+
+    const forbiddenKeys = [
+      "title",
+      "content",
+      "message",
+      "lastMessage",
+      "reasonText",
+      "recommendationReason",
+      "address",
+      "latitude",
+      "longitude",
+      "username",
+      "email",
+      "token",
+    ];
+
+    for (const call of trackSpy.mock.calls) {
+      const payload = call[1] as Record<string, unknown>;
+      for (const key of forbiddenKeys) {
+        expect(payload).not.toHaveProperty(key);
+      }
+    }
+  });
+
+  it("providerが例外を投げてもUI側(呼び出し元)へ伝播しない", () => {
+    setAnalyticsProvider({
+      track: () => {
+        throw new Error("provider failed");
+      },
+    });
+
+    expect(() => trackConsultationHistoryEntryClicked()).not.toThrow();
+    expect(() => trackConsultationHistoryListViewed({ historyCount: 0 })).not.toThrow();
+  });
+});
+
+describe("shouldTrackConsultationHistoryViewEvent", () => {
+  it("readyかつ未送信ならtrueを返す", () => {
+    expect(shouldTrackConsultationHistoryViewEvent({ isReady: true, alreadyTracked: false })).toBe(true);
+  });
+
+  it("readyだが送信済みならfalseを返す(重複防止)", () => {
+    expect(shouldTrackConsultationHistoryViewEvent({ isReady: true, alreadyTracked: true })).toBe(false);
+  });
+
+  it("ready未達(loading/unauthenticated/fetchFailed等)ならfalseを返す", () => {
+    expect(shouldTrackConsultationHistoryViewEvent({ isReady: false, alreadyTracked: false })).toBe(false);
+    expect(shouldTrackConsultationHistoryViewEvent({ isReady: false, alreadyTracked: true })).toBe(false);
+  });
+});

--- a/apps/mobile/lib/consultationHistoryAnalytics.ts
+++ b/apps/mobile/lib/consultationHistoryAnalytics.ts
@@ -1,0 +1,81 @@
+// apps/mobile/lib/consultationHistoryAnalytics.ts
+//
+// 相談履歴導線(MyPage入口・一覧表示・一覧→詳細遷移・詳細表示・詳細→神社詳細遷移)の
+// Analytics契約を集約するhelper。Event名・Payload・発火条件の根拠は
+// docs/analytics/consultation-history-events.md を正本とする。
+//
+// track()自体がnull/undefined除去・primitive型への制限・送信失敗の握り潰しを担うため、
+// ここではEvent名とPayloadの組み立てのみに責務を絞る(画面からPostHog providerを直接呼ばない)。
+import { track } from "./analytics";
+
+const PLATFORM = "mobile";
+const SOURCE_MYPAGE = "mypage";
+const SOURCE_LIST = "consultation_history";
+const SOURCE_LIST_CARD = "consultation_history_list";
+const SOURCE_DETAIL = "consultation_history_detail";
+
+export function trackConsultationHistoryEntryClicked(): void {
+  track("consultation_history_entry_clicked", {
+    platform: PLATFORM,
+    source: SOURCE_MYPAGE,
+  });
+}
+
+export function trackConsultationHistoryListViewed(params: { historyCount: number }): void {
+  track("consultation_history_list_viewed", {
+    platform: PLATFORM,
+    source: SOURCE_LIST,
+    historyCount: params.historyCount,
+  });
+}
+
+export function trackConsultationHistoryDetailOpened(params: {
+  threadId: string | number;
+  position: number;
+}): void {
+  track("consultation_history_detail_opened", {
+    platform: PLATFORM,
+    source: SOURCE_LIST_CARD,
+    threadId: params.threadId,
+    position: params.position,
+  });
+}
+
+export function trackConsultationHistoryDetailViewed(params: {
+  threadId: string | number;
+  recommendationCount: number;
+  messageCount: number;
+}): void {
+  track("consultation_history_detail_viewed", {
+    platform: PLATFORM,
+    source: SOURCE_DETAIL,
+    threadId: params.threadId,
+    recommendationCount: params.recommendationCount,
+    messageCount: params.messageCount,
+  });
+}
+
+export function trackConsultationHistoryShrineOpened(params: {
+  threadId: string | number;
+  shrineId: string | number;
+  recommendationRank: number;
+}): void {
+  track("consultation_history_shrine_opened", {
+    platform: PLATFORM,
+    source: SOURCE_DETAIL,
+    threadId: params.threadId,
+    shrineId: params.shrineId,
+    recommendationRank: params.recommendationRank,
+  });
+}
+
+// 画面の表示Event(list_viewed/detail_viewed)が「状態がreadyになった」かつ「まだ送っていない」
+// ときにのみ発火すべきかを判定する純粋関数。Screen側はuseRefで「送信済みか」を保持し、
+// 判定ロジックのみをここへ集約することでvitest.config.ts(lib/__tests__/配下のみ対象)で
+// テスト可能にする。
+export function shouldTrackConsultationHistoryViewEvent(params: {
+  isReady: boolean;
+  alreadyTracked: boolean;
+}): boolean {
+  return params.isReady && !params.alreadyTracked;
+}

--- a/apps/web/src/app/mypage/tests/consultation-history-entry.test.tsx
+++ b/apps/web/src/app/mypage/tests/consultation-history-entry.test.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import MyPageView from "@/components/views/MyPageView";
+
+const mocks = vi.hoisted(() => ({ trackConsultationHistoryEntryClicked: vi.fn() }));
+const initialUser = {
+  id: 1,
+  username: "tarou",
+  email: "tarou@example.com",
+  profile: { nickname: "太郎", is_public: true, birthday: null, birth_time: null, birth_place: "", worship_style: "" },
+};
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => "profile" }),
+}));
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: () => ({ user: initialUser, loading: false, isLoggedIn: true, refreshMe: vi.fn() }),
+}));
+vi.mock("@/lib/api/users", () => ({ updateUser: vi.fn() }));
+vi.mock("@/lib/analytics/consultationHistoryEvents", () => ({
+  trackConsultationHistoryEntryClicked: mocks.trackConsultationHistoryEntryClicked,
+}));
+
+describe("MyPage 相談履歴導線", () => {
+  it("相談履歴リンクは/mypage/historyを指し、クリックでconsultation_history_entry_clickedを送る", () => {
+    render(<MyPageView initialFavorites={[]} />);
+
+    const link = screen.getByRole("link", { name: "相談履歴" });
+    expect(link).toHaveAttribute("href", "/mypage/history");
+
+    fireEvent.click(link);
+
+    expect(mocks.trackConsultationHistoryEntryClicked).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/views/ConsultationHistoryDetailView.tsx
+++ b/apps/web/src/components/views/ConsultationHistoryDetailView.tsx
@@ -1,10 +1,15 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { buildLoginHref } from "@/lib/nav/login";
 import { pickReasonV4FactText } from "@/features/concierge/reasonV4FactPriority";
+import {
+  trackConsultationHistoryDetailViewed,
+  trackConsultationHistoryShrineOpened,
+} from "@/lib/analytics/consultationHistoryEvents";
 import type { ConciergeThreadDetail, ConciergeRecommendation } from "@/lib/api/concierge/types";
 
 type Props = {
@@ -38,7 +43,15 @@ function extractShrineId(rec: ConciergeRecommendation): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-function RecommendationCard({ rec, tid }: { rec: ConciergeRecommendation; tid: string }) {
+function RecommendationCard({
+  rec,
+  tid,
+  rank,
+}: {
+  rec: ConciergeRecommendation;
+  tid: string;
+  rank: number;
+}) {
   const shrineId = extractShrineId(rec);
   const factText = pickReasonV4FactText(rec.recommendation_reason_v4_detail?.fact);
   const actionLabel = rec.action_state ? ACTION_STATE_LABEL[rec.action_state] : null;
@@ -58,6 +71,9 @@ function RecommendationCard({ rec, tid }: { rec: ConciergeRecommendation; tid: s
       {shrineId != null ? (
         <Link
           href={`/shrines/${shrineId}?ctx=concierge&tid=${encodeURIComponent(tid)}`}
+          onClick={() =>
+            trackConsultationHistoryShrineOpened({ threadId: tid, shrineId, recommendationRank: rank })
+          }
           className="mt-3 inline-block text-xs font-semibold text-emerald-800 underline"
         >
           神社の詳細を見る
@@ -70,6 +86,21 @@ function RecommendationCard({ rec, tid }: { rec: ConciergeRecommendation; tid: s
 export default function ConsultationHistoryDetailView({ tid, thread, fetchFailed }: Props) {
   const { loading, isLoggedIn } = useAuth();
   const router = useRouter();
+
+  // 認証済みかつ取得成功でthreadが正常表示された時点で、同一tidの同一マウント中に1回だけ発火する。
+  const trackedDetailViewTidRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (loading || !isLoggedIn || fetchFailed || !thread) return;
+    if (trackedDetailViewTidRef.current === tid) return;
+    trackedDetailViewTidRef.current = tid;
+
+    const recommendations = thread.recommendations_v2 ?? thread.recommendations ?? [];
+    trackConsultationHistoryDetailViewed({
+      threadId: thread.id,
+      recommendationCount: recommendations.length,
+      messageCount: thread.messages.length,
+    });
+  }, [loading, isLoggedIn, fetchFailed, thread, tid]);
 
   if (loading) {
     return (
@@ -143,7 +174,12 @@ export default function ConsultationHistoryDetailView({ tid, thread, fetchFailed
           <h2 className="mb-2 text-sm font-semibold text-stone-700">当時推薦された神社</h2>
           <ul className="space-y-3">
             {recommendations.map((rec, idx) => (
-              <RecommendationCard key={`${extractShrineId(rec) ?? rec.name}-${idx}`} rec={rec} tid={tid} />
+              <RecommendationCard
+                key={`${extractShrineId(rec) ?? rec.name}-${idx}`}
+                rec={rec}
+                tid={tid}
+                rank={idx + 1}
+              />
             ))}
           </ul>
         </section>

--- a/apps/web/src/components/views/ConsultationHistoryListView.tsx
+++ b/apps/web/src/components/views/ConsultationHistoryListView.tsx
@@ -1,9 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { buildLoginHref } from "@/lib/nav/login";
+import {
+  trackConsultationHistoryDetailOpened,
+  trackConsultationHistoryListViewed,
+} from "@/lib/analytics/consultationHistoryEvents";
 import type { ConciergeThread } from "@/lib/api/concierge/types";
 
 type Props = {
@@ -26,6 +31,16 @@ function normalizePreview(value: string | null | undefined): string {
 export default function ConsultationHistoryListView({ initialThreads, fetchFailed }: Props) {
   const { loading, isLoggedIn } = useAuth();
   const router = useRouter();
+
+  // 認証済みかつ取得成功で一覧が表示可能になった時点で1回だけ発火する(0件でも発火する)。
+  // 再レンダーでの重複防止はhasTrackedListViewRefで行う。
+  const hasTrackedListViewRef = useRef(false);
+  useEffect(() => {
+    if (loading || !isLoggedIn || fetchFailed) return;
+    if (hasTrackedListViewRef.current) return;
+    hasTrackedListViewRef.current = true;
+    trackConsultationHistoryListViewed({ historyCount: initialThreads.length });
+  }, [loading, isLoggedIn, fetchFailed, initialThreads.length]);
 
   if (loading) {
     return (
@@ -92,10 +107,13 @@ export default function ConsultationHistoryListView({ initialThreads, fetchFaile
     <main className="mx-auto max-w-3xl p-6 text-stone-800">
       <h1 className="mb-4 text-xl font-semibold">相談履歴</h1>
       <ul className="space-y-3">
-        {initialThreads.map((thread) => (
+        {initialThreads.map((thread, idx) => (
           <li key={thread.id}>
             <Link
               href={`/mypage/history/${thread.id}`}
+              onClick={() =>
+                trackConsultationHistoryDetailOpened({ threadId: thread.id, position: idx + 1 })
+              }
               className="block rounded-2xl border border-stone-200/20 bg-stone-50/30 p-4 transition hover:bg-stone-50/60"
             >
               <div className="flex items-center justify-between gap-3">

--- a/apps/web/src/components/views/MyPageView.tsx
+++ b/apps/web/src/components/views/MyPageView.tsx
@@ -11,6 +11,7 @@ import FavoritesSection from "@/features/mypage/components/FavoritesSection";
 import Link from "next/link";
 import { buildLoginHref } from "@/lib/nav/login";
 import { buildDerivedProfile, buildDirectionProfile } from "@/lib/profile/derivedProfile";
+import { trackConsultationHistoryEntryClicked } from "@/lib/analytics/consultationHistoryEvents";
 
 type Props = { initialFavorites: Favorite[] };
 type MyPageTab = "profile" | "goshuin" | "favorites" | "submissions" | "visits";
@@ -279,6 +280,14 @@ export default function MyPageView({ initialFavorites }: Props) {
         <TabLink href="/mypage?tab=visits" active={tab === "visits"}>
           参拝履歴
         </TabLink>
+
+        <Link
+          href="/mypage/history"
+          onClick={() => trackConsultationHistoryEntryClicked()}
+          className="rounded-full border border-stone-200/20 bg-stone-50/20 px-3 py-1.5 text-sm text-stone-500 transition hover:bg-stone-100/40 hover:text-stone-800"
+        >
+          相談履歴
+        </Link>
       </div>
 
       {tab === "goshuin" ? (

--- a/apps/web/src/components/views/__tests__/ConsultationHistoryDetailView.test.tsx
+++ b/apps/web/src/components/views/__tests__/ConsultationHistoryDetailView.test.tsx
@@ -5,6 +5,8 @@ import type { ConciergeThreadDetail } from "@/lib/api/concierge/types";
 
 const refreshMock = vi.fn();
 const useAuthMock = vi.fn();
+const trackDetailViewedMock = vi.fn();
+const trackShrineOpenedMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: refreshMock, push: vi.fn() }),
@@ -12,6 +14,11 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/auth/AuthProvider", () => ({
   useAuth: () => useAuthMock(),
+}));
+
+vi.mock("@/lib/analytics/consultationHistoryEvents", () => ({
+  trackConsultationHistoryDetailViewed: (...args: unknown[]) => trackDetailViewedMock(...args),
+  trackConsultationHistoryShrineOpened: (...args: unknown[]) => trackShrineOpenedMock(...args),
 }));
 
 const THREAD: ConciergeThreadDetail = {
@@ -82,6 +89,13 @@ describe("ConsultationHistoryDetailView", () => {
     expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
+  it("fetchFailed時はdetail_viewedを送らない", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="42" thread={null} fetchFailed={true} />);
+
+    expect(trackDetailViewedMock).not.toHaveBeenCalled();
+  });
+
   it("Direct Navigation: 不正または存在しないtid(thread=null)のとき見つからない旨を表示する", () => {
     useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
     render(<ConsultationHistoryDetailView tid="999" thread={null} fetchFailed={false} />);
@@ -90,7 +104,14 @@ describe("ConsultationHistoryDetailView", () => {
     expect(screen.getByRole("link", { name: "相談履歴の一覧へ戻る" })).toHaveAttribute("href", "/mypage/history");
   });
 
-  it("正常系: 会話履歴と推薦神社カード、Fact要約、action_stateバッジを表示する", () => {
+  it("not_found(thread=null)時はdetail_viewedを送らない", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="999" thread={null} fetchFailed={false} />);
+
+    expect(trackDetailViewedMock).not.toHaveBeenCalled();
+  });
+
+  it("正常系: 会話履歴と推薦神社カード、Fact要約、action_stateバッジを表示し、detail_viewedを送る", () => {
     useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
     render(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
 
@@ -102,6 +123,25 @@ describe("ConsultationHistoryDetailView", () => {
     expect(screen.getByText("気になる登録済み")).toBeInTheDocument();
     // Fact優先順位: deityが最優先。place_context(住所)はFact本文として使われない。
     expect(screen.getByText("須佐之男命")).toBeInTheDocument();
+
+    expect(trackDetailViewedMock).toHaveBeenCalledWith({
+      threadId: 42,
+      recommendationCount: 1,
+      messageCount: 2,
+    });
+    expect(trackDetailViewedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("同一tidの再レンダーではdetail_viewedが重複発火しない", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    const { rerender } = render(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
+
+    expect(trackDetailViewedMock).toHaveBeenCalledTimes(1);
+
+    rerender(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
+    rerender(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
+
+    expect(trackDetailViewedMock).toHaveBeenCalledTimes(1);
   });
 
   it("Shrine Detail遷移: 推薦神社カードのリンクがctx=concierge&tidを維持する", () => {
@@ -112,5 +152,14 @@ describe("ConsultationHistoryDetailView", () => {
       "href",
       "/shrines/5?ctx=concierge&tid=42",
     );
+  });
+
+  it("神社詳細操作時にshrine_openedをthreadId・shrineId・recommendationRank(1始まり)で送る", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryDetailView tid="42" thread={THREAD} fetchFailed={false} />);
+
+    fireEvent.click(screen.getByRole("link", { name: "神社の詳細を見る" }));
+
+    expect(trackShrineOpenedMock).toHaveBeenCalledWith({ threadId: "42", shrineId: 5, recommendationRank: 1 });
   });
 });

--- a/apps/web/src/components/views/__tests__/ConsultationHistoryListView.test.tsx
+++ b/apps/web/src/components/views/__tests__/ConsultationHistoryListView.test.tsx
@@ -5,6 +5,8 @@ import type { ConciergeThread } from "@/lib/api/concierge/types";
 
 const refreshMock = vi.fn();
 const useAuthMock = vi.fn();
+const trackListViewedMock = vi.fn();
+const trackDetailOpenedMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ refresh: refreshMock, push: vi.fn() }),
@@ -12,6 +14,11 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("@/lib/auth/AuthProvider", () => ({
   useAuth: () => useAuthMock(),
+}));
+
+vi.mock("@/lib/analytics/consultationHistoryEvents", () => ({
+  trackConsultationHistoryListViewed: (...args: unknown[]) => trackListViewedMock(...args),
+  trackConsultationHistoryDetailOpened: (...args: unknown[]) => trackDetailOpenedMock(...args),
 }));
 
 const THREADS: ConciergeThread[] = [
@@ -43,6 +50,13 @@ describe("ConsultationHistoryListView", () => {
     );
   });
 
+  it("未ログイン時はlist_viewedを送らない", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: false });
+    render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={false} />);
+
+    expect(trackListViewedMock).not.toHaveBeenCalled();
+  });
+
   it("取得失敗時はError状態とRetry導線を表示し、クリックでrouter.refreshが呼ばれる", () => {
     useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
     render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={true} />);
@@ -52,15 +66,24 @@ describe("ConsultationHistoryListView", () => {
     expect(refreshMock).toHaveBeenCalledTimes(1);
   });
 
-  it("ログイン済みで0件のときEmpty状態を表示する", () => {
+  it("fetchFailed時はlist_viewedを送らない", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={true} />);
+
+    expect(trackListViewedMock).not.toHaveBeenCalled();
+  });
+
+  it("ログイン済みで0件のときEmpty状態を表示し、list_viewedをhistoryCount:0で送る", () => {
     useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
     render(<ConsultationHistoryListView initialThreads={[]} fetchFailed={false} />);
 
     expect(screen.getByText("まだ相談履歴がありません。")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "コンシェルジュに相談する" })).toHaveAttribute("href", "/concierge");
+    expect(trackListViewedMock).toHaveBeenCalledWith({ historyCount: 0 });
+    expect(trackListViewedMock).toHaveBeenCalledTimes(1);
   });
 
-  it("正常系: 相談履歴一覧を表示し、詳細画面へのリンクを持つ", () => {
+  it("正常系: 相談履歴一覧を表示し、詳細画面へのリンクを持ち、list_viewedを送る", () => {
     useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
     render(<ConsultationHistoryListView initialThreads={THREADS} fetchFailed={false} />);
 
@@ -68,5 +91,28 @@ describe("ConsultationHistoryListView", () => {
     expect(screen.getByText("仕事運の相談")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /縁結びの相談/ })).toHaveAttribute("href", "/mypage/history/1");
     expect(screen.getByRole("link", { name: /仕事運の相談/ })).toHaveAttribute("href", "/mypage/history/2");
+    expect(trackListViewedMock).toHaveBeenCalledWith({ historyCount: 2 });
+    expect(trackListViewedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("再レンダーではlist_viewedが重複発火しない", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    const { rerender } = render(<ConsultationHistoryListView initialThreads={THREADS} fetchFailed={false} />);
+
+    expect(trackListViewedMock).toHaveBeenCalledTimes(1);
+
+    rerender(<ConsultationHistoryListView initialThreads={THREADS} fetchFailed={false} />);
+    rerender(<ConsultationHistoryListView initialThreads={THREADS} fetchFailed={false} />);
+
+    expect(trackListViewedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("履歴カード操作時にdetail_openedをthreadId・position(1始まり)で送る", () => {
+    useAuthMock.mockReturnValue({ loading: false, isLoggedIn: true });
+    render(<ConsultationHistoryListView initialThreads={THREADS} fetchFailed={false} />);
+
+    fireEvent.click(screen.getByRole("link", { name: /仕事運の相談/ }));
+
+    expect(trackDetailOpenedMock).toHaveBeenCalledWith({ threadId: 2, position: 2 });
   });
 });

--- a/apps/web/src/lib/analytics/__tests__/consultationHistoryEvents.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/consultationHistoryEvents.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const trackMock = vi.fn();
+
+vi.mock("@/lib/analytics/track", () => ({
+  track: (...args: unknown[]) => trackMock(...args),
+}));
+
+import {
+  trackConsultationHistoryDetailOpened,
+  trackConsultationHistoryDetailViewed,
+  trackConsultationHistoryEntryClicked,
+  trackConsultationHistoryListViewed,
+  trackConsultationHistoryShrineOpened,
+} from "../consultationHistoryEvents";
+
+const FORBIDDEN_KEYS = [
+  "consultationSummary",
+  "title",
+  "content",
+  "message",
+  "reason",
+  "recommendationReason",
+  "address",
+  "lat",
+  "lng",
+  "latitude",
+  "longitude",
+];
+
+describe("consultationHistoryEvents", () => {
+  beforeEach(() => {
+    trackMock.mockReset();
+  });
+
+  it("trackConsultationHistoryEntryClicked: event名・platform・固定sourceを送る", () => {
+    trackConsultationHistoryEntryClicked();
+
+    expect(trackMock).toHaveBeenCalledWith("consultation_history_entry_clicked", {
+      platform: "web",
+      source: "mypage",
+    });
+  });
+
+  it("trackConsultationHistoryListViewed: historyCountを送る", () => {
+    trackConsultationHistoryListViewed({ historyCount: 3 });
+
+    expect(trackMock).toHaveBeenCalledWith("consultation_history_list_viewed", {
+      platform: "web",
+      source: "consultation_history",
+      historyCount: 3,
+    });
+  });
+
+  it("trackConsultationHistoryListViewed: 0件でもhistoryCount:0を送る", () => {
+    trackConsultationHistoryListViewed({ historyCount: 0 });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "consultation_history_list_viewed",
+      expect.objectContaining({ historyCount: 0 }),
+    );
+  });
+
+  it("trackConsultationHistoryDetailOpened: threadId・positionを送る", () => {
+    trackConsultationHistoryDetailOpened({ threadId: 42, position: 1 });
+
+    expect(trackMock).toHaveBeenCalledWith("consultation_history_detail_opened", {
+      platform: "web",
+      source: "consultation_history_list",
+      threadId: 42,
+      position: 1,
+    });
+  });
+
+  it("trackConsultationHistoryDetailViewed: threadId・recommendationCount・messageCountを送る", () => {
+    trackConsultationHistoryDetailViewed({ threadId: "42", recommendationCount: 2, messageCount: 5 });
+
+    expect(trackMock).toHaveBeenCalledWith("consultation_history_detail_viewed", {
+      platform: "web",
+      source: "consultation_history_detail",
+      threadId: "42",
+      recommendationCount: 2,
+      messageCount: 5,
+    });
+  });
+
+  it("trackConsultationHistoryShrineOpened: threadId・shrineId・recommendationRankを送る", () => {
+    trackConsultationHistoryShrineOpened({ threadId: 42, shrineId: 5, recommendationRank: 2 });
+
+    expect(trackMock).toHaveBeenCalledWith("consultation_history_shrine_opened", {
+      platform: "web",
+      source: "consultation_history_detail",
+      threadId: 42,
+      shrineId: 5,
+      recommendationRank: 2,
+    });
+  });
+
+  it("禁止Payload: いずれのEventも相談本文・タイトル・住所等のkeyを含まない", () => {
+    trackConsultationHistoryEntryClicked();
+    trackConsultationHistoryListViewed({ historyCount: 1 });
+    trackConsultationHistoryDetailOpened({ threadId: 1, position: 1 });
+    trackConsultationHistoryDetailViewed({ threadId: 1, recommendationCount: 1, messageCount: 1 });
+    trackConsultationHistoryShrineOpened({ threadId: 1, shrineId: 1, recommendationRank: 1 });
+
+    for (const call of trackMock.mock.calls) {
+      const payload = call[1] as Record<string, unknown>;
+      for (const forbiddenKey of FORBIDDEN_KEYS) {
+        expect(payload).not.toHaveProperty(forbiddenKey);
+      }
+    }
+  });
+
+  it("Helperはtrack()を薄くラップするのみで、独自のtry/catchを持たない", () => {
+    // track()自体(apps/web/src/lib/analytics/track.ts)が本番環境での送信失敗を
+    // 内部で握り潰す実装であることは track.test.ts で検証済み。
+    // ここでは、本Helperがtrack()の例外をさらに握り潰す独自のtry/catchを持たない
+    // (=障害の握り潰しをtrack()へ一本化している)ことを、mockの例外がそのまま
+    // 伝播することで確認する。
+    trackMock.mockImplementationOnce(() => {
+      throw new Error("track failed");
+    });
+
+    expect(() => trackConsultationHistoryEntryClicked()).toThrow("track failed");
+  });
+});

--- a/apps/web/src/lib/analytics/consultationHistoryEvents.ts
+++ b/apps/web/src/lib/analytics/consultationHistoryEvents.ts
@@ -1,0 +1,70 @@
+// apps/web/src/lib/analytics/consultationHistoryEvents.ts
+//
+// 相談履歴導線(MyPage入口・一覧表示・一覧→詳細遷移・詳細表示・詳細→神社詳細遷移)の
+// Analytics契約を集約するhelper。Event名・Payload・発火条件の根拠は
+// docs/analytics/consultation-history-events.md を正本とする。
+//
+// track()自体がセッションID付与・開発ログ・送信失敗の握り潰しを担うため、
+// ここではEvent名とPayloadの組み立てのみに責務を絞る(画面からPostHog SDKを直接呼ばない)。
+import { track } from "@/lib/analytics/track";
+
+const PLATFORM = "web";
+const SOURCE_MYPAGE = "mypage";
+const SOURCE_LIST = "consultation_history";
+const SOURCE_LIST_CARD = "consultation_history_list";
+const SOURCE_DETAIL = "consultation_history_detail";
+
+export function trackConsultationHistoryEntryClicked(): void {
+  track("consultation_history_entry_clicked", {
+    platform: PLATFORM,
+    source: SOURCE_MYPAGE,
+  });
+}
+
+export function trackConsultationHistoryListViewed(params: { historyCount: number }): void {
+  track("consultation_history_list_viewed", {
+    platform: PLATFORM,
+    source: SOURCE_LIST,
+    historyCount: params.historyCount,
+  });
+}
+
+export function trackConsultationHistoryDetailOpened(params: {
+  threadId: string | number;
+  position: number;
+}): void {
+  track("consultation_history_detail_opened", {
+    platform: PLATFORM,
+    source: SOURCE_LIST_CARD,
+    threadId: params.threadId,
+    position: params.position,
+  });
+}
+
+export function trackConsultationHistoryDetailViewed(params: {
+  threadId: string | number;
+  recommendationCount: number;
+  messageCount: number;
+}): void {
+  track("consultation_history_detail_viewed", {
+    platform: PLATFORM,
+    source: SOURCE_DETAIL,
+    threadId: params.threadId,
+    recommendationCount: params.recommendationCount,
+    messageCount: params.messageCount,
+  });
+}
+
+export function trackConsultationHistoryShrineOpened(params: {
+  threadId: string | number;
+  shrineId: string | number;
+  recommendationRank: number;
+}): void {
+  track("consultation_history_shrine_opened", {
+    platform: PLATFORM,
+    source: SOURCE_DETAIL,
+    threadId: params.threadId,
+    shrineId: params.shrineId,
+    recommendationRank: params.recommendationRank,
+  });
+}

--- a/docs/analytics/README.md
+++ b/docs/analytics/README.md
@@ -19,6 +19,7 @@ KAMI MUSUBIのイベント、Payload、KPI、Funnelおよび計測責務に関�
 | `direction-events.md` | Web／Mobile共通の方位分析Event名・Payload・禁止属性契約を管理する |
 | `mobile-search-events.md` | Mobile Search導線(Home入口・画面表示・一覧/人気神社/地図からの詳細遷移・外部経路CTA)のEvent名・Payload・禁止属性契約を管理する |
 | `mobile-reflection-to-consultation.md` | Mobile Reflection保存後に表示される再相談CTAのEvent名・Payload・禁止属性契約を管理する |
+| `consultation-history-events.md` | Web／Mobile共通の相談履歴導線(MyPage入口・一覧・詳細・神社詳細遷移)のEvent名・Payload・重複防止・禁止属性契約を管理する |
 | `direction-analytics-dashboard.md` | 方位利用ファネル、KPI、PostHog設定案、異常値・日盤検討基準を管理する |
 | `direction-analytics-data-quality.md` | 方位Eventの機械可読品質契約、重複・欠損・禁止属性、障害調査手順を管理する |
 | `action-suggestion-funnel.md` | Action Suggestion関連Event（PostHog view計測 / Backend `ActionEvent`）の現状を管理する |

--- a/docs/analytics/consultation-history-events.md
+++ b/docs/analytics/consultation-history-events.md
@@ -1,0 +1,159 @@
+> **Status: Active / Contract**
+
+# Consultation History導線のイベント契約
+
+Web／Mobile共通の「相談履歴」導線(MyPageからの入口、履歴一覧、履歴詳細、履歴詳細からの神社詳細遷移)を対象とするEvent契約を管理する。実装は`apps/web/src/lib/analytics/consultationHistoryEvents.ts`(Web)・`apps/mobile/lib/consultationHistoryAnalytics.ts`(Mobile)を正本とし、送信はそれぞれの既存`track()`パイプライン(`apps/web/src/lib/analytics/track.ts`、`apps/mobile/lib/analytics.ts`)へ委譲する。
+
+画面からPostHog SDK等を直接呼ばず、必ずこれらのhelper経由でEventを送信する。Event名と固定`source`/`platform`はhelper内に集約し、画面コードへ分散させない。
+
+## 対象範囲
+
+- Web: `apps/web/src/components/views/MyPageView.tsx`(相談履歴導線)、`ConsultationHistoryListView.tsx`、`ConsultationHistoryDetailView.tsx`
+- Mobile: `apps/mobile/app/mypage/index.tsx`(相談履歴導線)、`apps/mobile/app/consultation-history/index.tsx`、`apps/mobile/app/consultation-history/[id].tsx`
+
+対象は既存の相談履歴実装([PR #2215](https://github.com/etsu33/jinja_app/pull/2215) Web、[PR #2216](https://github.com/etsu33/jinja_app/pull/2216) Mobile)であり、本書はEvent契約のみを追加する。既存UI・文言・Navigation契約(Route名、`ctx=concierge&tid=`、Shrine Detailへのroute params等)は変更しない。
+
+## Event一覧
+
+| Event | 発火条件 | Payload | 重複の単位 |
+| --- | --- | --- | --- |
+| `consultation_history_entry_clicked` | MyPageの相談履歴導線を明示操作したとき | `platform`, `source: "mypage"` | 操作ごと |
+| `consultation_history_list_viewed` | 認証済みかつ一覧取得が成功し、一覧状態が表示可能になったとき(0件でも発火) | `platform`, `source: "consultation_history"`, `historyCount` | 画面マウント中に1回 |
+| `consultation_history_detail_opened` | 一覧のカードを明示操作し、詳細画面へ遷移するとき | `platform`, `source: "consultation_history_list"`, `threadId`, `position` | 操作ごと |
+| `consultation_history_detail_viewed` | 認証済みかつ詳細取得が成功し、threadが正常表示されたとき(Direct Navigationでも発火) | `platform`, `source: "consultation_history_detail"`, `threadId`, `recommendationCount`, `messageCount` | 同一tidの同一画面マウント中に1回 |
+| `consultation_history_shrine_opened` | 詳細画面内の「神社の詳細を見る」を明示操作したとき | `platform`, `source: "consultation_history_detail"`, `threadId`, `shrineId`, `recommendationRank` | 操作ごと |
+
+`platform`は`"web"`または`"mobile"`を実装側の定数として固定する(呼び出し元からは受け取らない)。
+
+## 発火条件の詳細
+
+### 表示Event(`list_viewed`/`detail_viewed`)
+
+- 発火は「認証済み」かつ「取得成功」かつ「表示可能な状態になった」ときのみ
+- `loading`状態では発火しない
+- `unauthenticated`(未ログイン)状態では発火しない
+- `fetchFailed`/`error`(API取得失敗)状態では発火しない
+- `detail_viewed`はさらに`not_found`(不正または存在しないtid)状態でも発火しない
+- `list_viewed`は履歴0件(Empty状態)でも`historyCount: 0`で発火する(0件と取得失敗を区別するため)
+- Direct Navigation(URL直接アクセス、Mobileの`/consultation-history/[id]`への直接遷移)でも、認証済み・取得成功・正常表示であれば`detail_viewed`は通常どおり発火する
+
+### 実行Event(`entry_clicked`/`detail_opened`/`shrine_opened`)
+
+- いずれもユーザーの明示操作(タップ・クリック)を契機とし、既存の遷移(Web: `<Link>`のhref、Mobile: `router.push`)を維持したまま、遷移前にEventを送信する
+- 表示のみでは発火しない(カードが画面に表示されただけでは`detail_opened`は発火しない)
+
+## Payload
+
+### `consultation_history_entry_clicked`
+
+```json
+{ "platform": "web" | "mobile", "source": "mypage" }
+```
+
+### `consultation_history_list_viewed`
+
+```json
+{ "platform": "web" | "mobile", "source": "consultation_history", "historyCount": number }
+```
+
+`historyCount`は一覧に含まれるThread件数(0以上の整数)。
+
+### `consultation_history_detail_opened`
+
+```json
+{ "platform": "web" | "mobile", "source": "consultation_history_list", "threadId": string | number, "position": number }
+```
+
+`position`は一覧内の並び順で1始まり(0始まりではない)。Mobileは日付ごとにグルーピング表示するが、`position`は一覧全体(グルーピング前)における通し番号を送る。
+
+### `consultation_history_detail_viewed`
+
+```json
+{ "platform": "web" | "mobile", "source": "consultation_history_detail", "threadId": string | number, "recommendationCount": number, "messageCount": number }
+```
+
+`recommendationCount`はThread Detailの`recommendations_v2`(存在すれば優先)または`recommendations`の件数。`messageCount`は`messages`配列の件数(Backend側の`message_count`フィールドではなく、実際に表示するmessages配列の長さを送る)。
+
+### `consultation_history_shrine_opened`
+
+```json
+{ "platform": "web" | "mobile", "source": "consultation_history_detail", "threadId": string | number, "shrineId": string | number, "recommendationRank": number }
+```
+
+`recommendationRank`は詳細画面内の推薦神社カード一覧における並び順で1始まり。
+
+## 重複発火防止
+
+- `list_viewed`・`detail_viewed`は、画面が表示可能状態(`ready`)になった時点で1回だけ発火するよう、`React.useRef`による送信済みフラグで制御する
+- Pull to Refresh(Mobile)・Retry操作(Web/Mobile共通の「もう一度読み込む」)による再取得や、その他の理由による再レンダーでは、既に送信済みであれば再発火しない
+- `detail_viewed`は「同一tidの同一マウント中に1回」を単位とする。マウントされたまま`tid`が変わる導線は現状存在しないが、`tid`ごとに送信済みフラグを保持することで将来の導線変更にも耐える
+- `entry_clicked`・`detail_opened`・`shrine_opened`はユーザー操作ごとに発火する実行Eventであり、重複防止の対象ではない(意図的な複数回操作はそれぞれ計測する)
+
+## Direct Navigationの扱い
+
+- Web: `/mypage/history/[tid]`へURLを直接開いた場合も、Server ComponentがThread Detailを取得し、Client Componentが`ready`状態に到達すれば`detail_viewed`を発火する。一覧を経由していないため`detail_opened`は発火しない
+- Mobile: `/consultation-history/[id]`へ直接遷移した場合(Deep Link等)も同様に、`ready`状態に到達すれば`detail_viewed`のみが発火し、`detail_opened`は発火しない
+- 不正または存在しないtidの場合(`not_found`状態)は、Direct Navigationであっても`detail_viewed`は発火しない
+
+## 0件と取得失敗の区別
+
+- 履歴0件(Empty状態、認証済み・取得成功・件数0)は`list_viewed`を`historyCount: 0`で発火する
+- 未ログイン(`unauthenticated`)・API取得失敗(`fetchFailed`/`error`)はいずれも`list_viewed`を発火しない
+- 上記3状態(0件・未ログイン・取得失敗)はUI表示文言が異なるだけでなく、Analytics上も明確に区別される(未ログイン/取得失敗は`historyCount`という概念自体が存在しないため、`0`と区別なく送ることを避ける)
+
+## WebとMobileの共通契約
+
+- Event名は完全に同一の文字列を使用する
+- Payloadのkey名・意味・型(`threadId`/`shrineId`は`string | number`、`historyCount`/`position`/`recommendationRank`/`recommendationCount`/`messageCount`は`number`)を一致させる
+- `source`の固定値もWeb/Mobile間で同一の文字列を使用する
+- 差分は`platform`の値(`"web"` / `"mobile"`)のみ
+- 実装は共有せず(型・helperはWeb/Mobileそれぞれの言語・基盤に合わせて個別実装する)、契約(Event名・Payloadの意味)のみを揃える
+
+## Privacy／禁止Payload
+
+次の値はEvent名を問わず送信しない。
+
+- 相談本文、相談タイトル、メッセージ本文(`messages[].content`)
+- 推薦理由本文(`recommendation_reason_v4`、`recommendation_reason_v4_detail`、`reason_facts`等の全文)
+- 住所、緯度・経度
+- ユーザー名、メールアドレス、トークン、Cookie
+- APIレスポンス全文
+
+`platform`・`source`・`threadId`・`shrineId`・`historyCount`・`position`・`recommendationCount`・`messageCount`・`recommendationRank`のみを許可する。
+
+Web側の`track()`はセッションID(`analyticsSessionId`/`sessionId`)を自動付与するが、これはWebの既存セッション追跡機構であり、相談Thread ID(`threadId`)とは独立したPropertyとして扱う。WebのsessionIdを相談threadIdの代用として使用しない。
+
+## Funnel定義
+
+1. `consultation_history_entry_clicked`(MyPageから相談履歴を開く)
+2. `consultation_history_list_viewed`(履歴一覧を正常表示する)
+3. `consultation_history_detail_opened`(一覧から履歴詳細を開く)
+4. `consultation_history_detail_viewed`(履歴詳細を正常表示する)
+5. `consultation_history_shrine_opened`(履歴詳細から神社詳細を開く)
+
+各段階は前段階を経由しなくても発火しうる(Direct Navigationにより3を経由せず4が発火する等)。Funnel分析ではDirect Navigation経由の`detail_viewed`が2→4に直接接続する経路として扱われることを前提とする。
+
+## Payload型
+
+- primitive型(string/number/boolean)のみを許可する
+- nested object・配列を送らない
+- `null`/`undefined`は送信前に除外する(Web: `track()`のシリアライズ、Mobile: `apps/mobile/lib/analytics.ts`の`serializeAnalyticsPayload`が構造的に担う)
+- 送信失敗はいずれのhelperも内部で握り潰し、呼び出し元(画面のUI・Navigation)を止めない
+
+## 実装ファイル一覧
+
+- `apps/web/src/lib/analytics/consultationHistoryEvents.ts`(Web helper、正本)
+- `apps/web/src/components/views/MyPageView.tsx`(`entry_clicked`)
+- `apps/web/src/components/views/ConsultationHistoryListView.tsx`(`list_viewed`/`detail_opened`)
+- `apps/web/src/components/views/ConsultationHistoryDetailView.tsx`(`detail_viewed`/`shrine_opened`)
+- `apps/mobile/lib/consultationHistoryAnalytics.ts`(Mobile helper、正本)
+- `apps/mobile/app/mypage/index.tsx`(`entry_clicked`)
+- `apps/mobile/app/consultation-history/index.tsx`(`list_viewed`/`detail_opened`)
+- `apps/mobile/app/consultation-history/[id].tsx`(`detail_viewed`/`shrine_opened`)
+
+## 変更ルール
+
+- Event名またはPayloadを変更する場合は、Web/Mobile双方のhelper実装と本書を同じPRで更新する
+- WebとMobileで同じEvent名を使う場合は意味とPayloadを一致させる(本書の「WebとMobileの共通契約」節を参照)
+- 表示Event(`list_viewed`/`detail_viewed`)と実行Event(`entry_clicked`/`detail_opened`/`shrine_opened`)を区別し、混同しない
+- 相談履歴の既存UI・文言・Navigation契約(Route名、Shrine Detail route params等)は本書の対象外であり、変更する場合は`docs/product/history-recommendation-navigation-design.md`を更新する


### PR DESCRIPTION
## 背景

Web([PR #2215](https://github.com/etsu33/jinja_app/pull/2215))・Mobile([PR #2216](https://github.com/etsu33/jinja_app/pull/2216))に実装済みの相談履歴導線へ、共通意味を持つAnalytics Eventを追加する。

対象Funnel: MyPageから開く → 一覧表示 → 詳細を開く → 詳細表示 → 神社詳細へ遷移。

## 変更内容

### Docs
- `docs/analytics/consultation-history-events.md`(新規): 対象範囲・Event一覧・発火条件・Payload・重複防止・Direct Navigationの扱い・0件と取得失敗の区別・WebとMobileの共通契約・禁止Payload・Funnel定義・実装ファイル一覧を記載
- `docs/analytics/README.md`: Active文書として追加

### Web
- `apps/web/src/lib/analytics/consultationHistoryEvents.ts`(新規): `apps/web/src/lib/analytics/track.ts`の`track()`を利用した型付きHelper。5 EventのEvent名・固定source/platformを集約
- `MyPageView.tsx`: `/mypage/history`への「相談履歴」リンクを新設し(既存はどこからも遷移できないデッドエンド画面だったため)、クリックで`entry_clicked`を送信
- `ConsultationHistoryListView.tsx`: `useRef`+`useEffect`で表示可能状態(認証済み・取得成功)になった時点で1回のみ`list_viewed`を送信(0件でも送る)。カードクリックで`detail_opened`を送信してから既存`<Link>`遷移を維持
- `ConsultationHistoryDetailView.tsx`: 同一tidの同一マウント中に1回のみ`detail_viewed`を送信。神社詳細リンククリックで`shrine_opened`(recommendationRankは1始まり)を送信

### Mobile
- `apps/mobile/lib/consultationHistoryAnalytics.ts`(新規): `apps/mobile/lib/analytics.ts`の`track()`を利用した型付きHelper。Web版とEvent名・Payloadの意味を一致させる。重複判定を`shouldTrackConsultationHistoryViewEvent`という純粋関数として切り出し、vitest.config.tsの対象(`lib/__tests__/**/*.test.ts`)でテスト可能にした(vitest.config.tsは変更していない)
- `apps/mobile/app/mypage/index.tsx`: 「相談履歴」カードのonPressで`entry_clicked`送信後に既存`router.push`を実行
- `apps/mobile/app/consultation-history/index.tsx`: `state.kind === "ready"`になった時点で1回のみ`list_viewed`を送信。Pull to Refresh・Retryでは再発火しない。カード押下時に一覧全体(グルーピング前)での1始まりpositionで`detail_opened`を送信
- `apps/mobile/app/consultation-history/[id].tsx`: 同一tidで1回のみ`detail_viewed`を送信。神社詳細押下時に`shrine_opened`(recommendationRankは1始まり)を送信してから既存route paramsで`router.push`を実行(Shrine Detail側のparams構造は変更なし)

## テスト

- `apps/web/src/lib/analytics/__tests__/consultationHistoryEvents.test.ts`(新規): 各Eventの名前・platform・固定source・Payload、禁止Payload、trackへの委譲構造を検証
- `apps/mobile/lib/__tests__/consultationHistoryAnalytics.test.ts`(新規): 同様の検証に加え、providerが例外を投げてもUI側へ伝播しないこと、`shouldTrackConsultationHistoryViewEvent`の重複判定ロジックを検証
- 既存View/MyPageViewテストを更新: List/Detail正常表示時のEvent発火、0件時のhistoryCount:0、未ログイン/fetchFailed/not_found時の非発火、カード・神社詳細操作時のEvent、再レンダーでの非重複を追加

## Validation

- Web typecheck: エラーなし
- Web関連テスト: 112 files / 692 tests 全通過
- Mobile typecheck: エラーなし
- Mobile全テスト: 23 files / 247 tests 全通過(実行数は変動しうる)
- `git diff --check`: エラーなし
- 変更範囲確認: Backend・API契約・OpenAPI・CI・Husky・相談本文/タイトル/メッセージ本文/推薦理由/住所/緯度経度のPayload混入、いずれもなし

## QA(Backend + Web dev server / Expo Web)

テストユーザー・テストスレッド(推薦神社1件付き)を作成し、Web・Mobile双方で以下を実機確認した(`localStorage`のdevイベントログ・コンソールログでPayload内容まで確認)。

- 未ログイン状態で`/mypage/history`を開いても`list_viewed`が送られないことを確認
- ログイン後、MyPageの「相談履歴」→`entry_clicked`(`source: "mypage"`)
- 一覧表示→`list_viewed`(`historyCount: 1`)
- カードタップ→`detail_opened`(`threadId`, `position: 1`)
- 詳細表示→`detail_viewed`(`threadId`, `recommendationCount: 1`, `messageCount: 2`)
- 「神社の詳細を見る」タップ→`shrine_opened`(`threadId`, `shrineId`, `recommendationRank: 1`)
- 5イベントとも重複発火なし、Web/Mobileで値・意味が一致することを確認
- iOS Simulatorは、ホストのXcode SDK(iOS 26.5)とインストール済みシミュレータランタイム(iOS 26.0/26.1)の不一致により利用不能(過去セッションで確認済みの既知の制約、Xcode Platform Componentの追加インストールが必要でパスワードが必要なため対応不可)。Expo Webへ切り替えて検証した
- QA用データ・サーバーは作業後にクリーンアップ済み

## 対象外(本PRでは行っていない)

- Backend・API契約・OpenAPI本体の変更
- CI workflow・Husky設定の変更
- 相談履歴の既存UI・文言・Navigation契約(Route名、Shrine Detail route params等)の変更
- Web MyPageのIA再設計(既存の`?tab=`タブ機構とは独立した単純なLinkとして追加)

## マージについて

**本PRはマージせず、母艦判断待ちとします。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)