### PR TITLE
fix(backend): temples/queriesのGIS importをGDAL不要な遅延importへ(S2.5A)

### DIFF
--- a/backend/temples/queries.py
+++ b/backend/temples/queries.py
@@ -4,8 +4,6 @@ from typing import List, Tuple
 
 from django.conf import settings
 from django.db import connection
-from django.contrib.gis.db.models.functions import Distance, Transform
-from django.contrib.gis.geos import Point
 from django.db.models import Case, FloatField, IntegerField, Value, When, F
 from django.db.models.expressions import RawSQL
 
@@ -47,6 +45,9 @@ def nearest_queryset(lon: float, lat: float):
         )
     # Spatialite (SQLite, GISあり) – <-> は使えない。Transform(4326→3857)して距離[m]で注釈
     if _use_real_gis() and connection.vendor == "sqlite":
+        from django.contrib.gis.db.models.functions import Distance, Transform
+        from django.contrib.gis.geos import Point
+
         p = Point(lon, lat, srid=4326)
         qs = Shrine.objects.filter(location__isnull=False).annotate(
             distance_m=Distance(Transform("location", 3857), Transform(p, 3857))
@@ -123,6 +124,9 @@ def nearest_shrines(lon: float, lat: float, limit: int = 20, radius_m: int | Non
 
     # Spatialite (SQLite, GISあり) – GeoDjangoの距離で[m]算出
     if _use_real_gis() and connection.vendor == "sqlite":
+        from django.contrib.gis.db.models.functions import Distance, Transform
+        from django.contrib.gis.geos import Point
+
         p = Point(lon, lat, srid=4326)
         qs = Shrine.objects.filter(location__isnull=False).annotate(
             d_m=Distance(Transform("location", 3857), Transform(p, 3857))

--- a/backend/temples/tests/test_queries_gis_import_guard.py
+++ b/backend/temples/tests/test_queries_gis_import_guard.py
@@ -1,0 +1,79 @@
+# backend/temples/tests/test_queries_gis_import_guard.py
+#
+# temples/queries.py は import 時点で GDAL を要求してはいけない
+# (USE_GIS=False の環境で `python manage.py makemigrations --check` や
+# urlconf のロードが GDAL 未導入のまま落ちていた実障害の再発防止)。
+import ast
+import inspect
+
+import pytest
+from django.db import connection
+
+from temples import queries as queries_module
+from temples.models import Shrine
+from temples.queries import nearest_queryset, nearest_shrines
+
+GIS_MODULE_PREFIX = "django.contrib.gis"
+
+
+def _module_ast() -> ast.Module:
+    source = inspect.getsource(queries_module)
+    return ast.parse(source, filename=queries_module.__file__)
+
+
+def test_queries_module_has_no_top_level_gis_import():
+    """temples.queries を import するだけでは GDAL を要求しない。"""
+    tree = _module_ast()
+    top_level_gis_imports = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module
+        and node.module.startswith(GIS_MODULE_PREFIX)
+    ]
+    assert top_level_gis_imports == []
+
+
+def test_gis_symbols_are_locally_imported_inside_real_gis_branches():
+    """Distance/Transform/Point は _use_real_gis() で分岐した関数内でのみ import される
+    （GIS有効時の挙動は維持しつつ、import自体は遅延させていることを保証する）。"""
+    tree = _module_ast()
+    function_defs = [node for node in tree.body if isinstance(node, ast.FunctionDef)]
+    assert {f.name for f in function_defs} >= {"nearest_queryset", "nearest_shrines"}
+
+    for func in function_defs:
+        if func.name not in {"nearest_queryset", "nearest_shrines"}:
+            continue
+        local_gis_imports = [
+            node
+            for node in ast.walk(func)
+            if isinstance(node, ast.ImportFrom)
+            and node.module
+            and node.module.startswith(GIS_MODULE_PREFIX)
+        ]
+        imported_names = {alias.name for node in local_gis_imports for alias in node.names}
+        assert {"Distance", "Transform", "Point"} <= imported_names, func.name
+
+
+@pytest.mark.django_db
+def test_non_gis_path_works_when_real_gis_is_disabled(settings):
+    """USE_GIS=False（DISABLE_GIS_FOR_TESTS相当）でも nearest_queryset/nearest_shrines は
+    Postgres非GIS(haversine)経路で正しく動く。"""
+    settings.USE_GIS = False
+    assert queries_module._use_real_gis() is False
+    assert connection.vendor == "postgresql"
+
+    shrine = Shrine.objects.create(
+        name_jp="Non-GIS経路テスト神社",
+        address="dummy",
+        latitude=35.0,
+        longitude=135.0,
+    )
+
+    qs = nearest_queryset(135.0, 35.0)
+    by_id = {row.id: row for row in qs}
+    assert shrine.id in by_id
+    assert float(by_id[shrine.id].d_m) < 1
+
+    limited = nearest_shrines(135.0, 35.0, limit=1)
+    assert list(limited.values_list("id", flat=True)) == [shrine.id]


### PR DESCRIPTION
## Summary

PR #2240（S2.5 Backend PR CI）で史上初めてGitHub Actions上で実行された`call / unit`（GDAL未導入のubuntu-24.04）が、以下で失敗することが判明した:

```
django.core.exceptions.ImproperlyConfigured: Could not find the GDAL library
  temples/queries.py:7: from django.contrib.gis.db.models.functions import Distance, Transform
```

`temples/queries.py`は`USE_GIS=False`/`DISABLE_GIS_FOR_TESTS=1`のとき実行時に非GIS(haversine)経路へフォールバックする設計だったが、`Distance`/`Transform`/`Point`のimportがmodule top-levelで無条件に行われており、**import文自体がGDALの存在を要求していた**（`_use_real_gis()`によるランタイム分岐より前に発生するため、フラグの値に関わらず失敗する）。

## Root Cause & Fix

- `Distance`/`Transform`/`Point`は実際には`if _use_real_gis() and connection.vendor == "sqlite":`でgateされた2箇所（`nearest_queryset`, `nearest_shrines`）でしか使われていない
- それぞれの分岐内でのみimportするよう変更（lazy import）。GIS有効時のロジック（PostGIS/Spatialite分岐）・PostGIS/haversineフォールバックのSQLは一切変更していない
- Backend production code変更はこの2箇所のimport位置の移動のみ。Recommendation/Score/API schemaへの影響なし

## Additional findings（今回は未修正、報告のみ）

repo全体で同種のtop-level GIS import箇所を確認した結果:

- `temples/llm/tools/db_search.py`: 同一パターンのtop-level import。ただし現状どこからもimportされていないdead code（`temples.llm.tools.orchestrator`自体が生きたimport元を持たない）であることを確認済み。今回は対象外。
- `temples/tests/test_gis_smoke.py`: `from django.contrib.gis import gdal`がtop-levelにあり（`USE_GIS`チェックより前）、`pytest.ini`の`testpaths`に含まれるため**今回のfixだけではPR #2240の`call / unit`がまだgreenにならない可能性がある**。別途判断が必要な追加の発見としてここに記録する。

## Test plan

- [x] 新規テスト3件追加（`temples/tests/test_queries_gis_import_guard.py`）
  - `test_queries_module_has_no_top_level_gis_import`: ASTで top-level GIS import が無いことを静的に保証
  - `test_gis_symbols_are_locally_imported_inside_real_gis_branches`: Distance/Transform/Pointが該当2関数内でlocal importされていることを保証
  - `test_non_gis_path_works_when_real_gis_is_disabled`: `USE_GIS=False`でも`nearest_queryset`/`nearest_shrines`がPostgres非GIS(haversine)経路で正しく動くことを確認
- [x] `pytest -m "not postgis and not gis and not slow"` — 985 passed（既存982 + 新規3）, 1 skipped, 13 deselected
- [x] 既存GIS関連test（`test_nearest.py` / `test_nearby_query.py` / `test_nearest_extra.py`）再実行 — postgisマーク3件はローカルのnon-PostGIS環境で通常通りskip、`test_nearest_extra.py`（非GIS経路）PASS
- [x] `python manage.py makemigrations --check --dry-run` — migration drift なし
- [x] `git diff --check` — 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)