### PR TITLE
test(backend): Shrine Knowledge Model Foundation契約testのmigration番号依存を除去(S2.5D)

### DIFF
--- a/backend/temples/tests/test_shrine_knowledge_migration.py
+++ b/backend/temples/tests/test_shrine_knowledge_migration.py
@@ -5,8 +5,23 @@ import io
 import pytest
 from django.core.management import call_command
 from django.db import connection
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.state import ProjectState
 
 from temples.models import ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+
+# Knowledge Model Foundation（PR #2221）が導入した3モデル。
+KNOWLEDGE_MODEL_NAMES = {"ShrineKnowledgeSource", "ShrineHistory", "ShrineDeity"}
+
+# Knowledge Model導入によって型/DB semantics/validation semanticsが変わってはならない
+# 既存Shrineのlegacy fields。
+LEGACY_SHRINE_FIELDS = ("sajin", "description")
+
+# legacy fieldのfield定義差分として許容するkwargs。help_textはDB column/validationに
+# 影響しないDjango側の表示用メタデータのみのため、変更を許容する。
+_METADATA_ONLY_ALLOWED_KEYS = {"help_text"}
+
+_MISSING = object()
 
 
 def test_makemigrations_check_reports_no_pending_changes():
@@ -37,17 +52,104 @@ def test_shrine_knowledge_tables_exist_after_migration():
     assert ShrineKnowledgeSource._meta.db_table in table_names
 
 
+def _find_knowledge_migrations(loader: MigrationLoader) -> set[tuple[str, str]]:
+    """現在有効なtemples migration graph（GIS/NoGISいずれか）から、KNOWLEDGE_MODEL_NAMESの
+    いずれかをCreateModelするmigrationを動的に特定する。migration番号はハードコードしない。"""
+    migrations_by_created_model: dict[str, set[tuple[str, str]]] = {}
+    for key, migration in loader.disk_migrations.items():
+        if key[0] != "temples":
+            continue
+        for op in migration.operations:
+            if type(op).__name__ == "CreateModel" and op.name in KNOWLEDGE_MODEL_NAMES:
+                migrations_by_created_model.setdefault(op.name, set()).add(key)
+
+    missing = KNOWLEDGE_MODEL_NAMES - set(migrations_by_created_model)
+    assert not missing, f"CreateModelするmigrationが見つからないKnowledge Model: {missing}"
+
+    knowledge_keys: set[tuple[str, str]] = set()
+    for keys in migrations_by_created_model.values():
+        knowledge_keys |= keys
+    return knowledge_keys
+
+
+def _project_state_before(loader: MigrationLoader, key: tuple[str, str]) -> ProjectState:
+    """指定migration key適用前のProjectStateを、依存グラフを辿って再構築する。"""
+    plan = loader.graph.forwards_plan(key)
+    assert plan[-1] == key
+    state = ProjectState()
+    for ancestor_key in plan[:-1]:
+        # preserve=False: 逐次mutateして良い（このループ内でのみ使う使い捨てstate）
+        state = loader.disk_migrations[ancestor_key].mutate_state(state, preserve=False)
+    return state
+
+
+def _field_diff_keys(before: tuple, after: tuple) -> set[str] | None:
+    """2つのfield.deconstruct()結果を比較する。field class・位置引数が異なる場合はNoneを返す
+    （呼び出し側で無条件failとして扱う）。それ以外は、値が異なるkwargキーの集合を返す。"""
+    _, path_before, args_before, kwargs_before = before
+    _, path_after, args_after, kwargs_after = after
+    if path_before != path_after or args_before != args_after:
+        return None
+    all_keys = set(kwargs_before) | set(kwargs_after)
+    return {k for k in all_keys if kwargs_before.get(k, _MISSING) != kwargs_after.get(k, _MISSING)}
+
+
 @pytest.mark.django_db
-def test_shrine_knowledge_migration_does_not_touch_legacy_shrine_fields():
-    """Migration 0093はCreateModelのみで、既存Shrine.sajin/descriptionへのField変更・Data Migrationを含まない。"""
-    from django.db.migrations.loader import MigrationLoader
+def test_shrine_knowledge_model_foundation_does_not_touch_legacy_shrine_fields():
+    """Knowledge Model Foundation（ShrineDeity/ShrineHistory/ShrineKnowledgeSource追加）を導入した
+    migrationが、既存Shrineのlegacy fields(sajin/description)の型・DB semantics・validation
+    semanticsを変更していないことを保証する。
 
+    GIS環境とNoGIS環境（catch-up migrationへ統合済み）とでmigration番号・構成が異なるため、
+    migration番号をハードコードせず、CreateModelの対象からmigrationを動的に解決する。
+    「対象migrationがCreateModelのみで構成される」ことは要求しない（NoGIS側のcatch-up
+    migrationは他の変更も含む squashed migrationのため）。代わりに、migration適用前後の
+    ProjectStateを比較し、legacy fieldの実際の定義差分を検証する。help_textのみの差分は
+    （DB column/validationに影響しないDjango側の表示用メタデータのため）許容するが、
+    field class・null・blank・default等の変更やfield自体の消失/リネームは許容しない。
+    """
     loader = MigrationLoader(connection, ignore_no_migrations=True)
-    key = ("temples", "0093_shrine_knowledge_model_foundation")
-    migration = loader.disk_migrations[key]
+    knowledge_keys = _find_knowledge_migrations(loader)
 
-    operation_types = {type(op).__name__ for op in migration.operations}
-    assert operation_types == {"CreateModel"}
+    for key in knowledge_keys:
+        migration = loader.disk_migrations[key]
 
-    affected_models = {op.name for op in migration.operations}
-    assert affected_models == {"ShrineKnowledgeSource", "ShrineHistory", "ShrineDeity"}
+        # Data Operationの安全性は静的には証明できないため、存在自体を禁止する。
+        operation_types = {type(op).__name__ for op in migration.operations}
+        forbidden_data_ops = operation_types & {"RunPython", "RunSQL"}
+        assert not forbidden_data_ops, (
+            f"{key}: Knowledge Model migrationにRunPython/RunSQLが含まれている。"
+            f"legacy fieldsへの影響を安全に検証できないため許容しない: {forbidden_data_ops}"
+        )
+
+        state_before = _project_state_before(loader, key)
+        shrine_before = state_before.models[("temples", "shrine")]
+
+        state_after = migration.mutate_state(state_before, preserve=True)
+        shrine_after = state_after.models[("temples", "shrine")]
+
+        for field_name in LEGACY_SHRINE_FIELDS:
+            try:
+                field_before = shrine_before.get_field(field_name)
+            except KeyError:
+                pytest.fail(f"{key}: legacy field '{field_name}' がmigration適用前に存在しない")
+            try:
+                field_after = shrine_after.get_field(field_name)
+            except KeyError:
+                pytest.fail(
+                    f"{key}: legacy field '{field_name}' がmigration適用後に消失している"
+                    "（RemoveField/RenameField相当の変更）"
+                )
+
+            diff_keys = _field_diff_keys(field_before.deconstruct(), field_after.deconstruct())
+            if diff_keys is None:
+                pytest.fail(
+                    f"{key}: legacy field '{field_name}' のfield classまたは位置引数が変更されている "
+                    f"(before={field_before.deconstruct()}, after={field_after.deconstruct()})"
+                )
+
+            disallowed_diff = diff_keys - _METADATA_ONLY_ALLOWED_KEYS
+            assert not disallowed_diff, (
+                f"{key}: legacy field '{field_name}' に許容外の変更がある: {disallowed_diff} "
+                f"(before={field_before.deconstruct()}, after={field_after.deconstruct()})"
+            )


### PR DESCRIPTION
## Summary

S2.5C（#2242）で見つかった、`test_shrine_knowledge_migration_does_not_touch_legacy_shrine_fields`のmigration番号ハードコード問題を、migration-level contractを維持したまま修正する（#2241・#2242はマージ済み、developへrebase済み。diffはこのファイルのみ）。

## A. Original Contract

Knowledge Model Foundation（PR #2221）が`ShrineKnowledgeSource`/`ShrineHistory`/`ShrineDeity`を導入した際、既存`Shrine`のlegacy fields（`sajin`/`description`）へ意図しないschema/data変更を加えていないことの保証。

## B. Previous Weakening

前回リビジョンではmigration historyへの依存を完全に捨て、`Shrine._meta.get_field(...)`による現在のmodel metadataのみを検証していた。これは「今のfield定義が期待通りか」は保証するが、「Knowledge Model導入migration自体がlegacy fieldsに触れていないか」という元々の**migration-level contract**を保証しなくなっていた。今回はこれを復元する。

## C. Dynamic Migration Resolution

`MigrationLoader`で現在有効なtemples migration graph（`settings.MIGRATION_MODULES`に応じてGIS/NoGISいずれか）を走査し、`ShrineKnowledgeSource`/`ShrineHistory`/`ShrineDeity`のいずれかを`CreateModel`するmigrationを動的に特定する（migration番号のハードコードなし）。GIS環境では`0093_shrine_knowledge_model_foundation`、NoGIS環境では`0008_actionevent_conciergehistory_and_more`が動的に解決されることを確認済み。

「対象migrationがCreateModelのみで構成される」ことは要求していない。NoGIS側の`0008`は他8migration分の変更も含むsquashed catch-up migrationであり、この要求は成立しない。

## D. Legacy Field Guarantee

対象migration適用前後の`ProjectState`を`Migration.mutate_state()`で再構築し、`Shrine.sajin`/`Shrine.description`の実際のfield定義（`deconstruct()`）をbefore/after比較する。

- GIS（`0093`）: before/after完全一致（差分なし）。
- NoGIS（`0008`）: `sajin`に`help_text`のみの差分を検出。**これはKnowledge Model Foundationとは無関係**であることを実証的に確認済み — `migrations_nogis/0001_initial.py`（2025-11、nogis自身の初回migration）が元々`help_text`を記録していなかったための、nogis自身の既存drift（catch-up migrationへ squash された結果、同じファイルに同居しているだけ）。`help_text`はDB column/validation semanticsに影響しないDjango側の表示用メタデータのため、この差分のみ許容する。`description`は差分なし。

field class変更・`null`/`blank`/`default`等の変更・field自体の消失（RemoveField/RenameField相当）は、diffキーが`help_text`以外を含む場合や`get_field()`が`KeyError`になる場合として無条件でfailする。**Negative controlとして`null=False`への変更を意図的に注入し、diff検出ロジックが正しく非許容差分として検出することを確認済み**（assertionが弱すぎて何でも通す状態になっていないことの実証）。

## E. Data Operation Guarantee

対象migration内の`RunPython`/`RunSQL`の存在を確認 — GIS(`0093`)・NoGIS(`0008`)いずれにも存在しない。存在した場合は安全に証明できないため無条件でfailするようテストに実装済み（今回はassertが通る=存在しないことを確認できた状態）。

## F. GIS Tests

`pytest temples/tests/test_shrine_knowledge_migration.py`（ローカル`.env.test`のデフォルト`USE_GIS=1`）: **3 passed**

## G. NoGIS Tests

`settings.USE_GIS == False` / `settings.USE_SQLITE == False` / `settings.MIGRATION_MODULES["temples"] == "temples.migrations_nogis"`を確認した上で同ファイルを実行（`.env.test`は一時退避）: **3 passed**

`pytest -m "not postgis and not gis and not slow"`（NoGIS full suite）: **985 passed, 0 failed, 13 deselected**

## H. Migration Drift

- GIS: `makemigrations --check --dry-run` → `No changes detected`
- NoGIS: `makemigrations --check --dry-run` → `No changes detected`

## I. Changed Files

`backend/temples/tests/test_shrine_knowledge_migration.py`のみ。

## J. Commit SHA

`e2baf7b907e9e88cd00a9b7a02fc7813533f73b5`

## K. Required Checks

`analyze (javascript)` / `analyze (python)` / `review` — 全てPASS確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)