### PR TITLE
fix(security): WebログからCookieと機微情報の露出を除去(PR-S3B)

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -89,7 +89,7 @@ export async function POST(req: NextRequest) {
         status: r.status,
         upstreamPath,
         contentType,
-        bodyPreview: bodyText.slice(0, 300),
+        bodyLength: bodyText.length,
       });
 
       return NextResponse.json(
@@ -106,7 +106,7 @@ export async function POST(req: NextRequest) {
         requestId,
         upstreamPath,
         contentType,
-        bodyPreview: bodyText.slice(0, 300),
+        bodyLength: bodyText.length,
       });
       return NextResponse.json({ detail: "upstream returned bad json" }, { status: 502 });
     }

--- a/apps/web/src/app/api/concierge-threads/[id]/route.ts
+++ b/apps/web/src/app/api/concierge-threads/[id]/route.ts
@@ -27,7 +27,6 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
   console.log("[BFF_THREAD_DETAIL_REQUEST]", {
     path: upstreamPath,
     hasCookieHeader: Boolean(req.headers.get("cookie")),
-    cookieHeader: req.headers.get("cookie"),
   });
 
   console.log("[BFF_THREAD_DETAIL_UPSTREAM]", {

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -679,7 +679,6 @@ export default function ConciergeSectionsRenderer({
                       title={title}
                       onClose={() => onAction?.({ type: "filter_close" })}
                       onApply={() => {
-                        console.log("RENDERER_FILTER_APPLY_ACTION", { canApplyCompatFilter, state });
                         onAction?.({ type: "filter_apply" });
                       }}
                       canApply={canApplyCompatFilter}

--- a/apps/web/src/features/concierge/hooks.ts
+++ b/apps/web/src/features/concierge/hooks.ts
@@ -380,7 +380,7 @@ export function useConciergeChat(threadId: string | null, options?: UseConcierge
         if (axios.isAxiosError(err)) {
           console.error("CONCIERGE_CHAT_ERROR", {
             status: err.response?.status,
-            data: err.response?.data,
+            hasData: Boolean(err.response?.data),
             message: err.message,
           });
           msg = `チャット送信に失敗しました (${err.response?.status ?? "network error"})`;

--- a/apps/web/src/lib/server/bffFetch.ts
+++ b/apps/web/src/lib/server/bffFetch.ts
@@ -176,7 +176,7 @@ export async function bffFetchWithAuthFromReq(
     contentType,
     hasSetCookie: Boolean(upstream.headers.get("set-cookie")),
     isJson: contentType?.includes("application/json") ?? false,
-    bodyPreview: text.slice(0, 1000),
+    responseLength: text.length,
   });
 
 


### PR DESCRIPTION
## Summary

PR-S3 Security Auditで発見した、Web productionコード5箇所のraw Cookie header・upstream response body・birthdateログ出力を安全化する。auth/Cookie forwarding/refresh挙動・API response・Analytics event contractは一切変更していない。

## A. Raw Cookie Fix

`apps/web/src/app/api/concierge-threads/[id]/route.ts` — `[BFF_THREAD_DETAIL_REQUEST]`の`cookieHeader: req.headers.get("cookie")`（access_token/refresh_token等を含む生Cookie文字列）を削除。`hasCookieHeader`（boolean）は維持。既存の`[BFF_THREAD_ROUTE_IN]`側で`hasAccessCookie`/`hasRefreshCookie`/`hasAnonCookie`が既に安全な形で出力済みのため、新たなpresence-only fieldは追加せず単純に危険な行を削除する方針を採った。

## B. Raw Body Fix

- `apps/web/src/lib/server/bffFetch.ts` — `[BFF_UPSTREAM]`の`bodyPreview: text.slice(0, 1000)` → `responseLength: text.length`
- `apps/web/src/app/api/auth/login/route.ts` — `AUTH_LOGIN_UPSTREAM_NOT_OK`・`AUTH_LOGIN_UPSTREAM_BAD_JSON`の`bodyPreview: bodyText.slice(0, 300)` → `bodyLength: bodyText.length`（2箇所）。クライアントへ返すJSON response本文（`upstreamBody`）はAPI応答の一部であり今回対象外・無変更。

## C. PII Fix

- `apps/web/src/features/concierge/hooks.ts` — `CONCIERGE_CHAT_ERROR`の`data: err.response?.data`（生error response body）→ `hasData: Boolean(err.response?.data)`
- `apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx` — `RENDERER_FILTER_APPLY_ACTION`（`state.birthdate`/`state.extraCondition`等を含む`state`全体をdump）を削除。直後の`onAction?.({ type: "filter_apply" })`呼び出しはそのまま維持。

## D. Remaining Safe Logs

`hasCookieHeader`/`hasAccessCookie`/`hasRefreshCookie`/`hasAnonCookie`（boolean）、`status`/`contentType`/`isJson`/`hasSetCookie`（既存のまま）、`responseLength`/`bodyLength`（文字数のみ）、`hasData`（boolean）、`requestId`/`upstreamPath`（既存のまま）。

## E. Auth/Cookie Regression

なし。`bffFetchWithAuthFromReq`のCookie/Authorization転送ロジック・pre-refresh/401リトライ・`access_token`/`refresh_token`のcookie set処理は一切変更していない。`login/route.ts`のcredential読み取り・JWT取得・cookie発行ロジックも無変更。

## F. Analytics Regression

なし。`IMPRESSION_EVENT`（console.log、安全なpayloadのため対象外）・`trackSearchEvent("concierge_result_impression"/"shrine_detail_transition", ...)`の実送信は無変更。`RENDERER_FILTER_APPLY_ACTION`のconsole.log削除後も、実際のaction dispatch（`onAction?.({ type: "filter_apply" })`）はそのまま残っており、Analytics event自体のtrigger timing/payloadに影響なし。

## G. Tests

- 既存test（`ConciergeSectionsRenderer.coverage/otherRecommendations/reasonV4Detail.test.tsx`, `auth/login/route.test.ts`, `concierge/chat/route.test.ts`）: **4 test files / 31 tests PASS**（`filter_apply`アサーションは`onAction`呼び出しに対するもので、削除したconsole.log出力には依存していないことを確認済み）
- `pnpm typecheck`: エラーなし
- `pnpm test`（full suite）: **115 files / 731 tests PASS**
- `pnpm test:contract`: **115 files / 731 tests PASS**（テスト出力上でも`[BFF_UPSTREAM]`が`responseLength: 58`を正しく出力していることを直接確認）

## H. Security Search

修正後、対象5ファイルを`bodyPreview`/`cookieHeader:`/`access_token`/`refresh_token`/`birthdate`で再検索。残存するのは全てCookie存在判定用の正規表現（`.test(cookieHeader)`、値そのものは出力しない）と、`birthdate`を扱う通常のbusiness logic（入力正規化・payload構築、`console.*`呼び出しの外）のみであることを確認。repo全体の再検索でも、対象5ファイル以外に同種のraw token/cookie/bodyログは新たに見つからなかった。

## Test plan

- [x] 既存test 4 files / 31 tests PASS
- [x] typecheck エラーなし
- [x] `pnpm test` 731 tests PASS
- [x] `pnpm test:contract` 731 tests PASS
- [x] 修正後のセキュリティ再検索でraw payload残存なし
- [x] `git diff --check` clean
- [x] `git diff --name-only origin/develop...HEAD` が想定5ファイルと一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)