### PR TITLE
fix(security): profile更新ログからJWTとPIIを除去(PR-S3A)

### DIFF
--- a/backend/users/tests/test_views_no_sensitive_logging.py
+++ b/backend/users/tests/test_views_no_sensitive_logging.py
@@ -1,0 +1,88 @@
+# backend/users/tests/test_views_no_sensitive_logging.py
+#
+# users/views.py (MeView.patch / MeIconUploadView.post) is not currently wired
+# into ROOT_URLCONF (shrine_project.urls) — it's only reachable via the unused
+# backend/config/urls.py. It is still exercised directly here (bypassing URL
+# routing) so a regression of the JWT/PII logging bug fixed in this file would
+# be caught even though no live HTTP route currently reaches this code.
+from __future__ import annotations
+
+import logging
+
+import pytest
+from rest_framework.parsers import FormParser, JSONParser, MultiPartParser
+from rest_framework.request import Request as DRFRequest
+from rest_framework.test import APIRequestFactory
+
+from tests.factories import UserFactory
+from users.models import UserProfile
+from users.views import MeIconUploadView, MeView
+
+SENTINEL_JWT = "eyJhbGciOiJIUzI1NiJ9.SENTINEL_PAYLOAD.SENTINEL_SIGNATURE"
+
+
+class _FakeToken:
+    """SimpleJWT's Token.__str__() signs and returns the raw JWT string.
+    This double reproduces that behavior so the test fails loudly if
+    request.auth is ever passed into a log call again."""
+
+    def __str__(self) -> str:
+        return SENTINEL_JWT
+
+
+def _drf_request(django_request, parsers):
+    request = DRFRequest(django_request, parsers=parsers)
+    request._user = django_request.user
+    request._auth = django_request.auth
+    return request
+
+
+@pytest.mark.django_db
+def test_me_view_patch_does_not_log_auth_token_or_username(caplog):
+    user = UserFactory(username="sensitive-username-should-not-log")
+    UserProfile.objects.get_or_create(user=user)
+
+    django_request = APIRequestFactory().patch(
+        "/users/me/", {"nickname": "NewNick"}, format="json"
+    )
+    django_request.user = user
+    django_request.auth = _FakeToken()
+    request = _drf_request(django_request, [JSONParser()])
+
+    view = MeView()
+    view.request = request
+    view.format_kwarg = None
+
+    with caplog.at_level(logging.INFO, logger="users.views"):
+        view.patch(request)
+
+    logged_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert SENTINEL_JWT not in logged_text
+    assert user.username not in logged_text
+
+
+@pytest.mark.django_db
+def test_me_icon_upload_view_does_not_log_raw_files_or_username(caplog):
+    from django.core.files.uploadedfile import SimpleUploadedFile
+
+    user = UserFactory(username="another-sensitive-username")
+    UserProfile.objects.get_or_create(user=user)
+
+    icon = SimpleUploadedFile("icon.png", b"fake-image-bytes", content_type="image/png")
+    django_request = APIRequestFactory().post(
+        "/users/me/icon/", {"icon": icon}, format="multipart"
+    )
+    django_request.user = user
+    django_request.auth = _FakeToken()
+    request = _drf_request(django_request, [MultiPartParser(), FormParser()])
+
+    view = MeIconUploadView()
+    view.request = request
+    view.format_kwarg = None
+
+    with caplog.at_level(logging.INFO, logger="users.views"):
+        view.post(request)
+
+    logged_text = "\n".join(record.getMessage() for record in caplog.records)
+    assert SENTINEL_JWT not in logged_text
+    assert user.username not in logged_text

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -33,10 +33,9 @@ class MeView(GenericAPIView):
 
     def patch(self, request, *args, **kwargs):
         log.info(
-            "[MeView.patch] is_authenticated=%s, user=%s, auth=%s",
+            "[MeView.patch] authenticated=%s user_id=%s",
             getattr(request.user, "is_authenticated", False),
-            getattr(request.user, "username", None),
-            request.auth,
+            getattr(request.user, "id", None),
         )
 
         # ★ ここも get_serializer を使う（context 付き）
@@ -46,9 +45,11 @@ class MeView(GenericAPIView):
 
         # ★ ログ・レスポンスも get_serializer を通す（context 付き）
         ser_after = self.get_serializer(user)
+        profile_data = ser_after.data.get("profile")
         log.info(
-            "[MeView.patch] updated profile: %s",
-            ser_after.data.get("profile"),
+            "[MeView.patch] profile updated user_id=%s field_count=%s",
+            getattr(user, "id", None),
+            len(profile_data) if isinstance(profile_data, dict) else None,
         )
         return Response(ser_after.data)
 
@@ -72,8 +73,11 @@ class MeIconUploadView(GenericAPIView):
     def post(self, request, *args, **kwargs):
         from django.utils.datastructures import MultiValueDict
 
-        # ★ 追加：FILES と POST をログ
-        log.info("[MeIconUploadView] FILES=%s, POST=%s", request.FILES, request.POST)
+        log.info(
+            "[MeIconUploadView] user_id=%s has_icon=%s",
+            getattr(request.user, "id", None),
+            "icon" in request.FILES,
+        )
 
         file = request.FILES.get("icon")
         if not file:
@@ -87,8 +91,8 @@ class MeIconUploadView(GenericAPIView):
         prof.save()
 
         log.info(
-            "[MeIconUploadView] uploaded icon for user=%s",
-            request.user.username,
+            "[MeIconUploadView] icon uploaded user_id=%s",
+            getattr(request.user, "id", None),
         )
 
         return Response(


### PR DESCRIPTION
## Summary

PR-S3 Security Auditで最重要指摘とされた`backend/users/views.py`のJWT/PIIログ問題を修正する。

## 重要な追加の発見（要確認）

**`backend/users/views.py`はROOT_URLCONF（`shrine_project.urls`）から到達不能であることを確認した。**

- `MeView`/`CurrentUserView`/`MeIconUploadView`を参照する`backend/users/urls.py`は`backend/config/urls.py`からのみincludeされている
- `backend/config/urls.py`はどの`DJANGO_SETTINGS_MODULE`（`shrine_project.settings` — `wsgi.py`/`manage.py`とも一致）からも参照されない、実際には使われていない設定ファイル
- 実際にactiveな`/api/users/me/`エンドポイントは`users/api/views.py::MeView`が処理しており、そちらには元々`request.auth`等のログ出力は一切存在しない（既に安全）
- アイコンアップロード機能もactiveなurls（`users/api/urls.py`）には登録されておらず、シリアライザ側でも`icon`は`read_only`

**つまり今回のfixはdead codeに対する修正であり、本番環境で現在進行形のJWT漏洩ではなかった。** Security Auditでの「🔴 Critical — 現在進行形」という評価は訂正が必要（実際には「到達不能コード中に存在」）。ただし修正自体は安全側の変更（regressionリスクなし）であり、将来`config/urls.py`が再度配線される可能性・dead codeとしての保守負債は残るため、そのまま維持する。

`backend/users/views.py`・`backend/users/urls.py`・`backend/config/`自体をdead codeとして削除するかどうかは、本PRのスコープ外の別判断として残す。

## Removed Sensitive Logs (A)

`MeView.patch`:
- `is_authenticated=%s, user=%s, auth=%s`（username + **署名済みJWT文字列そのもの**）→ 削除
- `updated profile: %s`（profile全フィールドの値）→ 削除

`MeIconUploadView.post`:
- `FILES=%s, POST=%s`（生dict dump）→ 削除
- `uploaded icon for user=%s`（username）→ 削除

## Remaining Safe Metadata (B)

`billing.py`と同じpatternへ統一:
- `authenticated: bool`
- `user_id`
- `field_count`（更新fieldの**値ではなく件数**のみ）
- `has_icon: bool`

## API Behavior Regression (C)

なし。Authentication・JWT発行/検証・Serializer・APIレスポンス・request body処理・permissionは一切変更していない。ログ出力内容のみの変更。

## Security Regression Search (D)

`request.auth` / `Authorization` / `access_token` / `refresh_token` / `request.data` / `request.POST` / `request.FILES`をrepo全体で検索。他ファイルでの同種の直接ログ出力は見つからなかった（`temples/api_views_concierge.py`の`request.auth = token`は代入のみで、隣接するログ出力はなし）。PR-S3監査で見つかった他ファイルの指摘（`temples/geocoding/client.py`等）は本PRでは対象外・未修正。

## Tests (E)

- 新規: `backend/users/tests/test_views_no_sensitive_logging.py`（2件）— `backend/users/views.py`がURLルーティングを経由せずには到達できない（=通常のAPI経由テストでは検証不能な）dead codeであるため、`MeView`/`MeIconUploadView`を直接呼び出してログ内容を検証。**修正前のコードに対して実行し、実際にJWTとusernameを検出してfailすることを確認済み**（negative control）。
- 既存`users/tests/`（`test_smoke_me.py`, `test_users_me_api.py` — active `users/api/views.py::MeView`を経由）: 8/8 PASS、無変更。
- `pytest -m "not postgis and not gis and not slow"`: **987 passed**（既存985 + 新規2）, 1 skipped, 13 deselected。
- `makemigrations --check --dry-run`: `No changes detected`。
- `git diff --check`: 問題なし。

## Test plan

- [x] Negative control（修正前のコードで新規testが実際にfailすることを確認）
- [x] 既存`users/tests/`全PASS
- [x] non-GIS full suite 987 passed
- [x] migration drift なし
- [x] `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)