### PR TITLE
feat(backend): Evidence Gate Foundation(PR-A)を実装

### DIFF
--- a/backend/temples/api/serializers/shrine.py
+++ b/backend/temples/api/serializers/shrine.py
@@ -5,7 +5,6 @@ from drf_spectacular.utils import OpenApiTypes, extend_schema_field
 
 from temples.geo_utils import to_lat_lng_dict
 from temples.models import (
-    KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
     GoriyakuTag,
     Shrine,
     ShrineDeity,
@@ -13,6 +12,7 @@ from temples.models import (
     ShrineKnowledgeSource,
     Visit,
 )
+from temples.services import evidence_gate
 
 from rest_framework import serializers
 from temples.models import GoriyakuTag, Shrine
@@ -42,10 +42,24 @@ class ShrineKnowledgeSourceSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+def _fact_ready_sources(obj) -> list[ShrineKnowledgeSource]:
+    """関連Sourceのうちfact-readyなものだけを返す。
+
+    View側のPrefetchで既に絞り込まれている場合はそのまま、Serializerが
+    Prefetchを経由せず単独で呼ばれた場合（例: 単体テスト）でも同じ結果になるよう、
+    ここでも明示的にevidence_gateの基準でフィルタする。
+    """
+    return [
+        s
+        for s in obj.sources.all()
+        if s.verification_status in evidence_gate.FACT_READY_VERIFICATION_STATUSES
+    ]
+
+
 class ShrineDeitySerializer(serializers.ModelSerializer):
     """docs/knowledge/shrine-knowledge-contract.md「deity契約」のRead専用表示。"""
 
-    sources = ShrineKnowledgeSourceSerializer(many=True, read_only=True)
+    sources = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = ShrineDeity
@@ -61,11 +75,17 @@ class ShrineDeitySerializer(serializers.ModelSerializer):
         ]
         read_only_fields = fields
 
+    @extend_schema_field(ShrineKnowledgeSourceSerializer(many=True))
+    def get_sources(self, obj):
+        return ShrineKnowledgeSourceSerializer(
+            _fact_ready_sources(obj), many=True, context=self.context
+        ).data
+
 
 class ShrineHistorySerializer(serializers.ModelSerializer):
     """docs/knowledge/shrine-knowledge-contract.md「shrine_history契約」のRead専用表示。"""
 
-    sources = ShrineKnowledgeSourceSerializer(many=True, read_only=True)
+    sources = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = ShrineHistory
@@ -82,6 +102,12 @@ class ShrineHistorySerializer(serializers.ModelSerializer):
             "sources",
         ]
         read_only_fields = fields
+
+    @extend_schema_field(ShrineKnowledgeSourceSerializer(many=True))
+    def get_sources(self, obj):
+        return ShrineKnowledgeSourceSerializer(
+            _fact_ready_sources(obj), many=True, context=self.context
+        ).data
 
 
 class _DistanceFieldsMixin:
@@ -153,9 +179,11 @@ class ShrineListSerializer(ShrineBaseSerializer):
 
 
 class ShrineDetailSerializer(ShrineBaseSerializer):
-    """Shrine Detail API専用。deities/historiesはdocs/knowledge/shrine-knowledge-contract.md
-    「Evidence Gate要件」に従い、verification_statusがFact利用可能な状態
-    （source_confirmed/reviewed）のもののみ返却する。Knowledge未登録時は[]を返し、
+    """Shrine Detail API専用。deities/historiesはtemples.services.evidence_gateの
+    Evidence Gate判定（Fact自身のverification_statusがfact-ready、かつ
+    fact-readyなSourceを1件以上Relation）を満たすもの（usable=True）のみ返却する。
+    Recommendation側（shrine_knowledge_selector.py）と同一のEvidence Gateを使うため、
+    両経路のFact利用可否は常に一致する。Knowledge未登録時は[]を返し、
     Legacy Field（sajin/description）へのfallbackは行わない。
     """
 
@@ -188,7 +216,11 @@ class ShrineDetailSerializer(ShrineBaseSerializer):
         items = [
             d
             for d in obj.deities.all()
-            if d.verification_status in KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+            if evidence_gate.decide_fact_usability(
+                verification_status=d.verification_status,
+                confidence=d.confidence,
+                source_verification_statuses=(s.verification_status for s in d.sources.all()),
+            ).usable
         ]
         return ShrineDeitySerializer(items, many=True, context=self.context).data
 
@@ -197,7 +229,11 @@ class ShrineDetailSerializer(ShrineBaseSerializer):
         items = [
             h
             for h in obj.histories.all()
-            if h.verification_status in KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+            if evidence_gate.decide_fact_usability(
+                verification_status=h.verification_status,
+                confidence=h.confidence,
+                source_verification_statuses=(s.verification_status for s in h.sources.all()),
+            ).usable
         ]
         return ShrineHistorySerializer(items, many=True, context=self.context).data
 

--- a/backend/temples/api/views/shrine.py
+++ b/backend/temples/api/views/shrine.py
@@ -34,12 +34,12 @@ from temples.api.serializers.shrine import (
     ShrineWriteSerializer,
 )
 from temples.models import (
-    KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
     Shrine,
     ShrineDeity,
     ShrineHistory,
     ShrineKnowledgeSource,
 )
+from temples.services import evidence_gate
 from temples.queries import (
     nearest_queryset as q_nearest_queryset,
     nearest_shrines as q_nearest_shrines,
@@ -296,17 +296,19 @@ class ShrineViewSet(viewsets.ModelViewSet):
         qs = qs.distinct()
 
         # Shrine Detail APIのみdeities/historiesをprefetchする（N+1回避）。
-        # docs/knowledge/shrine-knowledge-contract.md「Evidence Gate要件」に従い、
-        # Fact利用可能なverification_statusのみを事前フィルタする。
-        # ネストされるsourcesも同様にFact利用可能なverification_statusのみへ絞る
-        # （Knowledge本体だけでなくSource自体も未公開statusを返さないため）。
+        # ここではFact自身のverification_statusによる候補絞り込みと、ネストする
+        # sourcesのfact-ready絞り込みのみを行う（クエリ件数を減らすための事前フィルタ）。
+        # 「fact-readyなSourceを1件以上持つか」を含む最終的なusable判定は
+        # temples.services.evidence_gateへ一本化しており、
+        # ShrineDetailSerializer.get_deities()/get_histories()で行う
+        # （Recommendation側のshrine_knowledge_selector.pyと同じEvidence Gateを使う）。
         if self.action in ("retrieve",):
 
             def _fact_ready_sources_prefetch() -> Prefetch:
                 return Prefetch(
                     "sources",
                     queryset=ShrineKnowledgeSource.objects.filter(
-                        verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+                        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
                     ),
                 )
 
@@ -314,7 +316,7 @@ class ShrineViewSet(viewsets.ModelViewSet):
                 Prefetch(
                     "deities",
                     queryset=ShrineDeity.objects.filter(
-                        verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+                        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
                     )
                     .prefetch_related(_fact_ready_sources_prefetch())
                     .order_by("sort_order", "id"),
@@ -322,7 +324,7 @@ class ShrineViewSet(viewsets.ModelViewSet):
                 Prefetch(
                     "histories",
                     queryset=ShrineHistory.objects.filter(
-                        verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+                        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
                     )
                     .prefetch_related(_fact_ready_sources_prefetch())
                     .order_by("sort_order", "id"),

--- a/backend/temples/services/evidence_gate.py
+++ b/backend/temples/services/evidence_gate.py
@@ -1,0 +1,89 @@
+"""Evidence Gate Foundation。
+
+docs/knowledge/shrine-knowledge-contract.md「Evidence Gate要件」の実装。
+
+ShrineDeity / ShrineHistory（Fact）がRecommendation / Shrine Detailの両経路で
+利用可能（usable）かどうかを、単一のロジックで判定する。従来はこの判定が
+Recommendation側（shrine_knowledge_selector.pyのQuerySet条件）とShrine Detail側
+（ShrineViewSet.get_queryset()のPrefetch + Serializer）とで別々に実装されており、
+「Fact ready + fact-ready Sourceなし」のケースでRecommendationは除外・Detailは
+表示という非対称性があった。本モジュールを両経路の正本とすることでこれを解消する。
+
+PR-Aでは以下のみを扱う。confidenceによる表現制御・disputed専用表示・数値スコアは
+PR-B以降へ延期する（本ファイルのdocstring/コメントを参照）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from temples.models import KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+
+# Fact自身・Sourceの双方で「fact-ready」とみなすverification_status。
+# 値そのものはtemples.models.KNOWLEDGE_FACT_READY_VERIFICATION_STATUSESを正本とし、
+# ここでは再定義せず re-export するのみ（判定基準の二重管理を避ける）。
+FACT_READY_VERIFICATION_STATUSES = KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES
+
+
+@dataclass(frozen=True)
+class EvidenceDecision:
+    """Fact 1件の利用可否判定結果。
+
+    display_mode / reason_strengthはPR-Aでは"usableの言い換え"に過ぎない
+    固定契約（full/hidden, assertive/suppressed）。将来のPR-B以降で
+    confidenceに応じたweakened/moderate等を追加する余地として型を分けている。
+    """
+
+    usable: bool
+    display_mode: str
+    reason_strength: str
+    verification_status: str
+    confidence: str
+    reason: str
+
+
+def decide_fact_usability(
+    *,
+    verification_status: str,
+    confidence: str,
+    source_verification_statuses: Iterable[str],
+) -> EvidenceDecision:
+    """Fact 1件のEvidence Gate判定。
+
+    usable == True となる条件（PR-A契約）:
+      1. Fact自身のverification_statusがFACT_READY_VERIFICATION_STATUSESに含まれる
+      2. RelationされたSourceのうち最低1件のverification_statusが
+         FACT_READY_VERIFICATION_STATUSESに含まれる
+    上記のANDを満たさない場合はusable=Falseとし、display_mode="hidden"とする。
+    confidenceは判定に使わず、metadataとしてDecisionへそのまま保持するのみ。
+    """
+
+    fact_ready = verification_status in FACT_READY_VERIFICATION_STATUSES
+    has_ready_source = any(
+        status in FACT_READY_VERIFICATION_STATUSES for status in source_verification_statuses
+    )
+    usable = fact_ready and has_ready_source
+
+    if usable:
+        reason = "fact_ready_with_source"
+    elif not fact_ready:
+        reason = "fact_not_ready"
+    else:
+        reason = "no_fact_ready_source"
+
+    return EvidenceDecision(
+        usable=usable,
+        display_mode="full" if usable else "hidden",
+        reason_strength="assertive" if usable else "suppressed",
+        verification_status=verification_status,
+        confidence=confidence,
+        reason=reason,
+    )
+
+
+__all__ = [
+    "FACT_READY_VERIFICATION_STATUSES",
+    "EvidenceDecision",
+    "decide_fact_usability",
+]

--- a/backend/temples/services/shrine_knowledge_selector.py
+++ b/backend/temples/services/shrine_knowledge_selector.py
@@ -1,10 +1,15 @@
 """Recommendation専用のKnowledge読み取りselector。
 
 docs/knowledge/shrine-knowledge-contract.md「Fact利用条件」に従い、
-ShrineDeity / ShrineHistoryのうちFact利用可能なもの
-（verification_status in KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES、かつ
- fact-readyなShrineKnowledgeSourceを1件以上持つもの）だけをRecommendation
-入力向けの最小dictへ変換する。
+ShrineDeity / ShrineHistoryのうちFact利用可能なものだけをRecommendation入力向けの
+最小dictへ変換する。利用可否の判定そのもの（Fact自身のverification_status +
+Relation済みSourceのverification_status）はtemples.services.evidence_gateへ委譲し、
+本モジュールでは判定条件をSQLへ再実装しない。
+
+このモジュールの責務は「候補Factの取得（N+1を発生させない）」に限定し、
+「Factを使えるか判断する」責務はevidence_gate.decide_fact_usability()に一本化する。
+これによりRecommendationとShrine Detail（temples/api/serializers/shrine.py）が
+同一のEvidence Gate判定を共有する。
 
 DRF Serializer/ViewとRecommendation内部契約を混在させないため、
 temples.api配下（Serializer/View）には一切依存しない。
@@ -14,11 +19,18 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any
 
-from temples.models import (
-    KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
-    ShrineDeity,
-    ShrineHistory,
-)
+from django.db.models import Prefetch
+from temples.models import ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services import evidence_gate
+
+
+def _fact_ready_sources_prefetch() -> Prefetch:
+    return Prefetch(
+        "sources",
+        queryset=ShrineKnowledgeSource.objects.filter(
+            verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
+        ),
+    )
 
 
 def fetch_fact_ready_knowledge_deities(
@@ -26,34 +38,36 @@ def fetch_fact_ready_knowledge_deities(
 ) -> dict[int, list[dict[str, Any]]]:
     """対象shrine_ids分のFact-ready ShrineDeityを、shrine_id単位でまとめて取得する。
 
-    N+1回避のため、対象Shrine数に関わらず1クエリのみ発行する。
+    候補（Fact自身のverification_statusがfact-ready）をshrine_ids一括で1クエリ取得し、
+    Sourceをまとめてprefetchする（合計2クエリ、対象Shrine数に関わらず一定）。
+    usable判定自体はevidence_gate.decide_fact_usability()で行う。
     """
     if not shrine_ids:
         return {}
 
-    rows = (
+    candidates = (
         ShrineDeity.objects.filter(
             shrine_id__in=shrine_ids,
-            verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
-            sources__verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+            verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES,
         )
         .order_by("sort_order", "id")
-        .values("id", "shrine_id", "display_name", "sort_order", "confidence")
+        .prefetch_related(_fact_ready_sources_prefetch())
     )
 
     result: dict[int, list[dict[str, Any]]] = defaultdict(list)
-    seen_ids: set[int] = set()
-    for row in rows:
-        # sources__verification_status__inのJOINにより、fact-ready Sourceを
-        # 複数持つDeityは行が重複し得るため、id単位で重複排除する。
-        if row["id"] in seen_ids:
+    for deity in candidates:
+        decision = evidence_gate.decide_fact_usability(
+            verification_status=deity.verification_status,
+            confidence=deity.confidence,
+            source_verification_statuses=(s.verification_status for s in deity.sources.all()),
+        )
+        if not decision.usable:
             continue
-        seen_ids.add(row["id"])
-        result[row["shrine_id"]].append(
+        result[deity.shrine_id].append(
             {
-                "display_name": row["display_name"],
-                "sort_order": row["sort_order"],
-                "confidence": row["confidence"],
+                "display_name": deity.display_name,
+                "sort_order": deity.sort_order,
+                "confidence": deity.confidence,
             }
         )
     return dict(result)
@@ -64,44 +78,39 @@ def fetch_fact_ready_knowledge_histories(
 ) -> dict[int, list[dict[str, Any]]]:
     """対象shrine_ids分のFact-ready ShrineHistoryを、shrine_id単位でまとめて取得する。
 
-    N+1回避のため、対象Shrine数に関わらず1クエリのみ発行する。
+    候補（Fact自身のverification_statusがfact-ready）をshrine_ids一括で1クエリ取得し、
+    Sourceをまとめてprefetchする（合計2クエリ、対象Shrine数に関わらず一定）。
+    usable判定自体はevidence_gate.decide_fact_usability()で行う。
     """
     if not shrine_ids:
         return {}
 
-    rows = (
+    candidates = (
         ShrineHistory.objects.filter(
             shrine_id__in=shrine_ids,
-            verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
-            sources__verification_status__in=KNOWLEDGE_FACT_READY_VERIFICATION_STATUSES,
+            verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES,
         )
         .order_by("sort_order", "id")
-        .values(
-            "id",
-            "shrine_id",
-            "history_type",
-            "title",
-            "content",
-            "period_text",
-            "sort_order",
-            "confidence",
-        )
+        .prefetch_related(_fact_ready_sources_prefetch())
     )
 
     result: dict[int, list[dict[str, Any]]] = defaultdict(list)
-    seen_ids: set[int] = set()
-    for row in rows:
-        if row["id"] in seen_ids:
+    for history in candidates:
+        decision = evidence_gate.decide_fact_usability(
+            verification_status=history.verification_status,
+            confidence=history.confidence,
+            source_verification_statuses=(s.verification_status for s in history.sources.all()),
+        )
+        if not decision.usable:
             continue
-        seen_ids.add(row["id"])
-        result[row["shrine_id"]].append(
+        result[history.shrine_id].append(
             {
-                "history_type": row["history_type"],
-                "title": row["title"],
-                "content": row["content"],
-                "period_text": row["period_text"],
-                "sort_order": row["sort_order"],
-                "confidence": row["confidence"],
+                "history_type": history.history_type,
+                "title": history.title,
+                "content": history.content,
+                "period_text": history.period_text,
+                "sort_order": history.sort_order,
+                "confidence": history.confidence,
             }
         )
     return dict(result)

--- a/backend/temples/tests/api/test_evidence_gate_recommendation_detail_contract.py
+++ b/backend/temples/tests/api/test_evidence_gate_recommendation_detail_contract.py
@@ -1,0 +1,126 @@
+"""Evidence Gate Foundation: Recommendation / Shrine Detail 非対称性解消テスト。
+
+導入前は「Fact ready + fact-ready Sourceなし」の場合に
+Recommendation selector = 除外（usable=False相当）
+Shrine Detail API      = 表示（sourcesが空配列のまま表示）
+という非対称な挙動だった。
+
+Evidence Gate導入後は、同じFactに対してRecommendation selectorの利用可否と
+Shrine Detail APIの利用可否が常に一致することを固定する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from temples.models import Shrine, ShrineDeity, ShrineKnowledgeSource
+from temples.services.shrine_knowledge_selector import fetch_fact_ready_knowledge_deities
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_shrine(name: str = "非対称性監査神社") -> Shrine:
+    return Shrine.objects.create(
+        name_jp=name,
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def _create_source(verification_status: str, **kwargs) -> ShrineKnowledgeSource:
+    defaults = dict(
+        source_type="shrine_official",
+        title=f"出典-{verification_status}",
+        verification_status=verification_status,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineKnowledgeSource.objects.create(**defaults)
+
+
+def _create_deity(shrine: Shrine, verification_status: str, **kwargs) -> ShrineDeity:
+    defaults = dict(display_name="祭神", verification_status=verification_status)
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineDeity.objects.create(shrine=shrine, **defaults)
+
+
+def _is_recommendation_usable(shrine: Shrine) -> bool:
+    result = fetch_fact_ready_knowledge_deities([shrine.id])
+    return len(result.get(shrine.id, [])) == 1
+
+
+def _is_detail_usable(shrine: Shrine) -> bool:
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+    assert resp.status_code == 200
+    return len(resp.json()["deities"]) == 1
+
+
+def test_fact_ready_without_any_source_is_unusable_on_both_paths():
+    # 旧: Recommendation=False, Detail=True という非対称の再発防止テスト。
+    shrine = _create_shrine()
+    _create_deity(shrine, "source_confirmed")
+
+    assert _is_recommendation_usable(shrine) is False
+    assert _is_detail_usable(shrine) is False
+
+
+def test_fact_ready_with_only_draft_source_is_unusable_on_both_paths():
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "source_confirmed")
+    deity.sources.add(_create_source("draft"))
+
+    assert _is_recommendation_usable(shrine) is False
+    assert _is_detail_usable(shrine) is False
+
+
+def test_fact_ready_with_ready_source_is_usable_on_both_paths():
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "source_confirmed")
+    deity.sources.add(_create_source("source_confirmed"))
+
+    assert _is_recommendation_usable(shrine) is True
+    assert _is_detail_usable(shrine) is True
+
+
+@pytest.mark.parametrize("fact_status", ["draft", "unverified", "disputed", "outdated", "rejected"])
+def test_non_fact_ready_fact_is_unusable_on_both_paths_even_with_ready_source(fact_status):
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, fact_status)
+    deity.sources.add(_create_source("source_confirmed"))
+
+    assert _is_recommendation_usable(shrine) is False
+    assert _is_detail_usable(shrine) is False
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        {"fact_status": "source_confirmed", "source_statuses": []},
+        {"fact_status": "source_confirmed", "source_statuses": ["draft"]},
+        {"fact_status": "source_confirmed", "source_statuses": ["draft", "disputed"]},
+        {"fact_status": "draft", "source_statuses": ["source_confirmed"]},
+        {"fact_status": "disputed", "source_statuses": ["source_confirmed"]},
+        {"fact_status": "source_confirmed", "source_statuses": ["source_confirmed"]},
+        {"fact_status": "reviewed", "source_statuses": ["reviewed"]},
+        {"fact_status": "source_confirmed", "source_statuses": ["source_confirmed", "draft"]},
+    ],
+)
+def test_recommendation_and_detail_agree_for_every_combination(case):
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, case["fact_status"])
+    for i, status in enumerate(case["source_statuses"]):
+        deity.sources.add(_create_source(status, title=f"出典{i}-{status}"))
+
+    recommendation_usable = _is_recommendation_usable(shrine)
+    detail_usable = _is_detail_usable(shrine)
+
+    assert recommendation_usable == detail_usable, (
+        f"非対称: case={case} recommendation={recommendation_usable} " f"detail={detail_usable}"
+    )

--- a/backend/temples/tests/api/test_shrine_detail_knowledge_api.py
+++ b/backend/temples/tests/api/test_shrine_detail_knowledge_api.py
@@ -61,10 +61,15 @@ def _create_source(verification_status: str, title: str = "出典", **kwargs) ->
 
 def test_shrine_detail_api_returns_only_fact_ready_knowledge():
     shrine = _create_shrine()
-    _create_deity(shrine, "source_confirmed", sort_order=0)
-    _create_deity(shrine, "draft", sort_order=1)
-    _create_history(shrine, "reviewed", sort_order=0)
-    _create_history(shrine, "unverified", sort_order=1)
+    source = _create_source("source_confirmed")
+    ready_deity = _create_deity(shrine, "source_confirmed", sort_order=0)
+    ready_deity.sources.add(source)
+    draft_deity = _create_deity(shrine, "draft", sort_order=1)
+    draft_deity.sources.add(source)
+    ready_history = _create_history(shrine, "reviewed", sort_order=0)
+    ready_history.sources.add(source)
+    unverified_history = _create_history(shrine, "unverified", sort_order=1)
+    unverified_history.sources.add(source)
 
     client = APIClient()
     resp = client.get(f"/api/shrines/{shrine.id}/")
@@ -151,21 +156,27 @@ def test_shrine_detail_api_returns_fact_ready_source(verification_status):
     "verification_status",
     ["draft", "unverified", "disputed", "outdated", "rejected"],
 )
-def test_shrine_detail_api_excludes_non_fact_ready_source(verification_status):
+def test_shrine_detail_api_excludes_non_fact_ready_source_from_nested_sources(verification_status):
+    # deityはfact-ready Sourceを別途1件持つためusable=True。nested sourcesからは
+    # 非fact-ready Sourceのみが除外されることを確認する（Evidence Gate: Case D相当）。
     shrine = _create_shrine()
     deity = _create_deity(shrine, "source_confirmed")
-    source = _create_source(verification_status)
-    deity.sources.add(source)
+    ready_source = _create_source("source_confirmed", title="ready")
+    non_ready_source = _create_source(verification_status, title="non-ready")
+    deity.sources.add(ready_source, non_ready_source)
 
     client = APIClient()
     resp = client.get(f"/api/shrines/{shrine.id}/")
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["deities"][0]["sources"] == []
+    assert len(body["deities"]) == 1
+    assert [s["verification_status"] for s in body["deities"][0]["sources"]] == ["source_confirmed"]
 
 
-def test_shrine_detail_api_returns_empty_sources_when_no_fact_ready_source_for_history():
+def test_shrine_detail_api_hides_history_when_no_fact_ready_source():
+    # Evidence Gate: Case B相当（Fact ready + Source draft/unverified等のみ）。
+    # fact-ready Sourceが1件も無いため、history自体がusable=Falseとなり非表示になる。
     shrine = _create_shrine()
     history = _create_history(shrine, "reviewed")
     source = _create_source("unverified")
@@ -176,10 +187,14 @@ def test_shrine_detail_api_returns_empty_sources_when_no_fact_ready_source_for_h
 
     assert resp.status_code == 200
     body = resp.json()
-    assert body["histories"][0]["sources"] == []
+    assert body["histories"] == []
 
 
-def test_shrine_detail_api_keeps_knowledge_when_all_its_sources_are_excluded():
+def test_shrine_detail_api_hides_knowledge_when_all_its_sources_are_excluded():
+    # Evidence Gate: Case A/B相当（Fact ready + fact-ready Sourceなし）。
+    # 旧実装では「deity自体はverification_statusのみで表示され、sourcesが空配列になる」
+    # という非対称な挙動だったが、Evidence Gate導入後はRecommendationと同様に
+    # deity自体が非表示になる。
     shrine = _create_shrine()
     deity = _create_deity(shrine, "source_confirmed")
     deity.sources.add(_create_source("draft"), _create_source("disputed"))
@@ -189,9 +204,7 @@ def test_shrine_detail_api_keeps_knowledge_when_all_its_sources_are_excluded():
 
     assert resp.status_code == 200
     body = resp.json()
-    assert len(body["deities"]) == 1
-    assert body["deities"][0]["verification_status"] == "source_confirmed"
-    assert body["deities"][0]["sources"] == []
+    assert body["deities"] == []
 
 
 def test_shrine_detail_api_source_filtering_does_not_increase_query_count():

--- a/backend/temples/tests/serializers/test_shrine_knowledge_serializers.py
+++ b/backend/temples/tests/serializers/test_shrine_knowledge_serializers.py
@@ -48,13 +48,25 @@ def test_shrine_detail_serializer_returns_empty_list_when_no_knowledge():
 
 def test_shrine_detail_serializer_returns_only_fact_ready_deities():
     shrine = _create_shrine()
-    _create_deity(shrine, "source_confirmed", display_name="確認済み祭神")
-    _create_deity(shrine, "reviewed", display_name="レビュー済み祭神")
-    _create_deity(shrine, "draft", display_name="下書き祭神")
-    _create_deity(shrine, "unverified", display_name="未確認祭神")
-    _create_deity(shrine, "disputed", display_name="矛盾祭神")
-    _create_deity(shrine, "outdated", display_name="陳腐化祭神")
-    _create_deity(shrine, "rejected", display_name="却下祭神")
+    # Evidence Gateはstatus判定に加えてfact-ready Source Relationも要求するため、
+    # 全候補へ共通のfact-ready Sourceを付与し、status差だけを検証対象にする。
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="共通出典",
+        verification_status="source_confirmed",
+        verified_at=timezone.now(),
+    )
+    for verification_status, name in [
+        ("source_confirmed", "確認済み祭神"),
+        ("reviewed", "レビュー済み祭神"),
+        ("draft", "下書き祭神"),
+        ("unverified", "未確認祭神"),
+        ("disputed", "矛盾祭神"),
+        ("outdated", "陳腐化祭神"),
+        ("rejected", "却下祭神"),
+    ]:
+        deity = _create_deity(shrine, verification_status, display_name=name)
+        deity.sources.add(source)
 
     data = ShrineDetailSerializer(shrine).data
     names = {d["display_name"] for d in data["deities"]}
@@ -63,9 +75,19 @@ def test_shrine_detail_serializer_returns_only_fact_ready_deities():
 
 def test_shrine_detail_serializer_returns_only_fact_ready_histories():
     shrine = _create_shrine()
-    _create_history(shrine, "source_confirmed", title="確認済み由緒")
-    _create_history(shrine, "draft", title="下書き由緒")
-    _create_history(shrine, "disputed", title="矛盾由緒")
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="共通出典",
+        verification_status="source_confirmed",
+        verified_at=timezone.now(),
+    )
+    for verification_status, title in [
+        ("source_confirmed", "確認済み由緒"),
+        ("draft", "下書き由緒"),
+        ("disputed", "矛盾由緒"),
+    ]:
+        history = _create_history(shrine, verification_status, title=title)
+        history.sources.add(source)
 
     data = ShrineDetailSerializer(shrine).data
     titles = {h["title"] for h in data["histories"]}

--- a/backend/temples/tests/services/test_evidence_gate.py
+++ b/backend/temples/tests/services/test_evidence_gate.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+
+from temples.services.evidence_gate import decide_fact_usability
+
+
+# --- Case A: Fact ready / Source Relationなし ---
+
+
+def test_case_a_fact_ready_without_any_source_is_not_usable():
+    decision = decide_fact_usability(
+        verification_status="source_confirmed",
+        confidence="high",
+        source_verification_statuses=[],
+    )
+    assert decision.usable is False
+    assert decision.display_mode == "hidden"
+    assert decision.reason_strength == "suppressed"
+
+
+# --- Case B: Fact ready / Source draftのみ ---
+
+
+def test_case_b_fact_ready_with_only_draft_source_is_not_usable():
+    decision = decide_fact_usability(
+        verification_status="source_confirmed",
+        confidence="high",
+        source_verification_statuses=["draft"],
+    )
+    assert decision.usable is False
+
+
+# --- Case C: Fact draft / Source ready ---
+
+
+def test_case_c_fact_draft_with_ready_source_is_not_usable():
+    decision = decide_fact_usability(
+        verification_status="draft",
+        confidence="high",
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert decision.usable is False
+
+
+# --- Case D: Fact ready / ready Source + draft Source ---
+
+
+def test_case_d_fact_ready_with_ready_and_draft_source_is_usable():
+    decision = decide_fact_usability(
+        verification_status="source_confirmed",
+        confidence="high",
+        source_verification_statuses=["source_confirmed", "draft"],
+    )
+    assert decision.usable is True
+    assert decision.display_mode == "full"
+    assert decision.reason_strength == "assertive"
+
+
+# --- Case E: Fact reviewed / Source reviewed ---
+
+
+def test_case_e_fact_reviewed_with_reviewed_source_is_usable():
+    decision = decide_fact_usability(
+        verification_status="reviewed",
+        confidence="medium",
+        source_verification_statuses=["reviewed"],
+    )
+    assert decision.usable is True
+
+
+# --- Case F: disputed ---
+
+
+def test_case_f_disputed_fact_is_not_usable():
+    decision = decide_fact_usability(
+        verification_status="disputed",
+        confidence="high",
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert decision.usable is False
+
+
+@pytest.mark.parametrize(
+    "verification_status", ["draft", "unverified", "disputed", "outdated", "rejected"]
+)
+def test_non_fact_ready_fact_status_is_never_usable_even_with_ready_source(verification_status):
+    decision = decide_fact_usability(
+        verification_status=verification_status,
+        confidence="high",
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert decision.usable is False
+
+
+@pytest.mark.parametrize(
+    "source_status", ["draft", "unverified", "disputed", "outdated", "rejected"]
+)
+def test_non_fact_ready_source_status_alone_never_makes_fact_usable(source_status):
+    decision = decide_fact_usability(
+        verification_status="source_confirmed",
+        confidence="high",
+        source_verification_statuses=[source_status],
+    )
+    assert decision.usable is False
+
+
+def test_confidence_does_not_affect_usable():
+    # PR-Aではconfidenceによる利用可否の変更は行わない。metadataとして保持するのみ。
+    for confidence in ("high", "medium", "low", ""):
+        decision = decide_fact_usability(
+            verification_status="source_confirmed",
+            confidence=confidence,
+            source_verification_statuses=["source_confirmed"],
+        )
+        assert decision.usable is True
+        assert decision.confidence == confidence

--- a/backend/temples/tests/services/test_evidence_gate_pilot_regression.py
+++ b/backend/temples/tests/services/test_evidence_gate_pilot_regression.py
@@ -1,0 +1,161 @@
+"""Evidence Gate Foundation: Pilot回帰テスト。
+
+明治神宮Pilot / 品川神社Pilot（Pilot Evidence Readiness QA: PASS済み）と
+同等の条件をfactoryで再現し、Evidence Gate導入後もRecommendation selector /
+Shrine Detail双方で同じFactが選ばれ続けることを確認する。
+実DBのShrine ID（1, 50等）には依存しない。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services.evidence_gate import decide_fact_usability
+from temples.services.shrine_knowledge_selector import (
+    fetch_fact_ready_knowledge_deities,
+    fetch_fact_ready_knowledge_histories,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_shrine(name: str) -> Shrine:
+    return Shrine.objects.create(
+        name_jp=name,
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def _create_source(
+    title: str, verification_status: str = "source_confirmed", **kwargs
+) -> ShrineKnowledgeSource:
+    defaults = dict(
+        source_type="shrine_official",
+        title=title,
+        verification_status=verification_status,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineKnowledgeSource.objects.create(**defaults)
+
+
+def _create_deity(shrine: Shrine, display_name: str, sort_order: int, **kwargs) -> ShrineDeity:
+    defaults = dict(
+        display_name=display_name,
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineDeity.objects.create(shrine=shrine, **defaults)
+
+
+def _create_history(shrine: Shrine, title: str, sort_order: int, **kwargs) -> ShrineHistory:
+    defaults = dict(
+        history_type="founding",
+        title=title,
+        content="内容",
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineHistory.objects.create(shrine=shrine, **defaults)
+
+
+# --- 明治神宮Pilot相当 ---
+
+
+def test_meiji_jingu_equivalent_pilot_is_usable_on_both_paths():
+    shrine = _create_shrine("Pilot監査-明治神宮相当")
+    source = _create_source("公式サイト「明治神宮とは」")
+
+    deity1 = _create_deity(shrine, "明治天皇", sort_order=0)
+    deity2 = _create_deity(shrine, "昭憲皇太后", sort_order=1)
+    history = _create_history(shrine, "明治神宮の創建", sort_order=0)
+    for fact in (deity1, deity2, history):
+        fact.sources.add(source)
+
+    for fact in (deity1, deity2, history):
+        decision = decide_fact_usability(
+            verification_status=fact.verification_status,
+            confidence=fact.confidence,
+            source_verification_statuses=[s.verification_status for s in fact.sources.all()],
+        )
+        assert decision.usable is True
+
+    deities_result = fetch_fact_ready_knowledge_deities([shrine.id])
+    histories_result = fetch_fact_ready_knowledge_histories([shrine.id])
+    assert len(deities_result.get(shrine.id, [])) == 2
+    assert len(histories_result.get(shrine.id, [])) == 1
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["deities"]) == 2
+    assert len(body["histories"]) == 1
+
+
+# --- 品川神社Pilot相当 ---
+
+
+def test_shinagawa_jinja_equivalent_pilot_preserves_differing_source_relations():
+    shrine = _create_shrine("Pilot監査-品川神社相当")
+    source_a = _create_source("品川神社公式")
+    source_b = _create_source("東京都神社庁")
+
+    deity1 = _create_deity(shrine, "天比理乃咩命", sort_order=0)
+    deity2 = _create_deity(shrine, "宇賀之売命", sort_order=1)
+    deity3 = _create_deity(shrine, "素盞嗚尊", sort_order=2)
+    for deity in (deity1, deity2, deity3):
+        deity.sources.add(source_a, source_b)
+
+    history1 = _create_history(shrine, "1187年の創始", sort_order=0)
+    history1.sources.add(source_a, source_b)
+    history2 = _create_history(shrine, "1319年の奉祀", sort_order=1)
+    history2.sources.add(source_a)
+    history3 = _create_history(shrine, "1478年の奉祀", sort_order=2)
+    history3.sources.add(source_a)
+
+    for fact in (deity1, deity2, deity3, history1, history2, history3):
+        decision = decide_fact_usability(
+            verification_status=fact.verification_status,
+            confidence=fact.confidence,
+            source_verification_statuses=[s.verification_status for s in fact.sources.all()],
+        )
+        assert decision.usable is True
+
+    deities_result = fetch_fact_ready_knowledge_deities([shrine.id])[shrine.id]
+    histories_result = fetch_fact_ready_knowledge_histories([shrine.id])[shrine.id]
+    assert len(deities_result) == 3
+    assert [d["sort_order"] for d in deities_result] == [0, 1, 2]
+    assert len(histories_result) == 3
+    assert [h["sort_order"] for h in histories_result] == [0, 1, 2]
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["deities"]) == 3
+    assert len(body["histories"]) == 3
+    assert [d["sort_order"] for d in body["deities"]] == [0, 1, 2]
+    assert [h["sort_order"] for h in body["histories"]] == [0, 1, 2]
+
+    # Source Relationの差(1187=A+B, 1319/1478=Aのみ)がDetail nested sourcesへ
+    # そのまま反映されることを確認する。
+    histories_by_title = {h["title"]: h for h in body["histories"]}
+    assert {s["id"] for s in histories_by_title["1187年の創始"]["sources"]} == {
+        source_a.id,
+        source_b.id,
+    }
+    assert {s["id"] for s in histories_by_title["1319年の奉祀"]["sources"]} == {source_a.id}
+    assert {s["id"] for s in histories_by_title["1478年の奉祀"]["sources"]} == {source_a.id}

--- a/backend/temples/tests/services/test_shrine_knowledge_selector.py
+++ b/backend/temples/tests/services/test_shrine_knowledge_selector.py
@@ -135,7 +135,10 @@ def test_fetch_fact_ready_knowledge_deities_batches_across_multiple_shrines_with
         result = fetch_fact_ready_knowledge_deities([s.id for s in shrines])
 
     assert all(len(result.get(s.id, [])) == 1 for s in shrines)
-    assert len(ctx.captured_queries) == 1
+    # Evidence Gate導入後は「候補Deity取得」+「fact-ready Source prefetch」の
+    # 合計2クエリで、対象Shrine数に関わらず一定であることを確認する
+    # （N+1になっていないことが本質であり、クエリ数そのものは1固定ではない）。
+    assert len(ctx.captured_queries) == 2
 
 
 def test_fetch_fact_ready_knowledge_deities_empty_shrine_ids_returns_empty_dict():
@@ -205,7 +208,10 @@ def test_fetch_fact_ready_knowledge_histories_batches_across_multiple_shrines_wi
         result = fetch_fact_ready_knowledge_histories([s.id for s in shrines])
 
     assert all(len(result.get(s.id, [])) == 1 for s in shrines)
-    assert len(ctx.captured_queries) == 1
+    # Evidence Gate導入後は「候補History取得」+「fact-ready Source prefetch」の
+    # 合計2クエリで、対象Shrine数に関わらず一定であることを確認する
+    # （N+1になっていないことが本質であり、クエリ数そのものは1固定ではない）。
+    assert len(ctx.captured_queries) == 2
 
 
 def test_fetch_fact_ready_knowledge_histories_empty_shrine_ids_returns_empty_dict():


### PR DESCRIPTION
## Summary
- Recommendation(`shrine_knowledge_selector.py`)とShrine Detail(`ShrineViewSet`/`ShrineDetailSerializer`)で別々に実装されていたKnowledge Fact（ShrineDeity/ShrineHistory）の利用可否判定を、`temples/services/evidence_gate.py`の`EvidenceDecision`/`decide_fact_usability()`へ一本化。
- usable条件: Fact自身の`verification_status`がfact-ready **AND** Relation済みSourceのうち1件以上がfact-ready。
- 旧実装では「Fact ready + fact-ready Sourceなし」の場合にRecommendation=除外・Detail=表示という非対称が存在していたが、両経路が同一のEvidence Gateを使うことで解消。
- nested sources（`ShrineDeitySerializer`/`ShrineHistorySerializer`の`sources`）のfact-readyフィルタをSerializer側にも明示化し、ViewのPrefetchを経由しない呼び出しでも契約を維持。
- `shrine_knowledge_selector.py`の責務を「候補Fact取得」に限定し、usable判定のSQLへの二重実装を廃止（1クエリ→候補取得1クエリ+Source prefetch1クエリの計2クエリ、対象Shrine数に関わらず一定でN+1なし）。

## 変更していないもの
- Model / Migration / DBデータ
- Recommendation Score / Ranking / Legacy fallback / recommendation_reason_v4 schema
- Public API Schema（deities/histories/sourcesのフィールド構成、型）— `manage.py spectacular`で生成差分を確認済み。既存の`api_schema.yaml`自体が本PR以前から陳腐化(ShrineDeity/History未反映)しているが、これは本PR起因ではなく別issue。
- confidenceによる表現制御・disputed専用UI・数値スコア（PR-B以降へ延期）

## Test plan
- [x] `pytest`（backend全体）: 912 passed, 9 skipped
- [x] Evidence Gate unit tests（Negative Case A〜F + 追加パラメタライズ）: `temples/tests/services/test_evidence_gate.py`
- [x] Pilot回帰テスト（明治神宮/品川神社相当をfactoryで再現）: `temples/tests/services/test_evidence_gate_pilot_regression.py`
- [x] Recommendation/Detail非対称性解消の固定テスト: `temples/tests/api/test_evidence_gate_recommendation_detail_contract.py`
- [x] 既存テストのうち旧非対称挙動を前提にしていた3件を新契約に合わせて更新（`test_shrine_detail_knowledge_api.py`）
- [x] `ruff check`（新規/変更ファイル）: 新規コード起因の指摘なし
- [x] `manage.py makemigrations --check --dry-run`: No changes detected
- [x] `manage.py spectacular`生成差分確認: 構造差分なし（docstring文言のみ）
- [x] pre-push hook（OpenAPI lint / Web契約テスト702件）: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)