### PR TITLE
feat(backend): Shrine Knowledge ModelをRecommendation入力へ最小接続

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -296,12 +296,46 @@ def _first_recommendation(recs: dict[str, Any]) -> dict[str, Any]:
     return recommendations[0] if recommendations else {}
 
 
+def _join_knowledge_deity_names(knowledge_deities: Any) -> str | None:
+    """Fact-ready ShrineDeityの名称を sort_order 昇順・読点結合でReason入力用文字列にする。
+
+    canonical_name/roleはReason文字列へ含めない（docs/knowledge/shrine-knowledge-contract.md
+    のFact利用条件に従い、Sourceにない称号を推測しないため）。結合件数の上限は設けない。
+    """
+    if not isinstance(knowledge_deities, list):
+        return None
+    items = [d for d in knowledge_deities if isinstance(d, dict) and str(d.get("display_name") or "").strip()]
+    if not items:
+        return None
+    ordered = sorted(items, key=lambda d: d.get("sort_order") if isinstance(d.get("sort_order"), int) else 0)
+    names = [str(d["display_name"]).strip() for d in ordered]
+    return "、".join(names) if names else None
+
+
+def _pick_primary_knowledge_history_content(knowledge_histories: Any) -> str | None:
+    """Fact-ready ShrineHistoryのうち、sort_order最小の1件のcontentのみを採用する。
+
+    history_typeによる独自の優先順位（founding優先等）は今回導入しない。
+    複数Historyの結合も今回は行わない。
+    """
+    if not isinstance(knowledge_histories, list):
+        return None
+    items = [h for h in knowledge_histories if isinstance(h, dict) and str(h.get("content") or "").strip()]
+    if not items:
+        return None
+    ordered = sorted(items, key=lambda h: h.get("sort_order") if isinstance(h.get("sort_order"), int) else 0)
+    return str(ordered[0]["content"]).strip()
+
+
 def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
     meaning_payload = rec.get("meaning_payload") if isinstance(rec.get("meaning_payload"), dict) else {}
     source = meaning_payload.get("source") if isinstance(meaning_payload.get("source"), dict) else {}
     breakdown = rec.get("breakdown") if isinstance(rec.get("breakdown"), dict) else {}
     breakdown_detail = rec.get("breakdown_detail") if isinstance(rec.get("breakdown_detail"), dict) else {}
     features = breakdown_detail.get("features") if isinstance(breakdown_detail.get("features"), dict) else {}
+
+    knowledge_deity_names = _join_knowledge_deity_names(rec.get("knowledge_deities"))
+    knowledge_history_content = _pick_primary_knowledge_history_content(rec.get("knowledge_histories"))
 
     return {
         "shrine_id": rec.get("shrine_id") or rec.get("id") or source.get("shrineId"),
@@ -310,8 +344,11 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
         "goriyaku": rec.get("goriyaku") or source.get("goriyaku"),
         "goriyaku_tags": rec.get("goriyaku_tags") or source.get("goriyakuTags") or breakdown.get("matched_need_tags") or [],
         "visit_style_tags": rec.get("visit_style_tags") or features.get("visit_style") or [],
-        "deity": rec.get("sajin") or source.get("sajin"),
-        "shrine_history": rec.get("description") or source.get("description"),
+        # Fact-ready ShrineDeity/ShrineHistory（新Knowledge）をfield単位で優先し、
+        # 存在しない場合のみLegacy（sajin/description）へfallbackする。
+        # 新KnowledgeとLegacyを同一field内で混在させない（片方の値のみを採用する）。
+        "deity": knowledge_deity_names if knowledge_deity_names is not None else (rec.get("sajin") or source.get("sajin")),
+        "shrine_history": knowledge_history_content if knowledge_history_content is not None else (rec.get("description") or source.get("description")),
         "place_context": rec.get("address") or source.get("address"),
         "place_id": rec.get("place_id"),
         "behavior_signals": rec.get("behavior_signals") if isinstance(rec.get("behavior_signals"), dict) else {},

--- a/backend/temples/services/concierge_chat_candidates.py
+++ b/backend/temples/services/concierge_chat_candidates.py
@@ -16,6 +16,10 @@ from temples.services.shrine_trust_metadata import get_shrine_trust_metadata
 
 from temples.services.shrine_meaning_composer import compose_shrine_meaning_payload
 from temples.services.meaning_translation import translate_meaning
+from temples.services.shrine_knowledge_selector import (
+    fetch_fact_ready_knowledge_deities,
+    fetch_fact_ready_knowledge_histories,
+)
 
 log = logging.getLogger(__name__)
 
@@ -96,10 +100,13 @@ def build_chat_candidates(
         qs = qs.order_by("id")
 
     pool_limit = max(limit * 5, 50)
-    qs = qs[:pool_limit]
+    shrines = list(qs[:pool_limit])
+    shrine_ids = [s.id for s in shrines]
+    knowledge_deities_by_shrine = fetch_fact_ready_knowledge_deities(shrine_ids)
+    knowledge_histories_by_shrine = fetch_fact_ready_knowledge_histories(shrine_ids)
 
     candidates: List[Dict[str, Any]] = []
-    for s in qs:
+    for s in shrines:
         dist = _distance_m(lat, lng, s.latitude, s.longitude)
 
         pref = getattr(s, "place_ref", None)
@@ -128,6 +135,8 @@ def build_chat_candidates(
                 "goriyaku": getattr(s, "goriyaku", None),
                 "sajin": getattr(s, "sajin", None),
                 "description": getattr(s, "description", None),
+                "knowledge_deities": knowledge_deities_by_shrine.get(s.id, []),
+                "knowledge_histories": knowledge_histories_by_shrine.get(s.id, []),
                 "astro_tags": getattr(s, "astro_tags", None),
                 "astro_elements": getattr(s, "astro_elements", None),
                 "visit_style_tags": getattr(s, "visit_style_tags", None),

--- a/backend/temples/services/shrine_knowledge_selector.py
+++ b/backend/temples/services/shrine_knowledge_selector.py
@@ -1,0 +1,113 @@
+"""Recommendation専用のKnowledge読み取りselector。
+
+docs/knowledge/shrine-knowledge-contract.md「Fact利用条件」に従い、
+ShrineDeity / ShrineHistoryのうちFact利用可能なもの
+（verification_status in KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES、かつ
+ fact-readyなShrineKnowledgeSourceを1件以上持つもの）だけをRecommendation
+入力向けの最小dictへ変換する。
+
+DRF Serializer/ViewとRecommendation内部契約を混在させないため、
+temples.api配下（Serializer/View）には一切依存しない。
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from temples.models import (
+    KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+    ShrineDeity,
+    ShrineHistory,
+)
+
+
+def fetch_fact_ready_knowledge_deities(
+    shrine_ids: list[int],
+) -> dict[int, list[dict[str, Any]]]:
+    """対象shrine_ids分のFact-ready ShrineDeityを、shrine_id単位でまとめて取得する。
+
+    N+1回避のため、対象Shrine数に関わらず1クエリのみ発行する。
+    """
+    if not shrine_ids:
+        return {}
+
+    rows = (
+        ShrineDeity.objects.filter(
+            shrine_id__in=shrine_ids,
+            verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+            sources__verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+        )
+        .order_by("sort_order", "id")
+        .values("id", "shrine_id", "display_name", "sort_order", "confidence")
+    )
+
+    result: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    seen_ids: set[int] = set()
+    for row in rows:
+        # sources__verification_status__inのJOINにより、fact-ready Sourceを
+        # 複数持つDeityは行が重複し得るため、id単位で重複排除する。
+        if row["id"] in seen_ids:
+            continue
+        seen_ids.add(row["id"])
+        result[row["shrine_id"]].append(
+            {
+                "display_name": row["display_name"],
+                "sort_order": row["sort_order"],
+                "confidence": row["confidence"],
+            }
+        )
+    return dict(result)
+
+
+def fetch_fact_ready_knowledge_histories(
+    shrine_ids: list[int],
+) -> dict[int, list[dict[str, Any]]]:
+    """対象shrine_ids分のFact-ready ShrineHistoryを、shrine_id単位でまとめて取得する。
+
+    N+1回避のため、対象Shrine数に関わらず1クエリのみ発行する。
+    """
+    if not shrine_ids:
+        return {}
+
+    rows = (
+        ShrineHistory.objects.filter(
+            shrine_id__in=shrine_ids,
+            verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+            sources__verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+        )
+        .order_by("sort_order", "id")
+        .values(
+            "id",
+            "shrine_id",
+            "history_type",
+            "title",
+            "content",
+            "period_text",
+            "sort_order",
+            "confidence",
+        )
+    )
+
+    result: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    seen_ids: set[int] = set()
+    for row in rows:
+        if row["id"] in seen_ids:
+            continue
+        seen_ids.add(row["id"])
+        result[row["shrine_id"]].append(
+            {
+                "history_type": row["history_type"],
+                "title": row["title"],
+                "content": row["content"],
+                "period_text": row["period_text"],
+                "sort_order": row["sort_order"],
+                "confidence": row["confidence"],
+            }
+        )
+    return dict(result)
+
+
+__all__ = [
+    "fetch_fact_ready_knowledge_deities",
+    "fetch_fact_ready_knowledge_histories",
+]

--- a/backend/temples/tests/services/test_concierge_build_chat_candidates_contract.py
+++ b/backend/temples/tests/services/test_concierge_build_chat_candidates_contract.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
-from temples.models import PlaceRef, Shrine
+from temples.models import PlaceRef, Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
 from temples.services.concierge_chat_candidates import build_chat_candidates
 
 
@@ -188,3 +191,72 @@ def test_candidates_are_sorted_by_popular_score_desc(shrine_factory):
     names = [c["name"] for c in cands]
 
     assert names.index("人気高") < names.index("人気低")
+
+
+def _create_source(verification_status: str = "source_confirmed") -> ShrineKnowledgeSource:
+    kwargs = dict(source_type="shrine_official", title="出典", verification_status=verification_status)
+    if verification_status in ("source_confirmed", "reviewed"):
+        kwargs["verified_at"] = timezone.now()
+    return ShrineKnowledgeSource.objects.create(**kwargs)
+
+
+@pytest.mark.django_db
+def test_candidates_include_fact_ready_knowledge_deities_and_histories(shrine_factory):
+    shrine = shrine_factory(name="Knowledge神社", latitude=35.0, longitude=139.0)
+    source = _create_source("source_confirmed")
+
+    deity = ShrineDeity.objects.create(
+        shrine=shrine, display_name="祭神A", sort_order=0, verification_status="source_confirmed",
+        verified_at=timezone.now(),
+    )
+    deity.sources.add(source)
+
+    history = ShrineHistory.objects.create(
+        shrine=shrine, history_type="official_origin", title="由緒A", content="内容A", sort_order=0,
+        verification_status="source_confirmed", verified_at=timezone.now(),
+    )
+    history.sources.add(source)
+
+    cands = build_chat_candidates(lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=None, trace_id="test")
+    cand = next(c for c in cands if c["name"] == "Knowledge神社")
+
+    assert cand["knowledge_deities"] == [{"display_name": "祭神A", "sort_order": 0, "confidence": ""}]
+    assert cand["knowledge_histories"][0]["content"] == "内容A"
+
+
+@pytest.mark.django_db
+def test_candidates_exclude_non_fact_ready_knowledge(shrine_factory):
+    shrine = shrine_factory(name="Draft神社", latitude=35.0, longitude=139.0)
+    source = _create_source("source_confirmed")
+
+    deity = ShrineDeity.objects.create(
+        shrine=shrine, display_name="下書き祭神", sort_order=0, verification_status="draft",
+    )
+    deity.sources.add(source)
+
+    cands = build_chat_candidates(lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=None, trace_id="test")
+    cand = next(c for c in cands if c["name"] == "Draft神社")
+
+    assert cand["knowledge_deities"] == []
+
+
+@pytest.mark.django_db
+def test_candidates_knowledge_lookup_does_not_scale_query_count_with_shrine_count(shrine_factory):
+    source = _create_source("source_confirmed")
+    for i in range(10):
+        shrine = shrine_factory(name=f"多数神社{i}", latitude=35.0, longitude=139.0)
+        deity = ShrineDeity.objects.create(
+            shrine=shrine, display_name=f"祭神{i}", sort_order=0, verification_status="source_confirmed",
+            verified_at=timezone.now(),
+        )
+        deity.sources.add(source)
+
+    with CaptureQueriesContext(connection) as ctx:
+        cands = build_chat_candidates(lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=None, trace_id="test")
+
+    assert len(cands) >= 10
+    # Knowledge selectorはshrine数によらず一定数のクエリ(deity/history各1本)のみ発行する。
+    # 全体のクエリ数がshrine数に比例して増えていないことを確認する（目安として30件未満）。
+    assert len(ctx.captured_queries) < 30, (
+        f"expected knowledge lookup to avoid N+1, got {len(ctx.captured_queries)} queries"
+    )

--- a/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
+++ b/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
@@ -31,3 +31,334 @@ def test_build_score_v3_candidate_profile_handles_missing_shrine_fields():
     assert profile["deity"] is None
     assert profile["shrine_history"] is None
     assert profile["place_context"] is None
+
+
+# --- Deity正規化 ---
+
+
+def test_candidate_profile_deity_falls_back_to_sajin_when_no_knowledge_deities():
+    rec = {"shrine_id": 1, "sajin": "櫛真智命", "knowledge_deities": []}
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "櫛真智命"
+
+
+def test_candidate_profile_deity_uses_single_knowledge_deity():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "レガシー祭神",
+        "knowledge_deities": [{"display_name": "明治天皇", "sort_order": 0, "confidence": "high"}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "明治天皇"
+
+
+def test_candidate_profile_deity_joins_multiple_by_sort_order():
+    rec = {
+        "shrine_id": 50,
+        "knowledge_deities": [
+            {"display_name": "素盞嗚尊", "sort_order": 2, "confidence": "high"},
+            {"display_name": "天比理乃咩命", "sort_order": 0, "confidence": "high"},
+            {"display_name": "宇賀之売命", "sort_order": 1, "confidence": "high"},
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "天比理乃咩命、宇賀之売命、素盞嗚尊"
+
+
+def test_candidate_profile_deity_does_not_mix_knowledge_and_sajin():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "レガシー祭神",
+        "knowledge_deities": [{"display_name": "明治天皇", "sort_order": 0, "confidence": "high"}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert "レガシー祭神" not in profile["deity"]
+    assert profile["deity"] == "明治天皇"
+
+
+# --- History正規化 ---
+
+
+def test_candidate_profile_shrine_history_falls_back_to_description_when_no_knowledge_histories():
+    rec = {"shrine_id": 1, "description": "レガシー由緒", "knowledge_histories": []}
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history"] == "レガシー由緒"
+
+
+def test_candidate_profile_shrine_history_uses_single_knowledge_history_content():
+    rec = {
+        "shrine_id": 1,
+        "description": "レガシー由緒",
+        "knowledge_histories": [
+            {
+                "history_type": "official_origin",
+                "title": "明治神宮の創建",
+                "content": "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+                "period_text": "大正9年（1920）",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history"] == "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。"
+
+
+def test_candidate_profile_shrine_history_uses_only_lowest_sort_order_entry():
+    rec = {
+        "shrine_id": 50,
+        "knowledge_histories": [
+            {
+                "history_type": "historical_event",
+                "title": "1319年",
+                "content": "二階堂道蘊公が宇賀之売命を祀った。",
+                "period_text": "元応元年（1319年）",
+                "sort_order": 1,
+                "confidence": "high",
+            },
+            {
+                "history_type": "founding",
+                "title": "1187年",
+                "content": "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎え、海上交通安全と祈願成就を祈ったことを創始とする。",
+                "period_text": "文治3年（1187年）",
+                "sort_order": 0,
+                "confidence": "high",
+            },
+            {
+                "history_type": "historical_event",
+                "title": "1478年",
+                "content": "太田道灌公が素盞嗚尊を祀った。",
+                "period_text": "文明10年（1478年）",
+                "sort_order": 2,
+                "confidence": "high",
+            },
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history"] == (
+        "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎え、海上交通安全と祈願成就を祈ったことを創始とする。"
+    )
+    # 1319年/1478年のcontentはshrine_historyへ混入しない
+    assert "二階堂道蘊公" not in profile["shrine_history"]
+    assert "太田道灌公" not in profile["shrine_history"]
+
+
+def test_candidate_profile_shrine_history_ignores_history_type_priority():
+    """history_type独自の優先順位（founding優先等）は導入しない。sort_orderのみで決まる。"""
+    rec = {
+        "shrine_id": 1,
+        "knowledge_histories": [
+            {
+                "history_type": "historical_event",
+                "title": "sort_order 0",
+                "content": "sort_order最小の内容",
+                "sort_order": 0,
+                "confidence": "high",
+            },
+            {
+                "history_type": "founding",
+                "title": "sort_order 1",
+                "content": "foundingだがsort_orderは1",
+                "sort_order": 1,
+                "confidence": "high",
+            },
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history"] == "sort_order最小の内容"
+
+
+def test_candidate_profile_shrine_history_does_not_mix_knowledge_and_description():
+    rec = {
+        "shrine_id": 1,
+        "description": "レガシー由緒",
+        "knowledge_histories": [
+            {"history_type": "official_origin", "content": "新Knowledgeの由緒", "sort_order": 0}
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert "レガシー由緒" not in profile["shrine_history"]
+    assert profile["shrine_history"] == "新Knowledgeの由緒"
+
+
+# --- Field単位fallback ---
+
+
+def test_candidate_profile_field_level_fallback_deity_new_history_legacy():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "レガシー祭神",
+        "description": "レガシー由緒",
+        "knowledge_deities": [{"display_name": "新祭神", "sort_order": 0}],
+        "knowledge_histories": [],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "新祭神"
+    assert profile["shrine_history"] == "レガシー由緒"
+
+
+def test_candidate_profile_field_level_fallback_deity_legacy_history_new():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "レガシー祭神",
+        "description": "レガシー由緒",
+        "knowledge_deities": [],
+        "knowledge_histories": [{"history_type": "official_origin", "content": "新由緒", "sort_order": 0}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "レガシー祭神"
+    assert profile["shrine_history"] == "新由緒"
+
+
+def test_candidate_profile_field_level_fallback_both_new():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "レガシー祭神",
+        "description": "レガシー由緒",
+        "knowledge_deities": [{"display_name": "新祭神", "sort_order": 0}],
+        "knowledge_histories": [{"history_type": "official_origin", "content": "新由緒", "sort_order": 0}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "新祭神"
+    assert profile["shrine_history"] == "新由緒"
+
+
+def test_candidate_profile_field_level_fallback_both_legacy():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "レガシー祭神",
+        "description": "レガシー由緒",
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "レガシー祭神"
+    assert profile["shrine_history"] == "レガシー由緒"
+
+
+# --- Pilot fixtures ---
+
+
+def test_candidate_profile_matches_pilot_1_meiji_jingu():
+    rec = {
+        "shrine_id": 1,
+        "sajin": "",
+        "description": None,
+        "knowledge_deities": [
+            {"display_name": "明治天皇", "sort_order": 0, "confidence": "high"},
+            {"display_name": "昭憲皇太后", "sort_order": 1, "confidence": "high"},
+        ],
+        "knowledge_histories": [
+            {
+                "history_type": "official_origin",
+                "title": "明治神宮の創建",
+                "content": "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+                "period_text": "大正9年（1920）",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "明治天皇、昭憲皇太后"
+    assert profile["shrine_history"] == "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。"
+
+
+def test_candidate_profile_matches_pilot_2_shinagawa():
+    rec = {
+        "shrine_id": 50,
+        "sajin": "",
+        "description": None,
+        "knowledge_deities": [
+            {"display_name": "天比理乃咩命", "sort_order": 0, "confidence": "high"},
+            {"display_name": "宇賀之売命", "sort_order": 1, "confidence": "high"},
+            {"display_name": "素盞嗚尊", "sort_order": 2, "confidence": "high"},
+        ],
+        "knowledge_histories": [
+            {
+                "history_type": "founding",
+                "title": "文治3年（1187年）の創始",
+                "content": (
+                    "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎え、"
+                    "海上交通安全と祈願成就を祈ったことを創始とする。"
+                ),
+                "period_text": "文治3年（1187年）",
+                "sort_order": 0,
+                "confidence": "high",
+            },
+            {
+                "history_type": "historical_event",
+                "title": "元応元年（1319年）の宇賀之売命奉祀",
+                "content": "二階堂道蘊公が宇賀之売命を祀った。",
+                "period_text": "元応元年（1319年）",
+                "sort_order": 1,
+                "confidence": "high",
+            },
+            {
+                "history_type": "historical_event",
+                "title": "文明10年（1478年）の素盞嗚尊奉祀",
+                "content": "太田道灌公が素盞嗚尊を祀った。",
+                "period_text": "文明10年（1478年）",
+                "sort_order": 2,
+                "confidence": "high",
+            },
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "天比理乃咩命、宇賀之売命、素盞嗚尊"
+    assert profile["shrine_history"] == (
+        "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎え、海上交通安全と祈願成就を祈ったことを創始とする。"
+    )
+    # 1319年/1478年はcandidate structured arrayに存在するが、shrine_history projectionには混入しない
+    assert "二階堂道蘊公" not in profile["shrine_history"]
+    assert "太田道灌公" not in profile["shrine_history"]
+
+
+def test_candidate_profile_zero_knowledge_shrine_matches_legacy_output():
+    """新Knowledge未投入Shrineの回帰: 現行(sajin/description由来)のoutputと一致する。"""
+    rec_without_knowledge_keys = {"shrine_id": 99, "sajin": "", "description": None}
+    rec_with_empty_knowledge = {
+        "shrine_id": 99,
+        "sajin": "",
+        "description": None,
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+
+    profile_a = _build_score_v3_candidate_profile(rec_without_knowledge_keys)
+    profile_b = _build_score_v3_candidate_profile(rec_with_empty_knowledge)
+
+    assert profile_a["deity"] is None
+    assert profile_a["shrine_history"] is None
+    assert profile_a["deity"] == profile_b["deity"]
+    assert profile_a["shrine_history"] == profile_b["shrine_history"]

--- a/backend/temples/tests/services/test_shrine_knowledge_selector.py
+++ b/backend/temples/tests/services/test_shrine_knowledge_selector.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services.shrine_knowledge_selector import (
+    fetch_fact_ready_knowledge_deities,
+    fetch_fact_ready_knowledge_histories,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_shrine(name: str = "Selector監査神社") -> Shrine:
+    return Shrine.objects.create(
+        name_jp=name,
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def _create_source(verification_status: str = "source_confirmed", **kwargs) -> ShrineKnowledgeSource:
+    defaults = dict(
+        source_type="shrine_official",
+        title=f"出典-{verification_status}",
+        verification_status=verification_status,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineKnowledgeSource.objects.create(**defaults)
+
+
+def _create_deity(shrine: Shrine, verification_status: str, sort_order: int = 0, **kwargs) -> ShrineDeity:
+    defaults = dict(
+        display_name=f"祭神-{verification_status}-{sort_order}",
+        verification_status=verification_status,
+        sort_order=sort_order,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineDeity.objects.create(shrine=shrine, **defaults)
+
+
+def _create_history(shrine: Shrine, verification_status: str, sort_order: int = 0, **kwargs) -> ShrineHistory:
+    defaults = dict(
+        history_type="official_origin",
+        title=f"由緒-{verification_status}-{sort_order}",
+        content="内容",
+        verification_status=verification_status,
+        sort_order=sort_order,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineHistory.objects.create(shrine=shrine, **defaults)
+
+
+# --- ShrineDeity selector ---
+
+
+@pytest.mark.parametrize("verification_status", ["source_confirmed", "reviewed"])
+def test_fetch_fact_ready_knowledge_deities_includes_fact_ready_status(verification_status):
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, verification_status)
+    deity.sources.add(_create_source("source_confirmed"))
+
+    result = fetch_fact_ready_knowledge_deities([shrine.id])
+
+    assert len(result.get(shrine.id, [])) == 1
+    assert result[shrine.id][0]["display_name"] == deity.display_name
+
+
+@pytest.mark.parametrize(
+    "verification_status", ["draft", "unverified", "disputed", "outdated", "rejected"]
+)
+def test_fetch_fact_ready_knowledge_deities_excludes_non_fact_ready_status(verification_status):
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, verification_status)
+    deity.sources.add(_create_source("source_confirmed"))
+
+    result = fetch_fact_ready_knowledge_deities([shrine.id])
+
+    assert result.get(shrine.id, []) == []
+
+
+def test_fetch_fact_ready_knowledge_deities_excludes_deity_without_fact_ready_source():
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "source_confirmed")
+    deity.sources.add(_create_source("draft"))
+
+    result = fetch_fact_ready_knowledge_deities([shrine.id])
+
+    assert result.get(shrine.id, []) == []
+
+
+def test_fetch_fact_ready_knowledge_deities_preserves_sort_order():
+    shrine = _create_shrine()
+    source = _create_source("source_confirmed")
+    d2 = _create_deity(shrine, "source_confirmed", sort_order=1, display_name="二番目")
+    d1 = _create_deity(shrine, "source_confirmed", sort_order=0, display_name="一番目")
+    for d in (d1, d2):
+        d.sources.add(source)
+
+    result = fetch_fact_ready_knowledge_deities([shrine.id])
+
+    names = [item["display_name"] for item in result[shrine.id]]
+    assert names == ["一番目", "二番目"]
+
+
+def test_fetch_fact_ready_knowledge_deities_dedupes_when_deity_has_multiple_fact_ready_sources():
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "source_confirmed")
+    deity.sources.add(_create_source("source_confirmed", title="出典A"))
+    deity.sources.add(_create_source("reviewed", title="出典B"))
+
+    result = fetch_fact_ready_knowledge_deities([shrine.id])
+
+    assert len(result[shrine.id]) == 1
+
+
+def test_fetch_fact_ready_knowledge_deities_batches_across_multiple_shrines_without_n_plus_1():
+    shrines = [_create_shrine(f"神社{i}") for i in range(5)]
+    source = _create_source("source_confirmed")
+    for shrine in shrines:
+        deity = _create_deity(shrine, "source_confirmed")
+        deity.sources.add(source)
+
+    with CaptureQueriesContext(connection) as ctx:
+        result = fetch_fact_ready_knowledge_deities([s.id for s in shrines])
+
+    assert all(len(result.get(s.id, [])) == 1 for s in shrines)
+    assert len(ctx.captured_queries) == 1
+
+
+def test_fetch_fact_ready_knowledge_deities_empty_shrine_ids_returns_empty_dict():
+    assert fetch_fact_ready_knowledge_deities([]) == {}
+
+
+# --- ShrineHistory selector ---
+
+
+@pytest.mark.parametrize("verification_status", ["source_confirmed", "reviewed"])
+def test_fetch_fact_ready_knowledge_histories_includes_fact_ready_status(verification_status):
+    shrine = _create_shrine()
+    history = _create_history(shrine, verification_status)
+    history.sources.add(_create_source("source_confirmed"))
+
+    result = fetch_fact_ready_knowledge_histories([shrine.id])
+
+    assert len(result.get(shrine.id, [])) == 1
+    assert result[shrine.id][0]["content"] == history.content
+
+
+@pytest.mark.parametrize(
+    "verification_status", ["draft", "unverified", "disputed", "outdated", "rejected"]
+)
+def test_fetch_fact_ready_knowledge_histories_excludes_non_fact_ready_status(verification_status):
+    shrine = _create_shrine()
+    history = _create_history(shrine, verification_status)
+    history.sources.add(_create_source("source_confirmed"))
+
+    result = fetch_fact_ready_knowledge_histories([shrine.id])
+
+    assert result.get(shrine.id, []) == []
+
+
+def test_fetch_fact_ready_knowledge_histories_excludes_history_without_fact_ready_source():
+    shrine = _create_shrine()
+    history = _create_history(shrine, "source_confirmed")
+    history.sources.add(_create_source("disputed"))
+
+    result = fetch_fact_ready_knowledge_histories([shrine.id])
+
+    assert result.get(shrine.id, []) == []
+
+
+def test_fetch_fact_ready_knowledge_histories_preserves_sort_order():
+    shrine = _create_shrine()
+    source = _create_source("source_confirmed")
+    h2 = _create_history(shrine, "source_confirmed", sort_order=1, title="1319年")
+    h1 = _create_history(shrine, "source_confirmed", sort_order=0, title="1187年")
+    for h in (h1, h2):
+        h.sources.add(source)
+
+    result = fetch_fact_ready_knowledge_histories([shrine.id])
+
+    titles = [item["title"] for item in result[shrine.id]]
+    assert titles == ["1187年", "1319年"]
+
+
+def test_fetch_fact_ready_knowledge_histories_batches_across_multiple_shrines_without_n_plus_1():
+    shrines = [_create_shrine(f"神社{i}") for i in range(5)]
+    source = _create_source("source_confirmed")
+    for shrine in shrines:
+        history = _create_history(shrine, "source_confirmed")
+        history.sources.add(source)
+
+    with CaptureQueriesContext(connection) as ctx:
+        result = fetch_fact_ready_knowledge_histories([s.id for s in shrines])
+
+    assert all(len(result.get(s.id, [])) == 1 for s in shrines)
+    assert len(ctx.captured_queries) == 1
+
+
+def test_fetch_fact_ready_knowledge_histories_empty_shrine_ids_returns_empty_dict():
+    assert fetch_fact_ready_knowledge_histories([]) == {}


### PR DESCRIPTION
## 目的

Shrine Knowledge Model Foundation（`ShrineDeity`/`ShrineHistory`/`ShrineKnowledgeSource`、PR #2221）を、Recommendation入力へ最小接続する。「RecommendationがどこからFactを読むか」だけを変更し、Evidence Gate・Score・Prompt・Web/Mobile・公開API Schemaは変更しない。

## 実装前の重複確認

同目的のOPEN PR・既存実装は見つかりませんでした（`git branch -a` / `gh pr list`で確認済み）。

## 採用Schema（案B）

事前監査（`audit/recommendation-knowledge-schema-design`）で比較したSchema案のうち、案Bを採用。candidateではstructured arrayを保持し、`_build_score_v3_candidate_profile()`で既存のstring型`deity`/`shrine_history`へ正規化する。`_build_fact()`・`build_recommendation_reason_v4()`の内部ロジック、公開API Schema（`fact.deity`/`fact.shrine_history`は引き続き`string | null`）は一切変更しない。

## 変更内容

### Knowledge selectorの実装位置

新規: [backend/temples/services/shrine_knowledge_selector.py](backend/temples/services/shrine_knowledge_selector.py)

- `fetch_fact_ready_knowledge_deities(shrine_ids)` / `fetch_fact_ready_knowledge_histories(shrine_ids)`
- DRF Serializer/Viewには一切依存しない（Recommendation内部契約とAPI表示契約を分離）

### fact-ready filterの実装位置

selector内のqueryset filter:

```python
verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,  # source_confirmed / reviewed
sources__verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
```

Deity/History自身の`verification_status`に加え、Relationされた`ShrineKnowledgeSource`側もfact-ready（`source_confirmed`/`reviewed`）であることを要求する。draft/unverified/disputed/outdated/rejectedはDeity/History・Source側どちらでも除外される。Source metadata自体（title/url等）はcandidateへ含めない。

### N+1回避方式

`build_chat_candidates()`（[concierge_chat_candidates.py](backend/temples/services/concierge_chat_candidates.py)）が候補Shrine群を取得した直後に、対象`shrine_ids`をまとめてselectorへ1回だけ渡す。Shrine数に関わらずDeity/History取得はそれぞれ1クエリのみ（selector単体テストでCaptureQueriesContextにより`len(queries) == 1`を確認、候補生成の統合テストでも10 Shrine投入時にクエリ数が線形増加しないことを確認）。

### candidate新Schema

```python
"knowledge_deities": [{"display_name": str, "sort_order": int, "confidence": str}, ...],
"knowledge_histories": [{"history_type": str, "title": str, "content": str, "period_text": str, "sort_order": int, "confidence": str}, ...],
```

既存の`sajin`/`description`キーは変更なし（並存）。

### candidate_profileへの正規化方式

[concierge_chat.py](backend/temples/services/concierge_chat.py) `_build_score_v3_candidate_profile()`:

- Deity: `knowledge_deities`をsort_order昇順で並べ、`display_name`を「、」で結合（件数上限なし。`canonical_name`/`role`はReason文字列へ含めない）
- History: `knowledge_histories`をsort_order昇順で並べ、**先頭1件のみ**の`content`を採用（`history_type`独自の優先順位は導入しない。複数結合もしない）

### Legacy fallbackの実装位置

`_build_score_v3_candidate_profile()`内、field単位（deity/shrine_historyそれぞれ独立）:

- `knowledge_deities`が空 → `sajin`（Legacy）
- `knowledge_histories`が空 → `description`（Legacy）
- 新KnowledgeとLegacyを同一field内で混在させない（片方の値のみ採用）
- Deity新/History旧、Deity旧/History新という部分投入状態も許容する（field単位fallbackのテストで確認）

## 実行結果

### 明治神宮での結果

`knowledge_deities`（明治天皇、昭憲皇太后）→ `deity = "明治天皇、昭憲皇太后"`。`knowledge_histories`（official_origin 1件）→ `shrine_history` = その`content`。テスト`test_candidate_profile_matches_pilot_1_meiji_jingu`で確認。

### 品川神社での結果

`knowledge_deities`（3件）→ `deity = "天比理乃咩命、宇賀之売命、素盞嗚尊"`。`knowledge_histories`（founding/1187・historical_event/1319・historical_event/1478の3件）→ sort_order最小の1187年founding entryの`content`のみ採用。1319年・1478年のcontentはcandidate structured arrayに保持されるが`shrine_history`には混入しない。テスト`test_candidate_profile_matches_pilot_2_shinagawa`で確認。

### 0 Knowledge Shrineの回帰結果

`knowledge_deities`/`knowledge_histories`キーが存在しない場合、または空配列の場合のいずれも、現行の`sajin`/`description`由来の出力と完全一致することを確認（`test_candidate_profile_zero_knowledge_shrine_matches_legacy_output`）。未投入Shrineへの回帰なし。

## 実行したtestsと結果

- 新規42件（selector 23件、candidate_profile正規化16件、build_chat_candidates統合3件）全PASS
- 既存`test_recommendation_reason_v4.py`・`test_action_suggestion_builder.py`・`test_concierge_chat_response_body_contract.py`等、無変更で全PASS
- Backend全体: **870 passed, 9 skipped**（developでも同一原因で失敗する既存7件のみ除外。本PR由来ではないことを確認済み）
- 除外理由と比較結果: `test_billing_status_contract.py::test_billing_status_contract_default`ほか6件の`concierge_rate_limit`系テストは、developで同一コマンドを実行しても同じ7件が失敗することを確認済み（timezone/rate-limit関連の環境依存で、本PR由来ではない）

## lint/type/OpenAPI/contract結果

- `ruff check`: 変更対象2ファイル（`concierge_chat.py`/`concierge_chat_candidates.py`）とも既存warning件数から増加なし（developと同一の6件、行番号のみ変化）。新規2ファイルはクリーン
- `mypy`: `backend/mypy.ini`の対象は`temples/views.py`/`temples/permissions.py`のみで、本PRの変更ファイルはスコープ外（既存の3件のエラーも本PR由来ではないことを確認）
- `pnpm lint:openapi`: 0 error
- `pnpm test:contract`: 692 passed

## Migrationなし確認

`manage.py makemigrations --check --dry-run` → `No changes detected`。Model変更を一切行っていないため。

## Score/Ranking非変更確認

`_build_score_v3_candidate_profile()`はcandidate_profileの`deity`/`shrine_history`フィールドの値のみを変更し、スコアリング・ランキングロジック（`recommendation_algorithm_v3.py`/`recommendation_score_v2.py`/`concierge_chat_ranking.py`のスコア計算部分）には一切触れていない。

## Web/Mobile非変更確認

`apps/web/`・`apps/mobile/`配下の変更なし（`git status --short`で確認）。`fact.deity`/`fact.shrine_history`の型（`string | null`）は変更していないため、Frontend側の`reasonV4FactPriority.ts`等は無変更のまま動作する。

## 変更ファイル一覧

- 新規: `backend/temples/services/shrine_knowledge_selector.py`
- 新規: `backend/temples/tests/services/test_shrine_knowledge_selector.py`
- 変更: `backend/temples/services/concierge_chat_candidates.py`
- 変更: `backend/temples/services/concierge_chat.py`
- 変更: `backend/temples/tests/services/test_concierge_build_chat_candidates_contract.py`
- 変更: `backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py`

## 変更禁止範囲（遵守確認）

`_build_fact()`/`build_recommendation_reason_v4()`内部ロジック、Score/Ranking計算、Prompt、Web、Mobile、Shrine Detail Serializer、ShrineDeity/ShrineHistory Serializer、公開API Schema、Model定義、Migration、Evidence Gate固有ロジック（confidence閾値・disputed高度処理・Source矛盾解決）、105件Rollout、`sajin`/`description`削除 — いずれも変更していません。

## Rollback

このPRをrevertすれば、selector新規ファイルと候補生成/正規化ロジックの追加分のみが取り消される。既存の`sajin`/`description`ベースの経路はそのまま残っているため、Legacy動作への影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)