### PR TITLE
fix(security): production loggingから認証token・PII露出を除去(PR-S1)

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -59,11 +59,9 @@ export async function POST(req: NextRequest) {
   try {
     const upstreamPath = "/api/auth/jwt/create/";
 
-    console.log("[AUTH_LOGIN_UPSTREAM_REQUEST]", {
+    serverLog("debug", "AUTH_LOGIN_UPSTREAM_REQUEST", {
       requestId,
       upstreamPath,
-      username,
-      djangoOrigin: process.env.DJANGO_ORIGIN || process.env.BACKEND_ORIGIN || "http://127.0.0.1:8000",
     });
 
     const r = await djFetch(upstreamPath, {
@@ -79,11 +77,10 @@ export async function POST(req: NextRequest) {
     const contentType = r.headers.get("content-type") || "";
     const bodyText = await r.text();
 
-    console.log("[AUTH_LOGIN_UPSTREAM_RESPONSE]", {
+    serverLog("debug", "AUTH_LOGIN_UPSTREAM_RESPONSE", {
       requestId,
       status: r.status,
       contentType,
-      bodyText,
     });
 
     if (!r.ok) {
@@ -134,8 +131,6 @@ export async function POST(req: NextRequest) {
     });
     return res;
   } catch (e) {
-    console.log("[AUTH_LOGIN_ROUTE_FAILED]", e);
-
     serverLog("error", "AUTH_LOGIN_ROUTE_FAILED", {
       requestId,
       message: e instanceof Error ? e.message : String(e),

--- a/apps/web/src/lib/server/backend.ts
+++ b/apps/web/src/lib/server/backend.ts
@@ -132,9 +132,6 @@ export async function djFetch(
 
   const response = await fetch(url, finalInit);
 
-  const responseHeadersAny = response.headers as Headers & {
-    raw?: () => Record<string, string[]>;
-  };
   const responseSetCookies = readResponseSetCookies(response);
 
   console.log("[DJ_FETCH_RESPONSE]", {
@@ -143,14 +140,7 @@ export async function djFetch(
     status: response.status,
     contentType: response.headers.get("content-type"),
     setCookieCount: responseSetCookies.length,
-    setCookies: responseSetCookies,
     hasLocation: Boolean(response.headers.get("location")),
-  });
-
-  console.log("[DJ_FETCH_RESPONSE_HEADERS]", {
-    keys: Array.from(response.headers.keys()),
-    setCookie: response.headers.get("set-cookie"),
-    rawSetCookie: typeof responseHeadersAny.raw === "function" ? responseHeadersAny.raw()?.["set-cookie"] ?? null : null,
   });
 
   return response;

--- a/backend/temples/api/views/billing.py
+++ b/backend/temples/api/views/billing.py
@@ -51,7 +51,11 @@ class BillingStatusView(APIView):
 
     def get(self, request):
         st = get_billing_status(user=getattr(request, "user", None))
-        print("[BILLING_STATUS_AUTH]", request.user, getattr(request.user, "is_authenticated", None), getattr(request.user, "id", None), getattr(request.user, "email", None))
+        log.debug(
+            "[BILLING_STATUS_AUTH] authenticated=%s user_id=%s",
+            getattr(request.user, "is_authenticated", None),
+            getattr(request.user, "id", None),
+        )
         ser = BillingStatusSerializer(
             instance={
                 "plan": st.plan,


### PR DESCRIPTION
## Summary

Runtime/CI/Supply Chain Security Baseline Auditで検出した、production環境でも無条件に出力されていた認証token・Cookie生値・PIIのログ出力を除去する。

- `apps/web/src/app/api/auth/login/route.ts`: ログインレスポンス本文（access/refresh JWTを含む）とusernameを無条件`console.log`していた箇所を除去し、`serverLog("debug", ...)`（`DEBUG_LOG`環境変数が明示ONの時のみ発火、本番デフォルトでは発火しない）へ移行。requestId/upstreamPath/status/contentTypeのみ残す。catchブロック内の重複した生エラーログ（既に直後に構造化された`serverLog("error", ...)`があった）も削除。
- `apps/web/src/lib/server/backend.ts`: バックエンドfetchのたびにSet-Cookie生値を無条件`console.log`していた箇所を除去。cookieの有無を示す`setCookieCount`（既存）は維持し、生値専用の`[DJ_FETCH_RESPONSE_HEADERS]`ログは丸ごと削除。
- `backend/temples/api/views/billing.py`: `request.user.email`を含むbare `print()`を、既存の`logging.getLogger`（`log.debug(...)`、user_id/authenticated booleanのみ）へ置換。

Authentication挙動・Cookie発行ロジック・レスポンススキーマは変更していない。

## Test plan

- [x] `pnpm typecheck`（apps/web）— エラーなし
- [x] `pnpm test`（apps/web, Vitest）— 115 files / 731 tests 全PASS
- [x] `python -m pytest -m "not postgis and not gis and not slow"`（backend）— 982 passed, 1 skipped(GDAL未導入によりローカル限定), 13 deselected
- [x] `python -m pytest temples/tests/api/test_billing_status_contract.py`（billing.py対象の狙い撃ちテスト）— 6/6 PASS
- [x] `git diff --check` — 問題なし
- [x] pre-push hook（OpenAPI lint + Web契約テスト）— 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)