### PR TITLE
ci(backend): CI Postgresテストパスワードのハードコード除去とdiagnostic整理(PR-S3F)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -122,8 +122,13 @@ jobs:
       - name: Generate per-run test DB password
         id: gen
         run: |
+          # ::add-mask::はここでは登録しない: GitHub Actionsはmask登録済みの
+          # 値をjob outputへ設定しようとすると "Skip output ... since it may
+          # contain secret" として出力自体を落とすため(実測で確認)。
+          # この値はここでは一切echo/printされずGITHUB_OUTPUTへ書き込まれる
+          # だけなので、mask未登録でもこのjobのログには出力されない。
+          # 参照する側の各jobで individually ::add-mask:: を登録する。
           PG_PASSWORD="$(openssl rand -hex 24)"
-          echo "::add-mask::$PG_PASSWORD"
           echo "pg_password=$PG_PASSWORD" >> "$GITHUB_OUTPUT"
 
   unit:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -113,8 +113,22 @@ jobs:
           path: logs/recommendation_quality_audit.json
           if-no-files-found: ignore
 
+  setup-db-credentials:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      pg_password: ${{ steps.gen.outputs.pg_password }}
+    steps:
+      - name: Generate per-run test DB password
+        id: gen
+        run: |
+          PG_PASSWORD="$(openssl rand -hex 24)"
+          echo "::add-mask::$PG_PASSWORD"
+          echo "pg_password=$PG_PASSWORD" >> "$GITHUB_OUTPUT"
+
   unit:
     if: ${{ inputs.mode != 'integration' }}
+    needs: setup-db-credentials
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     concurrency:
@@ -126,7 +140,7 @@ jobs:
         env:
           POSTGRES_DB: jinja_db
           POSTGRES_USER: admin
-          POSTGRES_PASSWORD: jdb50515
+          POSTGRES_PASSWORD: ${{ needs.setup-db-credentials.outputs.pg_password }}
         ports: ["5432:5432"]
         options: >-
           --health-cmd "pg_isready -U admin -d jinja_db"
@@ -142,7 +156,7 @@ jobs:
       DISABLE_GIS_FOR_TESTS: "1"
       USE_SQLITE: "0"
       USE_GIS: "0"
-      DATABASE_URL: postgres://admin:jdb50515@localhost:5432/jinja_db
+      DATABASE_URL: postgres://admin:${{ needs.setup-db-credentials.outputs.pg_password }}@localhost:5432/jinja_db
 
       CONCIERGE_USE_LLM: "1"
       AUTO_GEOCODE_ON_SAVE: "0"
@@ -156,15 +170,10 @@ jobs:
       run:
         working-directory: ./backend
     steps:
-      - uses: actions/checkout@v7
+      - name: Register DB password mask
+        run: echo "::add-mask::${{ needs.setup-db-credentials.outputs.pg_password }}"
 
-      - name: Show git ref & SHA
-        run: |
-          echo "GITHUB_REF=$GITHUB_REF"
-          echo "GITHUB_SHA=$GITHUB_SHA"
-          git status --porcelain=v1 || true
-          git rev-parse HEAD
-          git log -1 --oneline
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
@@ -178,7 +187,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt -r requirements-dev.txt
-      
+
       - name: Show concierge LLM flag
         run: |
           python - <<'PY'
@@ -190,21 +199,6 @@ jobs:
           print("ENV USE_LLM_CONCIERGE =", os.getenv("USE_LLM_CONCIERGE"))
           print("settings.CONCIERGE_USE_LLM =", getattr(settings, "CONCIERGE_USE_LLM", None))
           print("settings.USE_LLM_CONCIERGE =", getattr(settings, "USE_LLM_CONCIERGE", None))
-          PY
-
-      - name: Show import path & locate temples
-        shell: bash
-        run: |
-          python - <<'PY'
-          import sys, importlib
-          print("=== sys.path ===")
-          print("\n".join(sys.path))
-          print("=== try import temples ===")
-          try:
-              m = importlib.import_module("temples")
-              print("temples OK:", m, getattr(m, "__file__", None))
-          except Exception as e:
-              print("temples NG:", repr(e))
           PY
 
       - name: Wait for DB
@@ -227,13 +221,6 @@ jobs:
         working-directory: backend
         run: python manage.py migrate --plan
 
-      - name: Show shrine.py around RankingAPIView
-        run: |
-          echo "---- grep RankingAPIView / Visit references ----"
-          rg -n "class RankingAPIView|class PopularShrineListView|temples_visit|Visit" temples/api/views/shrine.py || true
-          echo "---- shrine.py (first 220 lines, with line numbers) ----"
-          nl -ba temples/api/views/shrine.py | sed -n '1,220p'
-
       - name: Run pytest (unit, postgres nogis)
         env:
           PYTHONPATH: ${{ github.workspace }}/backend
@@ -250,6 +237,7 @@ jobs:
 
   integration:
     if: ${{ inputs.mode == 'integration' }}
+    needs: setup-db-credentials
     runs-on: ubuntu-24.04
     timeout-minutes: 40
     concurrency:
@@ -261,7 +249,7 @@ jobs:
         env:
           POSTGRES_DB: jinja_db
           POSTGRES_USER: admin
-          POSTGRES_PASSWORD: jdb50515
+          POSTGRES_PASSWORD: ${{ needs.setup-db-credentials.outputs.pg_password }}
         ports: ["5432:5432"]
         options: >-
           --health-cmd "pg_isready -U admin -d jinja_db"
@@ -278,7 +266,7 @@ jobs:
       USE_GIS: "1"
       CONCIERGE_USE_LLM: "1"
       AUTO_GEOCODE_ON_SAVE: "0"
-      DATABASE_URL: postgis://admin:jdb50515@localhost:5432/jinja_db
+      DATABASE_URL: postgis://admin:${{ needs.setup-db-credentials.outputs.pg_password }}@localhost:5432/jinja_db
       CONCIERGE_THROTTLE: ${{ inputs.concierge_throttle || github.event.inputs.concierge_throttle || '1000/min' }}
       GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY || 'dummy' }}
       GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY || 'dummy' }}
@@ -289,15 +277,10 @@ jobs:
       run:
         working-directory: ./backend
     steps:
+      - name: Register DB password mask
+        run: echo "::add-mask::${{ needs.setup-db-credentials.outputs.pg_password }}"
+
       - uses: actions/checkout@v7
-
-      - name: Show git ref & SHA
-        run: |
-          echo "GITHUB_REF=$GITHUB_REF"
-          echo "GITHUB_SHA=$GITHUB_SHA"
-          git rev-parse HEAD
-          git log -1 --oneline
-
 
       - uses: actions/setup-python@v7
         with:
@@ -355,20 +338,6 @@ jobs:
           done
           pg_isready -h localhost -p 5432 -U admin -d jinja_db
 
-      - name: Show import path & locate temples
-        run: |
-          python - <<'PY'
-          import sys, importlib
-          print("=== sys.path ===")
-          print("\n".join(sys.path))
-          print("=== try import temples ===")
-          try:
-              m = importlib.import_module("temples")
-              print("temples OK:", m, getattr(m, "__file__", None))
-          except Exception as e:
-              print("temples NG:", repr(e))
-          PY
-
       # ★ Django を触るのは BLAS 導入 “後”
       - name: Show effective settings flags
         run: |
@@ -399,20 +368,6 @@ jobs:
         working-directory: backend
         run: python manage.py migrate --plan
 
-      - name: Show shrine.py around RankingAPIView
-        if: failure()
-        run: |
-          python - <<'PY'
-          import inspect
-          import temples.api.views.shrine as m
-          print("shrine module file:", inspect.getsourcefile(m))
-          PY
-          echo "---- grep RankingAPIView / Visit references ----"
-          rg -n "class RankingAPIView|class PopularShrineListView|temples_visit|Visit" temples/api/views/shrine.py || true
-          echo "---- shrine.py (first 220 lines, with line numbers) ----"
-          nl -ba temples/api/views/shrine.py | sed -n '1,220p'
-      
-      
       - name: Run pytest (integration, postgis)
         env:
           PYTHONPATH: ${{ github.workspace }}/backend

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -175,10 +175,10 @@ jobs:
       run:
         working-directory: ./backend
     steps:
+      - uses: actions/checkout@v7
+
       - name: Register DB password mask
         run: echo "::add-mask::${{ needs.setup-db-credentials.outputs.pg_password }}"
-
-      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:
@@ -282,10 +282,10 @@ jobs:
       run:
         working-directory: ./backend
     steps:
+      - uses: actions/checkout@v7
+
       - name: Register DB password mask
         run: echo "::add-mask::${{ needs.setup-db-credentials.outputs.pg_password }}"
-
-      - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -178,7 +178,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Register DB password mask
-        run: echo "::add-mask::${{ needs.setup-db-credentials.outputs.pg_password }}"
+        env:
+          PG_PASSWORD: ${{ needs.setup-db-credentials.outputs.pg_password }}
+        run: echo "::add-mask::$PG_PASSWORD"
 
       - uses: actions/setup-python@v7
         with:
@@ -285,7 +287,9 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Register DB password mask
-        run: echo "::add-mask::${{ needs.setup-db-credentials.outputs.pg_password }}"
+        env:
+          PG_PASSWORD: ${{ needs.setup-db-credentials.outputs.pg_password }}
+        run: echo "::add-mask::$PG_PASSWORD"
 
       - uses: actions/setup-python@v7
         with:


### PR DESCRIPTION
## 目的

Backend CIの`.github/workflows/backend-tests.yml`に残っていた、CI専用
Postgres service containerのplaintext test DB password
(`POSTGRES_PASSWORD: jdb50515`、unit/integration双方でPOSTGRES_PASSWORD
とDATABASE_URLに計4箇所ハードコード)を除去し、あわせて過去のdebug由来
diagnostic stepのうち不要なものを削除する。CI test behaviorは変更しない。

本番DB credentialは対象外。CI専用Postgres service containerのtest
credentialのみを扱う。

## Password戦略

- **Option A (Repository Secret)**: 不採用。本リポジトリはPUBLIC repoで
  あり、`backend-pr.yml`は`pull_request`トリガー(`pull_request_target`
  ではない)のため、GitHub Actionsの仕様上fork PRにはsecretsが渡らない
  (既存の`GOOGLE_MAPS_API_KEY`/`GOOGLE_PLACES_API_KEY`が
  `|| 'dummy'`でfallbackしているのと同じ制約)。
- **Option B (per-run生成) — 採用**: 前段の`setup-db-credentials` jobで
  `openssl rand`によりrandom passwordを生成し、`needs.<job>.outputs`
  経由でunit/integration双方の`services.postgres.env`と`DATABASE_URL`へ
  同一値を渡す。Repository Secret新設不要で、fork PR/`workflow_dispatch`/
  `pull_request`いずれでも同一に動作する。
- **Option C (固定値+add-mask)**: 不採用。

## 既知の残存事項(実CIで確認・完全解消は不可)

実際に3回CIを走らせて検証した結果、以下2箇所で生成したpasswordの値が
平文でログに出ることを確認した(値はrun毎に異なる使い捨て値。恒久的な
git履歴上の値ではない):

1. `docker create`システムコマンド行(service container起動、jobの
   最初のstepより前に発生。`::add-mask::`はstep実行後にしか効かない
   ため原理的に間に合わない)
2. mask登録stepの`env:`プリアンブル表示(値をstepへ渡す時点で
   GitHub側が自動的にそのstepの`env:`一覧へ表示するため。登録後は
   後続の全step・pip install・pytest出力では一切出現しないことを
   実測で確認済み)

これは`needs.job.outputs`由来の値全般に共通するGitHub Actionsの構造的
制約であり、`secrets:`コンテキスト由来の値のみがこの種のシステム生成
ログ行でも自動マスク対象になる。この残存露出を完全に閉じるには
Repository Secret新設(Option A、fork PR制約とのトレードオフあり)が
必要。詳細はPRコメント/レポート参照。

## Diagnostic整理

**REMOVE**: `Show git ref & SHA` / `Show import path & locate temples` /
`Show shrine.py around RankingAPIView`(unit: 無条件実行のまま残存して
いた。integration: `if: failure()`付きだが`pytest`実行より前に配置され
実質発火しない上、同じ`django.setup()`なしimportバグも未修正のまま
残存していた)

**KEEP**: `Show concierge LLM flag` / `Show effective settings flags` /
`Show migrate plan` / `Show DB container logs (always)` / `Echo throttle`

## 変更していないもの

backend application code / migrations / tests / Web / Mobile /
branch protection / production secrets / Render・Vercel・EAS secrets。
`backend-pr.yml`/`backend-integration.yml`は未変更。

## 実CI検証

- `call / unit`: pass（最終run 1m22s）
- `call / integration`: workflow_dispatchで実測、pass（1m37s）
- 3回のCI実行を通じて2つの構造的バグ(job output maskによるskip、
  step設定順序、inline式展開によるecho漏れ)を発見・修正

## Changed Files

- `.github/workflows/backend-tests.yml`

PR作成後停止。マージしない。