### PR TITLE
refactor(mobile): Shrine Knowledge Fact Section component境界(PR-M3A)

### DIFF
--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -24,18 +24,13 @@ import {
 } from "../../lib/visitReflectionAnalytics";
 import { AuthPrompt } from "../../components/common/AuthPrompt";
 import Button from "../../components/ui/Button";
+import { ShrineKnowledgeFactSection } from "../../components/shrine/ShrineKnowledgeFactSection";
 import {
   buildReasonV4Sections,
   normalizeRecommendationReasonV4Detail,
   type RecommendationReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
-import {
-  buildShrineFactViewModel,
-  hasVisibleKnowledgeFact,
-  isDisputedDisplayState,
-  type ShrineDeity,
-  type ShrineHistory,
-} from "../../lib/shrineKnowledgeFact";
+import { buildShrineFactViewModel, type ShrineDeity, type ShrineHistory } from "../../lib/shrineKnowledgeFact";
 
 type RecommendationReasonFactAxis =
   | "need"
@@ -160,26 +155,6 @@ type ShrineApiResponse = {
 const SHRINE_API_ID_BY_LOCAL_ID: Record<string, string> = {
   fushimi: "2",
 };
-
-// docs/knowledge/shrine-knowledge-contract.md「分類案（To-Be）」の定義に基づく固定ラベル。
-// apps/web/src/lib/shrine/buildShrineFactSection.tsのHISTORY_TYPE_LABELSと同じ対応表
-// （コードは共有せず、文言の意味だけを揃える）。宗教的・歴史的な意味を新たに解釈しない。
-const HISTORY_TYPE_LABELS: Record<string, string> = {
-  official_origin: "由緒",
-  founding: "創始",
-  historical_event: "歴史",
-  tradition: "伝承",
-  regional_context: "地域史",
-  editorial_summary: "要約",
-};
-
-function resolveHistoryTypeLabel(historyType: string): string {
-  return HISTORY_TYPE_LABELS[historyType] ?? historyType;
-}
-
-// disputed Factに付与する状態ラベル。文言はここ1箇所でのみ定義する。
-// Webの「異なる見解を含む情報」と意味を揃えるが、Webコンポーネントはimportしない。
-const FACT_DISPUTED_LABEL = "異なる見解を含む情報";
 
 function asTrimmedString(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -404,7 +379,6 @@ export default function ShrineDetail() {
     () => buildShrineFactViewModel(shrine ?? {}),
     [shrine],
   );
-  const showKnowledgeFactSection = hasVisibleKnowledgeFact(factViewModel);
 
   const reasonFactItems = buildReasonFactItems(contextReasonFacts ?? shrine?.reasonFacts).slice(0, 3);
 
@@ -848,62 +822,9 @@ export default function ShrineDetail() {
         )}
 
         {/* 祭神・由緒（Knowledge Fact）。Legacy「神社について」とは独立した表示責務。
-            Knowledge未登録（deities/historiesとも空）の場合はセクション自体を表示しない。
+            Knowledge未登録（deities/historiesとも空）時の非表示判定はcomponent内部で行う。
             Legacy Fieldの表示・非表示には一切影響しない。 */}
-        {showKnowledgeFactSection ? (
-          <View style={styles.factCard}>
-            <Text style={styles.cardTitle}>祭神・由緒</Text>
-
-            {factViewModel.deities.length > 0 ? (
-              <View style={styles.factSection}>
-                <Text style={styles.factSubLabel}>御祭神</Text>
-                <View style={styles.factDeityRow}>
-                  {factViewModel.deities.map((deity, index) => (
-                    <View key={`${deity.displayName}:${index}`} style={styles.factDeityPill}>
-                      <Text style={styles.factDeityText}>{deity.displayName}</Text>
-                      {isDisputedDisplayState(deity.displayState) ? (
-                        <View style={styles.factDisputedBadge}>
-                          <Text style={styles.factDisputedBadgeText}>{FACT_DISPUTED_LABEL}</Text>
-                        </View>
-                      ) : null}
-                    </View>
-                  ))}
-                </View>
-              </View>
-            ) : null}
-
-            {factViewModel.histories.length > 0 ? (
-              <View style={styles.factSection}>
-                <Text style={styles.factSubLabel}>由緒・歴史</Text>
-                <View style={styles.factHistoryList}>
-                  {factViewModel.histories.map((history, index) => (
-                    <View key={`${history.title}:${index}`} style={styles.factHistoryItem}>
-                      <View style={styles.factHistoryMetaRow}>
-                        <Text style={styles.factHistoryTypeLabel}>
-                          {resolveHistoryTypeLabel(history.historyType)}
-                        </Text>
-                        {history.periodText ? (
-                          <Text style={styles.factHistoryPeriod}>{history.periodText}</Text>
-                        ) : null}
-                        {isDisputedDisplayState(history.displayState) ? (
-                          <View style={styles.factDisputedBadge}>
-                            <Text style={styles.factDisputedBadgeText}>{FACT_DISPUTED_LABEL}</Text>
-                          </View>
-                        ) : null}
-                      </View>
-                      {history.title ? (
-                        <Text style={styles.factHistoryTitle}>{history.title}</Text>
-                      ) : null}
-                      {history.content ? (
-                        <Text style={styles.factHistoryContent}>{history.content}</Text>
-                      ) : null}
-                    </View>
-                  ))}
-                </View>
-              </View>
-            ) : null}
-          </View>
-        ) : null}
+        <ShrineKnowledgeFactSection factViewModel={factViewModel} />
 
         {/* 説明文 */}
         <View style={styles.descCard}>
@@ -1232,105 +1153,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     lineHeight: 20,
     fontWeight: "600",
-  },
-
-  // 祭神・由緒（Knowledge Fact）
-  factCard: {
-    marginHorizontal: spacing.screenX,
-    marginTop: spacing.sectionTop,
-    backgroundColor: theme.surface,
-    borderRadius: radius.xl,
-    borderWidth: cardSizes.borderWidth,
-    borderColor: theme.border,
-    padding: cardSizes.cardPaddingLg,
-    gap: spacing.mdGap,
-  },
-  factSection: {
-    gap: spacing.smGap,
-  },
-  factSubLabel: {
-    color: theme.goldSoft,
-    fontSize: 11,
-    fontWeight: "900",
-    letterSpacing: 1.1,
-  },
-  factDeityRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: spacing.inlineGap,
-  },
-  factDeityPill: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    alignItems: "center",
-    maxWidth: "100%",
-    flexShrink: 1,
-    gap: spacing.tightGap,
-    paddingHorizontal: ctaSizes.pillPaddingX,
-    paddingVertical: 5,
-    borderRadius: radius.pill,
-    borderWidth: cardSizes.borderWidth,
-    borderColor: theme.borderSoft,
-    backgroundColor: theme.surfaceSoft,
-  },
-  factDeityText: {
-    color: theme.text,
-    fontSize: 13,
-    fontWeight: "700",
-    flexShrink: 1,
-  },
-  factHistoryList: {
-    gap: spacing.smGap,
-  },
-  factHistoryItem: {
-    borderRadius: radius.md,
-    borderWidth: cardSizes.borderWidth,
-    borderColor: theme.borderSoft,
-    backgroundColor: theme.surfaceSoft,
-    padding: cardSizes.cardPaddingMd,
-    gap: spacing.tightGap,
-  },
-  factHistoryMetaRow: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    alignItems: "center",
-    gap: spacing.inlineGap,
-  },
-  factHistoryTypeLabel: {
-    color: theme.muted,
-    fontSize: 11,
-    fontWeight: "800",
-    letterSpacing: 0.4,
-  },
-  factHistoryPeriod: {
-    color: theme.muted,
-    fontSize: 12,
-    fontWeight: "600",
-  },
-  factHistoryTitle: {
-    color: theme.text,
-    fontSize: 14,
-    lineHeight: 20,
-    fontWeight: "800",
-  },
-  factHistoryContent: {
-    color: theme.mutedSoft,
-    fontSize: 13,
-    lineHeight: 21,
-    fontWeight: "500",
-  },
-  factDisputedBadge: {
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: radius.pill,
-    borderWidth: cardSizes.borderWidth,
-    borderColor: theme.border,
-    backgroundColor: "transparent",
-  },
-  factDisputedBadgeText: {
-    color: theme.muted,
-    fontSize: 10,
-    fontWeight: "700",
   },
 
   // 説明文カード

--- a/apps/mobile/components/shrine/ShrineKnowledgeFactSection.tsx
+++ b/apps/mobile/components/shrine/ShrineKnowledgeFactSection.tsx
@@ -1,0 +1,212 @@
+// apps/mobile/components/shrine/ShrineKnowledgeFactSection.tsx
+import * as React from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { kamimusubiDark as theme } from "../../design/theme";
+import { spacing } from "../../design/spacing";
+import { cardSizes } from "../../design/cardSizes";
+import { radius } from "../../design/radius";
+import { ctaSizes } from "../../design/ctaSizes";
+import {
+  hasVisibleKnowledgeFact,
+  isDisputedDisplayState,
+  type ShrineFactViewModel,
+} from "../../lib/shrineKnowledgeFact";
+
+// docs/knowledge/shrine-knowledge-contract.md「分類案（To-Be）」の定義に基づく固定ラベル。
+// apps/web/src/lib/shrine/buildShrineFactSection.tsのHISTORY_TYPE_LABELSと同じ対応表
+// （コードは共有せず、文言の意味だけを揃える）。宗教的・歴史的な意味を新たに解釈しない。
+const HISTORY_TYPE_LABELS: Record<string, string> = {
+  official_origin: "由緒",
+  founding: "創始",
+  historical_event: "歴史",
+  tradition: "伝承",
+  regional_context: "地域史",
+  editorial_summary: "要約",
+};
+
+function resolveHistoryTypeLabel(historyType: string): string {
+  return HISTORY_TYPE_LABELS[historyType] ?? historyType;
+}
+
+// disputed Factに付与する状態ラベル。文言はここ1箇所でのみ定義する。
+// Webの「異なる見解を含む情報」と意味を揃えるが、Webコンポーネントはimportしない。
+const FACT_DISPUTED_LABEL = "異なる見解を含む情報";
+
+type ShrineKnowledgeFactSectionProps = {
+  factViewModel: ShrineFactViewModel;
+};
+
+// Mobile Shrine Detail「祭神・由緒」Section。
+//
+// 責務: Knowledge Fact Section自体の表示可否・Deity/History描画・displayStateによる
+// 状態ラベル表示・Mobile向けlayoutのみ。
+// 責務ではないもの: API fetch・toShrine・Evidence判定・Recommendation・Navigation・
+// Analytics・Storage・Favorites・Auth（propsはShrineFactViewModelのみを受け取り、
+// verification_status文字列はこのcomponent内で一切判定しない）。
+export function ShrineKnowledgeFactSection({ factViewModel }: ShrineKnowledgeFactSectionProps) {
+  if (!hasVisibleKnowledgeFact(factViewModel)) return null;
+
+  return (
+    <View style={styles.factCard}>
+      <Text style={styles.sectionTitle}>祭神・由緒</Text>
+
+      {factViewModel.deities.length > 0 ? (
+        <View style={styles.factSection}>
+          <Text style={styles.factSubLabel}>御祭神</Text>
+          <View style={styles.factDeityRow}>
+            {factViewModel.deities.map((deity, index) => (
+              <View key={`${deity.displayName}:${index}`} style={styles.factDeityPill}>
+                <Text style={styles.factDeityText}>{deity.displayName}</Text>
+                {isDisputedDisplayState(deity.displayState) ? (
+                  <View style={styles.factDisputedBadge}>
+                    <Text style={styles.factDisputedBadgeText}>{FACT_DISPUTED_LABEL}</Text>
+                  </View>
+                ) : null}
+              </View>
+            ))}
+          </View>
+        </View>
+      ) : null}
+
+      {factViewModel.histories.length > 0 ? (
+        <View style={styles.factSection}>
+          <Text style={styles.factSubLabel}>由緒・歴史</Text>
+          <View style={styles.factHistoryList}>
+            {factViewModel.histories.map((history, index) => (
+              <View key={`${history.title}:${index}`} style={styles.factHistoryItem}>
+                <View style={styles.factHistoryMetaRow}>
+                  <Text style={styles.factHistoryTypeLabel}>
+                    {resolveHistoryTypeLabel(history.historyType)}
+                  </Text>
+                  {history.periodText ? (
+                    <Text style={styles.factHistoryPeriod}>{history.periodText}</Text>
+                  ) : null}
+                  {isDisputedDisplayState(history.displayState) ? (
+                    <View style={styles.factDisputedBadge}>
+                      <Text style={styles.factDisputedBadgeText}>{FACT_DISPUTED_LABEL}</Text>
+                    </View>
+                  ) : null}
+                </View>
+                {history.title ? <Text style={styles.factHistoryTitle}>{history.title}</Text> : null}
+                {history.content ? (
+                  <Text style={styles.factHistoryContent}>{history.content}</Text>
+                ) : null}
+              </View>
+            ))}
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export default ShrineKnowledgeFactSection;
+
+const styles = StyleSheet.create({
+  factCard: {
+    marginHorizontal: spacing.screenX,
+    marginTop: spacing.sectionTop,
+    backgroundColor: theme.surface,
+    borderRadius: radius.xl,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.border,
+    padding: cardSizes.cardPaddingLg,
+    gap: spacing.mdGap,
+  },
+  // apps/mobile/app/shrines/[id].tsxのstyles.cardTitleと同一の値（他セクション見出しとの
+  // 視覚的整合を保つため）。componentをscreenのstylesから独立させるためここで複製する。
+  sectionTitle: {
+    color: theme.text,
+    fontSize: 16,
+    lineHeight: 22,
+    fontWeight: "900",
+  },
+  factSection: {
+    gap: spacing.smGap,
+  },
+  factSubLabel: {
+    color: theme.goldSoft,
+    fontSize: 11,
+    fontWeight: "900",
+    letterSpacing: 1.1,
+  },
+  factDeityRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: spacing.inlineGap,
+  },
+  factDeityPill: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    maxWidth: "100%",
+    flexShrink: 1,
+    gap: spacing.tightGap,
+    paddingHorizontal: ctaSizes.pillPaddingX,
+    paddingVertical: 5,
+    borderRadius: radius.pill,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderSoft,
+    backgroundColor: theme.surfaceSoft,
+  },
+  factDeityText: {
+    color: theme.text,
+    fontSize: 13,
+    fontWeight: "700",
+    flexShrink: 1,
+  },
+  factHistoryList: {
+    gap: spacing.smGap,
+  },
+  factHistoryItem: {
+    borderRadius: radius.md,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.borderSoft,
+    backgroundColor: theme.surfaceSoft,
+    padding: cardSizes.cardPaddingMd,
+    gap: spacing.tightGap,
+  },
+  factHistoryMetaRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: spacing.inlineGap,
+  },
+  factHistoryTypeLabel: {
+    color: theme.muted,
+    fontSize: 11,
+    fontWeight: "800",
+    letterSpacing: 0.4,
+  },
+  factHistoryPeriod: {
+    color: theme.muted,
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  factHistoryTitle: {
+    color: theme.text,
+    fontSize: 14,
+    lineHeight: 20,
+    fontWeight: "800",
+  },
+  factHistoryContent: {
+    color: theme.mutedSoft,
+    fontSize: 13,
+    lineHeight: 21,
+    fontWeight: "500",
+  },
+  factDisputedBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: radius.pill,
+    borderWidth: cardSizes.borderWidth,
+    borderColor: theme.border,
+    backgroundColor: "transparent",
+  },
+  factDisputedBadgeText: {
+    color: theme.muted,
+    fontSize: 10,
+    fontWeight: "700",
+  },
+});


### PR DESCRIPTION
## Summary

PR-M2でShrine Detail screen（`apps/mobile/app/shrines/[id].tsx`）内部へ直接実装したKnowledge Fact UI（「祭神・由緒」セクション）を、`apps/mobile/components/shrine/ShrineKnowledgeFactSection.tsx`へ責務分離する。**挙動変更ではない。** 目的は、将来のMobile Evidence Flow integration testを、Detail screen全体の大量mockなしで実施できる境界を作ること。

- `ShrineKnowledgeFactSection`: `ShrineFactViewModel`のみをpropsとして受け取る表示専用component。API fetch・`toShrine`・Evidence判定・Recommendation・Navigation・Analytics・Storage・Favorites・Authのいずれにも依存しない
- `apps/mobile/app/shrines/[id].tsx`: `buildShrineFactViewModel()`の結果を`<ShrineKnowledgeFactSection factViewModel={factViewModel} />`へ渡すだけの構造に変更。重複していたJSX・StyleSheetエントリ・`history_type`ラベル対応表・disputed文言定数を削除（screenは186行の純減）
- Legacy「神社について」・表示順・見出し文言・disputed文言・Fact本文・UI情報量はいずれも変更していない

## Manual QA

Expo web（375px幅）で、PR-M2と同一のfixtureを用いて以下を再検証し、**PR-M2と完全に同一の見た目**であることを確認した。QA用の一時コードは検証後に削除済み（PR diffには含まれない）。

- Knowledge Factあり／なし（0件時はセクション自体が非表示、Legacy「神社について」は影響を受けず表示される）
- 複数祭神・長い祭神名（disputed）の折り返し（`flexShrink`/`flexWrap`/`maxWidth`、PR-M2で修正した対策も維持）
- 複数History（disputed 2件）の個別表示
- Legacy「神社について」との共存

## 変更禁止事項の遵守

- `backend/` `apps/web/` `docs/`: 変更なし
- `package.json` / lockfile / vitest config / CI workflow: 変更なし
- Model / Migration / DB / API Schema / Recommendation / Evidence Gate / Navigation: 変更なし
- Legacy field削除・Source UI追加: なし
- 新規RN testing dependency: 追加していない
- UI挙動変更: なし（Manual QAで見た目の完全一致を確認）

## Test plan

- [x] `apps/mobile`: `npx vitest run` → 265 tests / 24 files 全PASS。既存`shrineKnowledgeFact.test.ts`（18 tests）は無変更のまま全PASS
- [x] `apps/mobile`: `npx tsc -p tsconfig.json --noEmit` → develop baselineと同一の6件（`ShrineSearchMap.native.tsx`、本PR範囲外の既存エラー）のみ。新規エラーなし
- [x] Manual QA（Expo web、375px幅）: full/disputed表示・複数祭神・長い祭神名折り返し・複数History・Knowledge Fact 0件時非表示・Legacy共存がPR-M2と同一であることを確認
- [x] `git diff --check` → 空白エラーなし
- [x] `git status --porcelain -- backend apps/web docs package.json pnpm-lock.yaml apps/mobile/package.json apps/mobile/vitest.config.ts .github/workflows/mobile-ci.yml` → 空（変更禁止対象への影響なし）
- [x] pre-push hook（OpenAPI lint / Web `test:contract` 731 tests）通過（Web側は無変更のため影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>