### PR TITLE
PR-S3D: Debug Marker Cleanup

### DIFF
--- a/apps/web/src/app/api/concierge-threads/[id]/route.ts
+++ b/apps/web/src/app/api/concierge-threads/[id]/route.ts
@@ -24,15 +24,6 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string 
     hasRefreshCookie,
   });
 
-  console.log("[BFF_THREAD_DETAIL_REQUEST]", {
-    path: upstreamPath,
-    hasCookieHeader: Boolean(req.headers.get("cookie")),
-  });
-
-  console.log("[BFF_THREAD_DETAIL_UPSTREAM]", {
-    upstreamPath,
-  });
-
   return bffFetchWithAuthFromReq(req, upstreamPath, {
     method: "GET",
     headers: { Accept: "application/json" },

--- a/apps/web/src/app/api/concierge/chat/route.ts
+++ b/apps/web/src/app/api/concierge/chat/route.ts
@@ -105,9 +105,6 @@ export async function POST(req: NextRequest) {
   const doChat = (accessToken: string | null) => {
     const upstreamUrl = "/api/concierge/chat/";
 
-    console.log("🔥 BFF → backend 投げる直前 🔥");
-    console.log("🔥 BFF → backend URL", upstreamUrl);
-
     return djFetch(req, upstreamUrl, {
       method: "POST",
       headers: {

--- a/apps/web/src/app/api/my/goshuins/route.ts
+++ b/apps/web/src/app/api/my/goshuins/route.ts
@@ -41,7 +41,6 @@ export async function POST(req: NextRequest) {
   }
 
   out.append("image", new Blob([new Uint8Array(jpegBuf)], { type: "image/jpeg" }), "upload.jpg");
-  console.log("[BFF] outbound image:", "image/jpeg", "upload.jpg", jpegBuf.length);
 
   return bffFetchWithAuthFromReq(req, "/api/my/goshuins/", {
     method: "POST",

--- a/apps/web/src/app/media/[...path]/route.ts
+++ b/apps/web/src/app/media/[...path]/route.ts
@@ -13,7 +13,6 @@ export async function HEAD(req: NextRequest, ctx: { params: Promise<{ path: stri
 
 
 export async function GET(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
-  console.log("[media route] HIT", req.nextUrl.pathname);
   const { path } = await ctx.params;
 
   // パスは一応エスケープ（変な文字や ../ 対策）

--- a/apps/web/src/app/providers/ClientBootstrap.tsx
+++ b/apps/web/src/app/providers/ClientBootstrap.tsx
@@ -7,12 +7,6 @@ import { getAnalyticsProvider } from "@/lib/analytics/providers";
 export default function ClientBootstrap() {
   useEffect(() => {
     // api interceptors are defined in "@/lib/api/client"
-    console.info("POSTHOG_ENV_CHECK", {
-      nodeEnv: process.env.NODE_ENV,
-      hasKey: Boolean(process.env.NEXT_PUBLIC_POSTHOG_KEY),
-      host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
-    });
-
     if (process.env.NODE_ENV !== "production") return;
 
     try {

--- a/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
@@ -242,7 +242,6 @@ export default function ConciergeFilterPanel({
         <button
           type="button"
           onClick={() => {
-            console.log("FILTER_PANEL_APPLY_CLICK", { canApply });
             onApply();
           }}
           disabled={false}

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -361,12 +361,6 @@ export default function ConciergeSectionsRenderer({
       if (trackedImpressionKeysRef.current.has(impressionKey)) return;
 
       trackedImpressionKeysRef.current.add(impressionKey);
-      console.log("IMPRESSION_EVENT", {
-        resultSetId,
-        item,
-        resultImpressionsLength: resultImpressions.length,
-        trackedImpressionKeysCount: trackedImpressionKeysRef.current.size,
-      });
       trackSearchEvent("concierge_result_impression", {
         source: "concierge_result",
         threadId: tid ?? undefined,

--- a/apps/web/src/features/map/components/NearbyShrineCardListClient.tsx
+++ b/apps/web/src/features/map/components/NearbyShrineCardListClient.tsx
@@ -33,8 +33,6 @@ function logDedupe(label: string, arr: any[]) {
   const keys = arr.map((p) => dedupeKey(p));
   const unique = new Set(keys);
   clientLog(label, { total: keys.length, unique: unique.size, dup: keys.length - unique.size });
-  // 必要ならこれも（重いので普段はオフ）
-  // console.log(keys);
 }
 
 function clientLog(event: string, payload?: Record<string, unknown>) {

--- a/apps/web/src/lib/api/shrines.server.ts
+++ b/apps/web/src/lib/api/shrines.server.ts
@@ -25,8 +25,6 @@ export async function getShrineDetailServer(id: number): Promise<Shrine> {
   const base = resolveBackendPublicBaseUrl() ?? (await resolveServerBaseUrl());
   const url = `${base}/api/shrines/${id}/data/`;
 
-  console.log("[getShrineDetailServer]", { id, base, url });
-
   const res = await fetch(url, { cache: "no-store" });
   if (!res.ok) {
     const body = await res.text().catch(() => "<failed to read body>");

--- a/apps/web/src/lib/server/backend.ts
+++ b/apps/web/src/lib/server/backend.ts
@@ -37,14 +37,6 @@ export async function djFetch(
   const origin = getDjangoOrigin();
   const url = new URL(path, origin).toString();
 
-  console.log("[DJ_FETCH]", {
-    origin,
-    path,
-    url,
-    method: init.method || (req ? req.method : "GET"),
-    forwardAuth: init.forwardAuth ?? true,
-  });
-
   const headers = new Headers(init.headers ?? {});
   const forwardAuth = init.forwardAuth ?? true;
 

--- a/apps/web/src/lib/server/bffFetch.ts
+++ b/apps/web/src/lib/server/bffFetch.ts
@@ -146,8 +146,6 @@ export async function bffFetchWithAuthFromReq(
       hasRefreshCookie,
     });
 
-    console.log("[BFF_FETCH_URL]", `${apiBase()}${upstreamPath}`);
-
     return fetch(`${apiBase()}${upstreamPath}`, {
       ...init,
       cache: "no-store",

--- a/backend/temples/api_views_concierge.py
+++ b/backend/temples/api_views_concierge.py
@@ -573,7 +573,6 @@ class ConciergeChatView(APIView):
         t0_total = time.perf_counter()
         rid = uuid.uuid4().hex[:8]
         log.info("[concierge] chat.post rid=%s", rid)
-        log.info("🔥 CHAT ENTRY HIT 🔥")
 
         response = None
         total_status = 500

--- a/backend/temples/llm/backfill.py
+++ b/backend/temples/llm/backfill.py
@@ -80,8 +80,6 @@ def _log_details_req(place_id: str) -> None:
         "language": "ja",
         "fields": "formatted_address,address_components",
     }
-    # （必要ならこちらでだけデバッグ出力する）
-    # print(f"[DETAILS DEBUG] place_id={place_id}")
     GP.req_history.append((_DETAIL_URL, dict(params)))
 
 


### PR DESCRIPTION
## 目的

PR-S3 Logging/Security Hardeningの仕上げとして、production codeに残っている一時debug marker・冗長なconsole出力を安全に除去する。security-sensitive loggingの再修正・logging framework刷新・Analytics contract変更・API behavior変更は行っていない。

前提としてPR-S1/S3A/S3B/S3C/S3F/S3Eはすべてmerge済み。develop HEAD `2814e42705333862132ebd4dfe656650eed7a879` から再監査した。

## A. Inventory

- Web console.*: before 64 → after 52(-12)
- Mobile console.*: before 23 → after 23(±0、削除対象なし)
- Backend bare print(非test/非migration): before 8 → after 7(-1、コメントアウト済みdebug printを削除)
- 🔥 emoji marker: before 3箇所 → after 0

## B. Removed Debug Logs

**Web**
- `app/api/concierge/chat/route.ts`: 🔥marker 2行(payload無し、直後の`[BFF_CHAT_ENTRY]`と重複)
- `app/providers/ClientBootstrap.tsx`: `POSTHOG_ENV_CHECK`(NODE_ENV判定でgateされておらず全productionユーザーで毎回発火する client bootstrap確認)
- `app/media/[...path]/route.ts`: media proxy routeの無条件path dump
- `lib/api/shrines.server.ts`: SSR fetchの無条件URL dump(決定論的な値)
- `app/api/my/goshuins/route.ts`: outbound image log(定数文字列2つ+lengthのみ)
- `features/concierge/components/ConciergeFilterPanel.tsx`: ボタンclickのdebug echo(test参照なし確認済み)
- `features/concierge/components/ConciergeSectionsRenderer.tsx`: `IMPRESSION_EVENT`のconsole.log(直後の実`trackSearchEvent()`とは別物、そちらは無変更)
- `lib/server/backend.ts`: `[DJ_FETCH]`(より詳細な`DEBUG`-gated版`[DJ_FETCH_FORWARD]`と完全重複)
- `lib/server/bffFetch.ts`: `[BFF_FETCH_URL]`(直前の`[BFF_THREAD_UPSTREAM_REQUEST]`のupstreamPathと重複)
- `app/api/concierge-threads/[id]/route.ts`: `[BFF_THREAD_DETAIL_REQUEST]`/`[BFF_THREAD_DETAIL_UPSTREAM]`(直前の`[BFF_THREAD_ROUTE_IN]`と重複)
- `features/map/components/NearbyShrineCardListClient.tsx`: コメントアウト済みの死んだdebug console.log

**Backend**
- `temples/api_views_concierge.py`: emoji marker「🔥 CHAT ENTRY HIT 🔥」(直前の`rid`付きlogと完全重複)
- `temples/llm/backfill.py`: コメントアウト済みの死んだdebug print

## C. Kept Operational Logs(代表例)

- `[DJ_FETCH_RESPONSE]` / `[BFF_UPSTREAM]`: status code等、応答結果の観測に必要
- `[BFF_THREAD_ROUTE_IN]` / `[BFF_CHAT_ENTRY]`等のBFF_*トレース系: auth状態(boolean)を含む制御フロー可視化
- ClientBootstrap.tsxの`POSTHOG_HEALTH_CHECK_FAILED`(唯一の外部プロバイダ障害シグナル)
- `apps/web/src/app/api/my/goshuins/route.ts`の`sharp convert failed`(唯一の画像変換障害シグナル)
- Mobile全23件の`console.warn("[Component] failed", error)`系(唯一のnetwork/API障害observability。特に`lib/shrines.ts`の`fetchPopular`は失敗時にmockへ静かにfallbackするため、このwarnが唯一の検知手段)
- Backend `[anon_id]`系(signature validity、KEEP_SECURITY該当)、`concierge_observability.py`の1リクエスト1行JSON構造化ログ(意図的に設計された観測基盤)

## D. Analytics Safety

`track()` / `trackSearchEvent()` / `getAnalyticsProvider().track()` 等、実analyticsイベントのevent名・payload・呼び出し箇所は一切変更していない。console.logはanalytics呼び出しの「直前/直後の重複echo」としてのみ削除した。

## E. Security Regression

削除前後でAuthorization/access_token/refresh_token/Cookie header/bodyPreview/response body/birthdate/raw query/extra_condition/lat/lng/address/API keyの露出が復活していないことをgrepで再確認。該当なし。

## F. Web QA

- `pnpm --filter ./apps/web typecheck`: pass
- `pnpm --filter ./apps/web test`: 731/731 pass
- `pnpm --filter ./apps/web test:contract`: 731/731 pass

## G. Backend QA

- `python -m pytest -m "not postgis and not gis and not slow"`(非GIS): 990 passed, 13 deselected
- `python manage.py makemigrations --check --dry-run`: GIS/非GIS双方で `No changes detected`

## H. Mobile QA

Mobile側の変更なし(全23件のconsole.warnが既に適切な障害observabilityログであることを確認したのみ)。テスト実行は省略。

## I. Changed Files

13ファイル、44行削除のみ(純削除、追加行なし)。Web 11ファイル + Backend 2ファイル。Mobile/migrations/workflow/lockファイルへの変更なし。

## J. git diff --check

Clean(exit 0)。

## K. Commit SHA

`5dc651c1`

## L. PR URL

(このPR)

## M. CI Result

PR作成後に確認する。

## N. Remaining Review Logs

以下は独断で削除せずREVIEWとして報告する:

- `backend/temples/services/concierge_chat.py`(6箇所)・`concierge_chat_ranking.py`(3箇所)の`[dbg]`タグ付き`log.info(...)`。一部(`_attach_breakdown`)は推薦候補ごとにループ内で発火するため、リクエストあたり複数回・INFOレベルで実行される。tag/score/match理由等の詳細な診断payloadを持ち、recommendation pipelineのtroubleshootingに実質的な価値がある可能性が高い一方、`[dbg]`という命名は開発時の一時ログである可能性も示唆する。logger level変更(INFO→DEBUG)は本PRの禁止事項に該当するため、削除するか残すかは別PRでの判断を推奨する。
- `apps/web/src/app/api/my/goshuins/route.ts`の`[BFF] inbound image:` log(type/name/size)。一意の障害シグナルではないが、アップロード失敗の原因調査に一定の相関情報を持つため、確信を持って削除と判断しなかった。

## O. Merge Recommendation

Web/Backend QAともに green、純削除のみでAPI/Analytics/workflow/migrationへの影響なし。CI green確認後はmerge可能と判断する。ただしNのREVIEW項目(特に`[dbg]`タグ付きログのlog level見直し)は別途の判断・別PRを推奨する。

PR作成後停止。マージしない。