### PR TITLE
feat(mobile): Shrine Detail Fact UI(PR-M2)

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -29,7 +29,13 @@ import {
   normalizeRecommendationReasonV4Detail,
   type RecommendationReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
-import type { ShrineDeity, ShrineHistory } from "../../lib/shrineKnowledgeFact";
+import {
+  buildShrineFactViewModel,
+  hasVisibleKnowledgeFact,
+  isDisputedDisplayState,
+  type ShrineDeity,
+  type ShrineHistory,
+} from "../../lib/shrineKnowledgeFact";
 
 type RecommendationReasonFactAxis =
   | "need"
@@ -154,6 +160,26 @@ type ShrineApiResponse = {
 const SHRINE_API_ID_BY_LOCAL_ID: Record<string, string> = {
   fushimi: "2",
 };
+
+// docs/knowledge/shrine-knowledge-contract.md「分類案（To-Be）」の定義に基づく固定ラベル。
+// apps/web/src/lib/shrine/buildShrineFactSection.tsのHISTORY_TYPE_LABELSと同じ対応表
+// （コードは共有せず、文言の意味だけを揃える）。宗教的・歴史的な意味を新たに解釈しない。
+const HISTORY_TYPE_LABELS: Record<string, string> = {
+  official_origin: "由緒",
+  founding: "創始",
+  historical_event: "歴史",
+  tradition: "伝承",
+  regional_context: "地域史",
+  editorial_summary: "要約",
+};
+
+function resolveHistoryTypeLabel(historyType: string): string {
+  return HISTORY_TYPE_LABELS[historyType] ?? historyType;
+}
+
+// disputed Factに付与する状態ラベル。文言はここ1箇所でのみ定義する。
+// Webの「異なる見解を含む情報」と意味を揃えるが、Webコンポーネントはimportしない。
+const FACT_DISPUTED_LABEL = "異なる見解を含む情報";
 
 function asTrimmedString(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -370,6 +396,15 @@ export default function ShrineDetail() {
   const [authPromptVisible, setAuthPromptVisible] = React.useState(false);
   const shrine = apiShrine ?? localShrine;
   const tags = shrine?.tags ?? [];
+
+  // Knowledge Fact ViewModel（PR-M1のbuildShrineFactViewModel()をそのまま利用）。
+  // Evidence利用可否の再判定はここでは行わない。Backendが既にhidden相当を除外して
+  // 返したfull/disputed相当のFactを、表示用の形へ変換するだけ。
+  const factViewModel = React.useMemo(
+    () => buildShrineFactViewModel(shrine ?? {}),
+    [shrine],
+  );
+  const showKnowledgeFactSection = hasVisibleKnowledgeFact(factViewModel);
 
   const reasonFactItems = buildReasonFactItems(contextReasonFacts ?? shrine?.reasonFacts).slice(0, 3);
 
@@ -812,6 +847,64 @@ export default function ShrineDetail() {
           </View>
         )}
 
+        {/* 祭神・由緒（Knowledge Fact）。Legacy「神社について」とは独立した表示責務。
+            Knowledge未登録（deities/historiesとも空）の場合はセクション自体を表示しない。
+            Legacy Fieldの表示・非表示には一切影響しない。 */}
+        {showKnowledgeFactSection ? (
+          <View style={styles.factCard}>
+            <Text style={styles.cardTitle}>祭神・由緒</Text>
+
+            {factViewModel.deities.length > 0 ? (
+              <View style={styles.factSection}>
+                <Text style={styles.factSubLabel}>御祭神</Text>
+                <View style={styles.factDeityRow}>
+                  {factViewModel.deities.map((deity, index) => (
+                    <View key={`${deity.displayName}:${index}`} style={styles.factDeityPill}>
+                      <Text style={styles.factDeityText}>{deity.displayName}</Text>
+                      {isDisputedDisplayState(deity.displayState) ? (
+                        <View style={styles.factDisputedBadge}>
+                          <Text style={styles.factDisputedBadgeText}>{FACT_DISPUTED_LABEL}</Text>
+                        </View>
+                      ) : null}
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ) : null}
+
+            {factViewModel.histories.length > 0 ? (
+              <View style={styles.factSection}>
+                <Text style={styles.factSubLabel}>由緒・歴史</Text>
+                <View style={styles.factHistoryList}>
+                  {factViewModel.histories.map((history, index) => (
+                    <View key={`${history.title}:${index}`} style={styles.factHistoryItem}>
+                      <View style={styles.factHistoryMetaRow}>
+                        <Text style={styles.factHistoryTypeLabel}>
+                          {resolveHistoryTypeLabel(history.historyType)}
+                        </Text>
+                        {history.periodText ? (
+                          <Text style={styles.factHistoryPeriod}>{history.periodText}</Text>
+                        ) : null}
+                        {isDisputedDisplayState(history.displayState) ? (
+                          <View style={styles.factDisputedBadge}>
+                            <Text style={styles.factDisputedBadgeText}>{FACT_DISPUTED_LABEL}</Text>
+                          </View>
+                        ) : null}
+                      </View>
+                      {history.title ? (
+                        <Text style={styles.factHistoryTitle}>{history.title}</Text>
+                      ) : null}
+                      {history.content ? (
+                        <Text style={styles.factHistoryContent}>{history.content}</Text>
+                      ) : null}
+                    </View>
+                  ))}
+                </View>
+              </View>
+            ) : null}
+          </View>
+        ) : null}
+
         {/* 説明文 */}
         <View style={styles.descCard}>
           <Text style={styles.descLabel}>神社について</Text>
@@ -1139,6 +1232,105 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 20,
     fontWeight: "600",
+  },
+
+  // 祭神・由緒（Knowledge Fact）
+  factCard: {
+    marginHorizontal: spacing.screenX,
+    marginTop: spacing.sectionTop,
+    backgroundColor: theme.surface,
+    borderRadius: radius.xl,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.border,
+    padding: cardSizes.cardPaddingLg,
+    gap: spacing.mdGap,
+  },
+  factSection: {
+    gap: spacing.smGap,
+  },
+  factSubLabel: {
+    color: theme.goldSoft,
+    fontSize: 11,
+    fontWeight: "900",
+    letterSpacing: 1.1,
+  },
+  factDeityRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.inlineGap,
+  },
+  factDeityPill: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    maxWidth: "100%",
+    flexShrink: 1,
+    gap: spacing.tightGap,
+    paddingHorizontal: ctaSizes.pillPaddingX,
+    paddingVertical: 5,
+    borderRadius: radius.pill,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderSoft,
+    backgroundColor: theme.surfaceSoft,
+  },
+  factDeityText: {
+    color: theme.text,
+    fontSize: 13,
+    fontWeight: "700",
+    flexShrink: 1,
+  },
+  factHistoryList: {
+    gap: spacing.smGap,
+  },
+  factHistoryItem: {
+    borderRadius: radius.md,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderSoft,
+    backgroundColor: theme.surfaceSoft,
+    padding: cardSizes.cardPaddingMd,
+    gap: spacing.tightGap,
+  },
+  factHistoryMetaRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: spacing.inlineGap,
+  },
+  factHistoryTypeLabel: {
+    color: theme.muted,
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.4,
+  },
+  factHistoryPeriod: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  factHistoryTitle: {
+    color: theme.text,
+    fontSize: 14,
+    lineHeight: 20,
+    fontWeight: "800",
+  },
+  factHistoryContent: {
+    color: theme.mutedSoft,
+    fontSize: 13,
+    lineHeight: 21,
+    fontWeight: "500",
+  },
+  factDisputedBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: radius.pill,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.border,
+    backgroundColor: "transparent",
+  },
+  factDisputedBadgeText: {
+    color: theme.muted,
+    fontSize: 10,
+    fontWeight: "700",
   },
 
   // 説明文カード

--- a/apps/mobile/lib/__tests__/shrineKnowledgeFact.test.ts
+++ b/apps/mobile/lib/__tests__/shrineKnowledgeFact.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildShrineFactViewModel,
+  hasVisibleKnowledgeFact,
+  isDisputedDisplayState,
   resolveFactDisplayState,
   type ShrineDeity,
   type ShrineHistory,
@@ -178,5 +180,32 @@ describe("buildShrineFactViewModel", () => {
     // 1要素へ統合されていないこと（titleが連結・要約されていない）
     expect(vm.histories[0].title).not.toContain("説B");
     expect(vm.histories[1].title).not.toContain("説A");
+  });
+});
+
+describe("isDisputedDisplayState", () => {
+  it("full -> disputed labelを表示しない(false)", () => {
+    expect(isDisputedDisplayState("full")).toBe(false);
+  });
+
+  it("disputed -> disputed labelを表示する(true)", () => {
+    expect(isDisputedDisplayState("disputed")).toBe(true);
+  });
+});
+
+describe("hasVisibleKnowledgeFact", () => {
+  it("Knowledge Factあり(deitiesのみ) -> section visible(true)", () => {
+    const vm = buildShrineFactViewModel({ deities: [makeDeity()], histories: [] });
+    expect(hasVisibleKnowledgeFact(vm)).toBe(true);
+  });
+
+  it("Knowledge Factあり(historiesのみ) -> section visible(true)", () => {
+    const vm = buildShrineFactViewModel({ deities: [], histories: [makeHistory()] });
+    expect(hasVisibleKnowledgeFact(vm)).toBe(true);
+  });
+
+  it("Knowledge Factなし(両方空) -> section visible(false)", () => {
+    const vm = buildShrineFactViewModel({ deities: [], histories: [] });
+    expect(hasVisibleKnowledgeFact(vm)).toBe(false);
   });
 });

--- a/apps/mobile/lib/shrineKnowledgeFact.ts
+++ b/apps/mobile/lib/shrineKnowledgeFact.ts
@@ -124,3 +124,16 @@ export function buildShrineFactViewModel(shrine: {
     })),
   };
 }
+
+// UI（PR-M2）向けの表示条件判定。UI側でverification_status/displayStateの
+// 比較をJSX内へ散らさないための唯一の判定地点とする。
+export function isDisputedDisplayState(displayState: FactDisplayState): boolean {
+  return displayState === "disputed";
+}
+
+// Knowledge Fact Section自体を表示するかどうかの判定。deities/historiesが
+// 両方空の場合はfalseを返し、UI側はセクション全体を非表示にする
+// （Legacy「神社について」は本判定と無関係に従来通り表示され続ける）。
+export function hasVisibleKnowledgeFact(viewModel: ShrineFactViewModel): boolean {
+  return viewModel.deities.length > 0 || viewModel.histories.length > 0;
+}


### PR DESCRIPTION
## Summary

PR-M1（#2236）で構築したKnowledge Fact ViewModel基盤を、Mobile Shrine Detail画面へ接続する。**UI接続のみ**。Backend・Recommendation・Evidence Policyは変更しない。Evidence利用可否の再判定はMobile側で一切行わず、`buildShrineFactViewModel()`の結果（`displayState`/Fact本文/`sortOrder`）だけを使う。

- `apps/mobile/lib/shrineKnowledgeFact.ts`: UI表示条件判定用の純粋関数`isDisputedDisplayState()`/`hasVisibleKnowledgeFact()`を追加（PR-M1のViewModel基盤自体は再設計しない）
- `apps/mobile/app/shrines/[id].tsx`: 「祭神・由緒」Knowledge Fact Sectionを新規追加
  - 1 Deity = 1 UI item（`displayName`をそのまま表示、連結しない）
  - 1 History = 1 UI item/card（`historyType`ラベル・`periodText`・`title`・`content`、加工しない）
  - disputed Factには状態ラベル「異なる見解を含む情報」を表示（Webコンポーネントは共有importせず、文言の意味だけを揃えた）
  - `verification_status`文字列をJSX内で直接判定しない
  - Knowledge未登録（`deities`/`histories`とも空）の場合はセクション自体を非表示（Legacy「神社について」は影響を受けず従来通り表示）
  - Legacy Field（`description`/`goriyaku`等）は削除・統合していない
  - Source UIは追加していない

## Manual QA

Expo web（`expo start --web`、実際のコンポーネントコードをブラウザで検証）で、iPhone相当375px幅・Android相当412px幅の両方を確認した。長い祭神名・複数祭神・長いHistory title/content・複数History・disputed labelを含むfixtureで検証。

**発見した不具合と修正**: 長い祭神名（disputed）のpillが画面幅を超えて折り返されず切れる問題を発見。`factDeityPill`/`factDeityText`へ`flexShrink`/`flexWrap`/`maxWidth`を追加して修正し、再検証で崩れ・重なりがないことを確認した。QA用の一時fixtureはスクリーンショット後に削除済み（PR diffには含まれない）。

## 変更禁止事項の遵守

- `backend/` `apps/web/`: 変更なし
- Model / Migration / DB / API Schema / Recommendation / Evidence Gate: 変更なし
- Navigation再設計: なし（Direct/Concierge/Favorites/Ranking/Search/Recently viewedいずれも同じShrine Detail screenを使用し、route paramsはEvidence表示に影響しない）
- Legacy field削除: なし
- Source UI / `FactSourceEvidence` / `EvidenceGroup`: 追加していない
- 新規RN component testing libraryは導入していない（既存vitest環境のみ使用）

## Test plan

- [x] `apps/mobile`: `npx vitest run` → 265 tests / 24 files 全PASS（新規5件含む: `isDisputedDisplayState`/`hasVisibleKnowledgeFact`。既存`buildShrineFactViewModel`テストも全PASS）
- [x] `apps/mobile`: `npx tsc -p tsconfig.json --noEmit` → develop baselineと同一の6件（`ShrineSearchMap.native.tsx`、本PR範囲外の既存エラー）のみ。本PRのファイルに起因する新規エラーなし
- [x] Manual QA（Expo web、375px/412px幅）: full表示・disputed状態ラベル・複数Fact個別表示・Legacy共存を確認、発見した折り返し不具合を修正
- [x] `git diff --check` → 空白エラーなし
- [x] `git diff --name-only` → Mobile 3ファイルのみ。Backend/Web差分なし
- [x] pre-push hook（OpenAPI lint / Web `test:contract` 731 tests）通過（Web側は無変更のため影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>