### PR TITLE
fix(security): Backendログから相談本文と位置情報の露出を除去(PR-S3C)

### DIFF
--- a/backend/temples/api/views/search.py
+++ b/backend/temples/api/views/search.py
@@ -266,7 +266,10 @@ def nearby_search(request):
         try:
             data = GP.nearby_search_new(lat=lat, lng=lng, radius=radius, limit=limit, keyword=keyword)
         except Exception as e:
-            logger.warning("nearby_search_new failed; fallback to legacy attempts: %s", repr(e))
+            logger.warning(
+                "nearby_search_new failed; fallback to legacy attempts: error_type=%s",
+                type(e).__name__,
+            )
             data = None
 
     # ② data が無ければ legacy attempts
@@ -298,18 +301,20 @@ def nearby_search(request):
             except TypeError as e:
                 first_err = first_err or e
                 logger.info(
-                    "places.nearby_search TypeError (attempt skipped): %s kwargs=%s",
-                    repr(e),
-                    kwargs,
+                    "places.nearby_search TypeError (attempt skipped): error_type=%s kwarg_keys=%s",
+                    type(e).__name__,
+                    sorted(kwargs.keys()),
                 )
                 continue
 
             except RuntimeError as e:
+                # msgはGoogle Places APIのstatus/error_messageに由来し、
+                # lat/lng/keyword等のrequest paramsを含まないことを確認済み。
                 msg = str(e)
                 logger.exception(
-                    "places.nearby_search RuntimeError: msg=%s kwargs=%s",
+                    "places.nearby_search RuntimeError: msg=%s kwarg_keys=%s",
                     msg,
-                    kwargs,
+                    sorted(kwargs.keys()),
                 )
 
                 if "INVALID_REQUEST" in msg:
@@ -323,18 +328,20 @@ def nearby_search(request):
                 )
 
             except Exception as e:
+                # requestsの接続/タイムアウト系例外はURL全体（API key含む）を
+                # メッセージへ埋め込むため、repr(e)/str(e)はログへ含めない（実測確認済み）。
                 first_err = first_err or e
                 logger.warning(
-                    "places.nearby_search Exception (attempt continue): %s kwargs=%s",
-                    repr(e),
-                    kwargs,
+                    "places.nearby_search Exception (attempt continue): error_type=%s kwarg_keys=%s",
+                    type(e).__name__,
+                    sorted(kwargs.keys()),
                 )
                 continue
 
         if data is None:
             logger.exception(
-                "places.nearby_search のフォールバックを全て失敗しました: first_err=%s",
-                repr(first_err),
+                "places.nearby_search のフォールバックを全て失敗しました: first_err_type=%s",
+                type(first_err).__name__ if first_err else None,
             )
             return Response(
                 {"detail": "places.nearby_search は内部エラーのため失敗しました"},
@@ -426,7 +433,13 @@ def photo(request):
         blob, content_type, _ttl = places_photo(ref, maxwidth=mw)
     except PlacesError as e:
         # status が 500 でも、ここは upstream 依存なので 502 に寄せる
-        logger.info("places.photo failed: %s", str(e))
+        # PlacesErrorは内部でstr(requests例外)を包む場合があり、requestsの
+        # 接続/タイムアウト系例外はURL全体（API key含む）を埋め込みうるため
+        # str(e)はログへ含めない（実測確認済み）。
+        logger.info(
+            "places.photo failed: error_status=%s",
+            getattr(e, "status", None),
+        )
         return Response(
             {"detail": "places.photo failed"},
             status=getattr(e, "status", 502) or 502,

--- a/backend/temples/geocoding/client.py
+++ b/backend/temples/geocoding/client.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 import typing as t
 from dataclasses import dataclass
 
 import requests
+
+logger = logging.getLogger(__name__)
 
 ParamValue = t.Union[str, int, float]
 
@@ -53,9 +56,11 @@ def geocode_google_point(
     area = (area or "").strip()
     key = _google_maps_api_key()
     if not key or not area:
-        print(
-            "[geocode_google_point] skip",
-            {"has_key": bool(key), "area": area},
+        logger.info(
+            "[geocode_google_point] skip has_key=%s has_area=%s area_length=%d",
+            bool(key),
+            bool(area),
+            len(area),
         )
         return None
 
@@ -76,14 +81,12 @@ def geocode_google_point(
         status = payload.get("status")
         results = payload.get("results") or []
 
-        print(
-            "[geocode_google_point] response",
-            {
-                "area": area,
-                "status": status,
-                "result_count": len(results),
-                "error_message": payload.get("error_message"),
-            },
+        logger.info(
+            "[geocode_google_point] response area_length=%d status=%s result_count=%d error_message=%s",
+            len(area),
+            status,
+            len(results),
+            payload.get("error_message"),
         )
 
         if status in {
@@ -101,19 +104,18 @@ def geocode_google_point(
         loc = (results[0].get("geometry") or {}).get("location") or {}
         lat, lng = loc.get("lat"), loc.get("lng")
         if lat is None or lng is None:
-            print("[geocode_google_point] missing location", {"area": area})
+            logger.warning("[geocode_google_point] missing location area_length=%d", len(area))
             return None
 
         return float(lat), float(lng)
 
     except Exception as e:
-        print(
-            "[geocode_google_point] exception",
-            {
-                "area": area,
-                "type": type(e).__name__,
-                "message": str(e),
-            },
+        # str(e)は含めない: requestsの接続/タイムアウト系例外はURL全体
+        # （API key・address含む）をメッセージへ埋め込むため（実測確認済み）。
+        logger.warning(
+            "[geocode_google_point] exception area_length=%d type=%s",
+            len(area),
+            type(e).__name__,
         )
         return None
 

--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -637,12 +637,12 @@ def build_chat_recommendations(
     visit_style_tags = extra_tags["visit_style_tags"]
 
     log.info(
-        "[dbg] extra_tags resolved sort=%r soft=%r visit_style=%r raw_query=%r raw_extra=%r",
+        "[dbg] extra_tags resolved sort=%r soft=%r visit_style=%r has_query=%s has_extra=%s",
         sorted(sort_tags),
         sorted(soft_signal_tags),
         sorted(visit_style_tags),
-        query,
-        extra_condition,
+        bool(query),
+        bool(str(extra_condition or "").strip()),
     )
 
     observe_candidate_pool(
@@ -894,7 +894,7 @@ def build_chat_recommendations(
         pass
 
     if llm_error:
-        log.warning("[build_chat_recommendations] LLM error: %s", llm_error)
+        log.warning("[build_chat_recommendations] LLM error occurred has_error=%s", bool(llm_error))
 
     recs = _attach_astro_meta(
         recs,

--- a/backend/temples/services/google_places.py
+++ b/backend/temples/services/google_places.py
@@ -4,7 +4,6 @@ import os
 import sys
 import time
 from typing import Any, Dict, List, Optional, Tuple, cast
-import traceback
 import requests
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -93,9 +92,10 @@ class GooglePlacesClient:
 
         resp = requests.get(url, params=q, timeout=self.timeout)
 
-        # ログ（キーは伏字）
+        # ログ: query string全体（location/keyword等を含みうる）を落とし、
+        # base URLだけ残す（key伏字だけでは不十分なため）。
         try:
-            safe_url = resp.url.replace(self.api_key or "", "****")
+            safe_url = resp.url.split("?", 1)[0]
         except Exception:
             safe_url = "<masked>"
         logger.info("Places upstream[%s] %s", path, safe_url)
@@ -326,9 +326,9 @@ class GooglePlacesClient:
         params = self.build_photo_params(photo_reference, maxwidth=maxwidth, maxheight=maxheight)
         resp = requests.get(url, params=params, timeout=self.timeout, stream=True)
 
-        # マスクしてログ
+        # ログ: query string全体を落とし、base URLだけ残す（key伏字だけでは不十分なため）。
         try:
-            safe_url = resp.url.replace(self.api_key or "", "****")
+            safe_url = resp.url.split("?", 1)[0]
         except Exception:
             safe_url = "<masked>"
         logger.info("Places upstream[photo]: %s", safe_url)
@@ -355,11 +355,10 @@ _TIMEOUT = 10
 
 
 def _log_upstream(kind: str, url: str, params: dict) -> None:
-    masked = dict(params or {})
-    if "key" in masked:
-        masked["key"] = "****"
-    qs = "&".join(f"{k}={v}" for k, v in masked.items() if v is not None)
-    logger.info("Places upstream[%s] %s?%s", kind, url, qs)
+    # paramsにはquery/input/location等の生テキストが入りうるため、値ではなく
+    # keyの一覧のみ出す（keyだけmaskしてもquery/location等が残ってしまうため）。
+    param_keys = sorted((params or {}).keys())
+    logger.info("Places upstream[%s] %s param_keys=%s", kind, url, param_keys)
 
 
 def textsearch(
@@ -441,8 +440,6 @@ def findplacefromtext(
         "locationbias": locationbias,
         "fields": fields,
     }
-    logger.warning("findplacefromtext called\n%s", "".join(traceback.format_stack(limit=12)))
-
     _log_upstream("findplacefromtext", url, params)
     clean = {k: v for k, v in params.items() if v is not None}
     _push_req_history(url, clean)

--- a/backend/temples/tests/services/test_geocode_google_point_logging.py
+++ b/backend/temples/tests/services/test_geocode_google_point_logging.py
@@ -1,0 +1,78 @@
+# backend/temples/tests/services/test_geocode_google_point_logging.py
+#
+# geocode_google_point() previously used bare print() calls that logged the
+# raw user-entered area/address text, and on exceptions logged str(e) —
+# which for requests connection/timeout errors embeds the full request URL
+# including the Google Maps API key and address query param (verified
+# empirically against the real requests library). This guards against that
+# class of leak recurring.
+from __future__ import annotations
+
+import logging
+
+import pytest
+import requests
+
+from temples.geocoding.client import geocode_google_point
+
+FAKE_API_KEY = "FAKE_GOOGLE_MAPS_KEY_FOR_TEST"
+SENSITIVE_AREA = "東京都渋谷区_SENSITIVE_ADDRESS_MARKER"
+
+
+def _logged_text(caplog: pytest.LogCaptureFixture) -> str:
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+def test_geocode_google_point_does_not_log_area_or_key_on_connection_error(
+    monkeypatch, requests_mock, caplog
+):
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", FAKE_API_KEY)
+
+    # requests_mock's ConnectionError path reproduces the same exception shape
+    # (URL with query string embedded in str(e)) as a real network failure.
+    requests_mock.get(
+        "https://maps.googleapis.com/maps/api/geocode/json",
+        exc=requests.exceptions.ConnectionError(
+            f"Max retries exceeded with url: /maps/api/geocode/json?key={FAKE_API_KEY}&address={SENSITIVE_AREA}"
+        ),
+    )
+
+    with caplog.at_level(logging.INFO, logger="temples.geocoding.client"):
+        result = geocode_google_point(SENSITIVE_AREA)
+
+    assert result is None
+    logged = _logged_text(caplog)
+    assert FAKE_API_KEY not in logged
+    assert SENSITIVE_AREA not in logged
+
+
+def test_geocode_google_point_does_not_log_area_on_skip(monkeypatch, caplog):
+    # _google_maps_api_key() also falls back to django.conf.settings, which is
+    # resolved once at process start, so clearing env vars alone can't force
+    # the "no key" branch reliably here — patch the resolver directly instead.
+    monkeypatch.setattr("temples.geocoding.client._google_maps_api_key", lambda: None)
+
+    with caplog.at_level(logging.INFO, logger="temples.geocoding.client"):
+        result = geocode_google_point(SENSITIVE_AREA)
+
+    assert result is None
+    logged = _logged_text(caplog)
+    assert SENSITIVE_AREA not in logged
+
+
+def test_geocode_google_point_does_not_log_area_on_response(monkeypatch, requests_mock, caplog):
+    monkeypatch.setenv("GOOGLE_MAPS_API_KEY", FAKE_API_KEY)
+
+    requests_mock.get(
+        "https://maps.googleapis.com/maps/api/geocode/json",
+        json={"status": "OK", "results": [{"geometry": {"location": {"lat": 35.0, "lng": 139.0}}}]},
+        status_code=200,
+    )
+
+    with caplog.at_level(logging.INFO, logger="temples.geocoding.client"):
+        result = geocode_google_point(SENSITIVE_AREA)
+
+    assert result == (35.0, 139.0)
+    logged = _logged_text(caplog)
+    assert SENSITIVE_AREA not in logged
+    assert FAKE_API_KEY not in logged


### PR DESCRIPTION
## Summary

PR-S3監査で発見した、geocoding/concierge_chat/search/google_placesの4ファイルに残っていた住所・相談free-text・lat/lng/keyword・外部APIの生exception文字列のログ出力を安全化する。API/検索/Recommendation挙動は一切変更していない。

## A. Geocoding Logging

`geocode_google_point()`のbare `print()`（4箇所）をloggerへ移行し、raw `area`を全箇所で削除（`area_length`/`has_area`のみ残す）。exception捕捉では`str(e)`を一切ログへ含めない。

**実測確認**: `requests`の`ConnectionError`/`Timeout`が接続失敗時にrequest URL全体（API key・address含む）をメッセージへ埋め込むことをfake key/fake URLで再現確認済み（実API keyは未使用）:
```
str(e): HTTPSConnectionPool(...): Max retries exceeded with url: /maps/api/geocode/json?key=FAKE_API_KEY_12345&address=FAKE_SECRET_ADDRESS_TOKYO ...
```

## B. Concierge Logging

`extra_tags`解決ログの`raw_query`/`raw_extra`（相談free-text本文）を`has_query`/`has_extra`(bool)へ置換。既存の隣接ログ（`[dbg] need_tags ...`）が既に採用していた安全なpatternと統一。LLM errorログも生文字列から`has_error`(bool)へ縮小。

## C. Search Logging

`nearby_search`内3箇所の`kwargs`（`lat`/`lng`/`keyword`等）dumpを`kwarg_keys`（パラメータ名のみ）へ置換。`TypeError`/`Exception`の`repr(e)`を`type(e).__name__`へ置換（`RuntimeError`の`msg`はGoogle Places APIの`status`/`error_message`由来でrequest paramsを含まないことをソース追跡で確認済みのため維持）。`nearby_search_new`失敗時の`repr(e)`、`places.photo`失敗時の`str(e)`（`PlacesError`が内部で`requests`例外の`str()`を包む場合があり、実際に`photo`リクエストのquery paramsにAPI keyが含まれることを確認済み）も同様に安全化。

## D. Google Places Logging

`safe_url`構築（2箇所）を「API keyのみmask」から「query string全体を除去してbase URLのみ残す」へ変更 — location/keywordがkey以外の部分に平文で残っていたため。`_log_upstream`の`params` dumpも値ではなく`param_keys`のみへ。`findplacefromtext`呼び出しごとに12フレームのstack traceを**成功時も含めて毎回**warningへ出していた箇所を削除（運用価値なし、未使用となった`traceback`importも削除）。

## E. External Exception Safety

- `requests`（`ConnectionError`/`Timeout`、GET・POST両方）: URLにAPI key/位置情報が埋め込まれることを実測確認。
- `openai` SDK: 同様の手法で`APIConnectionError`を再現したところ、メッセージは`"Connection error."`のみで、fake API key/promptマーカーいずれも含まれないことを確認（`requests`ベースの例外より本質的に安全）。ただし`AuthenticationError`等の他の例外型は未検証。

## F. Remaining Operational Metadata

`has_key`/`has_area`/`area_length`/`has_query`/`has_extra`/`has_error`(bool)、`status`/`result_count`/`error_message`（Google自身のstatus/error_message field）、`kwarg_keys`/`param_keys`（パラメータ名一覧）、`type(e).__name__`/`error_type`、`error_status`（`PlacesError.status`）。

## G. API Behavior Regression

なし。Google Places API呼び出し内容・geocoding処理・search result logic・retry policy・timeout・`RuntimeError`のcontrol flow（`"INVALID_REQUEST" in msg`判定）は一切変更していない。

## H. Tests

- 新規: `backend/temples/tests/services/test_geocode_google_point_logging.py`（3件、`geocode_google_point`に既存test coverageが無かったため追加）。**Negative control済み**: 修正後コードへ意図的にraw `area`を再導入（`print`→`logger`変換自体は維持したまま）した状態でテストが正しくfailすることを確認。
- targeted tests（concierge_chat / search / places関連）: **49 + 9 = 58 tests PASS**
- `pytest -m "not postgis and not gis and not slow"`（full suite）: **990 passed**（既存987 + 新規3）, 1 skipped, 13 deselected

## I. Migration Drift

GIS: `No changes detected`
NoGIS（`USE_GIS=0`/`DISABLE_GIS_FOR_TESTS=1`/`USE_SQLITE=0`）: `No changes detected`

## J. Security Search

修正後、4ファイルを`kwargs`/`params`/`repr(e)`/`str(e)`/raw `query`/`extra_condition`/`address`/`area`/`latitude`/`longitude`で再検索。残存する該当語は全て実際のAPIリクエスト構築（`params={"address": area, ...}`等、ログではない）または`**kwargs`のfunction signature転送のみであることを確認。repo全体の再検索でも、対象4ファイル以外に同種risk（`kwargs`/`params`のraw dump、`repr(e)`/`str(e)`のraw exception）は新たに見つからなかった。

## Test plan

- [x] targeted tests 58件 PASS（negative control含む）
- [x] full non-GIS suite 990 passed
- [x] migration drift なし（GIS/NoGIS両方）
- [x] `git diff --check` clean
- [x] `git diff --name-only origin/develop...HEAD`が想定4ファイル+新規testファイルと一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)