### PR TITLE
ci(backend): PR時にBackend unit testを実行する(S2.5)

### DIFF
--- a/.github/workflows/backend-pr.yml
+++ b/.github/workflows/backend-pr.yml
@@ -1,0 +1,24 @@
+name: backend-pr
+
+permissions:
+  contents: read
+on:
+  pull_request:
+    branches: [ develop ]
+    paths:
+      - 'backend/**'
+      - '.github/workflows/backend-pr.yml'
+      - '.github/workflows/backend-tests.yml'
+
+concurrency:
+  group: backend-pr-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  call:
+    uses: ./.github/workflows/backend-tests.yml
+    with:
+      mode: unit
+    secrets:
+      GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}
+      GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -229,16 +229,11 @@ jobs:
 
       - name: Show shrine.py around RankingAPIView
         run: |
-          python - <<'PY'
-          import inspect
-          import temples.api.views.shrine as m
-          print("shrine module file:", inspect.getsourcefile(m))
-          PY
           echo "---- grep RankingAPIView / Visit references ----"
           rg -n "class RankingAPIView|class PopularShrineListView|temples_visit|Visit" temples/api/views/shrine.py || true
           echo "---- shrine.py (first 220 lines, with line numbers) ----"
           nl -ba temples/api/views/shrine.py | sed -n '1,220p'
-      
+
       - name: Run pytest (unit, postgres nogis)
         env:
           PYTHONPATH: ${{ github.workspace }}/backend


### PR DESCRIPTION
## Summary

S2 Branch Protection監査でdevelopに保護を適用した際に判明した、「Backend変更を含むPRがmerge前に一切自動テストされていない」構造的ギャップを埋める。

現状:
- `backend-tests.yml`は`workflow_call`/`workflow_dispatch`のみで、`pull_request`/`push`トリガーを持たない
- `backend-integration.yml`は`push branches:[develop]`のみで、`pull_request`トリガーを持たない
- 結果: Backend変更PRはmerge前に一切自動テストされず、developへmerge後に初めて`backend-integration`（PostGIS込みintegration mode）で検証されていた

対応: `backend-integration.yml`と同じ薄いcaller workflowパターンで`backend-pr.yml`を新設し、既存の`backend-tests.yml`を`mode: unit`（postgres non-GIS、既存の`unit` job・pytestコマンドは無変更）で`pull_request`時に呼び出す。

- `backend-tests.yml` / `backend-integration.yml`の中身は無変更（test内容の再設計はしていない）
- merge後の`backend-integration`（PostGIS/GIS込み）はそのまま維持
- trigger: `pull_request branches:[develop] paths:[backend/**, .github/workflows/backend-pr.yml, .github/workflows/backend-tests.yml]`

## S2.5E: Diagnostic Step Fix

このPRの初回push時、`call / unit`（backend-tests.ymlの`unit` job）がGitHub Actions上で初めて実行され、以下の問題が順に発覚・解消された:

1. **GDAL top-level import**（`temples/queries.py`）→ [#2241](https://github.com/etsu33/jinja_app/pull/2241)で修正・マージ済み
2. **`migrations_nogis`の大規模drift**（9migration分未反映）→ [#2242](https://github.com/etsu33/jinja_app/pull/2242)で修正・マージ済み
3. **`test_shrine_knowledge_migration_does_not_touch_legacy_shrine_fields`のmigration番号ハードコード** → [#2243](https://github.com/etsu33/jinja_app/pull/2243)で修正・マージ済み
4. **本PRのdiagnostic stepでの`AppRegistryNotReady`**（今回のcommit `440f0909`で修正）: `"Show shrine.py around RankingAPIView"`ステップが`django.setup()`を呼ばずに`import temples.api.views.shrine`していたため発生。PR #618（無関係なfeature PR）由来の一度も実CIで検証されていないtroubleshooting用ログ出力で、CIの品質保証contractとしての役割は持たず、直後の`rg`/`nl`+`sed`（同じファイルパスを直接参照、Djangoロード不要）と内容が完全に重複していたため削除（Option A）。`rg`/`nl`+`sed`によるログ出力自体は維持。

**`call / unit`が本PRで初めてgreenになった。**

## Test plan

- [x] `actionlint`（新規/変更workflowファイル + 全workflow）— エラーなし
- [x] `git diff --check` — 問題なし
- [x] pre-push hook（OpenAPI lint + Web契約テスト）— 通過
- [x] **実GitHub Actions CI（本PR自身）**:
  - `analyze (javascript)` — PASS
  - `analyze (python)` — PASS
  - `review` — PASS
  - `call / recommendation-quality-audit` — PASS
  - `call / unit` — **PASS**（990 passed, 4 skipped in 27.23s。`makemigrations --check --dry-run` → `No changes detected`。GDAL未導入によりGIS依存2テストが既存のtry/except skip guardで正常にSKIP、クラッシュなし）
  - `call / integration` — skipping（`mode: unit`のため意図通り）
  - CodeQL / Vercel / Vercel Preview Comments — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)