### PR TITLE
feat(web): Shrine DetailへKnowledge Fact(祭神・由緒・歴史)を表示

### DIFF
--- a/apps/web/e2e/05_direction_flow.spec.ts
+++ b/apps/web/e2e/05_direction_flow.spec.ts
@@ -13,9 +13,36 @@ let fixedBackend: Server;
 test.beforeAll(async () => {
   fixedBackend = createServer((request, response) => {
     response.setHeader("Content-Type", "application/json");
+    // /navi/[id]等、既存Public経路(Public Serializer契約)が引き続き使用するため維持する。
     if (/^\/api\/public\/shrines\/\d+\/$/.test(request.url ?? "")) {
       const id = Number(request.url?.match(/\d+/)?.[0] ?? 508);
       response.end(JSON.stringify({ id, name_jp: `固定詳細神社${id}`, latitude: 35.68, longitude: 139.76, address: "固定テスト所在地" }));
+      return;
+    }
+    // Web Shrine Detail(getShrineDetailServer)が使用する通常Detail API
+    // (ShrineViewSet.retrieve → ShrineDetailSerializer契約)。
+    if (/^\/api\/shrines\/\d+\/data\/$/.test(request.url ?? "")) {
+      const id = Number(request.url?.match(/\d+/)?.[0] ?? 508);
+      response.end(
+        JSON.stringify({
+          id,
+          kind: "shrine",
+          name_jp: `固定詳細神社${id}`,
+          name_romaji: null,
+          address: "固定テスト所在地",
+          latitude: 35.68,
+          longitude: 139.76,
+          location: { lat: 35.68, lng: 139.76 },
+          goriyaku: null,
+          goriyaku_tags: [],
+          is_favorite: false,
+          distance: null,
+          distance_text: null,
+          kyusei: null,
+          deities: [],
+          histories: [],
+        }),
+      );
       return;
     }
     if ((request.url ?? "").includes("goshuin")) {

--- a/apps/web/src/app/api/shrines/[id]/data/route.ts
+++ b/apps/web/src/app/api/shrines/[id]/data/route.ts
@@ -1,0 +1,56 @@
+// apps/web/src/app/api/shrines/[id]/data/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { djFetch } from "@/lib/server/backend";
+
+type Ctx = { params: Promise<{ id: string }> };
+export const dynamic = "force-dynamic";
+
+// 通常Detail API（ShrineViewSet.retrieve、AllowAny）へのBFF境界。
+// /api/public/shrines/[id]/route.tsと同じ中継パターン（djFetch経由）に揃える。
+const DJANGO_SHRINE_DATA_BASE = "/api/shrines";
+
+export async function GET(req: NextRequest, ctx: Ctx) {
+  const { id } = await ctx.params;
+  if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 });
+
+  const upstreamPath = `${DJANGO_SHRINE_DATA_BASE}/${encodeURIComponent(id)}/data/`;
+  const upstream = await djFetch(req, upstreamPath, {
+    method: "GET",
+    forwardAuth: false,
+  });
+
+  const contentType = upstream.headers.get("content-type") ?? "";
+  const bodyText = await upstream.text();
+
+  if (!upstream.ok) {
+    return NextResponse.json(
+      {
+        error: "upstream_failed",
+        status: upstream.status,
+        upstream: upstream.url,
+        body: bodyText.slice(0, 1000),
+      },
+      { status: 502 },
+    );
+  }
+
+  // JSONじゃないなら、そのまま返す（事故防止）
+  if (!contentType.includes("application/json")) {
+    return new NextResponse(bodyText, {
+      status: upstream.status,
+      headers: { "Content-Type": contentType || "text/plain" },
+    });
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(bodyText);
+  } catch {
+    return NextResponse.json(
+      { error: "invalid_json", upstream: upstream.url, body: bodyText.slice(0, 400) },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json(raw, { status: upstream.status });
+}

--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -4,7 +4,7 @@ import type { Shrine } from "@/lib/api/shrines";
 import type { ConciergeBreakdown } from "@/lib/api/concierge";
 import { getConciergeThreadServer, getConciergeThreadsServer } from "@/lib/api/concierge.server";
 import { getBillingStatusServer } from "@/lib/api/billing.server";
-import { getShrinePublicServer } from "@/lib/api/shrines.server";
+import { getShrineDetailServer } from "@/lib/api/shrines.server";
 import { fetchPublicGoshuinsForShrineServer } from "@/lib/api/publicGoshuins.server";
 import { getShrineFavoriteInitialState } from "@/lib/server/favorites.server";
 
@@ -197,7 +197,7 @@ export default async function Page({ params, searchParams }: Props) {
 
   let shrine: Shrine | null;
   try {
-    shrine = await getShrinePublicServer(numericId);
+    shrine = await getShrineDetailServer(numericId);
   } catch (e) {
     serverLog("error", "GET_SHRINE_FAILED", {
       shrineId: numericId,

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -47,6 +47,7 @@ import ShrineJudgeSection from "@/components/shrine/detail/ShrineJudgeSection";
 import ShrineProposalSection from "@/components/shrine/detail/ShrineProposalSection";
 import ShrineReasonSection from "@/components/shrine/detail/ShrineReasonSection";
 import ShrineSupplementSection from "@/components/shrine/detail/ShrineSupplementSection";
+import ShrineFactSection from "@/components/shrine/detail/ShrineFactSection";
 import ShrineDetailHeroCard from "@/components/shrine/detail/ShrineDetailHeroCard";
 import DetailDisclosureBlock from "@/components/shrine/DetailDisclosureBlock";
 import { FAVORITE_LABELS } from "@/lib/ui/labels";
@@ -56,7 +57,7 @@ import { buildLoginHref } from "@/lib/nav/login";
 
 import type { ShrineTag } from "@/lib/shrine/tags/types";
 import type { ShrineCardAdapterProps } from "@/components/shrine/buildShrineCardProps";
-import type { ShrineDetailSectionModel } from "@/components/shrine/detail/types";
+import type { DetailFactSection, ShrineDetailSectionModel } from "@/components/shrine/detail/types";
 
 import { resolveAccessLevel } from "@/lib/premium/accessLevel";
 import { getVisibilityForCard, type CardVisibilityState } from "@/lib/premium/cardVisibility";
@@ -389,6 +390,7 @@ export default function ShrineDetailArticle({
   saveActionNode,
   actionState,
   directionSupportCopy = null,
+  factSection = null,
 }: {
   cardProps: ShrineCardAdapterProps;
   heroImageUrl?: string | null;
@@ -419,6 +421,7 @@ export default function ShrineDetailArticle({
   saveActionNode?: React.ReactNode;
   actionState?: "none" | "detail_viewed" | "saved" | "route_opened" | "visited" | "reflected" | null;
   directionSupportCopy?: string | null;
+  factSection?: DetailFactSection | null;
 }) {
 
   const hasLayeredSections = freeDisplaySections.length > 0 || premiumDisplaySections.length > 0;
@@ -661,6 +664,10 @@ export default function ShrineDetailArticle({
       ) : null}
 
       {/* Premium比較カードは後続PRで再設計する。 */}
+
+      {/* 神社Fact（祭神・由緒・歴史）。Interpretation/Recommendation/Actionとは独立した表示責務。
+          Premium gatingの対象にせず、Knowledge未登録（deities/historiesとも空）ならnullで非表示。 */}
+      {factSection ? <ShrineFactSection section={factSection} /> : null}
 
       {resolvedSaveActionNode ? (
         <section className="pt-4">

--- a/apps/web/src/components/shrine/detail/ShrineFactSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineFactSection.tsx
@@ -1,0 +1,75 @@
+// apps/web/src/components/shrine/detail/ShrineFactSection.tsx
+import type { DetailFactDeity, DetailFactHistoryItem, DetailFactSection } from "@/components/shrine/detail/types";
+
+type Props = {
+  section: DetailFactSection;
+};
+
+function DeityList({ deities }: { deities: DetailFactDeity[] }) {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-[var(--kt-color-text-primary)]">御祭神</h3>
+      <ul className="mt-2 flex flex-wrap gap-2">
+        {deities.map((deity, index) => (
+          <li
+            key={`${deity.display_name}:${index}`}
+            className="inline-flex items-center rounded-[var(--kt-radius-pill)] bg-[var(--kt-color-background-subtle)] px-3 py-1 text-sm text-[var(--kt-color-text-secondary)]"
+          >
+            {deity.display_name}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function HistoryList({ histories }: { histories: DetailFactHistoryItem[] }) {
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-[var(--kt-color-text-primary)]">由緒・歴史</h3>
+      <div className="mt-2 space-y-3">
+        {histories.map((history, index) => (
+          <div
+            key={`${history.title}:${index}`}
+            className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] p-3"
+          >
+            <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-[11px] font-semibold tracking-[0.04em] text-[var(--kt-color-text-muted)]">
+                {history.history_type_label}
+              </span>
+              {history.title ? (
+                <h4 className="text-sm font-semibold text-[var(--kt-color-text-primary)]">{history.title}</h4>
+              ) : null}
+              {history.period_text ? (
+                <span className="text-xs text-[var(--kt-color-text-muted)]">{history.period_text}</span>
+              ) : null}
+            </div>
+            {history.content ? (
+              <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-[var(--kt-color-text-secondary)]">
+                {history.content}
+              </p>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function ShrineFactSection({ section }: Props) {
+  const hasDeities = section.deities.length > 0;
+  const hasHistories = section.histories.length > 0;
+
+  if (!hasDeities && !hasHistories) return null;
+
+  return (
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">{section.heading}</h2>
+
+      <div className="mt-4 space-y-4">
+        {hasDeities ? <DeityList deities={section.deities} /> : null}
+        {hasHistories ? <HistoryList histories={section.histories} /> : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
@@ -662,4 +662,113 @@ describe("ShrineDetailArticle", () => {
       expect(wrapper?.className).toContain("bg-[var(--kt-color-background-subtle)]");
     });
   });
+
+  describe("神社について(Fact) Section", () => {
+    const baseProps = {
+      cardProps: {
+        title: "乃木神社",
+        href: "/shrines/17",
+        imageUrl: null,
+        badges: [],
+        metaChips: [],
+        address: "東京都港区赤坂",
+      } as any,
+      heroImageUrl: null,
+      heroMeaningCopy: null,
+      benefitLabels: [],
+      tags: [],
+      publicGoshuinsPreview: [],
+      publicGoshuinsViewAllHref: "",
+      sections: [],
+      recommendationMeta: null,
+      saveActionNode: null,
+    };
+
+    it("factSectionがnullの場合「神社について」を表示しない", () => {
+      render(<ShrineDetailArticle {...baseProps} factSection={null} />);
+
+      expect(screen.queryByText("神社について")).not.toBeInTheDocument();
+    });
+
+    it("御祭神とHistoryを表示する", () => {
+      render(
+        <ShrineDetailArticle
+          {...baseProps}
+          factSection={{
+            kind: "fact",
+            heading: "神社について",
+            deities: [
+              { display_name: "明治天皇", sort_order: 0 },
+              { display_name: "昭憲皇太后", sort_order: 1 },
+            ],
+            histories: [
+              {
+                history_type: "official_origin",
+                history_type_label: "由緒",
+                title: "明治神宮の創建",
+                content: "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+                period_text: "大正9年（1920）",
+                sort_order: 0,
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(screen.getByText("神社について")).toBeInTheDocument();
+      expect(screen.getByText("御祭神")).toBeInTheDocument();
+      expect(screen.getByText("明治天皇")).toBeInTheDocument();
+      expect(screen.getByText("昭憲皇太后")).toBeInTheDocument();
+      expect(screen.getByText("由緒・歴史")).toBeInTheDocument();
+      expect(screen.getByText("明治神宮の創建")).toBeInTheDocument();
+      expect(
+        screen.getByText("明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。"),
+      ).toBeInTheDocument();
+    });
+
+    it("複数Historyをすべて表示する（品川神社相当）", () => {
+      render(
+        <ShrineDetailArticle
+          {...baseProps}
+          factSection={{
+            kind: "fact",
+            heading: "神社について",
+            deities: [],
+            histories: [
+              {
+                history_type: "founding",
+                history_type_label: "創始",
+                title: "文治3年（1187年）の創始",
+                content: "創始の内容",
+                period_text: "文治3年（1187年）",
+                sort_order: 0,
+              },
+              {
+                history_type: "historical_event",
+                history_type_label: "歴史",
+                title: "元応元年（1319年）の宇賀之売命奉祀",
+                content: "1319年の内容",
+                period_text: "元応元年（1319年）",
+                sort_order: 1,
+              },
+              {
+                history_type: "historical_event",
+                history_type_label: "歴史",
+                title: "文明10年（1478年）の素盞嗚尊奉祀",
+                content: "1478年の内容",
+                period_text: "文明10年（1478年）",
+                sort_order: 2,
+              },
+            ],
+          }}
+        />,
+      );
+
+      expect(screen.getByText("文治3年（1187年）の創始")).toBeInTheDocument();
+      expect(screen.getByText("元応元年（1319年）の宇賀之売命奉祀")).toBeInTheDocument();
+      expect(screen.getByText("文明10年（1478年）の素盞嗚尊奉祀")).toBeInTheDocument();
+      // 御祭神が無い場合は見出しを出さない
+      expect(screen.queryByText("御祭神")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/components/shrine/detail/types.ts
+++ b/apps/web/src/components/shrine/detail/types.ts
@@ -46,9 +46,33 @@ export type DetailSupplementSection = {
   groups: DetailSupplementGroup[];
 };
 
+// 神社Fact（祭神・由緒・歴史）。Interpretation(meaning)・Recommendation(reason)・Action とは
+// 独立した表示責務として扱う。Premium gatingの対象にしない。
+export type DetailFactDeity = {
+  display_name: string;
+  sort_order: number;
+};
+
+export type DetailFactHistoryItem = {
+  history_type: string;
+  history_type_label: string;
+  title: string;
+  content: string;
+  period_text: string;
+  sort_order: number;
+};
+
+export type DetailFactSection = {
+  kind: "fact";
+  heading: string;
+  deities: DetailFactDeity[];
+  histories: DetailFactHistoryItem[];
+};
+
 export type ShrineDetailSectionModel =
   | DetailReasonSection
   | DetailProposalSection
   | DetailMeaningSection
   | DetailActionSection
-  | DetailSupplementSection;
+  | DetailSupplementSection
+  | DetailFactSection;

--- a/apps/web/src/lib/api/shrines.server.ts
+++ b/apps/web/src/lib/api/shrines.server.ts
@@ -18,16 +18,19 @@ function resolveBackendPublicBaseUrl(): string | null {
   return raw ? normalizeBaseUrl(raw) : null;
 }
 
-export async function getShrinePublicServer(id: number): Promise<Shrine> {
+// 通常Detail API（/api/shrines/{id}/data/、ShrineViewSet.retrieve）を使用する。
+// AllowAnyのためanonymous SSR fetchのまま（認証headerは付けない）。
+// Public API（/api/public/shrines/{id}/）は/navi/[id]専用として維持し、ここでは呼ばない。
+export async function getShrineDetailServer(id: number): Promise<Shrine> {
   const base = resolveBackendPublicBaseUrl() ?? (await resolveServerBaseUrl());
-  const url = `${base}/api/public/shrines/${id}/`;
+  const url = `${base}/api/shrines/${id}/data/`;
 
-  console.log("[getShrinePublicServer]", { id, base, url });
+  console.log("[getShrineDetailServer]", { id, base, url });
 
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) {
     const body = await res.text().catch(() => "<failed to read body>");
-    throw new Error(`getShrinePublicServer failed: ${res.status} body=${body.slice(0, 300)}`);
+    throw new Error(`getShrineDetailServer failed: ${res.status} body=${body.slice(0, 300)}`);
   }
 
   return (await res.json()) as Shrine;

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -17,6 +17,46 @@ export type GoriyakuTag = {
   category?: string | null;
 };
 
+// backend/temples/api/serializers/shrine.py の ShrineKnowledgeSourceSerializer に一致する
+// (note/verified_at/accessed_at/bibliography/languageは非公開。実際に返す field のみ定義する)
+export type ShrineKnowledgeSource = {
+  id: number;
+  source_type: string;
+  title: string;
+  publisher: string;
+  url: string;
+  verification_status: string;
+  confidence: string;
+};
+
+// backend/temples/api/serializers/shrine.py の ShrineDeitySerializer に一致する
+// (canonical_name/note/verified_at/aliasesは非公開。実際に返す field のみ定義する)
+export type ShrineDeity = {
+  id: number;
+  display_name: string;
+  canonical_name: string;
+  role: string;
+  sort_order: number;
+  verification_status: string;
+  confidence: string;
+  sources: ShrineKnowledgeSource[];
+};
+
+// backend/temples/api/serializers/shrine.py の ShrineHistorySerializer に一致する
+// (note/verified_atは非公開。実際に返す field のみ定義する)
+export type ShrineHistory = {
+  id: number;
+  history_type: string;
+  title: string;
+  content: string;
+  period_text: string;
+  event_date: string | null;
+  sort_order: number;
+  verification_status: string;
+  confidence: string;
+  sources: ShrineKnowledgeSource[];
+};
+
 export type ShrineBase = {
   id: number;
   name_jp: string;
@@ -37,6 +77,11 @@ export type ShrineBase = {
   sajin?: string;
   description?: string | null;
   goriyaku_tags: GoriyakuTag[];
+
+  // ShrineDetailSerializerのみ返す（ShrinePublicSerializer/ShrineListSerializerには存在しない）。
+  // 通常Detail API(/api/shrines/{id}/data/)経由でのみ値が入る。
+  deities?: ShrineDeity[];
+  histories?: ShrineHistory[];
 };
 
 export type Shrine = ShrineBase;

--- a/apps/web/src/lib/shrine/__tests__/buildShrineDetailModel.test.ts
+++ b/apps/web/src/lib/shrine/__tests__/buildShrineDetailModel.test.ts
@@ -670,3 +670,180 @@ describe("buildShrineDetailModel", () => {
     expect(result.heroImageUrl).toBeNull();
   });
 });
+
+describe("buildShrineDetailModel - factSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Knowledge未登録（deities/historiesとも無し）の場合はfactSectionがnull", () => {
+    const result = buildShrineDetailModel({
+      shrine: { ...shrineStub },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection).toBeNull();
+  });
+
+  it("Knowledge未登録（deities/historiesとも空配列）の場合はfactSectionがnull", () => {
+    const result = buildShrineDetailModel({
+      shrine: { ...shrineStub, deities: [], histories: [] },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection).toBeNull();
+  });
+
+  it("明治神宮相当: 2 Deity + 1 History", () => {
+    const result = buildShrineDetailModel({
+      shrine: {
+        ...shrineStub,
+        deities: [
+          { id: 1, display_name: "明治天皇", canonical_name: "", role: "enshrined", sort_order: 0, verification_status: "source_confirmed", confidence: "high", sources: [] },
+          { id: 2, display_name: "昭憲皇太后", canonical_name: "", role: "enshrined", sort_order: 1, verification_status: "source_confirmed", confidence: "high", sources: [] },
+        ],
+        histories: [
+          {
+            id: 1,
+            history_type: "official_origin",
+            title: "明治神宮の創建",
+            content: "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+            period_text: "大正9年（1920）",
+            event_date: null,
+            sort_order: 0,
+            verification_status: "source_confirmed",
+            confidence: "high",
+            sources: [],
+          },
+        ],
+      },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection).not.toBeNull();
+    expect(result.factSection?.deities.map((d) => d.display_name)).toEqual(["明治天皇", "昭憲皇太后"]);
+    expect(result.factSection?.histories).toHaveLength(1);
+    expect(result.factSection?.histories[0].content).toBe(
+      "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+    );
+    expect(result.factSection?.histories[0].history_type_label).toBe("由緒");
+  });
+
+  it("品川神社相当: 3 Deity + 3 History（全件表示。sort_order順を維持）", () => {
+    const result = buildShrineDetailModel({
+      shrine: {
+        ...shrineStub,
+        deities: [
+          { id: 3, display_name: "素盞嗚尊", canonical_name: "", role: "enshrined", sort_order: 2, verification_status: "source_confirmed", confidence: "high", sources: [] },
+          { id: 1, display_name: "天比理乃咩命", canonical_name: "", role: "enshrined", sort_order: 0, verification_status: "source_confirmed", confidence: "high", sources: [] },
+          { id: 2, display_name: "宇賀之売命", canonical_name: "", role: "enshrined", sort_order: 1, verification_status: "source_confirmed", confidence: "high", sources: [] },
+        ],
+        histories: [
+          {
+            id: 2,
+            history_type: "historical_event",
+            title: "元応元年（1319年）の宇賀之売命奉祀",
+            content: "二階堂道蘊公が宇賀之売命を祀った。",
+            period_text: "元応元年（1319年）",
+            event_date: null,
+            sort_order: 1,
+            verification_status: "source_confirmed",
+            confidence: "high",
+            sources: [],
+          },
+          {
+            id: 1,
+            history_type: "founding",
+            title: "文治3年（1187年）の創始",
+            content: "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎え、海上交通安全と祈願成就を祈ったことを創始とする。",
+            period_text: "文治3年（1187年）",
+            event_date: null,
+            sort_order: 0,
+            verification_status: "source_confirmed",
+            confidence: "high",
+            sources: [],
+          },
+          {
+            id: 3,
+            history_type: "historical_event",
+            title: "文明10年（1478年）の素盞嗚尊奉祀",
+            content: "太田道灌公が素盞嗚尊を祀った。",
+            period_text: "文明10年（1478年）",
+            event_date: null,
+            sort_order: 2,
+            verification_status: "source_confirmed",
+            confidence: "high",
+            sources: [],
+          },
+        ],
+      },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection?.deities.map((d) => d.display_name)).toEqual([
+      "天比理乃咩命",
+      "宇賀之売命",
+      "素盞嗚尊",
+    ]);
+    // Recommendationのshrine_history projection(先頭1件のみ)とは異なり、Detailは保存済み全Factを表示する
+    expect(result.factSection?.histories).toHaveLength(3);
+    expect(result.factSection?.histories.map((h) => h.title)).toEqual([
+      "文治3年（1187年）の創始",
+      "元応元年（1319年）の宇賀之売命奉祀",
+      "文明10年（1478年）の素盞嗚尊奉祀",
+    ]);
+  });
+
+  it("Deityのみ存在する場合はdeitiesのみ非空", () => {
+    const result = buildShrineDetailModel({
+      shrine: {
+        ...shrineStub,
+        deities: [
+          { id: 1, display_name: "祭神A", canonical_name: "", role: "unknown", sort_order: 0, verification_status: "reviewed", confidence: "", sources: [] },
+        ],
+        histories: [],
+      },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection?.deities).toHaveLength(1);
+    expect(result.factSection?.histories).toHaveLength(0);
+  });
+
+  it("Historyのみ存在する場合はhistoriesのみ非空", () => {
+    const result = buildShrineDetailModel({
+      shrine: {
+        ...shrineStub,
+        deities: [],
+        histories: [
+          {
+            id: 1,
+            history_type: "tradition",
+            title: "伝承A",
+            content: "内容A",
+            period_text: "",
+            event_date: null,
+            sort_order: 0,
+            verification_status: "source_confirmed",
+            confidence: "high",
+            sources: [],
+          },
+        ],
+      },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection?.deities).toHaveLength(0);
+    expect(result.factSection?.histories).toHaveLength(1);
+    expect(result.factSection?.histories[0].history_type_label).toBe("伝承");
+  });
+
+  it("Legacy descriptionが存在してもHistory fallbackとして使わない", () => {
+    const result = buildShrineDetailModel({
+      shrine: { ...shrineStub, description: "レガシーな説明文", deities: [], histories: [] },
+      publicGoshuins: [],
+    });
+
+    expect(result.factSection).toBeNull();
+  });
+});

--- a/apps/web/src/lib/shrine/buildShrineDetailModel.ts
+++ b/apps/web/src/lib/shrine/buildShrineDetailModel.ts
@@ -5,6 +5,7 @@ import type { ShrineTag } from "@/lib/shrine/tags/types";
 import type { PublicGoshuinItem } from "@/components/shrine/detail/PublicGoshuinSection";
 import type {
   DetailActionSection,
+  DetailFactSection,
   DetailMeaningItem,
   DetailMeaningSection,
   DetailProposalSection,
@@ -18,6 +19,7 @@ import type { ConciergeBreakdown } from "@/lib/api/concierge";
 import { buildShrineCardProps } from "@/components/shrine/buildShrineCardProps";
 import { getBenefitLabels } from "@/lib/shrine/getBenefitLabels";
 import { buildShrineExplanation } from "@/lib/shrine/buildShrineExplanation";
+import { buildShrineFactSection } from "@/lib/shrine/buildShrineFactSection";
 import { buildShrineJudge } from "@/lib/shrine/buildShrineJudge";
 import { buildShrineHref } from "@/lib/nav/buildShrineHref";
 import {
@@ -1678,6 +1680,8 @@ export function buildShrineDetailModel({
 
   const directionSupportCopy = shrineMeaningPayloadV2?.generated?.directionSupportCopy?.trim() || null;
 
+  const factSection: DetailFactSection | null = buildShrineFactSection(shrine);
+
   return {
     shrineId: shrine.id,
     cardProps,
@@ -1710,5 +1714,6 @@ export function buildShrineDetailModel({
     symbolTags,
     actionState,
     directionSupportCopy,
+    factSection,
   };
 }

--- a/apps/web/src/lib/shrine/buildShrineFactSection.ts
+++ b/apps/web/src/lib/shrine/buildShrineFactSection.ts
@@ -1,0 +1,59 @@
+import type { ShrineDeity, ShrineHistory } from "@/lib/api/types";
+import type { DetailFactHistoryItem, DetailFactSection } from "@/components/shrine/detail/types";
+
+// docs/knowledge/shrine-knowledge-contract.md「分類案（To-Be）」の定義に基づく固定ラベル。
+// 宗教的・歴史的な意味を新たに解釈しない。
+const HISTORY_TYPE_LABELS: Record<string, string> = {
+  official_origin: "由緒",
+  founding: "創始",
+  historical_event: "歴史",
+  tradition: "伝承",
+  regional_context: "地域史",
+  editorial_summary: "要約",
+};
+
+function resolveHistoryTypeLabel(historyType: string): string {
+  return HISTORY_TYPE_LABELS[historyType] ?? historyType;
+}
+
+function sortBySortOrder<T extends { sort_order: number }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.sort_order - b.sort_order);
+}
+
+/**
+ * Shrine Detail APIのdeities/historiesを「神社について」Fact Sectionへ変換する。
+ * Knowledge未登録（deities/historiesとも空）の場合はnullを返し、呼び出し側はSectionを表示しない。
+ * Legacy(sajin/description)へはfallbackしない。
+ */
+export function buildShrineFactSection(shrine: {
+  deities?: ShrineDeity[];
+  histories?: ShrineHistory[];
+}): DetailFactSection | null {
+  const deities = Array.isArray(shrine.deities) ? shrine.deities : [];
+  const histories = Array.isArray(shrine.histories) ? shrine.histories : [];
+
+  if (deities.length === 0 && histories.length === 0) {
+    return null;
+  }
+
+  const sortedDeities = sortBySortOrder(deities).map((deity) => ({
+    display_name: deity.display_name,
+    sort_order: deity.sort_order,
+  }));
+
+  const sortedHistories: DetailFactHistoryItem[] = sortBySortOrder(histories).map((history) => ({
+    history_type: history.history_type,
+    history_type_label: resolveHistoryTypeLabel(history.history_type),
+    title: history.title,
+    content: history.content,
+    period_text: history.period_text,
+    sort_order: history.sort_order,
+  }));
+
+  return {
+    kind: "fact",
+    heading: "神社について",
+    deities: sortedDeities,
+    histories: sortedHistories,
+  };
+}


### PR DESCRIPTION
## 目的

Web Shrine Detail画面へ、Shrine Knowledge Model Foundationで実装済みの`ShrineDeity`/`ShrineHistory`を接続し、「神社そのもののFact」（御祭神・由緒・歴史）をユーザーが確認できるようにする。RecommendationやMeaning Layerは変更しない。

## 実装前の重複確認

同目的のOPEN PR・未コミット変更は見つかりませんでした。

## 変更ファイル一覧

- 変更: `apps/web/src/lib/api/shrines.server.ts`
- 変更: `apps/web/src/lib/api/types.ts`
- 新規: `apps/web/src/lib/shrine/buildShrineFactSection.ts`
- 変更: `apps/web/src/lib/shrine/buildShrineDetailModel.ts`
- 新規: `apps/web/src/components/shrine/detail/ShrineFactSection.tsx`
- 変更: `apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx`
- 変更: `apps/web/src/components/shrine/detail/types.ts`
- 変更: `apps/web/src/app/shrines/[id]/page.tsx`
- 変更: `apps/web/src/lib/shrine/__tests__/buildShrineDetailModel.test.ts`
- 変更: `apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx`

## Web Detail API変更前/変更後

- 変更前: `getShrinePublicServer()` → `GET /api/public/shrines/{id}/`（`ShrinePublicSerializer`、deities/histories欠落）
- 変更後: `getShrineDetailServer()`（rename） → `GET /api/shrines/{id}/data/`（`ShrineViewSet.retrieve` → `ShrineDetailSerializer`、deities/histories含む）
- 既存の`/api/shrines/{id}/data/`は`getShrinePrivate()`（`GoshuinUploadForm.tsx`が使用）が既に使っている既存正本routeであり、それに合わせた
- 認証headerは追加していない。anonymous SSR fetch（`fetch(url, { cache: "no-store" })`のまま）
- `getShrinePublicClient()`・Public BFF route（`apps/web/src/app/api/public/shrines/[id]/route.ts`）・`/navi/[id]`は無変更

### 関数名rename

`getShrinePublicServer` → `getShrineDetailServer`（呼び出し元は`page.tsx`の1箇所のみで差分が小さいため実施）

## 使用した通常Detail endpoint

`GET /api/shrines/{id}/data/`

## Frontend追加型

`apps/web/src/lib/api/types.ts`へ`ShrineKnowledgeSource`/`ShrineDeity`/`ShrineHistory`を追加。Backend Serializerが実際に返すfieldのみ定義（`note`/`verified_at`/`canonical_name`の非公開等は含めていない）。`Shrine`型へ`deities?`/`histories?`を追加（`ShrineDetailSerializer`のみ返すため`?`）。既存`sajin`/`description`は削除していない。

## Detail ViewModel追加内容

`buildShrineFactSection.ts`（新規、純粋関数）:
- `deities`/`histories`をsort_order昇順に正規化
- `canonical_name`/`roleはFact文言に含めない
- `history_type`の固定ラベル（`docs/knowledge/shrine-knowledge-contract.md`の分類定義に基づく: `official_origin`→由緒, `founding`→創始, `historical_event`→歴史, `tradition`→伝承, `regional_context`→地域史, `editorial_summary`→要約）
- Sourceにない内容の要約・補完は行わない
- `deities`/`histories`とも空の場合は`null`を返す（Legacy `description`へはfallbackしない）

`buildShrineDetailModel.ts`へ`factSection`フィールドを追加。

## UI Section構成

`ShrineFactSection.tsx`（新規）を`ShrineDetailArticle.tsx`へ追加。配置順序:

```
Hero
↓
既存Recommendation / Meaning導線 (①〜④)
↓
既存補足Section（ご利益等）
↓
神社について (NEW, factSectionがnullなら非表示)
↓
保存/参拝Action導線
```

Premium gatingは追加していない（`personalMeaningVisibility`等の既存Premium判定ロジックから独立して、常に表示するか非表示にするかのみ判定）。

## History typeの表示ルール

固定mapping（`buildShrineFactSection.ts`内`HISTORY_TYPE_LABELS`）。宗教的・歴史的な意味の新規解釈は行っていない。既存docs/glossary/UI copy contractに`history_type`のラベル定義は見つからなかったため、`docs/knowledge/shrine-knowledge-contract.md`の分類定義（内容説明）から直接ラベル化した。

## Legacy fallbackを使っていない確認

`buildShrineFactSection.ts`は`shrine.description`/`shrine.sajin`を一切参照しない。テスト`Legacy descriptionが存在してもHistory fallbackとして使わない`で確認済み。

## 明治神宮QA結果

ローカル環境（Django dev server + Next.js dev server、実データ）で確認。

```
御祭神: 明治天皇, 昭憲皇太后
由緒・歴史: 由緒 / 明治神宮の創建 / 大正9年（1920） / 明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。
```

期待通り表示された（PASS）。

## 品川神社QA結果

```
御祭神: 天比理乃咩命, 宇賀之売命, 素盞嗚尊
由緒・歴史: 創始/文治3年（1187年）の創始/... 、歴史/元応元年（1319年）の宇賀之売命奉祀/...、歴史/文明10年（1478年）の素盞嗚尊奉祀/...
```

3 Deity・3 History全件が表示された（PASS）。Recommendation Knowledge Connectionの1件projection契約はDetail UIに持ち込んでいない。

## Empty Knowledge QA結果

Knowledge未登録Shrine（`deities=[]`/`histories=[]`）で「神社について」Sectionが表示されず、既存画面（Meaning/Recommendation/補足/保存導線）はそのまま動作することを確認（PASS）。

## goriyaku_tags回帰確認

`getBenefitLabels()`のロジック自体は変更していない。明治神宮では`goriyaku_tags`（交通安全/厄除け/縁結び）と`goriyaku`文字列（"縁結び・厄除け・交通安全"）の内容が一致しており、可視的な差分は確認されなかった。また`benefitLabels`が実際に表示に使われるのは`ctx=concierge`かつ`hasSections`が偽の場合の限定的な経路であり、今回検証した明治神宮・品川神社のDirect Navigationではその経路自体が使用されないことをコードで確認した（`hasSections`が真のため、pill表示フォールバックは通らない）。意図しない回帰は確認されなかった。

## Mobile 375/390/430 QA

品川神社（3 Deity + 3 History、長い由緒本文含む）で375px/390px/430pxを確認。横スクロールなし、text clippingなし（`whitespace-pre-wrap break-words`適用済み）、section間隔崩れなし、CTA押下領域への干渉なし（PASS、スクリーンショット確認済み）。

## Public API regression

`/navi/1`にアクセスし、Network requestsで`GET /api/public/shrines/1/ → 200 OK`が引き続き発行されることを確認（BFF route・Public Serializerとも無変更）。

## 実行したtests

- 新規: `buildShrineFactSection`関連 8件、`ShrineDetailArticle`のFact Section関連 3件
- Web全体: **112 test files / 702 tests、全PASS**

## lint/typecheck/OpenAPI結果

- `eslint`: 対象ファイルすべてクリーン
- `tsc --noEmit`: エラー0件
- `pnpm lint:openapi`: 0 error
- `pnpm test:contract`: 692→変更なし（Web側テストの一部として702件に含まれる）

## Migrationなし確認

Backendコードを一切変更していないため、Migrationは発生しない（`git status --short`でBackend差分0件を確認）。

## Backend差分なし確認

`git status --short --porcelain`で`apps/web/`配下のみの変更であることを確認。`Shrine`/`ShrineDeity`/`ShrineHistory`/`ShrineKnowledgeSource`Model、`ShrineDetailSerializer`、`ShrineViewSet`、`PublicShrineDetailView`、`ShrinePublicSerializer`はいずれも無変更。

## Recommendation差分なし確認

`temples/services/shrine_knowledge_selector.py`、`concierge_chat.py`等Recommendation関連ファイルは無変更（Backend自体を変更していないため）。

## Public API差分なし確認

`ShrinePublicSerializer`・`PublicShrineDetailView`・Public BFF route・`getShrinePublicClient`はいずれも無変更。`/navi/[id]`の実地確認済み（上記）。

## 影響範囲

`apps/web/`のみ。Backend / Mobile / Payment / 105件Rollout / Admin / DB dataへの変更なし。

## Rollback方法

このPRをrevertすれば、Web Detailの取得先はPublic APIへ戻り、Knowledge Fact表示も消える。Backend・DBへの変更が無いため、revertのみで完全に元の状態に戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)