### PR TITLE
feat(backend): Evidence Gate PR-B(confidence表現強度制御)を実装

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -312,11 +312,31 @@ def _join_knowledge_deity_names(knowledge_deities: Any) -> str | None:
     return "、".join(names) if names else None
 
 
-def _pick_primary_knowledge_history_content(knowledge_histories: Any) -> str | None:
-    """Fact-ready ShrineHistoryのうち、sort_order最小の1件のcontentのみを採用する。
+def _resolve_knowledge_deity_confidence(knowledge_deities: Any) -> str | None:
+    """`_join_knowledge_deity_names()`が連結するのと同じDeity集合のconfidenceを返す。
 
-    history_typeによる独自の優先順位（founding優先等）は今回導入しない。
-    複数Historyの結合も今回は行わない。
+    全Deityのconfidenceが一致する場合のみその値を返す。以下はいずれもNoneを返す
+    （PR-B契約: 集約ルールが未確定なため、min/max/average/majority等を独自に
+    作らず、Noneを「現行互換の通常表現(assertive)」として扱う）。
+    - 対象Deityが1件もconfidenceを設定していない（空文字のみ）場合
+    - 複数DeityでconfidenceがHigh/Medium/Low等に混在している場合
+    """
+    if not isinstance(knowledge_deities, list):
+        return None
+    items = [d for d in knowledge_deities if isinstance(d, dict) and str(d.get("display_name") or "").strip()]
+    if not items:
+        return None
+    confidences = {str(d.get("confidence") or "").strip() for d in items}
+    if len(confidences) == 1:
+        value = confidences.pop()
+        return value or None
+    return None
+
+
+def _pick_primary_knowledge_history_item(knowledge_histories: Any) -> dict[str, Any] | None:
+    """`_pick_primary_knowledge_history_content()`と同じ基準でFact-ready ShrineHistory
+    1件（dict全体）を選定する。content用confidence用で選定ロジックを重複させず、
+    常に同一のHistoryを参照させるための共通ヘルパー。
     """
     if not isinstance(knowledge_histories, list):
         return None
@@ -324,7 +344,29 @@ def _pick_primary_knowledge_history_content(knowledge_histories: Any) -> str | N
     if not items:
         return None
     ordered = sorted(items, key=lambda h: h.get("sort_order") if isinstance(h.get("sort_order"), int) else 0)
-    return str(ordered[0]["content"]).strip()
+    return ordered[0]
+
+
+def _pick_primary_knowledge_history_content(knowledge_histories: Any) -> str | None:
+    """Fact-ready ShrineHistoryのうち、sort_order最小の1件のcontentのみを採用する。
+
+    history_typeによる独自の優先順位（founding優先等）は今回導入しない。
+    複数Historyの結合も今回は行わない。
+    """
+    item = _pick_primary_knowledge_history_item(knowledge_histories)
+    if item is None:
+        return None
+    return str(item["content"]).strip()
+
+
+def _pick_primary_knowledge_history_confidence(knowledge_histories: Any) -> str | None:
+    """`_pick_primary_knowledge_history_content()`が採用するのと同じHistory 1件の
+    confidenceを返す。別Historyのconfidenceを混ぜない（PR-B契約）。
+    """
+    item = _pick_primary_knowledge_history_item(knowledge_histories)
+    if item is None:
+        return None
+    return str(item.get("confidence") or "").strip() or None
 
 
 def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
@@ -337,6 +379,21 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
     knowledge_deity_names = _join_knowledge_deity_names(rec.get("knowledge_deities"))
     knowledge_history_content = _pick_primary_knowledge_history_content(rec.get("knowledge_histories"))
 
+    # confidenceはKnowledge Fact（新）を実際に採用した場合のみ意味を持つ。
+    # Legacy（sajin/description）へfallbackした場合、Legacy FieldにはKnowledge
+    # confidence概念が存在しないため常にNone（= PR-B契約: Legacy fallbackには
+    # confidenceによる表現制御を適用しない）。
+    deity_confidence = (
+        _resolve_knowledge_deity_confidence(rec.get("knowledge_deities"))
+        if knowledge_deity_names is not None
+        else None
+    )
+    shrine_history_confidence = (
+        _pick_primary_knowledge_history_confidence(rec.get("knowledge_histories"))
+        if knowledge_history_content is not None
+        else None
+    )
+
     return {
         "shrine_id": rec.get("shrine_id") or rec.get("id") or source.get("shrineId"),
         "name": rec.get("name") or source.get("nameJp"),
@@ -348,7 +405,11 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
         # 存在しない場合のみLegacy（sajin/description）へfallbackする。
         # 新KnowledgeとLegacyを同一field内で混在させない（片方の値のみを採用する）。
         "deity": knowledge_deity_names if knowledge_deity_names is not None else (rec.get("sajin") or source.get("sajin")),
+        # PR-B: Knowledge Fact confidence（high/medium/low/空）をそのままcandidate_profileへ
+        # 保持する。文字列（"deity"）自体へ文体を混ぜ込まず、強度情報は別fieldに分離する。
+        "deity_confidence": deity_confidence,
         "shrine_history": knowledge_history_content if knowledge_history_content is not None else (rec.get("description") or source.get("description")),
+        "shrine_history_confidence": shrine_history_confidence,
         "place_context": rec.get("address") or source.get("address"),
         "place_id": rec.get("place_id"),
         "behavior_signals": rec.get("behavior_signals") if isinstance(rec.get("behavior_signals"), dict) else {},

--- a/backend/temples/services/recommendation_reason_v4.py
+++ b/backend/temples/services/recommendation_reason_v4.py
@@ -127,10 +127,39 @@ def _copy_for_key(mapping: dict[str, str], key: str | None) -> str | None:
     return mapping.get(key, key)
 
 
-def _build_fact(candidate_profile: dict[str, Any], meaning_translation: dict[str, Any]) -> dict[str, Any]:
+# PR-B: Knowledge Fact confidence(high/medium/low)からRecommendation Reasonの
+# 表現強度への変換。Evidence Gate(temples.services.evidence_gate)のusable判定には
+# 一切影響しない、Reason生成内部だけで完結する変換であることに注意。
+_CONFIDENCE_TO_REASON_STRENGTH: dict[str, str] = {
+    "high": "assertive",
+    "medium": "weakened",
+    "low": "suppressed",
+}
+
+
+def _reason_strength_from_confidence(confidence: Any) -> str:
+    """confidence(""/None/未知の値を含む)をreason_strengthへ変換する。
+
+    空文字・None・未知の値は全て"assertive"(現行互換の通常表現)とする。
+    これはconfidence未設定を"high"の意味へ格上げするものではなく、単に
+    PR-A以前からの既存Reason文体を変更しないための後方互換上の選択。
+    """
+    if isinstance(confidence, str) and confidence in _CONFIDENCE_TO_REASON_STRENGTH:
+        return _CONFIDENCE_TO_REASON_STRENGTH[confidence]
+    return "assertive"
+
+
+def _build_fact(
+    candidate_profile: dict[str, Any], meaning_translation: dict[str, Any]
+) -> tuple[dict[str, Any], dict[str, str]]:
     """Build the Fact layer from shrine-side information only.
 
     Fact must not interpret the user's state or suggest the next action.
+
+    Returns a tuple of (fact, reason_strength). `fact`のkey構成はPR-B以前と
+    完全に同一（reason_strengthをfact dictへは混ぜない）。reason_strengthは
+    `_build_fact_text()`がテンプレート選択にのみ使う内部専用の値であり、
+    RecommendationReasonV4の公開dictへは含めない。
     """
     history_theme = _first_string(candidate_profile.get("history_theme"), meaning_translation.get("history_theme"))
     deity = _first_string(candidate_profile.get("deity"), candidate_profile.get("main_deity"), candidate_profile.get("enshrined_deity"))
@@ -139,6 +168,18 @@ def _build_fact(candidate_profile: dict[str, Any], meaning_translation: dict[str
     goriyaku = _first_string(candidate_profile.get("goriyaku"), candidate_profile.get("goriyaku_tags"))
     visit_style_tags = _as_list(candidate_profile.get("visit_style_tags"))
     name = _first_string(candidate_profile.get("name"))
+
+    deity_reason_strength = _reason_strength_from_confidence(candidate_profile.get("deity_confidence"))
+    shrine_history_reason_strength = _reason_strength_from_confidence(candidate_profile.get("shrine_history_confidence"))
+
+    # confidence=low(suppressed)のKnowledge Factは、Recommendation Reason
+    # （fact/evidence/used_fact/quality監査を含む）へ一切使用しない。
+    # EvidenceDecision.usable自体は変えない。DB・Knowledge selector・Detail APIには
+    # 影響しない（Reason生成内部だけのsuppression）。
+    if deity_reason_strength == "suppressed":
+        deity = None
+    if shrine_history_reason_strength == "suppressed":
+        shrine_history = None
 
     # label は互換目的の補助フィールド（既存テスト・evidence表示のみで参照）。
     # _build_reason_text の主判定には使用しない。place_context(住所)を含む算出方法は
@@ -162,7 +203,7 @@ def _build_fact(candidate_profile: dict[str, Any], meaning_translation: dict[str
     if name:
         evidence.append(f"name:{name}")
 
-    return {
+    fact = {
         "label": label,
         "name": name,
         "deity": deity,
@@ -173,6 +214,11 @@ def _build_fact(candidate_profile: dict[str, Any], meaning_translation: dict[str
         "visit_style_tags": visit_style_tags,
         "evidence": evidence,
     }
+    reason_strength = {
+        "deity": deity_reason_strength,
+        "shrine_history": shrine_history_reason_strength,
+    }
+    return fact, reason_strength
 
 
 def _build_used_fact(fact: dict[str, Any]) -> dict[str, Any]:
@@ -425,7 +471,7 @@ def build_recommendation_reason_quality_audit(reason: dict[str, Any]) -> dict[st
     }
 
 
-def _build_fact_text(fact: dict[str, Any]) -> str:
+def _build_fact_text(fact: dict[str, Any], reason_strength: dict[str, str] | None = None) -> str:
     """Compose the Fact sentence by branching on Fact type.
 
     Each Fact type (deity / shrine_history / goriyaku / history_theme) has its own
@@ -433,7 +479,13 @@ def _build_fact_text(fact: dict[str, Any]) -> str:
     place_context (raw address) is never used as the sentence subject: an address is
     not a shrine-specific feature, and stating "shrine X has the feature of <address>"
     reads as broken Japanese and misrepresents empty Fact data as grounded content.
+
+    `reason_strength`（PR-B）はKnowledge Fact confidenceから変換された表現強度
+    （"assertive"/"weakened"/"suppressed"）。fact["deity"]/fact["shrine_history"]は
+    suppressed時点で既にNoneになっている（`_build_fact()`側で処理済み）ため、ここでは
+    "weakened"時のみ文体を変える。値そのものは一切加工しない。
     """
+    strength = reason_strength or {}
     fact_name = _first_string(fact.get("name"))
     fact_deity = _first_string(fact.get("deity"))
     fact_shrine_history = _first_string(fact.get("shrine_history"))
@@ -445,12 +497,18 @@ def _build_fact_text(fact: dict[str, Any]) -> str:
     fact_details: list[str] = []
 
     if fact_deity:
-        fact_text = f"{subject}では、{fact_deity}が祀られています。"
+        if strength.get("deity") == "weakened":
+            fact_text = f"{subject}では、{fact_deity}が祀られているとされています。"
+        else:
+            fact_text = f"{subject}では、{fact_deity}が祀られています。"
         if fact_goriyaku:
             fact_details.append(f"{fact_goriyaku}の要素")
     elif fact_shrine_history:
         history_text = fact_shrine_history.rstrip("。")
-        fact_text = f"{subject}には、{history_text}という背景があります。"
+        if strength.get("shrine_history") == "weakened":
+            fact_text = f"{subject}には、{history_text}と伝えられています。"
+        else:
+            fact_text = f"{subject}には、{history_text}という背景があります。"
         if fact_goriyaku:
             fact_details.append(f"{fact_goriyaku}の要素")
     elif fact_goriyaku:
@@ -459,6 +517,7 @@ def _build_fact_text(fact: dict[str, Any]) -> str:
         fact_text = f"{subject}は、{fact_history_theme}という文脈で整理されています。"
     else:
         # deity / shrine_history / goriyaku / history_theme が一つもない場合。
+        # （confidence=lowによりsuppressされた場合を含む。）
         # place_context(住所)や神社名だけでは神社固有Factがあるとは表現しない。
         fact_text = "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
 
@@ -472,12 +531,17 @@ def _build_fact_text(fact: dict[str, Any]) -> str:
     return fact_text
 
 
-def _build_reason_text(fact: dict[str, Any], interpretation: dict[str, Any], action: dict[str, Any]) -> str:
+def _build_reason_text(
+    fact: dict[str, Any],
+    interpretation: dict[str, Any],
+    action: dict[str, Any],
+    reason_strength: dict[str, str] | None = None,
+) -> str:
     """Compose reason_text as Fact -> Interpretation -> Action.
 
     Keep each sentence responsible for one layer only.
     """
-    fact_text = _build_fact_text(fact)
+    fact_text = _build_fact_text(fact, reason_strength)
     interpretation_text = _first_string(interpretation.get("text")) or "相談内容から、今扱いたいテーマを読み取っています。"
     action_text = _first_string(action.get("text")) or "次に確認したいことを一つだけ決めます。"
 
@@ -503,7 +567,7 @@ def build_recommendation_reason_v4(
     meaning = _as_dict(meaning_translation) or _as_dict(recommendation_input.get("translation_result"))
     candidate = _as_dict(candidate_profile) or _as_dict(recommendation_input.get("candidate_profile"))
 
-    fact = _build_fact(candidate, meaning)
+    fact, reason_strength = _build_fact(candidate, meaning)
     interpretation_layer = _build_interpretation(interpretation, meaning)
     action = _build_action(interpretation, meaning)
     used_fact = _build_used_fact(fact)
@@ -511,7 +575,7 @@ def build_recommendation_reason_v4(
     used_action = _build_used_action(interpretation, meaning, action)
 
     reason = RecommendationReasonV4(
-        reason_text=_build_reason_text(fact, interpretation_layer, action),
+        reason_text=_build_reason_text(fact, interpretation_layer, action, reason_strength),
         fact=fact,
         interpretation=interpretation_layer,
         action=action,

--- a/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
+++ b/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
@@ -362,3 +362,161 @@ def test_candidate_profile_zero_knowledge_shrine_matches_legacy_output():
     assert profile_a["shrine_history"] is None
     assert profile_a["deity"] == profile_b["deity"]
     assert profile_a["shrine_history"] == profile_b["shrine_history"]
+
+
+# --- PR-B: confidence伝播 ---
+
+
+def test_candidate_profile_deity_confidence_is_propagated_from_single_knowledge_deity():
+    rec = {
+        "shrine_id": 1,
+        "knowledge_deities": [{"display_name": "明治天皇", "sort_order": 0, "confidence": "high"}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity_confidence"] == "high"
+
+
+def test_candidate_profile_deity_confidence_is_propagated_when_all_deities_share_same_value():
+    rec = {
+        "shrine_id": 50,
+        "knowledge_deities": [
+            {"display_name": "天比理乃咩命", "sort_order": 0, "confidence": "medium"},
+            {"display_name": "宇賀之売命", "sort_order": 1, "confidence": "medium"},
+            {"display_name": "素盞嗚尊", "sort_order": 2, "confidence": "medium"},
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity_confidence"] == "medium"
+
+
+def test_candidate_profile_deity_confidence_is_none_when_mixed_across_deities():
+    """複数Deityでconfidenceが混在する場合の集約ルールは契約上未確定のため、
+    勝手にmin/max/average等を採用せず、Noneへ倒す(=Reason側はassertive/現行互換扱い)。
+    """
+    rec = {
+        "shrine_id": 1,
+        "knowledge_deities": [
+            {"display_name": "A神", "sort_order": 0, "confidence": "high"},
+            {"display_name": "B神", "sort_order": 1, "confidence": "low"},
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity_confidence"] is None
+    # 集約せず(=特定の値を選ばず)Noneへ倒しているだけで、両Deityの名前は
+    # 引き続き結合される(usable Factが消えるわけではない)。
+    assert profile["deity"] == "A神、B神"
+
+
+def test_candidate_profile_deity_confidence_is_none_when_unset():
+    rec = {
+        "shrine_id": 1,
+        "knowledge_deities": [{"display_name": "明治天皇", "sort_order": 0}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity_confidence"] is None
+
+
+def test_candidate_profile_deity_confidence_is_none_when_legacy_fallback():
+    """Legacy(sajin)Fieldにはconfidence概念が存在しないため常にNone。"""
+    rec = {"shrine_id": 1, "sajin": "レガシー祭神", "knowledge_deities": []}
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "レガシー祭神"
+    assert profile["deity_confidence"] is None
+
+
+def test_candidate_profile_shrine_history_confidence_is_propagated_from_selected_history():
+    rec = {
+        "shrine_id": 1,
+        "knowledge_histories": [
+            {
+                "history_type": "official_origin",
+                "content": "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history_confidence"] == "high"
+
+
+def test_candidate_profile_shrine_history_confidence_matches_the_selected_history_only():
+    """sort_order最小の1件のconfidenceのみを採用し、他Historyのconfidenceを混ぜない。"""
+    rec = {
+        "shrine_id": 50,
+        "knowledge_histories": [
+            {
+                "history_type": "historical_event",
+                "content": "二階堂道蘊公が宇賀之売命を祀った。",
+                "sort_order": 1,
+                "confidence": "low",
+            },
+            {
+                "history_type": "founding",
+                "content": "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎えた。",
+                "sort_order": 0,
+                "confidence": "medium",
+            },
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history"] == "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎えた。"
+    assert profile["shrine_history_confidence"] == "medium"
+
+
+def test_candidate_profile_shrine_history_confidence_is_none_when_unset():
+    rec = {
+        "shrine_id": 1,
+        "knowledge_histories": [{"history_type": "official_origin", "content": "由緒", "sort_order": 0}],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history_confidence"] is None
+
+
+def test_candidate_profile_shrine_history_confidence_is_none_when_legacy_fallback():
+    """Legacy(description)Fieldにはconfidence概念が存在しないため常にNone。"""
+    rec = {"shrine_id": 1, "description": "レガシー由緒", "knowledge_histories": []}
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["shrine_history"] == "レガシー由緒"
+    assert profile["shrine_history_confidence"] is None
+
+
+def test_candidate_profile_pilot_1_meiji_jingu_confidence_is_high():
+    rec = {
+        "shrine_id": 1,
+        "knowledge_deities": [
+            {"display_name": "明治天皇", "sort_order": 0, "confidence": "high"},
+            {"display_name": "昭憲皇太后", "sort_order": 1, "confidence": "high"},
+        ],
+        "knowledge_histories": [
+            {
+                "history_type": "official_origin",
+                "content": "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity_confidence"] == "high"
+    assert profile["shrine_history_confidence"] == "high"

--- a/backend/temples/tests/services/test_reason_strength_pilot_and_regression.py
+++ b/backend/temples/tests/services/test_reason_strength_pilot_and_regression.py
@@ -1,0 +1,199 @@
+"""Evidence Gate PR-B: Pilot回帰・Legacy fallback回帰・verification_status回帰。
+
+confidenceによるRecommendation Reason表現強度制御(PR-B)が、
+- Pilot相当データ(confidence=high)で現行Reason文と完全互換であること
+- Legacy(sajin/description)にはconfidence制御を一切適用しないこと
+- verification_status(Evidence Gate PR-A)のusable判定にconfidenceが影響しないこと
+を固定するための回帰テスト。
+"""
+
+from __future__ import annotations
+
+from temples.services.concierge_chat import _build_score_v3_candidate_profile
+from temples.services.evidence_gate import decide_fact_usability
+from temples.services.recommendation_reason_v4 import build_recommendation_reason_v4
+
+# --- Pilot regression ---
+
+
+def test_pilot_meiji_jingu_equivalent_reason_text_is_current_compatible():
+    rec = {
+        "shrine_id": 1,
+        "name": "明治神宮",
+        "knowledge_deities": [
+            {"display_name": "明治天皇", "sort_order": 0, "confidence": "high"},
+            {"display_name": "昭憲皇太后", "sort_order": 1, "confidence": "high"},
+        ],
+        "knowledge_histories": [
+            {
+                "history_type": "official_origin",
+                "title": "明治神宮の創建",
+                "content": "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+                "period_text": "大正9年（1920）",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity"] == "明治天皇、昭憲皇太后"
+    assert profile["deity_confidence"] == "high"
+    assert profile["shrine_history_confidence"] == "high"
+    assert "明治神宮では、明治天皇、昭憲皇太后が祀られています。" in result["reason_text"]
+    # weakened/suppressed表現が混入しない(high confidenceでは現行文体のまま)
+    assert "とされています" not in result["reason_text"]
+    assert "伝えられています" not in result["reason_text"]
+
+
+def test_pilot_shinagawa_jinja_equivalent_reason_text_is_current_compatible():
+    rec = {
+        "shrine_id": 50,
+        "name": "品川神社",
+        "knowledge_deities": [
+            {"display_name": "天比理乃咩命", "sort_order": 0, "confidence": "high"},
+            {"display_name": "宇賀之売命", "sort_order": 1, "confidence": "high"},
+            {"display_name": "素盞嗚尊", "sort_order": 2, "confidence": "high"},
+        ],
+        "knowledge_histories": [
+            {
+                "history_type": "founding",
+                "title": "文治3年（1187年）の創始",
+                "content": (
+                    "源頼朝公が安房国の洲崎明神から天比理乃咩命を当地に迎え、"
+                    "海上交通安全と祈願成就を祈ったことを創始とする。"
+                ),
+                "period_text": "文治3年（1187年）",
+                "sort_order": 0,
+                "confidence": "high",
+            },
+            {
+                "history_type": "historical_event",
+                "title": "元応元年（1319年）の宇賀之売命奉祀",
+                "content": "二階堂道蘊公が宇賀之売命を祀った。",
+                "period_text": "元応元年（1319年）",
+                "sort_order": 1,
+                "confidence": "high",
+            },
+        ],
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity"] == "天比理乃咩命、宇賀之売命、素盞嗚尊"
+    assert profile["deity_confidence"] == "high"
+    # sort_order最小(1187年)のHistoryのみがshrine_historyへ採用される(既存契約通り)
+    assert profile["shrine_history_confidence"] == "high"
+    assert "二階堂道蘊公" not in profile["shrine_history"]
+    assert (
+        "品川神社では、天比理乃咩命、宇賀之売命、素盞嗚尊が祀られています。"
+        in result["reason_text"]
+    )
+    assert "とされています" not in result["reason_text"]
+    assert "伝えられています" not in result["reason_text"]
+
+
+# --- Legacy fallback regression ---
+
+
+def test_legacy_only_shrine_reason_text_unaffected_by_confidence_control():
+    """Knowledge未登録(Legacy sajin/descriptionのみ)のShrineは、PR-B前後でReason文が変わらない。"""
+    rec = {
+        "shrine_id": 99,
+        "name": "レガシー神社",
+        "sajin": "レガシー祭神",
+        "description": "レガシーの由緒文",
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity"] == "レガシー祭神"
+    assert profile["deity_confidence"] is None
+    assert profile["shrine_history"] == "レガシーの由緒文"
+    assert profile["shrine_history_confidence"] is None
+    # Legacy由来のdeityは常にassertive表現(現行互換)のまま。weakened/suppressedにならない。
+    assert "レガシー神社では、レガシー祭神が祀られています。" in result["reason_text"]
+    assert "とされています" not in result["reason_text"]
+    assert "レガシー祭神" in result["fact"]["deity"]
+
+
+def test_legacy_only_shrine_with_empty_knowledge_lists_matches_pure_legacy_shrine():
+    """knowledge_deities/knowledge_histories=[]のケースでもLegacy回帰は同一。"""
+    rec_pure_legacy = {"shrine_id": 99, "sajin": "レガシー祭神", "description": "レガシーの由緒文"}
+    rec_empty_knowledge = {
+        "shrine_id": 99,
+        "sajin": "レガシー祭神",
+        "description": "レガシーの由緒文",
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+
+    profile_a = _build_score_v3_candidate_profile(rec_pure_legacy)
+    profile_b = _build_score_v3_candidate_profile(rec_empty_knowledge)
+    result_a = build_recommendation_reason_v4(candidate_profile=profile_a)
+    result_b = build_recommendation_reason_v4(candidate_profile=profile_b)
+
+    assert profile_a["deity_confidence"] == profile_b["deity_confidence"] is None
+    assert profile_a["shrine_history_confidence"] == profile_b["shrine_history_confidence"] is None
+    assert result_a["reason_text"] == result_b["reason_text"]
+
+
+# --- verification_status regression (Evidence Gate PR-A) ---
+
+
+def test_disputed_high_confidence_is_still_unusable():
+    """confidence=highでもverification_status=disputedならusable=Falseのまま(PR-A不変)。"""
+    decision = decide_fact_usability(
+        verification_status="disputed",
+        confidence="high",
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert decision.usable is False
+
+
+def test_draft_high_confidence_is_still_unusable():
+    decision = decide_fact_usability(
+        verification_status="draft",
+        confidence="high",
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert decision.usable is False
+
+
+def test_fact_ready_without_source_is_still_unusable_regardless_of_confidence():
+    for confidence in ("high", "medium", "low", ""):
+        decision = decide_fact_usability(
+            verification_status="source_confirmed",
+            confidence=confidence,
+            source_verification_statuses=[],
+        )
+        assert (
+            decision.usable is False
+        ), f"confidence={confidence!r}でusableがTrueになってはいけない"
+
+
+def test_fact_ready_with_draft_source_only_is_still_unusable_regardless_of_confidence():
+    for confidence in ("high", "medium", "low", ""):
+        decision = decide_fact_usability(
+            verification_status="source_confirmed",
+            confidence=confidence,
+            source_verification_statuses=["draft"],
+        )
+        assert (
+            decision.usable is False
+        ), f"confidence={confidence!r}でusableがTrueになってはいけない"
+
+
+def test_fact_ready_with_ready_source_is_usable_regardless_of_confidence():
+    """usable=Trueになるかどうかはconfidenceに左右されない(low/emptyでもusableはTrue)。"""
+    for confidence in ("high", "medium", "low", ""):
+        decision = decide_fact_usability(
+            verification_status="source_confirmed",
+            confidence=confidence,
+            source_verification_statuses=["source_confirmed"],
+        )
+        assert decision.usable is True, f"confidence={confidence!r}でもusableはTrueのはず"

--- a/backend/temples/tests/services/test_recommendation_reason_v4.py
+++ b/backend/temples/tests/services/test_recommendation_reason_v4.py
@@ -666,6 +666,172 @@ def test_build_recommendation_reason_v4_shrine_history_uses_background_copy_with
     assert "たの特徴" not in result["reason_text"]
 
 
+# --- PR-B: Knowledge Fact confidenceによるReason表現強度制御 ---
+
+
+def test_reason_v4_deity_confidence_high_uses_current_compatible_wording():
+    result = build_recommendation_reason_v4(
+        candidate_profile={"name": "テスト神社", "deity": "テスト祭神", "deity_confidence": "high"},
+    )
+
+    assert "テスト神社では、テスト祭神が祀られています。" in result["reason_text"]
+    assert result["fact"]["deity"] == "テスト祭神"
+
+
+def test_reason_v4_deity_confidence_medium_uses_weakened_wording():
+    result = build_recommendation_reason_v4(
+        candidate_profile={"name": "テスト神社", "deity": "テスト祭神", "deity_confidence": "medium"},
+    )
+
+    assert "テスト神社では、テスト祭神が祀られているとされています。" in result["reason_text"]
+    # Fact値自体は加工されない(文体を混ぜ込まない)
+    assert result["fact"]["deity"] == "テスト祭神"
+    assert "可能性があります" not in result["reason_text"]
+    assert "かもしれません" not in result["reason_text"]
+    assert "おそらく" not in result["reason_text"]
+    assert "。。" not in result["reason_text"]
+
+
+def test_reason_v4_deity_confidence_low_suppresses_knowledge_fact_from_reason():
+    result = build_recommendation_reason_v4(
+        candidate_profile={"name": "テスト神社", "deity": "テスト祭神", "deity_confidence": "low"},
+    )
+
+    assert "テスト祭神" not in result["reason_text"]
+    # Fact自体(fact.deity/used_fact.deity)もReason生成の出力からは無くなる
+    # (Detail API・DB・Knowledge selectorには影響しない。これはReason生成内部の話)。
+    assert result["fact"]["deity"] is None
+    assert result["used_fact"]["deity"] is None
+
+
+def test_reason_v4_deity_confidence_empty_string_uses_current_compatible_wording():
+    result = build_recommendation_reason_v4(
+        candidate_profile={"name": "テスト神社", "deity": "テスト祭神", "deity_confidence": ""},
+    )
+
+    assert "テスト神社では、テスト祭神が祀られています。" in result["reason_text"]
+    assert result["fact"]["deity"] == "テスト祭神"
+
+
+def test_reason_v4_deity_confidence_missing_key_uses_current_compatible_wording():
+    """deity_confidence未指定(既存呼び出し互換)は現行のassertive表現のまま。"""
+    result = build_recommendation_reason_v4(
+        candidate_profile={"name": "テスト神社", "deity": "テスト祭神"},
+    )
+
+    assert "テスト神社では、テスト祭神が祀られています。" in result["reason_text"]
+
+
+def test_reason_v4_shrine_history_confidence_high_uses_current_compatible_wording():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "shrine_history_confidence": "high",
+        },
+    )
+
+    assert (
+        "テスト神社には、戦災で焼失した後、氏子により再建されたという背景があります。"
+        in result["reason_text"]
+    )
+
+
+def test_reason_v4_shrine_history_confidence_medium_uses_weakened_wording():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "shrine_history_confidence": "medium",
+        },
+    )
+
+    assert (
+        "テスト神社には、戦災で焼失した後、氏子により再建されたと伝えられています。"
+        in result["reason_text"]
+    )
+    assert result["fact"]["shrine_history"] == "戦災で焼失した後、氏子により再建された"
+    assert "。。" not in result["reason_text"]
+
+
+def test_reason_v4_shrine_history_confidence_low_suppresses_knowledge_fact_from_reason():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "shrine_history_confidence": "low",
+        },
+    )
+
+    assert "戦災で焼失した後" not in result["reason_text"]
+    assert result["fact"]["shrine_history"] is None
+    assert result["used_fact"]["shrine_history"] is None
+    # deity/shrine_history両方無い場合の既存fallback文言へ落ちる
+    assert "神社固有情報が十分でないため" in result["reason_text"]
+
+
+def test_reason_v4_shrine_history_confidence_empty_string_uses_current_compatible_wording():
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "shrine_history_confidence": "",
+        },
+    )
+
+    assert (
+        "テスト神社には、戦災で焼失した後、氏子により再建されたという背景があります。"
+        in result["reason_text"]
+    )
+
+
+def test_reason_v4_low_deity_falls_through_to_high_shrine_history():
+    """deityがlowでsuppressされても、shrine_historyが別confidenceなら独立してFactとして使われる。"""
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "deity": "テスト祭神",
+            "deity_confidence": "low",
+            "shrine_history": "戦災で焼失した後、氏子により再建された",
+            "shrine_history_confidence": "high",
+        },
+    )
+
+    assert "テスト祭神" not in result["reason_text"]
+    assert (
+        "テスト神社には、戦災で焼失した後、氏子により再建されたという背景があります。"
+        in result["reason_text"]
+    )
+
+
+def test_reason_v4_fact_schema_unchanged_when_confidence_fields_present():
+    """confidence関連fieldはfact dictへ混入しない(公開Schema不変)。"""
+    result = build_recommendation_reason_v4(
+        candidate_profile={
+            "name": "テスト神社",
+            "deity": "テスト祭神",
+            "deity_confidence": "medium",
+            "shrine_history": "背景",
+            "shrine_history_confidence": "low",
+        },
+    )
+
+    assert set(result["fact"].keys()) == {
+        "label",
+        "name",
+        "deity",
+        "shrine_history",
+        "place_context",
+        "history_theme",
+        "goriyaku",
+        "visit_style_tags",
+        "evidence",
+    }
+    assert "reason_strength" not in result["fact"]
+    assert "confidence" not in result["fact"]
+    assert "deity_confidence" not in result["fact"]
+
+
 def test_build_recommendation_reason_v4_all_facts_present_prioritizes_deity_and_excludes_place_context():
     result = build_recommendation_reason_v4(
         candidate_profile={


### PR DESCRIPTION
## Summary
- Evidence Gate PR-A(#2227)で一本化されたusable判定(`fact_ready AND ready Source>=1`)は変更しない。
- usable=TrueとなったKnowledge Fact(ShrineDeity/ShrineHistory)のconfidence(high/medium/low/空)に応じて、**Recommendation Reasonの表現強度だけ**を制御する。
  - high → 現行文言のまま(「〜が祀られています。」「〜という背景があります。」)
  - medium → 限定表現(「〜が祀られているとされています。」「〜と伝えられています。」)
  - low → Knowledge FactをReason文へ使用しない(fact/used_fact/evidenceからも除外。DB・selector・Detail APIへは一切影響しない)
  - 空文字/未設定 → 現行互換(assertive)。highへの読み替えはしない
- `concierge_chat.py`の`_join_knowledge_deity_names`/`_pick_primary_knowledge_history_content`の時点で失われていたconfidenceを、`candidate_profile["deity_confidence"]`/`["shrine_history_confidence"]`として新たに保持するよう変更（Fact値の文字列自体には一切文体を混ぜ込まない）。
- 複数DeityがReason文へ連結される場合、**全Deityのconfidenceが一致する場合のみ**その値を伝播する。混在する場合は集約ルールが契約上未確定のため、min/max/average等を独自に作らずNone(現行互換)へ倒す。
- Legacy(`Shrine.sajin`/`Shrine.description`)fallback時はKnowledge confidence概念が存在しないため、常にconfidence制御対象外(現行文言のまま)。
- `RecommendationReasonV4.fact`のkey構成(9キー)は完全に不変。confidence/reason_strengthはfact dictへ混入させず、Reason生成関数の内部でのみ扱う。

## 変更していないもの
- `temples/services/evidence_gate.py`(Evidence Gate PR-A本体、usable判定ロジック)
- Model / Migration / DBデータ
- Shrine Detail API(`temples/api/serializers/shrine.py`/`views/shrine.py`)
- Web / Mobile
- Public API Schema — `manage.py spectacular`生成結果に構造差分なし(PR-A時点との完全一致を確認済み)
- Recommendation Score / Ranking
- Source confidence(未接続のまま。参照・集約・計算を追加していない)
- `data_confidence_score` / disputed多説併記 / 105件Rollout

## Test plan
- [x] `pytest`(backend全体): **942 passed, 9 skipped**(PR-A時点912件から30件追加)
- [x] Deity/History × high/medium/low/empty confidenceの表現強度テスト: `test_recommendation_reason_v4.py`
- [x] candidate_profileへのconfidence伝播テスト(単一Deity/複数Deity同一値/複数Deity混在→None/Legacy fallback→None): `test_concierge_chat_score_v3_candidate_profile.py`
- [x] Pilot回帰(明治神宮/品川神社相当、confidence=highでReason文が現行と完全一致): `test_reason_strength_pilot_and_regression.py`
- [x] Legacy fallback回帰(sajin/descriptionのみのShrineでReason文不変): 同上
- [x] verification_status回帰(`disputed`+high confidence、`draft`+high confidence、Source欠如、draft Sourceのみ、いずれもconfidenceに関わらずusable不変): 同上
- [x] `ruff check`(変更/新規ファイル): 新規コード起因の指摘なし(既存ファイルの4件はPR-B以前からの既存差分と確認済み)
- [x] `manage.py makemigrations --check --dry-run`: No changes detected
- [x] `manage.py spectacular`生成差分確認: PR-A時点との完全一致(構造差分なし)
- [x] query count回帰テスト(selector/concierge candidates): 既存テスト全PASS、N+1増加なし
- [x] pre-push hook(OpenAPI lint / Web契約テスト702件): PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)