### PR TITLE
fix(backend): mixed Deity confidenceがassertive扱いになる不具合を修正

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -16,6 +16,7 @@ from temples.services.recommendation_input_profile import (
     build_recommendation_input_profile,
 )
 from temples.services.recommendation_reason_v4 import (
+    CONFIDENCE_MIXED,
     build_recommendation_reason_v4,
 )
 from temples.services.score_v3_observer import (
@@ -315,11 +316,16 @@ def _join_knowledge_deity_names(knowledge_deities: Any) -> str | None:
 def _resolve_knowledge_deity_confidence(knowledge_deities: Any) -> str | None:
     """`_join_knowledge_deity_names()`が連結するのと同じDeity集合のconfidenceを返す。
 
-    全Deityのconfidenceが一致する場合のみその値を返す。以下はいずれもNoneを返す
-    （PR-B契約: 集約ルールが未確定なため、min/max/average/majority等を独自に
-    作らず、Noneを「現行互換の通常表現(assertive)」として扱う）。
-    - 対象Deityが1件もconfidenceを設定していない（空文字のみ）場合
-    - 複数DeityでconfidenceがHigh/Medium/Low等に混在している場合
+    3つの状態を明確に区別する（PR-B follow-up）。
+    - 全Deityのconfidenceが同一の場合: その値を返す（空文字のみで一致する場合は
+      「confidence未設定」を意味するNoneを返す。＝現行互換のassertive扱い）
+    - 対象Deityが1件も無い場合: None（呼び出し側でLegacy fallback等が発生する経路）
+    - 複数DeityでconfidenceがHigh/Medium/Low/空等に混在している場合:
+      `CONFIDENCE_MIXED`を返す。これはNoneとは異なる状態であり、
+      Noneのように「現行互換の通常表現(assertive)」へは倒さない
+      （集約ルールが未確定なため、min/max/average/majority等を独自に作らず、
+      Reason生成側でsuppressed相当として扱う。Knowledge Fact自体は
+      Detail API・DB・Knowledge selectorからは一切消えない）。
     """
     if not isinstance(knowledge_deities, list):
         return None
@@ -330,7 +336,7 @@ def _resolve_knowledge_deity_confidence(knowledge_deities: Any) -> str | None:
     if len(confidences) == 1:
         value = confidences.pop()
         return value or None
-    return None
+    return CONFIDENCE_MIXED
 
 
 def _pick_primary_knowledge_history_item(knowledge_histories: Any) -> dict[str, Any] | None:

--- a/backend/temples/services/recommendation_reason_v4.py
+++ b/backend/temples/services/recommendation_reason_v4.py
@@ -127,22 +127,39 @@ def _copy_for_key(mapping: dict[str, str], key: str | None) -> str | None:
     return mapping.get(key, key)
 
 
-# PR-B: Knowledge Fact confidence(high/medium/low)からRecommendation Reasonの
-# 表現強度への変換。Evidence Gate(temples.services.evidence_gate)のusable判定には
-# 一切影響しない、Reason生成内部だけで完結する変換であることに注意。
+# PR-B follow-up: 複数Deity（または複数Fact）のconfidenceが一致しない場合に使う
+# Recommendation Reason内部専用のsentinel値。
+# temples.models.KNOWLEDGE_CONFIDENCE_CHOICES（low/medium/high）には存在しない
+# 値であり、Model/Migration/Public APIへは一切露出しない
+# （candidate_profile["deity_confidence"]等、内部dictの中だけを流れる）。
+#
+# "confidenceが1つも設定されていない(空文字のみ)"状態と、
+# "confidenceが複数Deity間で一致しない(空文字を含む混在も含む)"状態を、
+# 同じNoneへ丸めてしまうと、後者が誤って"legacy-compatible assertive"
+# （現行互換の通常表現）として扱われてしまう。両者は明確に別状態として扱う。
+CONFIDENCE_MIXED = "__mixed__"
+
+# PR-B: Knowledge Fact confidence(high/medium/low/CONFIDENCE_MIXED)から
+# Recommendation Reasonの表現強度への変換。
+# Evidence Gate(temples.services.evidence_gate)のusable判定には一切影響しない、
+# Reason生成内部だけで完結する変換であることに注意。
 _CONFIDENCE_TO_REASON_STRENGTH: dict[str, str] = {
     "high": "assertive",
     "medium": "weakened",
     "low": "suppressed",
+    # mixedはどの単一confidenceにも安全に倒せないため、lowと同様suppressed
+    # （Knowledge Deity/HistoryをReasonの生成材料として使わない）として扱う。
+    CONFIDENCE_MIXED: "suppressed",
 }
 
 
 def _reason_strength_from_confidence(confidence: Any) -> str:
-    """confidence(""/None/未知の値を含む)をreason_strengthへ変換する。
+    """confidence(""/None/CONFIDENCE_MIXED/未知の値を含む)をreason_strengthへ変換する。
 
     空文字・None・未知の値は全て"assertive"(現行互換の通常表現)とする。
     これはconfidence未設定を"high"の意味へ格上げするものではなく、単に
     PR-A以前からの既存Reason文体を変更しないための後方互換上の選択。
+    CONFIDENCE_MIXEDは明示的に"suppressed"へ変換される。
     """
     if isinstance(confidence, str) and confidence in _CONFIDENCE_TO_REASON_STRENGTH:
         return _CONFIDENCE_TO_REASON_STRENGTH[confidence]
@@ -594,6 +611,7 @@ def build_recommendation_reason_v4(
 
 
 __all__ = [
+    "CONFIDENCE_MIXED",
     "RecommendationReasonV4",
     "build_recommendation_reason_quality_audit",
     "build_recommendation_reason_v4",

--- a/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
+++ b/backend/temples/tests/services/test_concierge_chat_score_v3_candidate_profile.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from temples.services.concierge_chat import _build_score_v3_candidate_profile
+from temples.services.recommendation_reason_v4 import CONFIDENCE_MIXED
 
 
 def test_build_score_v3_candidate_profile_maps_deity_history_and_place_context():
@@ -393,9 +394,11 @@ def test_candidate_profile_deity_confidence_is_propagated_when_all_deities_share
     assert profile["deity_confidence"] == "medium"
 
 
-def test_candidate_profile_deity_confidence_is_none_when_mixed_across_deities():
+def test_candidate_profile_deity_confidence_is_mixed_sentinel_when_confidences_differ():
     """複数Deityでconfidenceが混在する場合の集約ルールは契約上未確定のため、
-    勝手にmin/max/average等を採用せず、Noneへ倒す(=Reason側はassertive/現行互換扱い)。
+    勝手にmin/max/average等を採用しない。ただしNone(confidence未設定/
+    Legacy fallback相当)と混同してはならないため、専用sentinel(CONFIDENCE_MIXED)
+    へ倒す(PR-B follow-up)。
     """
     rec = {
         "shrine_id": 1,
@@ -407,9 +410,11 @@ def test_candidate_profile_deity_confidence_is_none_when_mixed_across_deities():
 
     profile = _build_score_v3_candidate_profile(rec)
 
-    assert profile["deity_confidence"] is None
-    # 集約せず(=特定の値を選ばず)Noneへ倒しているだけで、両Deityの名前は
-    # 引き続き結合される(usable Factが消えるわけではない)。
+    assert profile["deity_confidence"] == CONFIDENCE_MIXED
+    assert profile["deity_confidence"] is not None
+    # 集約せず(=特定の値を選ばず)mixed扱いにしているだけで、両Deityの名前は
+    # 引き続き結合される(usable Factが消えるわけではない。Knowledge selector・
+    # Detail APIから消えるわけでもない)。
     assert profile["deity"] == "A神、B神"
 
 

--- a/backend/temples/tests/services/test_reason_strength_mixed_confidence.py
+++ b/backend/temples/tests/services/test_reason_strength_mixed_confidence.py
@@ -1,0 +1,311 @@
+"""PR #2228 follow-up: mixed Deity confidence fail-safe修正の回帰テスト。
+
+複数DeityのconfidenceがReason文へ連結される際に一致しない場合、
+"confidence未設定"や"Legacy fallback"と同じNoneへ丸めてしまうと、
+low相当のKnowledge Factが誤ってassertive表現でReasonへ出てしまう。
+
+CONFIDENCE_MIXED(内部専用sentinel)により、以下を明確に区別する。
+- confidence未設定（空文字のみで一致）: None → legacy-compatible assertive
+- 複数Deityでconfidenceが一致しない（空文字を含む混在も含む）: CONFIDENCE_MIXED → suppressed
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import _build_score_v3_candidate_profile
+from temples.services.evidence_gate import decide_fact_usability
+from temples.services.recommendation_reason_v4 import (
+    CONFIDENCE_MIXED,
+    build_recommendation_reason_v4,
+)
+from temples.services.shrine_knowledge_selector import fetch_fact_ready_knowledge_deities
+
+
+def _deities_rec(shrine_id: int, confidences: list[str], **extra) -> dict:
+    rec = {
+        "shrine_id": shrine_id,
+        "name": "テスト神社",
+        "knowledge_deities": [
+            {"display_name": f"祭神{i}", "sort_order": i, "confidence": c}
+            for i, c in enumerate(confidences)
+        ],
+    }
+    rec.update(extra)
+    return rec
+
+
+# --- 同一confidence（既存PR実装を維持） ---
+
+
+def test_case1_high_high_keeps_deity_and_uses_assertive():
+    rec = _deities_rec(1, ["high", "high"])
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] == "high"
+    assert result["fact"]["deity"] == "祭神0、祭神1"
+    assert "祭神0、祭神1が祀られています。" in result["reason_text"]
+
+
+def test_case2_medium_medium_keeps_deity_and_uses_weakened():
+    rec = _deities_rec(1, ["medium", "medium"])
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] == "medium"
+    assert result["fact"]["deity"] == "祭神0、祭神1"
+    assert "祭神0、祭神1が祀られているとされています。" in result["reason_text"]
+
+
+def test_case3_low_low_suppresses_deity_from_reason():
+    rec = _deities_rec(1, ["low", "low"])
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] == "low"
+    assert result["fact"]["deity"] is None
+    assert "祭神0" not in result["reason_text"]
+    assert "祭神1" not in result["reason_text"]
+
+
+def test_case4_empty_empty_keeps_deity_and_uses_legacy_compatible_assertive():
+    rec = _deities_rec(1, ["", ""])
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] is None
+    assert result["fact"]["deity"] == "祭神0、祭神1"
+    assert "祭神0、祭神1が祀られています。" in result["reason_text"]
+
+
+@pytest.mark.parametrize("confidence", ["high", "medium", "low", ""])
+def test_single_deity_confidence_matches_multi_deity_uniform_behavior(confidence):
+    rec = _deities_rec(1, [confidence])
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    if confidence == "low":
+        assert result["fact"]["deity"] is None
+        assert "祭神0" not in result["reason_text"]
+    else:
+        assert result["fact"]["deity"] == "祭神0"
+        if confidence == "medium":
+            assert "祭神0が祀られているとされています。" in result["reason_text"]
+        else:
+            assert "祭神0が祀られています。" in result["reason_text"]
+
+
+# --- mixed confidence ---
+
+
+@pytest.mark.parametrize(
+    "confidences",
+    [
+        ["high", "medium"],  # case5
+        ["high", "low"],  # case6
+        ["medium", "low"],  # case7
+        ["high", ""],  # case8
+        ["medium", ""],  # case9
+        ["low", ""],  # case10
+    ],
+)
+def test_mixed_confidence_suppresses_knowledge_deity_from_reason(confidences):
+    rec = _deities_rec(1, confidences)
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] == CONFIDENCE_MIXED
+    assert profile["deity_confidence"] is not None
+    assert result["fact"]["deity"] is None
+    assert result["used_fact"]["deity"] is None
+    assert "祭神0" not in result["reason_text"]
+    assert "祭神1" not in result["reason_text"]
+    assert "神社固有情報が十分でないため" in result["reason_text"]
+
+
+# --- 契約回帰 ---
+
+
+def test_mixed_confidence_does_not_change_evidence_gate_usable():
+    """case11: mixedでもEvidence Gate usable判定は変更されない。"""
+    for confidence in ("high", "medium", "low", ""):
+        decision = decide_fact_usability(
+            verification_status="source_confirmed",
+            confidence=confidence,
+            source_verification_statuses=["source_confirmed"],
+        )
+        assert decision.usable is True
+
+
+@pytest.mark.django_db
+def test_mixed_confidence_does_not_remove_deity_from_knowledge_selector():
+    """case12: mixedでもKnowledge selector結果からDeity自体は消えない。"""
+    from django.utils import timezone
+
+    from temples.models import Shrine, ShrineDeity, ShrineKnowledgeSource
+
+    shrine = Shrine.objects.create(
+        name_jp="mixed confidence監査神社",
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="出典",
+        verification_status="source_confirmed",
+        verified_at=timezone.now(),
+    )
+    deity_high = ShrineDeity.objects.create(
+        shrine=shrine,
+        display_name="高confidence祭神",
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=0,
+        verified_at=timezone.now(),
+    )
+    deity_low = ShrineDeity.objects.create(
+        shrine=shrine,
+        display_name="低confidence祭神",
+        verification_status="source_confirmed",
+        confidence="low",
+        sort_order=1,
+        verified_at=timezone.now(),
+    )
+    for deity in (deity_high, deity_low):
+        deity.sources.add(source)
+
+    result = fetch_fact_ready_knowledge_deities([shrine.id])[shrine.id]
+
+    # selectorはFact単位で返す(Reason文字列結合の責務は持たない)ため、
+    # confidence混在(高+低)でも両Deityともそのまま返る。
+    names = {item["display_name"] for item in result}
+    assert names == {"高confidence祭神", "低confidence祭神"}
+
+
+@pytest.mark.django_db
+def test_mixed_confidence_does_not_affect_shrine_detail_api():
+    """case13: mixedでもShrine Detail APIには影響しない。"""
+    from django.utils import timezone
+
+    from rest_framework.test import APIClient
+
+    from temples.models import Shrine, ShrineDeity, ShrineKnowledgeSource
+
+    shrine = Shrine.objects.create(
+        name_jp="mixed confidence Detail監査神社",
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="出典",
+        verification_status="source_confirmed",
+        verified_at=timezone.now(),
+    )
+    deity_high = ShrineDeity.objects.create(
+        shrine=shrine,
+        display_name="高confidence祭神",
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=0,
+        verified_at=timezone.now(),
+    )
+    deity_low = ShrineDeity.objects.create(
+        shrine=shrine,
+        display_name="低confidence祭神",
+        verification_status="source_confirmed",
+        confidence="low",
+        sort_order=1,
+        verified_at=timezone.now(),
+    )
+    for deity in (deity_high, deity_low):
+        deity.sources.add(source)
+
+    client = APIClient(SERVER_NAME="127.0.0.1")
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {d["display_name"] for d in body["deities"]}
+    assert names == {"高confidence祭神", "低confidence祭神"}
+
+
+def test_mixed_confidence_does_not_fallback_to_legacy_sajin():
+    """case14: mixed suppression後にLegacy sajinへfallbackしない。
+
+    Knowledge deityが存在する(usable)場合、confidenceがmixedであっても
+    candidate_profile["deity"]はKnowledge由来のまま(Legacy sajinへは
+    切り替わらない)。suppressionはReason生成内部(fact.deity)のみで起きる。
+    """
+    rec = _deities_rec(1, ["high", "low"], sajin="レガシー祭神(混入してはいけない)")
+    profile = _build_score_v3_candidate_profile(rec)
+
+    assert profile["deity"] == "祭神0、祭神1"
+    assert "レガシー祭神" not in profile["deity"]
+
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+    assert "レガシー祭神" not in result["reason_text"]
+    assert "祭神0" not in result["reason_text"]
+    assert "祭神1" not in result["reason_text"]
+
+
+def test_mixed_confidence_does_not_change_interpretation_or_action():
+    """case15: Interpretation/Actionは変更しない。"""
+    rec = _deities_rec(1, ["high", "low"])
+    profile = _build_score_v3_candidate_profile(rec)
+
+    result_mixed = build_recommendation_reason_v4(
+        candidate_profile=profile,
+        interpretation_profile={"state_profile": {"primary_state": "uncertain"}},
+    )
+    result_uniform = build_recommendation_reason_v4(
+        candidate_profile={**profile, "deity_confidence": "high"},
+        interpretation_profile={"state_profile": {"primary_state": "uncertain"}},
+    )
+
+    assert result_mixed["interpretation"] == result_uniform["interpretation"]
+    assert result_mixed["action"] == result_uniform["action"]
+
+
+# --- Pilot regression(全high、mixedとは無関係だが回帰確認として明記) ---
+
+
+def test_pilot_meiji_jingu_uniform_high_is_unaffected_by_mixed_confidence_change():
+    """case17: 明治神宮相当Pilot(全high)回帰PASS。"""
+    rec = {
+        "shrine_id": 1,
+        "name": "明治神宮",
+        "knowledge_deities": [
+            {"display_name": "明治天皇", "sort_order": 0, "confidence": "high"},
+            {"display_name": "昭憲皇太后", "sort_order": 1, "confidence": "high"},
+        ],
+    }
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] == "high"
+    assert "明治神宮では、明治天皇、昭憲皇太后が祀られています。" in result["reason_text"]
+
+
+def test_pilot_shinagawa_jinja_uniform_high_is_unaffected_by_mixed_confidence_change():
+    """case18: 品川神社相当Pilot(全high)回帰PASS。"""
+    rec = {
+        "shrine_id": 50,
+        "name": "品川神社",
+        "knowledge_deities": [
+            {"display_name": "天比理乃咩命", "sort_order": 0, "confidence": "high"},
+            {"display_name": "宇賀之売命", "sort_order": 1, "confidence": "high"},
+            {"display_name": "素盞嗚尊", "sort_order": 2, "confidence": "high"},
+        ],
+    }
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["deity_confidence"] == "high"
+    assert (
+        "品川神社では、天比理乃咩命、宇賀之売命、素盞嗚尊が祀られています。"
+        in result["reason_text"]
+    )


### PR DESCRIPTION
## Summary

PR #2228（Evidence Gate PR-B: confidence表現強度制御）のfollow-up修正。

複数DeityのconfidenceがReason文へ連結される際に一致しない場合（例: `high`+`low`）、`deity_confidence = None`としていた。しかし`None`は「confidence未設定」「Legacy fallback」と同じ経路であり、Reason生成側で**assertive表現（現行文言）として扱われてしまう**不具合があった。

```
Deity A = high, Deity B = low
修正前: deity_confidence=None → 「A、Bが祀られています。」(assertiveのまま出てしまう)
修正後: deity_confidence=CONFIDENCE_MIXED → Knowledge deityをReasonへ使わない(suppressed)
```

### 変更内容
- `temples/services/recommendation_reason_v4.py`: Model上の`KNOWLEDGE_CONFIDENCE_CHOICES`（low/medium/high）には存在しない内部専用sentinel`CONFIDENCE_MIXED`を追加。Model/Migration/Public APIへは一切露出しない（`candidate_profile`内部dictのみを流れる）。`_CONFIDENCE_TO_REASON_STRENGTH`マッピングで`suppressed`（lowと同じ扱い）に変換。
- `temples/services/concierge_chat.py`: `_resolve_knowledge_deity_confidence()`が、複数Deityでconfidenceが一致しない場合（空文字を含む混在も含む）に`None`ではなく`CONFIDENCE_MIXED`を返すよう変更。「confidence未設定（全件空文字で一致）」は引き続き`None`のまま区別を維持。

### 3状態の明確な区別
| 状態 | 値 | Reason挙動 |
|---|---|---|
| confidence未設定（全件空文字） | `None` | legacy-compatible assertive |
| Legacy fallback（Knowledge Deity自体が無い） | `None` | legacy-compatible assertive |
| 複数Deityでconfidence混在 | `CONFIDENCE_MIXED` | suppressed（Knowledge deityをReasonへ使わない） |

## 変更していないもの
- Evidence Gate usable判定（`temples/services/evidence_gate.py`は無変更）
- Knowledge selector・Shrine Detail API（confidence混在でもDeity自体はいずれからも消えない。回帰テストで確認）
- DB / Model / Migration / Admin
- Score / Ranking / Prompt / OpenAI API
- Legacy fallback: mixed suppression後もLegacy sajin/descriptionへは再fallbackしない（回帰テストで固定）

## Test plan
- [x] 同一confidence（high+high/medium+medium/low+low/empty+empty）: PASS
- [x] mixed confidence全6パターン（high+medium, high+low, medium+low, high+empty, medium+empty, low+empty）: PASS
- [x] Evidence Gate usable判定回帰（confidenceに関わらずusable不変）: PASS
- [x] Knowledge selectorからDeityが消えないことの回帰: PASS
- [x] Shrine Detail APIへの無影響確認: PASS
- [x] mixed suppression後にLegacy sajinへfallbackしないことの回帰: PASS
- [x] Interpretation/Action無変更の確認: PASS
- [x] Pilot回帰（明治神宮/品川神社相当、全high、mixed変更の影響なし）: PASS
- [x] `pytest`（backend全体）: **963 passed, 9 skipped**（PR-B時点942件から+21件）
- [x] `ruff check`（変更/新規ファイル）: 新規コード起因の指摘なし
- [x] `manage.py makemigrations --check --dry-run`: No changes detected
- [x] `manage.py spectacular`生成差分確認: PR-B時点との完全一致（構造差分なし）
- [x] `git diff --check`: クリーン
- [x] pre-push hook（OpenAPI lint / Web契約テスト702件）: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)