### PR TITLE
feat(web): Shrine Detail disputed FactへFactDisplayState表示を追加(PR-C4B2)

### DIFF
--- a/apps/web/src/components/shrine/detail/ShrineFactSection.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineFactSection.tsx
@@ -5,6 +5,20 @@ type Props = {
   section: DetailFactSection;
 };
 
+// disputed Factに付与する状態ラベル。文言はここ1箇所でのみ定義する（PR-C4B2）。
+// verification_statusの内部名（"disputed"等）はユーザーへ露出しない。
+// Source同士が明示的に矛盾していることは現行Modelから判定できないため、
+// 「矛盾しています」「誤り」等の断定語は使わず、中立的な表現に留める。
+const DISPUTED_FACT_LABEL = "異なる見解を含む情報";
+
+function DisputedBadge() {
+  return (
+    <span className="inline-flex items-center rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-default)] px-1.5 py-0.5 text-[10px] font-medium leading-none text-[var(--kt-color-text-muted)]">
+      {DISPUTED_FACT_LABEL}
+    </span>
+  );
+}
+
 function DeityList({ deities }: { deities: DetailFactDeity[] }) {
   return (
     <div>
@@ -13,9 +27,10 @@ function DeityList({ deities }: { deities: DetailFactDeity[] }) {
         {deities.map((deity, index) => (
           <li
             key={`${deity.display_name}:${index}`}
-            className="inline-flex items-center rounded-[var(--kt-radius-pill)] bg-[var(--kt-color-background-subtle)] px-3 py-1 text-sm text-[var(--kt-color-text-secondary)]"
+            className="inline-flex items-center gap-1.5 rounded-[var(--kt-radius-pill)] bg-[var(--kt-color-background-subtle)] px-3 py-1 text-sm text-[var(--kt-color-text-secondary)]"
           >
             {deity.display_name}
+            {deity.displayState === "disputed" ? <DisputedBadge /> : null}
           </li>
         ))}
       </ul>
@@ -43,6 +58,7 @@ function HistoryList({ histories }: { histories: DetailFactHistoryItem[] }) {
               {history.period_text ? (
                 <span className="text-xs text-[var(--kt-color-text-muted)]">{history.period_text}</span>
               ) : null}
+              {history.displayState === "disputed" ? <DisputedBadge /> : null}
             </div>
             {history.content ? (
               <p className="mt-2 whitespace-pre-wrap break-words text-sm leading-6 text-[var(--kt-color-text-secondary)]">

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
@@ -698,8 +698,8 @@ describe("ShrineDetailArticle", () => {
             kind: "fact",
             heading: "神社について",
             deities: [
-              { display_name: "明治天皇", sort_order: 0 },
-              { display_name: "昭憲皇太后", sort_order: 1 },
+              { display_name: "明治天皇", sort_order: 0, displayState: "full" },
+              { display_name: "昭憲皇太后", sort_order: 1, displayState: "full" },
             ],
             histories: [
               {
@@ -709,6 +709,7 @@ describe("ShrineDetailArticle", () => {
                 content: "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
                 period_text: "大正9年（1920）",
                 sort_order: 0,
+                displayState: "full",
               },
             ],
           }}
@@ -742,6 +743,7 @@ describe("ShrineDetailArticle", () => {
                 content: "創始の内容",
                 period_text: "文治3年（1187年）",
                 sort_order: 0,
+                displayState: "full",
               },
               {
                 history_type: "historical_event",
@@ -750,6 +752,7 @@ describe("ShrineDetailArticle", () => {
                 content: "1319年の内容",
                 period_text: "元応元年（1319年）",
                 sort_order: 1,
+                displayState: "full",
               },
               {
                 history_type: "historical_event",
@@ -758,6 +761,7 @@ describe("ShrineDetailArticle", () => {
                 content: "1478年の内容",
                 period_text: "文明10年（1478年）",
                 sort_order: 2,
+                displayState: "full",
               },
             ],
           }}

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineFactSection.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineFactSection.test.tsx
@@ -1,0 +1,183 @@
+// apps/web/src/components/shrine/detail/__tests__/ShrineFactSection.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ShrineFactSection from "../ShrineFactSection";
+import type { DetailFactSection } from "../types";
+
+function makeSection(overrides: Partial<DetailFactSection> = {}): DetailFactSection {
+  return {
+    kind: "fact",
+    heading: "神社について",
+    deities: [],
+    histories: [],
+    ...overrides,
+  };
+}
+
+describe("ShrineFactSection", () => {
+  it("deities/historiesが両方空ならnullを返す（非表示）", () => {
+    const { container } = render(<ShrineFactSection section={makeSection()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  describe("full Fact（回帰: 現行表示を完全維持する）", () => {
+    it("full Deityはdisputedラベルを表示しない", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            deities: [{ display_name: "確定祭神", sort_order: 0, displayState: "full" }],
+          })}
+        />,
+      );
+      expect(screen.getByText("確定祭神")).toBeInTheDocument();
+      expect(screen.queryByText("異なる見解を含む情報")).not.toBeInTheDocument();
+    });
+
+    it("full Historyはdisputedラベルを表示しない", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            histories: [
+              {
+                history_type: "founding",
+                history_type_label: "創始",
+                title: "確定由緒",
+                content: "確定した内容",
+                period_text: "大正9年",
+                sort_order: 0,
+                displayState: "full",
+              },
+            ],
+          })}
+        />,
+      );
+      expect(screen.getByText("確定由緒")).toBeInTheDocument();
+      expect(screen.getByText("確定した内容")).toBeInTheDocument();
+      expect(screen.getByText("大正9年")).toBeInTheDocument();
+      expect(screen.queryByText("異なる見解を含む情報")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("disputed Fact", () => {
+    it("disputed Deityは状態ラベルを表示する", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            deities: [{ display_name: "矛盾祭神", sort_order: 0, displayState: "disputed" }],
+          })}
+        />,
+      );
+      expect(screen.getByText("矛盾祭神")).toBeInTheDocument();
+      expect(screen.getByText("異なる見解を含む情報")).toBeInTheDocument();
+    });
+
+    it("disputed Historyは状態ラベルを表示し、本文はそのまま表示される", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            histories: [
+              {
+                history_type: "founding",
+                history_type_label: "創始",
+                title: "矛盾由緒",
+                content: "矛盾している内容そのもの",
+                period_text: "",
+                sort_order: 0,
+                displayState: "disputed",
+              },
+            ],
+          })}
+        />,
+      );
+      expect(screen.getByText("矛盾由緒")).toBeInTheDocument();
+      expect(screen.getByText("矛盾している内容そのもの")).toBeInTheDocument();
+      expect(screen.getByText("異なる見解を含む情報")).toBeInTheDocument();
+    });
+
+    it("複数disputed Historyは自動統合・自動グルーピングされず個別表示される", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            histories: [
+              {
+                history_type: "founding",
+                history_type_label: "創始",
+                title: "説A",
+                content: "説Aの内容",
+                period_text: "",
+                sort_order: 0,
+                displayState: "disputed",
+              },
+              {
+                history_type: "historical_event",
+                history_type_label: "歴史",
+                title: "説B",
+                content: "説Bの内容",
+                period_text: "",
+                sort_order: 1,
+                displayState: "disputed",
+              },
+            ],
+          })}
+        />,
+      );
+      expect(screen.getByText("説A")).toBeInTheDocument();
+      expect(screen.getByText("説Aの内容")).toBeInTheDocument();
+      expect(screen.getByText("説B")).toBeInTheDocument();
+      expect(screen.getByText("説Bの内容")).toBeInTheDocument();
+      // 「複数説があります」等の自動生成メタ文言が存在しないことを確認する
+      expect(screen.queryByText(/複数の説/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/複数説/)).not.toBeInTheDocument();
+      // 状態ラベルは各Factごとに独立して2つ存在する（1つへ統合されない）
+      expect(screen.getAllByText("異なる見解を含む情報")).toHaveLength(2);
+    });
+
+    it("full/disputedが混在しても、それぞれ独立して正しい表示になる", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            deities: [
+              { display_name: "確定祭神", sort_order: 0, displayState: "full" },
+              { display_name: "矛盾祭神", sort_order: 1, displayState: "disputed" },
+            ],
+          })}
+        />,
+      );
+      expect(screen.getByText("確定祭神")).toBeInTheDocument();
+      expect(screen.getByText("矛盾祭神")).toBeInTheDocument();
+      expect(screen.getAllByText("異なる見解を含む情報")).toHaveLength(1);
+    });
+
+    it("正誤判定・比較文・矛盾の断定文言を生成しない", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            deities: [{ display_name: "矛盾祭神", sort_order: 0, displayState: "disputed" }],
+          })}
+        />,
+      );
+      expect(screen.queryByText(/誤り/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/間違い/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/矛盾しています/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/正しい/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/有力/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
+    it("disputedラベルがradius-pill / border-defaultを参照する", () => {
+      render(
+        <ShrineFactSection
+          section={makeSection({
+            deities: [{ display_name: "矛盾祭神", sort_order: 0, displayState: "disputed" }],
+          })}
+        />,
+      );
+      const badge = screen.getByText("異なる見解を含む情報");
+      expect(badge.className).toContain("rounded-[var(--kt-radius-pill)]");
+      expect(badge.className).toContain("border-[var(--kt-color-border-default)]");
+      expect(badge.className).toContain("text-[var(--kt-color-text-muted)]");
+    });
+  });
+});

--- a/apps/web/src/components/shrine/detail/types.ts
+++ b/apps/web/src/components/shrine/detail/types.ts
@@ -48,9 +48,16 @@ export type DetailSupplementSection = {
 
 // 神社Fact（祭神・由緒・歴史）。Interpretation(meaning)・Recommendation(reason)・Action とは
 // 独立した表示責務として扱う。Premium gatingの対象にしない。
+//
+// Backend verification_statusをUI componentへ直接渡さず、buildShrineFactSection.ts内で
+// この型へ変換してから渡す（PR-C4B2）。hiddenはBackend側で既に除外されているため、
+// Web ViewModelはfull/disputedの2状態のみを持つ。
+export type FactDisplayState = "full" | "disputed";
+
 export type DetailFactDeity = {
   display_name: string;
   sort_order: number;
+  displayState: FactDisplayState;
 };
 
 export type DetailFactHistoryItem = {
@@ -60,6 +67,7 @@ export type DetailFactHistoryItem = {
   content: string;
   period_text: string;
   sort_order: number;
+  displayState: FactDisplayState;
 };
 
 export type DetailFactSection = {

--- a/apps/web/src/lib/shrine/__tests__/buildShrineFactSection.test.ts
+++ b/apps/web/src/lib/shrine/__tests__/buildShrineFactSection.test.ts
@@ -1,0 +1,185 @@
+// apps/web/src/lib/shrine/__tests__/buildShrineFactSection.test.ts
+import { describe, expect, it } from "vitest";
+
+import { buildShrineFactSection } from "../buildShrineFactSection";
+import type { ShrineDeity, ShrineHistory, ShrineKnowledgeSource } from "@/lib/api/types";
+
+function makeSource(overrides: Partial<ShrineKnowledgeSource> = {}): ShrineKnowledgeSource {
+  return {
+    id: 1,
+    source_type: "shrine_official",
+    title: "出典",
+    publisher: "",
+    url: "",
+    verification_status: "source_confirmed",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function makeDeity(overrides: Partial<ShrineDeity> = {}): ShrineDeity {
+  return {
+    id: 1,
+    display_name: "祭神A",
+    canonical_name: "祭神A",
+    role: "enshrined",
+    sort_order: 0,
+    verification_status: "source_confirmed",
+    confidence: "high",
+    sources: [makeSource()],
+    ...overrides,
+  };
+}
+
+function makeHistory(overrides: Partial<ShrineHistory> = {}): ShrineHistory {
+  return {
+    id: 1,
+    history_type: "founding",
+    title: "由緒A",
+    content: "内容A",
+    period_text: "",
+    event_date: null,
+    sort_order: 0,
+    verification_status: "source_confirmed",
+    confidence: "high",
+    sources: [makeSource()],
+    ...overrides,
+  };
+}
+
+describe("buildShrineFactSection", () => {
+  it("Knowledge未登録（deities/historiesとも空）はnullを返す", () => {
+    expect(buildShrineFactSection({ deities: [], histories: [] })).toBeNull();
+    expect(buildShrineFactSection({})).toBeNull();
+  });
+
+  describe("displayState変換", () => {
+    it.each(["source_confirmed", "reviewed"])(
+      "verification_status=%s のDeityはdisplayState=fullになる",
+      (verificationStatus) => {
+        const section = buildShrineFactSection({
+          deities: [makeDeity({ verification_status: verificationStatus })],
+        });
+        expect(section?.deities[0].displayState).toBe("full");
+      },
+    );
+
+    it("verification_status=disputed のDeityはdisplayState=disputedになる", () => {
+      const section = buildShrineFactSection({
+        deities: [makeDeity({ verification_status: "disputed" })],
+      });
+      expect(section?.deities[0].displayState).toBe("disputed");
+    });
+
+    it.each(["source_confirmed", "reviewed"])(
+      "verification_status=%s のHistoryはdisplayState=fullになる",
+      (verificationStatus) => {
+        const section = buildShrineFactSection({
+          histories: [makeHistory({ verification_status: verificationStatus })],
+        });
+        expect(section?.histories[0].displayState).toBe("full");
+      },
+    );
+
+    it("verification_status=disputed のHistoryはdisplayState=disputedになる", () => {
+      const section = buildShrineFactSection({
+        histories: [makeHistory({ verification_status: "disputed" })],
+      });
+      expect(section?.histories[0].displayState).toBe("disputed");
+    });
+
+    it("想定外のverification_statusはdisputedへ昇格せずfullとして扱う（fail-safe）", () => {
+      const section = buildShrineFactSection({
+        deities: [makeDeity({ verification_status: "unknown_future_status" })],
+        histories: [makeHistory({ verification_status: "unknown_future_status" })],
+      });
+      expect(section?.deities[0].displayState).toBe("full");
+      expect(section?.histories[0].displayState).toBe("full");
+    });
+
+    it("confidenceの値に関わらずdisplayStateはverification_statusのみで決まる", () => {
+      const section = buildShrineFactSection({
+        deities: [
+          makeDeity({ verification_status: "disputed", confidence: "high" }),
+          makeDeity({
+            id: 2,
+            display_name: "祭神B",
+            verification_status: "source_confirmed",
+            confidence: "",
+            sort_order: 1,
+          }),
+        ],
+      });
+      expect(section?.deities[0].displayState).toBe("disputed");
+      expect(section?.deities[1].displayState).toBe("full");
+    });
+
+    it("history_typeの値に関わらずdisplayStateはverification_statusのみで決まる", () => {
+      const section = buildShrineFactSection({
+        histories: [
+          makeHistory({ history_type: "tradition", verification_status: "disputed" }),
+          makeHistory({
+            id: 2,
+            title: "由緒B",
+            history_type: "official_origin",
+            verification_status: "source_confirmed",
+            sort_order: 1,
+          }),
+        ],
+      });
+      expect(section?.histories[0].displayState).toBe("disputed");
+      expect(section?.histories[1].displayState).toBe("full");
+    });
+  });
+
+  it("sort_orderを維持し、Fact本文（display_name/title/content等）を変更しない", () => {
+    const section = buildShrineFactSection({
+      deities: [
+        makeDeity({ display_name: "後の祭神", sort_order: 1 }),
+        makeDeity({ id: 2, display_name: "先の祭神", sort_order: 0 }),
+      ],
+      histories: [
+        makeHistory({
+          title: "後の由緒",
+          content: "後の内容",
+          period_text: "後の期間",
+          sort_order: 1,
+        }),
+        makeHistory({
+          id: 2,
+          title: "先の由緒",
+          content: "先の内容",
+          period_text: "先の期間",
+          sort_order: 0,
+        }),
+      ],
+    });
+
+    expect(section?.deities.map((d) => d.display_name)).toEqual(["先の祭神", "後の祭神"]);
+    expect(section?.deities.map((d) => d.sort_order)).toEqual([0, 1]);
+    expect(section?.histories.map((h) => h.title)).toEqual(["先の由緒", "後の由緒"]);
+    expect(section?.histories[0].content).toBe("先の内容");
+    expect(section?.histories[0].period_text).toBe("先の期間");
+  });
+
+  it("複数disputed Factを自動統合・自動グルーピングせず個別に保持する", () => {
+    const section = buildShrineFactSection({
+      histories: [
+        makeHistory({ title: "説A", content: "説Aの内容", verification_status: "disputed", sort_order: 0 }),
+        makeHistory({
+          id: 2,
+          title: "説B",
+          content: "説Bの内容",
+          verification_status: "disputed",
+          sort_order: 1,
+        }),
+      ],
+    });
+
+    expect(section?.histories).toHaveLength(2);
+    expect(section?.histories[0].title).toBe("説A");
+    expect(section?.histories[0].content).toBe("説Aの内容");
+    expect(section?.histories[1].title).toBe("説B");
+    expect(section?.histories[1].content).toBe("説Bの内容");
+  });
+});

--- a/apps/web/src/lib/shrine/buildShrineFactSection.ts
+++ b/apps/web/src/lib/shrine/buildShrineFactSection.ts
@@ -1,5 +1,9 @@
 import type { ShrineDeity, ShrineHistory } from "@/lib/api/types";
-import type { DetailFactHistoryItem, DetailFactSection } from "@/components/shrine/detail/types";
+import type {
+  DetailFactHistoryItem,
+  DetailFactSection,
+  FactDisplayState,
+} from "@/components/shrine/detail/types";
 
 // docs/knowledge/shrine-knowledge-contract.md「分類案（To-Be）」の定義に基づく固定ラベル。
 // 宗教的・歴史的な意味を新たに解釈しない。
@@ -14,6 +18,15 @@ const HISTORY_TYPE_LABELS: Record<string, string> = {
 
 function resolveHistoryTypeLabel(historyType: string): string {
   return HISTORY_TYPE_LABELS[historyType] ?? historyType;
+}
+
+// Backend verification_status（PR-C4B1でDetail APIはfull相当/disputedのみ返す）を
+// Web ViewModel専用のFactDisplayStateへ変換する唯一の地点。UI component（例:
+// ShrineFactSection.tsx）はこの変換結果だけを見て、Backendのverification_status文字列を
+// 直接判定しない。想定外の値が来た場合はdisputedへ昇格させず、現行互換のfullとして扱う
+// （fail-safe。confidence/history_typeはこの判定に使わない）。
+function resolveFactDisplayState(verificationStatus: string): FactDisplayState {
+  return verificationStatus === "disputed" ? "disputed" : "full";
 }
 
 function sortBySortOrder<T extends { sort_order: number }>(items: T[]): T[] {
@@ -39,6 +52,7 @@ export function buildShrineFactSection(shrine: {
   const sortedDeities = sortBySortOrder(deities).map((deity) => ({
     display_name: deity.display_name,
     sort_order: deity.sort_order,
+    displayState: resolveFactDisplayState(deity.verification_status),
   }));
 
   const sortedHistories: DetailFactHistoryItem[] = sortBySortOrder(histories).map((history) => ({
@@ -48,6 +62,7 @@ export function buildShrineFactSection(shrine: {
     content: history.content,
     period_text: history.period_text,
     sort_order: history.sort_order,
+    displayState: resolveFactDisplayState(history.verification_status),
   }));
 
   return {


### PR DESCRIPTION
## Summary

PR-C4B1でShrine Detail APIがfull相当/disputed Factを既存Schemaのまま返せるようになったことを受け、Web側で`verification_status`を安全にUIへ反映する。**Backendは変更しない。**

### FactDisplayState
Web内部専用の型を追加（`apps/web/src/components/shrine/detail/types.ts`）:
```ts
export type FactDisplayState = "full" | "disputed";
```
`DetailFactDeity`/`DetailFactHistoryItem`へ`displayState`を追加。hiddenはBackend側で既に除外されているため、Web ViewModelはfull/disputedの2状態のみを持つ。

### 変換境界
`apps/web/src/lib/shrine/buildShrineFactSection.ts`へ`resolveFactDisplayState()`を追加し、**この1箇所だけ**で`verification_status`→`FactDisplayState`を変換する。`ShrineFactSection.tsx`（UIコンポーネント）はBackendの`verification_status`文字列を直接判定しない。

```
source_confirmed → full
reviewed         → full
disputed         → disputed
それ以外（想定外の値。fail-safe） → full（disputedへ昇格させない）
```
`confidence`・`history_type`は判定に使わない。

### UI
`ShrineFactSection.tsx`で`displayState === "disputed"`の場合のみ、状態ラベル**「異なる見解を含む情報」**（1箇所で定義、`DISPUTED_FACT_LABEL`）を表示する。full Factの表示は完全に維持（回帰なし）。

- `verification_status`の内部名（`"disputed"`等）はユーザーへ露出しない
- 「複数説があります」の自動生成、AIによる正誤判定、「誤り」「有力」等の断定語は一切生成しない（Source同士が明示的に矛盾しているとは判定できないため）
- 1 Deity / 1 History = 1 UI itemの構造を維持。Fact同士を自動統合・自動グルーピングしない
- Fact本文（`display_name`/`title`/`content`等）・`sort_order`は変更しない

## Future Compatibility（今回追加していない）
- `groupId`/`groupType`/`conflictType`/`relationType`/`alternativeViewId`/`EvidenceGroup`はいずれも未追加
- Fact単位のViewModel/UI構造を維持しているため、将来`FactGroup`外側wrapperや`FactSourceEvidence`（supports/contradicts/mentions）が追加されても、既存構造を再利用できる見込み

## 視覚確認
Browser previewで一時的な確認ページを作成し、375px/390px/430pxで確認（確認後に削除、`git diff`には含まれない）。full回帰・disputed混在いずれも横スクロールなし、ラベル折返し崩れなし、長文History本文の折返しも崩れなしを確認。

## 変更していないもの
- Backend全般（`backend/`配下は`git status --short`で無変更を確認）
- Model / Migration / DB / Public API Schema
- Recommendation / Evidence Gate
- Score / Ranking / Prompt / OpenAI API
- Mobile / Payment
- Source confidence / Source priority / `FactSourceEvidence` / `EvidenceGroup`
- Premium gating（Fact SectionはPremium対象外のまま。gatingコード自体へ変更なし）

## Test plan
- [x] `buildShrineFactSection`変換テスト: full/disputed変換、fail-safe（想定外status→full）、confidence/history_type不使用、sort_order維持、Fact本文不変、複数disputed Factの非統合: `buildShrineFactSection.test.ts`
- [x] UIコンポーネントテスト: full回帰（ラベル非表示）、disputed状態表示、複数disputed Historyの個別表示、full/disputed混在、断定語・自動生成文言の非存在、Design Token参照: `ShrineFactSection.test.tsx`
- [x] 既存回帰テスト更新（`displayState`必須化に伴うfixture更新）: `ShrineDetailArticle.test.tsx`
- [x] Knowledge未登録回帰: 既存`ShrineDetailArticle.test.tsx`テストで確認
- [x] `pnpm typecheck`（`tsc --noEmit`）: エラーなし
- [x] `eslint`: 変更ファイルに関する指摘なし（既存の無関係ファイルの警告2件のみ、本PR起因ではない）
- [x] `vitest run`（web全体）: **723 passed**（本PR前702件から+21件）
- [x] `git diff --check`: クリーン
- [x] `git diff --name-only`: Webファイルのみ（`apps/web/`配下6ファイル）
- [x] pre-push hook（OpenAPI lint / Web契約テスト723件）: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)