### PR TITLE
fix: 神社Knowledge ModelのORM保存契約(full_clean)を強化

### DIFF
--- a/backend/temples/models.py
+++ b/backend/temples/models.py
@@ -476,6 +476,13 @@ class ShrineKnowledgeSource(models.Model):
         super().clean()
         _validate_verified_at_consistency(self.verification_status, self.verified_at)
 
+    def save(self, *args, **kwargs) -> None:
+        # Model.save()はDjangoの仕様上full_clean()を自動実行しないため、
+        # Admin(ModelForm経由)以外の保存経路（shell/ORM直接呼び出し等）でも
+        # clean()の契約（verified_at整合等）が確実に効くようここで明示的に呼ぶ。
+        self.full_clean()
+        super().save(*args, **kwargs)
+
 
 class ShrineDeity(models.Model):
     """神社の祭神Knowledge。docs/knowledge/shrine-knowledge-contract.md「deity契約」の実装。"""
@@ -518,6 +525,10 @@ class ShrineDeity(models.Model):
     def clean(self) -> None:
         super().clean()
         _validate_verified_at_consistency(self.verification_status, self.verified_at)
+
+    def save(self, *args, **kwargs) -> None:
+        self.full_clean()
+        super().save(*args, **kwargs)
 
 
 class ShrineHistory(models.Model):
@@ -571,6 +582,10 @@ class ShrineHistory(models.Model):
     def clean(self) -> None:
         super().clean()
         _validate_verified_at_consistency(self.verification_status, self.verified_at)
+
+    def save(self, *args, **kwargs) -> None:
+        self.full_clean()
+        super().save(*args, **kwargs)
 
 
 class Favorite(models.Model):

--- a/backend/temples/tests/test_models_shrine_knowledge.py
+++ b/backend/temples/tests/test_models_shrine_knowledge.py
@@ -252,3 +252,87 @@ def test_shrine_knowledge_source_shared_across_deity_and_history():
 
     assert source.deities.count() == 1
     assert source.histories.count() == 1
+
+
+# --- save()経由（.full_clean()を明示的に呼ばないORM直接呼び出し）でも
+# verified_at整合が保証されることの回帰テスト。
+# Django Model.save()はデフォルトではfull_clean()を実行しないため、
+# Admin(ModelForm経由)以外の経路（shell/ORM直接create等）でこのvalidationが
+# 抜け落ちていたことが判明した。save()にfull_clean()を追加する前は、
+# 以下のtestはValidationErrorが送出されずに失敗する。
+
+
+@pytest.mark.parametrize("verification_status", ["source_confirmed", "reviewed"])
+def test_shrine_knowledge_source_save_without_verified_at_is_rejected(verification_status):
+    with pytest.raises(ValidationError):
+        ShrineKnowledgeSource.objects.create(
+            source_type="shrine_official",
+            title="出典",
+            verification_status=verification_status,
+        )
+
+
+@pytest.mark.parametrize("verification_status", ["source_confirmed", "reviewed"])
+def test_shrine_deity_save_without_verified_at_is_rejected(verification_status):
+    shrine = _create_shrine()
+    with pytest.raises(ValidationError):
+        ShrineDeity.objects.create(
+            shrine=shrine, display_name="祭神", verification_status=verification_status
+        )
+
+
+@pytest.mark.parametrize("verification_status", ["source_confirmed", "reviewed"])
+def test_shrine_history_save_without_verified_at_is_rejected(verification_status):
+    shrine = _create_shrine()
+    with pytest.raises(ValidationError):
+        ShrineHistory.objects.create(
+            shrine=shrine,
+            history_type="official_origin",
+            title="由緒",
+            content="内容",
+            verification_status=verification_status,
+        )
+
+
+@pytest.mark.parametrize("verification_status", ["draft", "unverified"])
+def test_shrine_knowledge_source_save_without_verified_at_is_allowed_for_draft_like_status(
+    verification_status,
+):
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official", title="出典", verification_status=verification_status
+    )
+    assert source.verified_at is None
+
+
+@pytest.mark.parametrize("verification_status", ["disputed", "outdated", "rejected"])
+def test_shrine_knowledge_source_verified_at_is_preserved_when_status_changes_away_from_fact_ready(
+    verification_status,
+):
+    verified_time = timezone.now()
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="出典",
+        verification_status="source_confirmed",
+        verified_at=verified_time,
+    )
+
+    source.verification_status = verification_status
+    source.save()
+    source.refresh_from_db()
+
+    assert source.verification_status == verification_status
+    assert source.verified_at == verified_time
+
+
+def test_shrine_knowledge_source_save_does_not_auto_change_status_or_verified_at():
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="出典",
+        verification_status="draft",
+    )
+    source.note = "編集メモ"
+    source.save()
+    source.refresh_from_db()
+
+    assert source.verification_status == "draft"
+    assert source.verified_at is None

--- a/backend/temples/tests/test_shrine_knowledge_admin_validation.py
+++ b/backend/temples/tests/test_shrine_knowledge_admin_validation.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import re
+
+import pytest
+from django.urls import reverse
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+
+pytestmark = pytest.mark.django_db
+
+
+def _login_superuser(client, django_user_model, username="qa_admin"):
+    user = django_user_model.objects.create_superuser(
+        username=username, password="pass12345", email=f"{username}@example.com"
+    )
+    client.force_login(user)
+    return user
+
+
+def _split_datetime_now(client, url):
+    """Admin Add画面が初期表示するcreated_atのSplitDateTimeField値を取得する。"""
+    resp = client.get(url)
+    html = resp.content.decode()
+    date_ = re.search(r'name="created_at_0"[^>]*value="([^"]*)"', html).group(1)
+    time_ = re.search(r'name="created_at_1"[^>]*value="([^"]*)"', html).group(1)
+    return date_, time_
+
+
+def _errorlist_texts(content: str) -> list[str]:
+    return [
+        re.sub(r"<[^>]+>", "", block).strip()
+        for block in re.findall(r'<ul class="errorlist"[^>]*>(.*?)</ul>', content, re.S)
+    ]
+
+
+# --- ShrineKnowledgeSource: 独立Admin(Add/Change)経由の回帰テスト ---
+
+
+def test_admin_add_source_confirmed_without_verified_at_is_rejected(client, django_user_model):
+    _login_superuser(client, django_user_model)
+    url = reverse("admin:temples_shrineknowledgesource_add")
+    created_at_0, created_at_1 = _split_datetime_now(client, url)
+
+    resp = client.post(
+        url,
+        {
+            "source_type": "shrine_official",
+            "title": "Admin経由出典",
+            "publisher": "",
+            "url": "",
+            "bibliography": "",
+            "accessed_at": "",
+            "verified_at": "",
+            "verification_status": "source_confirmed",
+            "confidence": "",
+            "language": "",
+            "note": "",
+            "created_at_0": created_at_0,
+            "created_at_1": created_at_1,
+            "_save": "Save",
+        },
+    )
+
+    assert resp.status_code == 200  # フォーム再描画(保存失敗)
+    assert ShrineKnowledgeSource.objects.count() == 0
+    errors = _errorlist_texts(resp.content.decode())
+    assert any("verified_at" in "".join(errors) or "verification_status" in e for e in errors)
+    # 入力値がフォームに保持されていること(Error後に入力値を保持)
+    assert "Admin経由出典" in resp.content.decode()
+
+
+def test_admin_change_draft_to_source_confirmed_without_verified_at_is_rejected(
+    client, django_user_model
+):
+    _login_superuser(client, django_user_model, username="qa_admin_change")
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official", title="既存draft出典", verification_status="draft"
+    )
+    url = reverse("admin:temples_shrineknowledgesource_change", args=[source.id])
+    created_at_0, created_at_1 = _split_datetime_now(client, url)
+
+    resp = client.post(
+        url,
+        {
+            "source_type": "shrine_official",
+            "title": "既存draft出典",
+            "publisher": "",
+            "url": "",
+            "bibliography": "",
+            "accessed_at": "",
+            "verified_at": "",
+            "verification_status": "source_confirmed",
+            "confidence": "",
+            "language": "",
+            "note": "",
+            "created_at_0": created_at_0,
+            "created_at_1": created_at_1,
+            "_save": "Save",
+        },
+    )
+
+    assert resp.status_code == 200
+    source.refresh_from_db()
+    assert source.verification_status == "draft"
+    assert source.verified_at is None
+
+
+def test_admin_add_source_draft_without_verified_at_is_allowed(client, django_user_model):
+    _login_superuser(client, django_user_model, username="qa_admin_draft_ok")
+    url = reverse("admin:temples_shrineknowledgesource_add")
+    created_at_0, created_at_1 = _split_datetime_now(client, url)
+
+    resp = client.post(
+        url,
+        {
+            "source_type": "shrine_official",
+            "title": "Admin経由draft出典",
+            "publisher": "",
+            "url": "",
+            "bibliography": "",
+            "accessed_at": "",
+            "verified_at": "",
+            "verification_status": "draft",
+            "confidence": "",
+            "language": "",
+            "note": "",
+            "created_at_0": created_at_0,
+            "created_at_1": created_at_1,
+            "_save": "Save",
+        },
+    )
+
+    assert resp.status_code == 302  # 保存成功(Adminのredirect)
+    assert ShrineKnowledgeSource.objects.filter(title="Admin経由draft出典").exists()
+
+
+# --- ShrineDeity: 独立Admin(Add)経由の回帰テスト ---
+
+
+def _shrine():
+    return Shrine.objects.create(
+        name_jp="Admin監査神社",
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def test_admin_add_deity_source_confirmed_without_verified_at_is_rejected(
+    client, django_user_model
+):
+    _login_superuser(client, django_user_model, username="qa_admin_deity")
+    shrine = _shrine()
+    url = reverse("admin:temples_shrinedeity_add")
+    created_at_0, created_at_1 = _split_datetime_now(client, url)
+
+    resp = client.post(
+        url,
+        {
+            "shrine": str(shrine.id),
+            "display_name": "テスト祭神",
+            "canonical_name": "",
+            "role": "primary",
+            "sort_order": "0",
+            "verification_status": "source_confirmed",
+            "confidence": "",
+            "verified_at": "",
+            "note": "",
+            "sources": [],
+            "created_at_0": created_at_0,
+            "created_at_1": created_at_1,
+            "_save": "Save",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert ShrineDeity.objects.filter(shrine=shrine).count() == 0
+    errors = "".join(_errorlist_texts(resp.content.decode()))
+    assert "verified_at" in errors or "verification_status" in errors
+
+
+# --- ShrineHistory: 独立Admin(Add)経由の回帰テスト ---
+
+
+def test_admin_add_history_reviewed_without_verified_at_is_rejected(client, django_user_model):
+    _login_superuser(client, django_user_model, username="qa_admin_history")
+    shrine = _shrine()
+    url = reverse("admin:temples_shrinehistory_add")
+    created_at_0, created_at_1 = _split_datetime_now(client, url)
+
+    resp = client.post(
+        url,
+        {
+            "shrine": str(shrine.id),
+            "history_type": "official_origin",
+            "title": "テスト由緒",
+            "content": "内容",
+            "period_text": "",
+            "event_date": "",
+            "sort_order": "0",
+            "verification_status": "reviewed",
+            "confidence": "",
+            "verified_at": "",
+            "note": "",
+            "sources": [],
+            "created_at_0": created_at_0,
+            "created_at_1": created_at_1,
+            "_save": "Save",
+        },
+    )
+
+    assert resp.status_code == 200
+    assert ShrineHistory.objects.filter(shrine=shrine).count() == 0
+    errors = "".join(_errorlist_texts(resp.content.decode()))
+    assert "verified_at" in errors or "verification_status" in errors


### PR DESCRIPTION
## 背景・経緯

当初、Django Admin QAで「`ShrineKnowledgeSource`を`verification_status=source_confirmed`、`verified_at`空欄のまま保存できた」という報告があり、「Admin Validation不具合」として調査を開始した。

その後、報告元のスクリーンショットを再確認したところ、実際に保存されていたrecordの`verification_status`は`draft`であり、**Adminが該当validationを実際にすり抜けた事実は確認できていない**。調査によって以下が判明している。

- **Admin(標準ModelForm経由)は元々正しく動作している**: `ShrineKnowledgeSourceAdmin`/`ShrineDeityAdmin`/`ShrineHistoryAdmin`のAdd/Change、Shrine変更画面のTabularInlineいずれも、Django `ModelForm._post_clean()`が`instance.full_clean()`を呼ぶため、既存の`clean()`(`verified_at`整合チェック)が正しく働き保存をブロックすることを、Django Test Clientによる実地検証で確認済み。
- 一方、**`Model.save()`はDjangoの仕様上`full_clean()`を自動実行しない**ため、`ShrineKnowledgeSource.objects.create(verification_status="source_confirmed")`のようなORM直接呼び出し(shell/スクリプト等)では、このvalidationが完全に素通りすることを実際に確認した。

以上から、本PRは **「Admin Validation不具合修正」ではなく「ORMの通常保存経路(`save()`/`objects.create()`)でも`full_clean()`を強制するKnowledge Modelの保存契約強化」** として扱う。Admin自体に対する修正ではない。

## 変更内容

`ShrineKnowledgeSource` / `ShrineDeity` / `ShrineHistory`の`save()`に`self.full_clean()`呼び出しを追加した。

```python
def save(self, *args, **kwargs) -> None:
    self.full_clean()
    super().save(*args, **kwargs)
```

- `source_confirmed`/`reviewed`は`verified_at`必須（3モデルとも、ORM直接呼び出しでも）
- `draft`/`unverified`は`verified_at`空欄を許可（変更なし）
- `disputed`/`outdated`/`rejected`へ変更しても既存の`verified_at`は自動で消去されない（元々そのような処理は存在せず、今回追加もしていない）
- `verification_status`や`verified_at`を自動変更するロジックは追加していない

## 追加監査: 本契約強化の保証範囲と既存への影響

母艦からの指摘を受け、以下を追加調査した（すべて実地検証済み）。

| 項目 | 結果 |
|---|---|
| プロジェクト内で`save()`から`full_clean()`を呼ぶ既存方針 | **なし**。他モデル(`Shrine`含む)に同様のpatternはなく、`clean()`をoverrideしているのもこの3モデルのみ。今回が本パターンの初導入であり、既存方針の踏襲ではない |
| `save(update_fields=[...])`への影響 | 対象が既に妥当な状態なら問題なし(実測)。ただし`full_clean()`は`update_fields`を考慮せず**インスタンス全体を毎回検証**するため、他フィールドが何らかの経路で既に不整合な状態にあると、無関係なfieldだけを更新するはずの`update_fields`保存が意図せず`ValidationError`になり得ることを実測で確認した。このプロジェクトは`update_fields`を多用する(`management/commands/`等20箇所以上)ため、今後この3モデルに対して`update_fields`保存を行う処理を書く場合は留意が必要 |
| fixture/loaddata/raw保存への影響 | **保護されない**。Djangoの`loaddata`は`DeserializedObject.save()`が`Model.save_base(raw=True)`を直接呼びModel定義の`save()`を完全にバイパスする(Django本体のdocstringにも明記)。実際にfixtureを用意し、不整合データがそのまま読み込まれることを確認した |
| Factory・seed・import処理への影響 | 現時点でこの3モデル用のFactory/seed/importコマンドは存在せず、**影響なし**。将来追加する場合は既存テストヘルパーと同様に`source_confirmed`/`reviewed`では`verified_at`を明示する必要がある |
| `bulk_create`/`bulk_update`が保証対象外であること | その通り。**個々の`save()`を呼ばないため対象外**(Django標準の既知の制約)。`verification_status=source_confirmed, verified_at=None`のオブジェクトが`bulk_create`/`bulk_update`ではバリデーションなしに保存できることを実測で確認した。`QuerySet.update()`も同様に対象外 |
| `raw=True`の扱い | `raw`は`Model.save()`の公開シグネチャに存在しない引数であり、`save_base()`(loaddata専用の内部経路)にのみ存在する。ユーザーコードが`.save(raw=True)`を呼ぶことは通常なく、今回のoverrideも意識不要 |
| 3Modelだけに適用する設計の一貫性 | Model選定としては一貫している(`clean()`を持つのはこの3モデルのみ)。ただし「`save()`でfull_clean()を強制する」という**手法自体はプロジェクト全体で今回が初適用**であり、他の約40以上のモデルは引き続きDjango標準動作(ORM直接保存はvalidationされない)のままである |

**結論**: 本契約強化は「Admin」に限らず「ORM経由の`create`/`save`(および対象が既に妥当な場合の`update_fields`)」までしか保証できない。`bulk_create`/`bulk_update`/`QuerySet.update`/`loaddata`は最初から保証対象外であり、これはDjangoの構造的制約であって実装漏れではない。

## Tests

### Model/ORM経由（修正前に失敗することを確認済み）

`temples/tests/test_models_shrine_knowledge.py`に12件追加。`*_save_without_verified_at_is_rejected`系6件は、`save()`にfull_clean()を追加する前は`DID NOT RAISE ValidationError`で失敗し、追加後は成功することを確認済み。

### Admin POST経由（回帰防止の固定用）

`temples/tests/test_shrine_knowledge_admin_validation.py`を新規追加、5件。**Admin自体は元々正しく動作していたため、本PRの前後どちらでもPASSする**(fail before/passの対象はModel/ORM経由テストのみ)。この経路が今後も回帰しないことを固定する目的。

### 全体結果

- 新規17件 + 既存テスト、Backend全体: **845 passed, 9 skipped**（既存の環境依存7件のみ除外、developでも同一原因で失敗することを確認済みで本PR由来ではない）
- `manage.py check` / `makemigrations --check --dry-run`: 変更なし・クリーン(Migration追加なし)
- lint: 修正前後で件数不変(models.py: 5件、pre-existing)、新規テストファイルはクリーン
- `git diff --check`: クリーン
- pre-pushフック: `pnpm lint:openapi`、`pnpm test:contract`(692 passed)とも通過

## 変更範囲

`backend/temples/models.py`(save()追加のみ)、`backend/temples/tests/`のみ。Migration・Serializer・API公開契約・Django Admin(admin.py)は変更していない。Recommendation Reason / Evidence Gate / Score / Web / Mobileへの変更もない。

## Rollback

このPRをrevertすれば`save()`のfull_clean()呼び出しのみが削除され、既存データ・Migration・API契約への影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)