### PR TITLE
feat(backend): Shrine Detail disputed表示Policy(PR-C4B1)を実装

### DIFF
--- a/backend/temples/api/serializers/shrine.py
+++ b/backend/temples/api/serializers/shrine.py
@@ -180,11 +180,15 @@ class ShrineListSerializer(ShrineBaseSerializer):
 
 class ShrineDetailSerializer(ShrineBaseSerializer):
     """Shrine Detail API専用。deities/historiesはtemples.services.evidence_gateの
-    Evidence Gate判定（Fact自身のverification_statusがfact-ready、かつ
-    fact-readyなSourceを1件以上Relation）を満たすもの（usable=True）のみ返却する。
-    Recommendation側（shrine_knowledge_selector.py）と同一のEvidence Gateを使うため、
-    両経路のFact利用可否は常に一致する。Knowledge未登録時は[]を返し、
-    Legacy Field（sajin/description）へのfallbackは行わない。
+    decide_detail_display_state()判定（"full"または"disputed"）を満たすものだけを
+    返却する（PR-C4B1。"hidden"は返さない）。full/disputedいずれも既存の
+    verification_status/confidence/sources fieldのみで表現し、新規fieldは
+    追加しない。verification_status="disputed"のFactは、fact-readyなSourceを
+    1件以上Relationしていれば返る（本文・Source Relationは加工しない）。
+    Recommendation側（shrine_knowledge_selector.pyのdecide_fact_usability()）とは
+    別のPolicyであり、disputedの扱いは経路ごとに異なる（PR-C4A Disputed Evidence
+    Contractの契約通り、Recommendationはdisputedを常に除外する）。Knowledge未登録時は
+    []を返し、Legacy Field（sajin/description）へのfallbackは行わない。
     """
 
     deities = serializers.SerializerMethodField(read_only=True)
@@ -216,11 +220,11 @@ class ShrineDetailSerializer(ShrineBaseSerializer):
         items = [
             d
             for d in obj.deities.all()
-            if evidence_gate.decide_fact_usability(
+            if evidence_gate.decide_detail_display_state(
                 verification_status=d.verification_status,
-                confidence=d.confidence,
                 source_verification_statuses=(s.verification_status for s in d.sources.all()),
-            ).usable
+            )
+            in ("full", "disputed")
         ]
         return ShrineDeitySerializer(items, many=True, context=self.context).data
 
@@ -229,11 +233,11 @@ class ShrineDetailSerializer(ShrineBaseSerializer):
         items = [
             h
             for h in obj.histories.all()
-            if evidence_gate.decide_fact_usability(
+            if evidence_gate.decide_detail_display_state(
                 verification_status=h.verification_status,
-                confidence=h.confidence,
                 source_verification_statuses=(s.verification_status for s in h.sources.all()),
-            ).usable
+            )
+            in ("full", "disputed")
         ]
         return ShrineHistorySerializer(items, many=True, context=self.context).data
 

--- a/backend/temples/api/views/shrine.py
+++ b/backend/temples/api/views/shrine.py
@@ -298,10 +298,12 @@ class ShrineViewSet(viewsets.ModelViewSet):
         # Shrine Detail APIのみdeities/historiesをprefetchする（N+1回避）。
         # ここではFact自身のverification_statusによる候補絞り込みと、ネストする
         # sourcesのfact-ready絞り込みのみを行う（クエリ件数を減らすための事前フィルタ）。
-        # 「fact-readyなSourceを1件以上持つか」を含む最終的なusable判定は
-        # temples.services.evidence_gateへ一本化しており、
+        # 候補集合はDETAIL_CANDIDATE_VERIFICATION_STATUSES（full相当 + disputed）で
+        # あり、これはあくまで「候補に含めてよい範囲」に過ぎない。
+        # 実際にfull/disputed/hiddenのどれになるか（Source条件を含む最終判定）は
+        # temples.services.evidence_gate.decide_detail_display_state()へ一本化しており、
         # ShrineDetailSerializer.get_deities()/get_histories()で行う
-        # （Recommendation側のshrine_knowledge_selector.pyと同じEvidence Gateを使う）。
+        # （PR-C4B1。Recommendation側のshrine_knowledge_selector.pyとは別のPolicy）。
         if self.action in ("retrieve",):
 
             def _fact_ready_sources_prefetch() -> Prefetch:
@@ -316,7 +318,7 @@ class ShrineViewSet(viewsets.ModelViewSet):
                 Prefetch(
                     "deities",
                     queryset=ShrineDeity.objects.filter(
-                        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
+                        verification_status__in=evidence_gate.DETAIL_CANDIDATE_VERIFICATION_STATUSES
                     )
                     .prefetch_related(_fact_ready_sources_prefetch())
                     .order_by("sort_order", "id"),
@@ -324,7 +326,7 @@ class ShrineViewSet(viewsets.ModelViewSet):
                 Prefetch(
                     "histories",
                     queryset=ShrineHistory.objects.filter(
-                        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
+                        verification_status__in=evidence_gate.DETAIL_CANDIDATE_VERIFICATION_STATUSES
                     )
                     .prefetch_related(_fact_ready_sources_prefetch())
                     .order_by("sort_order", "id"),

--- a/backend/temples/services/evidence_gate.py
+++ b/backend/temples/services/evidence_gate.py
@@ -11,6 +11,13 @@ Recommendation側（shrine_knowledge_selector.pyのQuerySet条件）とShrine De
 
 PR-Aでは以下のみを扱う。confidenceによる表現制御・disputed専用表示・数値スコアは
 PR-B以降へ延期する（本ファイルのdocstring/コメントを参照）。
+
+PR-B（confidenceによるRecommendation Reason表現強度制御）を経て、PR-C4B1で
+Shrine Detail専用のdisputed表示判定（decide_detail_display_state）を追加した。
+これはRecommendation側のusable判定（decide_fact_usability/EvidenceDecision）
+とは独立した別関数であり、Recommendation側の挙動には一切影響しない
+（docs/knowledge/shrine-knowledge-contract.md「Disputed Evidence Contract」
+PR-C4Aを参照）。
 """
 
 from __future__ import annotations
@@ -82,8 +89,67 @@ def decide_fact_usability(
     )
 
 
+# Shrine Detail専用。disputedを含む3状態を表す。
+# Recommendation側のusable判定（decide_fact_usability）とは独立した値であり、
+# FACT_READY_VERIFICATION_STATUSES / decide_fact_usability() / EvidenceDecisionの
+# いずれも変更しない（PR-C4B1）。
+DETAIL_DISPUTED_VERIFICATION_STATUS = "disputed"
+
+# Shrine Detail用の候補verification_status（クエリ件数を減らすための事前フィルタに
+# のみ使う集合）。最終的なfull/disputed/hiddenの判定はdecide_detail_display_state()
+# が唯一の真実源であり、この集合自体は「候補に含めてよい範囲」を示すだけで、
+# 表示可否そのものを決定しない（Source側の条件を満たさなければ候補内でもhiddenになる）。
+DETAIL_CANDIDATE_VERIFICATION_STATUSES = FACT_READY_VERIFICATION_STATUSES + (
+    DETAIL_DISPUTED_VERIFICATION_STATUS,
+)
+
+
+def decide_detail_display_state(
+    *,
+    verification_status: str,
+    source_verification_statuses: Iterable[str],
+) -> str:
+    """Shrine Detail専用のFact表示状態判定（PR-C4B1、Disputed Evidence Contract PR-C4Aの実装）。
+
+    Recommendation側のdecide_fact_usability()/EvidenceDecisionとは別関数であり、
+    互いに影響しない。Recommendationのusable判定・Knowledge selectorの候補条件は
+    本関数の追加によって一切変わらない。
+
+    返り値: "full" | "disputed" | "hidden"
+      - "full": verification_statusがFACT_READY_VERIFICATION_STATUSES
+        （source_confirmed/reviewed）で、かつfact-ready Sourceを1件以上Relation
+      - "disputed": verification_statusがdisputedで、かつfact-ready Sourceを
+        1件以上Relation
+      - "hidden": 上記いずれにも該当しない場合
+        （draft/unverified/outdated/rejected、または
+         full/disputed相当のverification_statusでもfact-ready Sourceが
+         1件も無い場合）
+
+    Source側のverification_statusはFACT_READY_VERIFICATION_STATUSESと同一基準
+    （source_confirmed/reviewedのみ）で判定する。confidence・history_type・
+    Source confidence・Source priorityはいずれも判定に使わない。
+    """
+
+    has_ready_source = any(
+        status in FACT_READY_VERIFICATION_STATUSES for status in source_verification_statuses
+    )
+    if not has_ready_source:
+        return "hidden"
+
+    if verification_status in FACT_READY_VERIFICATION_STATUSES:
+        return "full"
+
+    if verification_status == DETAIL_DISPUTED_VERIFICATION_STATUS:
+        return "disputed"
+
+    return "hidden"
+
+
 __all__ = [
     "FACT_READY_VERIFICATION_STATUSES",
+    "DETAIL_DISPUTED_VERIFICATION_STATUS",
+    "DETAIL_CANDIDATE_VERIFICATION_STATUSES",
     "EvidenceDecision",
     "decide_fact_usability",
+    "decide_detail_display_state",
 ]

--- a/backend/temples/tests/api/test_evidence_gate_recommendation_detail_contract.py
+++ b/backend/temples/tests/api/test_evidence_gate_recommendation_detail_contract.py
@@ -7,6 +7,11 @@ Shrine Detail API      = 表示（sourcesが空配列のまま表示）
 
 Evidence Gate導入後は、同じFactに対してRecommendation selectorの利用可否と
 Shrine Detail APIの利用可否が常に一致することを固定する。
+
+例外: verification_status="disputed"のみ、PR-C4A（Disputed Evidence Contract）/
+PR-C4B1（Shrine Detail Disputed Display Policy）により意図的にRecommendationと
+Detailが異なる契約になった（Recommendation=常に除外、Detail=fact-ready Sourceが
+あれば表示）。この意図的な例外は本ファイル末尾の専用テストで固定する。
 """
 
 from __future__ import annotations
@@ -89,8 +94,13 @@ def test_fact_ready_with_ready_source_is_usable_on_both_paths():
     assert _is_detail_usable(shrine) is True
 
 
-@pytest.mark.parametrize("fact_status", ["draft", "unverified", "disputed", "outdated", "rejected"])
+@pytest.mark.parametrize("fact_status", ["draft", "unverified", "outdated", "rejected"])
 def test_non_fact_ready_fact_is_unusable_on_both_paths_even_with_ready_source(fact_status):
+    """draft/unverified/outdated/rejectedはPR-C4B1後もRecommendation/Detail双方で非表示のまま。
+
+    disputedはPR-C4B1でDetailのみ意図的に表示対象へ変わったため、このparametrizeから
+    除外し、専用テスト（test_disputed_is_intentionally_asymmetric_after_pr_c4b1）で扱う。
+    """
     shrine = _create_shrine()
     deity = _create_deity(shrine, fact_status)
     deity.sources.add(_create_source("source_confirmed"))
@@ -106,13 +116,15 @@ def test_non_fact_ready_fact_is_unusable_on_both_paths_even_with_ready_source(fa
         {"fact_status": "source_confirmed", "source_statuses": ["draft"]},
         {"fact_status": "source_confirmed", "source_statuses": ["draft", "disputed"]},
         {"fact_status": "draft", "source_statuses": ["source_confirmed"]},
-        {"fact_status": "disputed", "source_statuses": ["source_confirmed"]},
         {"fact_status": "source_confirmed", "source_statuses": ["source_confirmed"]},
         {"fact_status": "reviewed", "source_statuses": ["reviewed"]},
         {"fact_status": "source_confirmed", "source_statuses": ["source_confirmed", "draft"]},
     ],
 )
 def test_recommendation_and_detail_agree_for_every_combination(case):
+    """fact_status="disputed"はPR-C4B1により意図的な例外となったため、このparametrizeから
+    除外した（下の専用テストを参照）。それ以外の組み合わせでは引き続き常に一致する。
+    """
     shrine = _create_shrine()
     deity = _create_deity(shrine, case["fact_status"])
     for i, status in enumerate(case["source_statuses"]):
@@ -124,3 +136,28 @@ def test_recommendation_and_detail_agree_for_every_combination(case):
     assert recommendation_usable == detail_usable, (
         f"非対称: case={case} recommendation={recommendation_usable} " f"detail={detail_usable}"
     )
+
+
+def test_disputed_is_intentionally_asymmetric_after_pr_c4b1():
+    """PR-C4A/PR-C4B1で確定した意図的な非対称性を固定する回帰テスト。
+
+    disputed + fact-ready Sourceの場合:
+    - Recommendation: 常にFalse（Disputed Evidence Contractにより変更しない）
+    - Detail: True（fact-ready Sourceがあればdisputedとして表示する）
+    """
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "disputed")
+    deity.sources.add(_create_source("source_confirmed"))
+
+    assert _is_recommendation_usable(shrine) is False
+    assert _is_detail_usable(shrine) is True
+
+
+def test_disputed_without_ready_source_is_unusable_on_both_paths():
+    """disputedでもfact-ready Sourceが無ければDetailも非表示のまま（hidden）。"""
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "disputed")
+    deity.sources.add(_create_source("draft"))
+
+    assert _is_recommendation_usable(shrine) is False
+    assert _is_detail_usable(shrine) is False

--- a/backend/temples/tests/api/test_shrine_detail_knowledge_api.py
+++ b/backend/temples/tests/api/test_shrine_detail_knowledge_api.py
@@ -226,3 +226,153 @@ def test_shrine_detail_api_source_filtering_does_not_increase_query_count():
         f"expected source-level filtering via Prefetch to avoid N+1, "
         f"got {len(ctx.captured_queries)} queries"
     )
+
+
+# --- PR-C4B1: Shrine Detail Disputed Display Policy ---
+
+
+def test_shrine_detail_api_returns_disputed_deity_with_ready_source():
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "disputed", display_name="矛盾祭神", confidence="high")
+    deity.sources.add(_create_source("source_confirmed"))
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["deities"]) == 1
+    disputed = body["deities"][0]
+    assert disputed["display_name"] == "矛盾祭神"
+    assert disputed["verification_status"] == "disputed"
+    assert disputed["confidence"] == "high"
+    assert len(disputed["sources"]) == 1
+    assert disputed["sources"][0]["verification_status"] == "source_confirmed"
+
+
+def test_shrine_detail_api_returns_disputed_history_with_ready_source():
+    shrine = _create_shrine()
+    history = _create_history(
+        shrine, "disputed", title="矛盾由緒", content="内容", confidence="medium"
+    )
+    history.sources.add(_create_source("reviewed"))
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["histories"]) == 1
+    disputed = body["histories"][0]
+    assert disputed["title"] == "矛盾由緒"
+    assert disputed["verification_status"] == "disputed"
+    assert disputed["confidence"] == "medium"
+    assert len(disputed["sources"]) == 1
+    assert disputed["sources"][0]["verification_status"] == "reviewed"
+
+
+def test_shrine_detail_api_hides_disputed_deity_without_ready_source():
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "disputed")
+    deity.sources.add(_create_source("draft"))
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    assert resp.json()["deities"] == []
+
+
+def test_shrine_detail_api_hides_disputed_history_without_any_source():
+    shrine = _create_shrine()
+    _create_history(shrine, "disputed")
+    # Sourceを一切Relationしない
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    assert resp.json()["histories"] == []
+
+
+def test_shrine_detail_api_excludes_non_ready_source_from_disputed_deity_nested_sources():
+    """disputed Factでも、nested sourcesにはfact-readyなSourceのみが露出する
+    （draft/unverified/disputed/outdated/rejectedのSourceは出ない）契約を維持する。
+    """
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "disputed")
+    ready_source = _create_source("source_confirmed", title="ready")
+    non_ready_source = _create_source("draft", title="non-ready")
+    deity.sources.add(ready_source, non_ready_source)
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["deities"]) == 1
+    assert [s["verification_status"] for s in body["deities"][0]["sources"]] == ["source_confirmed"]
+
+
+def test_shrine_detail_api_lists_multiple_disputed_history_facts_independently():
+    """複数disputed Factが自動統合・自動グルーピングされず、個別に列挙される。"""
+    shrine = _create_shrine()
+    source = _create_source("source_confirmed")
+    history_a = _create_history(shrine, "disputed", sort_order=0, title="説A", content="説Aの内容")
+    history_b = _create_history(shrine, "disputed", sort_order=1, title="説B", content="説Bの内容")
+    history_a.sources.add(source)
+    history_b.sources.add(source)
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["histories"]) == 2
+    titles = [h["title"] for h in body["histories"]]
+    assert titles == ["説A", "説B"]
+    contents = [h["content"] for h in body["histories"]]
+    assert contents == ["説Aの内容", "説Bの内容"]
+    for h in body["histories"]:
+        assert h["verification_status"] == "disputed"
+
+
+def test_shrine_detail_api_disputed_and_full_facts_coexist():
+    shrine = _create_shrine()
+    source = _create_source("source_confirmed")
+    full_deity = _create_deity(shrine, "source_confirmed", sort_order=0, display_name="確定祭神")
+    disputed_deity = _create_deity(shrine, "disputed", sort_order=1, display_name="矛盾祭神")
+    full_deity.sources.add(source)
+    disputed_deity.sources.add(source)
+
+    client = APIClient()
+    resp = client.get(f"/api/shrines/{shrine.id}/")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["deities"]) == 2
+    statuses = {d["display_name"]: d["verification_status"] for d in body["deities"]}
+    assert statuses == {"確定祭神": "source_confirmed", "矛盾祭神": "disputed"}
+
+
+def test_shrine_detail_api_disputed_does_not_increase_query_count():
+    shrine = _create_shrine()
+    source = _create_source("source_confirmed")
+    for i in range(5):
+        deity = _create_deity(shrine, "disputed", sort_order=i)
+        deity.sources.add(source)
+    for i in range(5):
+        history = _create_history(shrine, "disputed", sort_order=i)
+        history.sources.add(source)
+
+    client = APIClient()
+    with CaptureQueriesContext(connection) as ctx:
+        resp = client.get(f"/api/shrines/{shrine.id}/")
+    assert resp.status_code == 200
+    assert len(resp.json()["deities"]) == 5
+    assert len(resp.json()["histories"]) == 5
+
+    assert len(ctx.captured_queries) < 20, (
+        f"expected disputed candidates to reuse existing Prefetch structure, "
+        f"got {len(ctx.captured_queries)} queries"
+    )

--- a/backend/temples/tests/serializers/test_shrine_knowledge_serializers.py
+++ b/backend/temples/tests/serializers/test_shrine_knowledge_serializers.py
@@ -46,7 +46,10 @@ def test_shrine_detail_serializer_returns_empty_list_when_no_knowledge():
     assert data["histories"] == []
 
 
-def test_shrine_detail_serializer_returns_only_fact_ready_deities():
+def test_shrine_detail_serializer_returns_full_and_disputed_deities_only():
+    """PR-C4B1: full(source_confirmed/reviewed)とdisputedはDetailへ返る。
+    draft/unverified/outdated/rejectedはhiddenのまま返らない。
+    """
     shrine = _create_shrine()
     # Evidence Gateはstatus判定に加えてfact-ready Source Relationも要求するため、
     # 全候補へ共通のfact-ready Sourceを付与し、status差だけを検証対象にする。
@@ -70,10 +73,13 @@ def test_shrine_detail_serializer_returns_only_fact_ready_deities():
 
     data = ShrineDetailSerializer(shrine).data
     names = {d["display_name"] for d in data["deities"]}
-    assert names == {"確認済み祭神", "レビュー済み祭神"}
+    assert names == {"確認済み祭神", "レビュー済み祭神", "矛盾祭神"}
+    disputed = next(d for d in data["deities"] if d["display_name"] == "矛盾祭神")
+    assert disputed["verification_status"] == "disputed"
 
 
-def test_shrine_detail_serializer_returns_only_fact_ready_histories():
+def test_shrine_detail_serializer_returns_full_and_disputed_histories_only():
+    """PR-C4B1: full(source_confirmed/reviewed)とdisputedはDetailへ返る。draftは返らない。"""
     shrine = _create_shrine()
     source = ShrineKnowledgeSource.objects.create(
         source_type="shrine_official",
@@ -91,7 +97,25 @@ def test_shrine_detail_serializer_returns_only_fact_ready_histories():
 
     data = ShrineDetailSerializer(shrine).data
     titles = {h["title"] for h in data["histories"]}
-    assert titles == {"確認済み由緒"}
+    assert titles == {"確認済み由緒", "矛盾由緒"}
+    disputed = next(h for h in data["histories"] if h["title"] == "矛盾由緒")
+    assert disputed["verification_status"] == "disputed"
+
+
+def test_shrine_detail_serializer_hides_disputed_deity_without_ready_source():
+    """PR-C4B1: disputedでもfact-ready Sourceが無ければhidden(非表示)のまま。"""
+    shrine = _create_shrine()
+    deity = _create_deity(shrine, "disputed", display_name="Sourceなし矛盾祭神")
+    deity.sources.add(
+        ShrineKnowledgeSource.objects.create(
+            source_type="shrine_official",
+            title="draft出典",
+            verification_status="draft",
+        )
+    )
+
+    data = ShrineDetailSerializer(shrine).data
+    assert data["deities"] == []
 
 
 def test_shrine_detail_serializer_does_not_fallback_to_legacy_fields():

--- a/backend/temples/tests/services/test_evidence_gate_detail_display_state.py
+++ b/backend/temples/tests/services/test_evidence_gate_detail_display_state.py
@@ -1,0 +1,100 @@
+"""PR-C4B1: Shrine Detail専用のdecide_detail_display_state()単体テスト。
+
+Recommendation側のdecide_fact_usability()/EvidenceDecisionは変更していない
+ため、既存のtest_evidence_gate.pyでの回帰テストと合わせて確認する。
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.evidence_gate import (
+    DETAIL_CANDIDATE_VERIFICATION_STATUSES,
+    DETAIL_DISPUTED_VERIFICATION_STATUS,
+    FACT_READY_VERIFICATION_STATUSES,
+    decide_detail_display_state,
+)
+
+
+@pytest.mark.parametrize("verification_status", ["source_confirmed", "reviewed"])
+def test_full_verification_status_with_ready_source_is_full(verification_status):
+    result = decide_detail_display_state(
+        verification_status=verification_status,
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert result == "full"
+
+
+def test_disputed_with_ready_source_is_disputed():
+    result = decide_detail_display_state(
+        verification_status="disputed",
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert result == "disputed"
+
+
+@pytest.mark.parametrize("verification_status", ["draft", "unverified", "outdated", "rejected"])
+def test_non_ready_non_disputed_verification_status_is_hidden(verification_status):
+    result = decide_detail_display_state(
+        verification_status=verification_status,
+        source_verification_statuses=["source_confirmed"],
+    )
+    assert result == "hidden"
+
+
+def test_disputed_without_any_source_is_hidden():
+    result = decide_detail_display_state(
+        verification_status="disputed",
+        source_verification_statuses=[],
+    )
+    assert result == "hidden"
+
+
+def test_disputed_with_only_draft_source_is_hidden():
+    result = decide_detail_display_state(
+        verification_status="disputed",
+        source_verification_statuses=["draft"],
+    )
+    assert result == "hidden"
+
+
+def test_full_verification_status_without_ready_source_is_hidden():
+    result = decide_detail_display_state(
+        verification_status="source_confirmed",
+        source_verification_statuses=["draft"],
+    )
+    assert result == "hidden"
+
+
+def test_disputed_with_ready_and_non_ready_source_mixed_is_disputed():
+    result = decide_detail_display_state(
+        verification_status="disputed",
+        source_verification_statuses=["draft", "source_confirmed"],
+    )
+    assert result == "disputed"
+
+
+def test_confidence_is_not_a_parameter():
+    """confidenceはdisplay state判定に使わない契約（PR-C4A）。
+    そもそも関数シグネチャに存在しないことを確認する。
+    """
+    import inspect
+
+    params = inspect.signature(decide_detail_display_state).parameters
+    assert "confidence" not in params
+    assert "history_type" not in params
+
+
+def test_detail_disputed_verification_status_constant_value():
+    assert DETAIL_DISPUTED_VERIFICATION_STATUS == "disputed"
+
+
+def test_detail_candidate_verification_statuses_is_fact_ready_plus_disputed():
+    assert set(DETAIL_CANDIDATE_VERIFICATION_STATUSES) == set(FACT_READY_VERIFICATION_STATUSES) | {
+        "disputed"
+    }
+
+
+def test_fact_ready_verification_statuses_unchanged():
+    """Recommendation側の定数は本PRで変更しない（回帰の固定）。"""
+    assert set(FACT_READY_VERIFICATION_STATUSES) == {"source_confirmed", "reviewed"}


### PR DESCRIPTION
## Summary

PR-C4A（Disputed Evidence Contract）に基づき、Shrine Detail APIで`verification_status="disputed"`のKnowledge Factを安全に取得可能にする。**Recommendationは一切変更しない**。Web UI実装はPR-C4B2へ分離。

### Detail Display Policy
`temples/services/evidence_gate.py`へ`decide_detail_display_state()`を新規追加（既存の`decide_fact_usability()`/`EvidenceDecision`/`FACT_READY_VERIFICATION_STATUSES`は無変更）。

| verification_status | Source条件 | 結果 |
|---|---|---|
| `source_confirmed`/`reviewed` | fact-ready Source ≥1 | `full` |
| `disputed` | fact-ready Source ≥1 | `disputed` |
| `draft`/`unverified`/`outdated`/`rejected` | 問わず | `hidden` |
| 上記full/disputed相当でも | fact-ready Sourceなし | `hidden` |

`confidence`・`history_type`・Source confidence・Source priorityはいずれも判定に使わない（PR-C4A契約通り）。

### 変更箇所
- **View**（`views.py`）: `ShrineViewSet.retrieve`のPrefetch候補集合を`DETAIL_CANDIDATE_VERIFICATION_STATUSES`（full相当+disputed）へ拡大。QuerySetはあくまで候補の事前フィルタであり、最終判定は`decide_detail_display_state()`に委譲（QuerySet単独を真実源にしない）。
- **Serializer**（`serializers/shrine.py`）: `get_deities()`/`get_histories()`の判定を`decide_fact_usability().usable`から`decide_detail_display_state() in ("full", "disputed")`へ置換。**新規API fieldは追加せず**、既存の`verification_status`/`confidence`/`sources`のみで表現。nested sourcesのfact-readyフィルタ（`_fact_ready_sources`）は無変更のため、disputedでも非fact-ready Sourceは引き続き露出しない。

### Recommendation非変更の確認
`shrine_knowledge_selector.py`/`recommendation_reason_v4.py`/`concierge_chat.py`はいずれも本PRのdiffに含まれていない（`git diff --name-only`で確認可能）。新規追加した`DETAIL_CANDIDATE_VERIFICATION_STATUSES`/`DETAIL_DISPUTED_VERIFICATION_STATUS`/`decide_detail_display_state`のいずれも、これら3ファイルから一切参照されていないことをgrepで確認済み。

## 変更していないもの
- Model / Migration / Admin / DBデータ
- Recommendation実装（selector/reason_v4/concierge_chat）
- Web / Mobile
- Score / Ranking / Prompt / OpenAI API
- Public API Schema（`manage.py spectacular`生成結果の構造差分なし。docstring文言のみ変更）
- Source confidence rule / Source priority判定
- `data_confidence_score`
- `FactSourceEvidence` / `EvidenceGroup`

## Test plan
- [x] Detail Policy unit tests（`decide_detail_display_state`の全分岐: full/disputed/hidden、Source条件混在含む）: `test_evidence_gate_detail_display_state.py`
- [x] API tests: disputed Deity/History＋ready SourceでAPIへ返る、`verification_status`/`confidence`/`sources`保持、non-ready Sourceがnested sourcesに出ない、複数disputed Factが自動統合されず個別列挙される、full/disputed共存: `test_shrine_detail_knowledge_api.py`
- [x] Recommendation regression: disputedがselector結果へ出ないこと・意図的な非対称性（Recommendation=除外、Detail=表示）を固定する専用テスト: `test_evidence_gate_recommendation_detail_contract.py`
- [x] 既存挙動回帰: source_confirmed/reviewedは従来どおり、draft/unverified/outdated/rejectedは従来どおり非表示: 既存テスト更新（`test_shrine_knowledge_serializers.py`ほか）
- [x] Pilot regression（明治神宮Deity2/History1、品川神社Deity3/History3、全件`source_confirmed`のため無影響）: 既存`test_evidence_gate_pilot_regression.py`が引き続きPASS
- [x] Performance: 既存query count test（`< 20`クエリ）に加え、disputed 5件×2でのquery count回帰テストを追加。新規クエリ増加なし
- [x] `pytest`（backend全体）: **987 passed, 9 skipped**（本PR前987−34≈953... 実測: 直前ブランチ963件から+24件）
- [x] `ruff check`（変更/新規ファイル）: `evidence_gate.py`・新規/変更テストファイルは全てクリーン。`views.py`/`serializers/shrine.py`の既存指摘（計18件）は全て本PR以前からの既存差分と確認済み（新規指摘なし）
- [x] `manage.py makemigrations --check --dry-run`: No changes detected
- [x] `manage.py spectacular`生成差分確認: 構造差分なし（`ShrineDetailSerializer`のdocstring文言のみ変更）
- [x] `git diff --check`: `serializers/shrine.py`のみ既知の誤検知（同ファイルは本PR以前からCRLF改行コードで管理されており、変更行の`\r`が"trailing whitespace"として検知される。他の全変更ファイルはクリーン）
- [x] pre-push hook（OpenAPI lint / Web契約テスト702件）: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)