### PR TITLE
feat(mobile): Knowledge Fact Type / ViewModel Foundation(PR-M1)

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -29,6 +29,7 @@ import {
   normalizeRecommendationReasonV4Detail,
   type RecommendationReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
+import type { ShrineDeity, ShrineHistory } from "../../lib/shrineKnowledgeFact";
 
 type RecommendationReasonFactAxis =
   | "need"
@@ -114,6 +115,10 @@ type Shrine = {
   tags?: string[];
   latitude?: number;
   longitude?: number;
+  // Knowledge Fact（PR-M1）。UIはまだこれらを描画しない。
+  // Backendが既にhidden相当を除外して返したfull/disputed相当のFactのみが入る。
+  deities?: ShrineDeity[];
+  histories?: ShrineHistory[];
 };
 
 type ShrineApiResponse = {
@@ -140,6 +145,10 @@ type ShrineApiResponse = {
   longitude?: number | null;
   goriyaku?: string | null;
   goriyaku_tags?: Array<{ id: number; name: string; category?: string }>;
+  // backend/temples/api/serializers/shrine.py ShrineDetailSerializer.get_deities/get_histories
+  // に一致する（PR-M1。Evidence Gate判定はBackendが既に済ませたfull/disputed相当のみ返る）。
+  deities?: ShrineDeity[];
+  histories?: ShrineHistory[];
 };
 
 const SHRINE_API_ID_BY_LOCAL_ID: Record<string, string> = {
@@ -246,6 +255,9 @@ function toShrine(api: ShrineApiResponse): Shrine {
     tags: api.goriyaku_tags?.map((tag) => tag.name) ?? [],
     latitude: typeof api.latitude === "number" ? api.latitude : undefined,
     longitude: typeof api.longitude === "number" ? api.longitude : undefined,
+    // Fact本文・confidence・sourcesは加工せずそのまま保持する（PR-M1）。
+    deities: Array.isArray(api.deities) ? api.deities : [],
+    histories: Array.isArray(api.histories) ? api.histories : [],
   };
 }
 

--- a/apps/mobile/lib/__tests__/shrineKnowledgeFact.test.ts
+++ b/apps/mobile/lib/__tests__/shrineKnowledgeFact.test.ts
@@ -1,0 +1,182 @@
+// apps/mobile/lib/__tests__/shrineKnowledgeFact.test.ts
+import { describe, expect, it } from "vitest";
+
+import {
+  buildShrineFactViewModel,
+  resolveFactDisplayState,
+  type ShrineDeity,
+  type ShrineHistory,
+  type ShrineKnowledgeSource,
+} from "../shrineKnowledgeFact";
+
+function makeSource(overrides: Partial<ShrineKnowledgeSource> = {}): ShrineKnowledgeSource {
+  return {
+    id: 1,
+    source_type: "shrine_official",
+    title: "出典",
+    publisher: "",
+    url: "",
+    verification_status: "source_confirmed",
+    confidence: "high",
+    ...overrides,
+  };
+}
+
+function makeDeity(overrides: Partial<ShrineDeity> = {}): ShrineDeity {
+  return {
+    id: 1,
+    display_name: "祭神A",
+    canonical_name: "祭神A",
+    role: "enshrined",
+    sort_order: 0,
+    verification_status: "source_confirmed",
+    confidence: "high",
+    sources: [makeSource()],
+    ...overrides,
+  };
+}
+
+function makeHistory(overrides: Partial<ShrineHistory> = {}): ShrineHistory {
+  return {
+    id: 1,
+    history_type: "founding",
+    title: "由緒A",
+    content: "内容A",
+    period_text: "",
+    event_date: null,
+    sort_order: 0,
+    verification_status: "source_confirmed",
+    confidence: "high",
+    sources: [makeSource()],
+    ...overrides,
+  };
+}
+
+describe("resolveFactDisplayState", () => {
+  it.each(["source_confirmed", "reviewed"])("verification_status=%s はfullになる", (status) => {
+    expect(resolveFactDisplayState(status)).toBe("full");
+  });
+
+  it("verification_status=disputed はdisputedになる", () => {
+    expect(resolveFactDisplayState("disputed")).toBe("disputed");
+  });
+
+  it("未知のverification_statusはdisputedへ昇格せずfullとして扱う（fail-safe）", () => {
+    expect(resolveFactDisplayState("unknown_future_status")).toBe("full");
+  });
+});
+
+describe("buildShrineFactViewModel", () => {
+  it("deitiesが保持される", () => {
+    const vm = buildShrineFactViewModel({ deities: [makeDeity()], histories: [] });
+    expect(vm.deities).toHaveLength(1);
+  });
+
+  it("historiesが保持される", () => {
+    const vm = buildShrineFactViewModel({ deities: [], histories: [makeHistory()] });
+    expect(vm.histories).toHaveLength(1);
+  });
+
+  it("deities/historiesが未指定でも空配列を返す", () => {
+    const vm = buildShrineFactViewModel({});
+    expect(vm.deities).toEqual([]);
+    expect(vm.histories).toEqual([]);
+  });
+
+  it("sort_orderが保持され、昇順に並び替えられる", () => {
+    const vm = buildShrineFactViewModel({
+      deities: [
+        makeDeity({ id: 2, display_name: "後の祭神", sort_order: 1 }),
+        makeDeity({ id: 1, display_name: "先の祭神", sort_order: 0 }),
+      ],
+    });
+    expect(vm.deities.map((d) => d.sortOrder)).toEqual([0, 1]);
+    expect(vm.deities.map((d) => d.displayName)).toEqual(["先の祭神", "後の祭神"]);
+  });
+
+  it("Fact本文（display_name/title/content/period_text/history_type）が改変されない", () => {
+    const vm = buildShrineFactViewModel({
+      deities: [makeDeity({ display_name: "確定祭神" })],
+      histories: [
+        makeHistory({
+          history_type: "official_origin",
+          title: "確定由緒",
+          content: "公式由緒に基づく内容そのもの。",
+          period_text: "大正9年（1920）",
+        }),
+      ],
+    });
+
+    expect(vm.deities[0].displayName).toBe("確定祭神");
+    expect(vm.histories[0].historyType).toBe("official_origin");
+    expect(vm.histories[0].title).toBe("確定由緒");
+    expect(vm.histories[0].content).toBe("公式由緒に基づく内容そのもの。");
+    expect(vm.histories[0].periodText).toBe("大正9年（1920）");
+  });
+
+  it("confidenceが保持される", () => {
+    const vm = buildShrineFactViewModel({
+      deities: [makeDeity({ confidence: "medium" })],
+      histories: [makeHistory({ confidence: "low" })],
+    });
+    expect(vm.deities[0].confidence).toBe("medium");
+    expect(vm.histories[0].confidence).toBe("low");
+  });
+
+  it("sourcesが保持される（Source UIは今回作らないが内部型としては保持する）", () => {
+    const source = makeSource({ id: 99, title: "史料X" });
+    const vm = buildShrineFactViewModel({
+      deities: [makeDeity({ sources: [source] })],
+      histories: [makeHistory({ sources: [source] })],
+    });
+    expect(vm.deities[0].sources).toEqual([source]);
+    expect(vm.histories[0].sources).toEqual([source]);
+  });
+
+  it("displayState変換: source_confirmed/reviewed -> full, disputed -> disputed", () => {
+    const vm = buildShrineFactViewModel({
+      deities: [
+        makeDeity({ id: 1, verification_status: "source_confirmed" }),
+        makeDeity({ id: 2, verification_status: "disputed", sort_order: 1 }),
+      ],
+      histories: [
+        makeHistory({ id: 1, verification_status: "reviewed" }),
+        makeHistory({ id: 2, verification_status: "disputed", sort_order: 1 }),
+      ],
+    });
+    expect(vm.deities[0].displayState).toBe("full");
+    expect(vm.deities[1].displayState).toBe("disputed");
+    expect(vm.histories[0].displayState).toBe("full");
+    expect(vm.histories[1].displayState).toBe("disputed");
+  });
+
+  it("複数disputed Factが別要素のまま保持される（自動統合されない）", () => {
+    const vm = buildShrineFactViewModel({
+      histories: [
+        makeHistory({
+          id: 1,
+          title: "説A",
+          content: "説Aの内容",
+          verification_status: "disputed",
+          sort_order: 0,
+        }),
+        makeHistory({
+          id: 2,
+          title: "説B",
+          content: "説Bの内容",
+          verification_status: "disputed",
+          sort_order: 1,
+        }),
+      ],
+    });
+
+    expect(vm.histories).toHaveLength(2);
+    expect(vm.histories[0].title).toBe("説A");
+    expect(vm.histories[0].content).toBe("説Aの内容");
+    expect(vm.histories[1].title).toBe("説B");
+    expect(vm.histories[1].content).toBe("説Bの内容");
+    // 1要素へ統合されていないこと（titleが連結・要約されていない）
+    expect(vm.histories[0].title).not.toContain("説B");
+    expect(vm.histories[1].title).not.toContain("説A");
+  });
+});

--- a/apps/mobile/lib/shrineKnowledgeFact.ts
+++ b/apps/mobile/lib/shrineKnowledgeFact.ts
@@ -1,0 +1,126 @@
+// apps/mobile/lib/shrineKnowledgeFact.ts
+//
+// Backend Shrine Detail API（backend/temples/api/serializers/shrine.py）が返す
+// Knowledge Fact（deities/histories）を、Mobile Shrine Detail画面向けの
+// ViewModelへ変換する。
+//
+// Evidence判定（usable/full/disputed/hiddenの決定）はここでは一切行わない。
+// Backendはhidden相当のFactを既にレスポンスから除外しており、ここへ届くのは
+// full相当（source_confirmed/reviewed + ready Source）またはdisputed相当
+// （disputed + ready Source）のFactのみという前提に立つ（PR-M1）。
+//
+// apps/web/src/lib/api/types.ts / apps/web/src/lib/shrine/buildShrineFactSection.ts
+// と概念を揃える（full/disputedの2状態、verification_status→表示状態の変換を
+// 1箇所へ集約するという方針）。コード自体は共有しない（Web=DOM/Tailwind、
+// Mobile=React Native View/StyleSheetでレンダリング層が異なるため）。
+
+// --- API Types（backend/temples/api/serializers/shrine.py に一致する） ---
+
+export type ShrineKnowledgeSource = {
+  id: number;
+  source_type: string;
+  title: string;
+  publisher: string;
+  url: string;
+  verification_status: string;
+  confidence: string;
+};
+
+export type ShrineDeity = {
+  id: number;
+  display_name: string;
+  canonical_name: string;
+  role: string;
+  sort_order: number;
+  verification_status: string;
+  confidence: string;
+  sources: ShrineKnowledgeSource[];
+};
+
+export type ShrineHistory = {
+  id: number;
+  history_type: string;
+  title: string;
+  content: string;
+  period_text: string;
+  event_date: string | null;
+  sort_order: number;
+  verification_status: string;
+  confidence: string;
+  sources: ShrineKnowledgeSource[];
+};
+
+// --- ViewModel ---
+
+// hiddenはBackendで除外済みのため、Mobile ViewModelへは持ち込まない。
+export type FactDisplayState = "full" | "disputed";
+
+export type FactDeityViewModel = {
+  displayName: string;
+  sortOrder: number;
+  confidence: string;
+  sources: ShrineKnowledgeSource[];
+  displayState: FactDisplayState;
+};
+
+export type FactHistoryViewModel = {
+  historyType: string;
+  title: string;
+  content: string;
+  periodText: string;
+  sortOrder: number;
+  confidence: string;
+  sources: ShrineKnowledgeSource[];
+  displayState: FactDisplayState;
+};
+
+export type ShrineFactViewModel = {
+  deities: FactDeityViewModel[];
+  histories: FactHistoryViewModel[];
+};
+
+// Backend verification_status → Mobile ViewModel専用のFactDisplayStateへ変換する
+// 唯一の地点。将来のUI実装(PR-M2)はこの変換結果だけを見て、Backendの
+// verification_status文字列を各所で直接判定しない。想定外の値が来た場合は
+// disputedへ昇格させずfullとして扱う（fail-safe。Webのresolve関数と同じ方針）。
+// confidence/history_typeはこの判定に使わない。
+export function resolveFactDisplayState(verificationStatus: string): FactDisplayState {
+  return verificationStatus === "disputed" ? "disputed" : "full";
+}
+
+function bySortOrder<T extends { sort_order: number }>(items: T[]): T[] {
+  return [...items].sort((a, b) => a.sort_order - b.sort_order);
+}
+
+// deities/historiesを、Mobile Shrine Detail向けのViewModelへ変換する。
+// Fact本文（display_name/title/content/period_text等）・confidence・sourcesは
+// 加工せずそのまま保持する。sourcesはSource UI未実装のため今回は表示に使わないが、
+// 将来のSource UI実装に備え内部型としては保持する。複数のFactは常に別要素の
+// ままとし、自動統合・自動要約・自動グルーピングは行わない。
+export function buildShrineFactViewModel(shrine: {
+  deities?: ShrineDeity[];
+  histories?: ShrineHistory[];
+}): ShrineFactViewModel {
+  const deities = Array.isArray(shrine.deities) ? shrine.deities : [];
+  const histories = Array.isArray(shrine.histories) ? shrine.histories : [];
+
+  return {
+    deities: bySortOrder(deities).map((deity) => ({
+      displayName: deity.display_name,
+      sortOrder: deity.sort_order,
+      confidence: deity.confidence,
+      sources: deity.sources,
+      displayState: resolveFactDisplayState(deity.verification_status),
+    })),
+    histories: bySortOrder(histories).map((history) => ({
+      historyType: history.history_type,
+      title: history.title,
+      content: history.content,
+      periodText: history.period_text,
+      sortOrder: history.sort_order,
+      confidence: history.confidence,
+      sources: history.sources,
+      displayState: resolveFactDisplayState(history.verification_status),
+    })),
+  };
+}


### PR DESCRIPTION
## Summary

Mobile Shrine Detailは現在、Backend Detail APIから`deities`/`histories`を既に受信しているが、`ShrineApiResponse`型と`toShrine()`がこれらを保持せず破棄していた（`audit/mobile-knowledge-fact-gap`監査で確認済みのGap）。本PRはUIを変更せず、Knowledge FactをMobile内部へ安全に取り込みViewModelまで構築する**基盤のみ**を追加する。

- `apps/mobile/lib/shrineKnowledgeFact.ts`（新規）: Backend Serializerに一致するAPI型（`ShrineKnowledgeSource`/`ShrineDeity`/`ShrineHistory`）、Mobile ViewModel専用の`FactDisplayState`（`full`|`disputed`）、`verification_status`→`FactDisplayState`変換を1箇所に集約する`resolveFactDisplayState()`、`deities`/`histories`をViewModelへ変換する`buildShrineFactViewModel()`
- `apps/mobile/app/shrines/[id].tsx`: `ShrineApiResponse`/`Shrine`型へ`deities`/`histories`を追加し、`toShrine()`で欠落させず保持する。**UI/JSXは変更しない**

Evidence判定（usable/hidden等の決定）はMobile側で一切行わない。hiddenはBackendで除外済みのためViewModelへ持ち込まない。Fact本文・confidence・sourcesは加工せず保持し、複数Factは常に別要素のまま保持する（自動統合・自動要約・自動グルーピングはしない）。

## 変更禁止事項の遵守

- `backend/` `apps/web/`: 変更なし
- Model / Migration / DB / API Schema: 変更なし
- Mobile UI / Navigation: 変更なし（`[id].tsx`の差分はimport追加・型追加・`toShrine()`への2行追加のみ）
- Legacy field（`description`/`goriyaku`等）: 削除・変更なし
- Source UI / Source confidence判定 / Source priority判定 / `FactSourceEvidence`: 追加していない
- 新規RN component testing libraryは導入していない（既存vitest環境のみ使用）

## Test plan

- [x] `apps/mobile`: `npx vitest run` → 260 tests / 24 files 全PASS（新規`shrineKnowledgeFact.test.ts` 13件含む）
- [x] `apps/mobile`: `npx tsc -p tsconfig.json --noEmit` → develop baselineと同一の6件（`ShrineSearchMap.native.tsx`、本PR範囲外の既存エラー）のみ。本PRのファイルに起因する新規エラーなし（git stashで比較確認済み）
- [x] Mobile用ESLintは本リポジトリに存在しない（`eslint.config.mjs`が`apps/mobile/**`を明示的にignore）ため実行対象外
- [x] `git diff --check` → 空白エラーなし
- [x] `git diff --name-only` → `apps/mobile/app/shrines/[id].tsx`（+新規2ファイル）のみ。Backend/Web差分なし
- [x] pre-push hook（OpenAPI lint / Web `test:contract` 731 tests）通過（Web側は無変更のため影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>