### PR TITLE
Emergency Security Fix: Harden LLM error response

### DIFF
--- a/backend/temples/services/concierge_chat_llm_route.py
+++ b/backend/temples/services/concierge_chat_llm_route.py
@@ -11,6 +11,37 @@ from temples.services.concierge_chat_ranking import _prefilter_candidates_for_ne
 log = logging.getLogger(__name__)
 
 
+def _safe_llm_error_code(exc: Exception) -> str:
+    """
+    LLM呼び出し例外をclient/log双方に安全な固定カテゴリ文字列へ縮退する。
+
+    openai SDKの例外はサブクラスによってstr()の中身が大きく異なり、
+    AuthenticationError/BadRequestError/RateLimitError等(APIStatusErrorの
+    サブクラス)はOpenAI側のresponse bodyをそのまま埋め込むため、
+    request内容やAPI keyの断片を含みうる(実測確認済み)。
+    ここではexception messageそのものは一切参照せず、型のisinstance判定
+    だけでカテゴリを決定する。
+    """
+    try:
+        import openai
+    except Exception:
+        return "unknown_error"
+
+    if isinstance(exc, getattr(openai, "APITimeoutError", ())):
+        return "connection_error"
+    if isinstance(exc, getattr(openai, "APIConnectionError", ())):
+        return "connection_error"
+    if isinstance(exc, getattr(openai, "AuthenticationError", ())):
+        return "authentication_error"
+    if isinstance(exc, getattr(openai, "RateLimitError", ())):
+        return "rate_limit"
+    if isinstance(exc, getattr(openai, "BadRequestError", ())):
+        return "bad_request"
+    if isinstance(exc, getattr(openai, "APIStatusError", ())):
+        return "provider_error"
+    return "unknown_error"
+
+
 def resolve_llm_route(
     *,
     query: str,
@@ -49,8 +80,16 @@ def resolve_llm_route(
                 candidates=valid_candidates,
             )
         except Exception as e:
-            llm_error = f"{type(e).__name__}: {e}"
-            log.exception("[resolve_llm_route] LLM exception traceback")
+            llm_error = _safe_llm_error_code(e)
+            # str(e)/exc_infoは含めない: openai SDKのAPIStatusError系は
+            # provider response bodyをそのまま埋め込むため、request内容や
+            # API keyの断片が混入しうる(実測確認済み)。type(e).__name__と
+            # 上で分類したsafe categoryのみ記録する。
+            log.warning(
+                "[resolve_llm_route] LLM call failed error_class=%s safe_code=%s",
+                type(e).__name__,
+                llm_error,
+            )
 
             prefiltered = _prefilter_candidates_for_need(
                 valid_candidates,

--- a/backend/temples/tests/services/test_concierge_llm_error_response_safety.py
+++ b/backend/temples/tests/services/test_concierge_llm_error_response_safety.py
@@ -1,0 +1,168 @@
+# backend/temples/tests/services/test_concierge_llm_error_response_safety.py
+#
+# resolve_llm_route() used to store f"{type(e).__name__}: {e}" in llm_error,
+# which flows through build_signals() -> _signals.llm.error -> the live
+# /api/concierge/chat/ response body (backend/temples/api_views_concierge.py
+# _build_chat_response: data = dict(recs); body["data"] = data). For
+# openai's APIStatusError subclasses (AuthenticationError/BadRequestError/
+# RateLimitError/generic APIStatusError), str(e) embeds OpenAI's own
+# response body verbatim, which can include an API key fragment (auth
+# failures) or request content (validation failures) -- verified earlier
+# with dummy credentials against the real openai SDK. This guards that the
+# fix (a fixed safe-category string) actually holds for every relevant
+# exception class, using only synthetic sentinels, no real API calls.
+from __future__ import annotations
+
+import logging
+
+import httpx
+import pytest
+from openai import (
+    APIConnectionError,
+    APIStatusError,
+    APITimeoutError,
+    AuthenticationError,
+    BadRequestError,
+    RateLimitError,
+)
+
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_llm_route import resolve_llm_route
+
+API_KEY_SENTINEL = "sk-test-secret-do-not-leak"
+QUERY_SENTINEL = "PRIVATE_CONSULTATION_SENTINEL"
+UPSTREAM_BODY_SENTINEL = "PRIVATE_UPSTREAM_BODY_SENTINEL"
+
+SAFE_CODES = {
+    "connection_error",
+    "authentication_error",
+    "rate_limit",
+    "bad_request",
+    "provider_error",
+    "unknown_error",
+}
+
+
+def _fake_request() -> httpx.Request:
+    return httpx.Request(
+        "POST",
+        "https://api.openai.com/v1/chat/completions",
+        headers={"Authorization": f"Bearer {API_KEY_SENTINEL}"},
+        json={"messages": [{"role": "user", "content": QUERY_SENTINEL}]},
+    )
+
+
+def _fake_response(status: int, message: str) -> httpx.Response:
+    req = _fake_request()
+    return httpx.Response(status, request=req, json={"error": {"message": message}})
+
+
+def _make_exception(kind: str) -> Exception:
+    req = _fake_request()
+    if kind == "connection_error":
+        return APIConnectionError(request=req)
+    if kind == "timeout":
+        return APITimeoutError(request=req)
+    if kind == "authentication_error":
+        resp = _fake_response(401, f"Incorrect API key provided: {API_KEY_SENTINEL}")
+        return AuthenticationError(message=f"Error code: 401 - {resp.json()}", response=resp, body=resp.json())
+    if kind == "bad_request":
+        resp = _fake_response(400, f"Invalid content: '{QUERY_SENTINEL}'")
+        return BadRequestError(message=f"Error code: 400 - {resp.json()}", response=resp, body=resp.json())
+    if kind == "rate_limit":
+        resp = _fake_response(429, UPSTREAM_BODY_SENTINEL)
+        return RateLimitError(message=f"Error code: 429 - {resp.json()}", response=resp, body=resp.json())
+    if kind == "provider_error":
+        resp = _fake_response(500, UPSTREAM_BODY_SENTINEL)
+        return APIStatusError(message=f"Error code: 500 - {resp.json()}", response=resp, body=resp.json())
+    raise AssertionError(f"unknown kind {kind}")
+
+
+def _assert_no_sentinel(text: str) -> None:
+    assert API_KEY_SENTINEL not in text
+    assert QUERY_SENTINEL not in text
+    assert UPSTREAM_BODY_SENTINEL not in text
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "kind,expected_code",
+    [
+        ("connection_error", "connection_error"),
+        ("timeout", "connection_error"),
+        ("authentication_error", "authentication_error"),
+        ("bad_request", "bad_request"),
+        ("rate_limit", "rate_limit"),
+        ("provider_error", "provider_error"),
+    ],
+)
+def test_resolve_llm_route_returns_safe_code_only(monkeypatch, settings, caplog, kind, expected_code):
+    settings.CONCIERGE_USE_LLM = True
+
+    from temples.llm import orchestrator as orch_mod
+
+    exc = _make_exception(kind)
+
+    def _boom(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(orch_mod.ConciergeOrchestrator, "suggest", _boom, raising=True)
+
+    with caplog.at_level(logging.INFO, logger="temples.services.concierge_chat_llm_route"):
+        out = resolve_llm_route(
+            query=QUERY_SENTINEL,
+            valid_candidates=[],
+            need_tags=[],
+            llm_enabled=True,
+        )
+
+    assert out["llm_error"] == expected_code
+    assert out["llm_error"] in SAFE_CODES
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    _assert_no_sentinel(logged)
+
+
+@pytest.mark.django_db
+def test_build_chat_recommendations_response_has_no_sentinel_on_llm_failure(monkeypatch, settings, caplog):
+    settings.CONCIERGE_USE_LLM = True
+
+    from temples.llm import orchestrator as orch_mod
+
+    exc = _make_exception("authentication_error")
+
+    def _boom(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr(orch_mod.ConciergeOrchestrator, "suggest", _boom, raising=True)
+
+    with caplog.at_level(logging.INFO):
+        recs = build_chat_recommendations(
+            query=QUERY_SENTINEL,
+            language="ja",
+            candidates=[],
+            bias=None,
+            birthdate=None,
+            goriyaku_tag_ids=None,
+            extra_condition=None,
+            flow="A",
+        )
+
+    llm_signal = (recs.get("_signals") or {}).get("llm") or {}
+    assert llm_signal.get("error") == "authentication_error"
+    assert llm_signal.get("error") in SAFE_CODES
+
+    import json
+
+    # Scope note: this only checks the field this fix touches
+    # (_signals.llm.error), not the full recs payload. A separate,
+    # pre-existing, unconditional issue was found during this audit where
+    # recs["_debug"] embeds raw consultation query text (unrelated to LLM
+    # exception handling) and is copied wholesale into the live API
+    # response by _build_chat_response(); that is out of scope for this
+    # fix and is reported separately.
+    llm_signal_serialized = json.dumps(llm_signal, ensure_ascii=False, default=str)
+    _assert_no_sentinel(llm_signal_serialized)
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    _assert_no_sentinel(logged)


### PR DESCRIPTION
## Emergency Security Fix

Security Audit Final中に発見された、LLM/OpenAI例外の生内容が live `/api/concierge/chat/` レスポンスへ到達する経路を修正する。

## 1. 確認済みexposure経路

```
concierge_chat_llm_route.py
  llm_error = f"{type(e).__name__}: {e}"
    ↓
concierge_chat_response_meta.py (build_signals)
  "llm": {"enabled": ..., "used": ..., "error": llm_error}
    ↓
api_views_concierge.py (_build_chat_response)
  data = dict(recs or {})   # _signalsごとコピー
  body = {..., "data": data, ...}
  return Response(body, status=200)  # 実際のresponse
```

openai SDKの例外はサブクラスにより`str(e)`の中身が大きく異なる。fake API key / fake prompt / fake upstream response bodyを使った実測(実API・実credentialは不使用)で、`AuthenticationError`/`BadRequestError`/`RateLimitError`等(`APIStatusError`のサブクラス)はOpenAI側のresponse bodyをそのまま`str(e)`へ埋め込み、認証失敗時はAPI key断片、content検証失敗時はrequest内容断片が混入することを確認済み。rate limit/認証エラー等、現実的に発生しうる失敗シナリオでこの文字列が`/api/concierge/chat/`のresponse bodyへ直接返っていた。

## 2. Safe fixed-categoryへの置換

`_safe_llm_error_code(exc)`を追加。exception messageは一切参照せず、型のisinstance判定のみで以下の固定文字列へ縮退:

`connection_error` / `authentication_error` / `rate_limit` / `bad_request` / `provider_error` / `unknown_error`

`signals.llm.error`のshape(`{enabled, used, error}`、`error`は`Optional[str]`)は維持。中身がraw exception textから固定safe categoryへ変わっただけ。

## 3. Server loggingのhardening

`log.exception(...)`(exc_info付きtraceback、最終行に`str(e)`相当のexception messageが付く)を`log.warning(...)`へ変更し、`error_class=%s safe_code=%s`(`type(e).__name__` + 上記safe category)のみを記録。`str(e)`/`repr(e)`/prompt/queryはserver logへも一切出さない。

## 4. Web/Mobile contract影響

`_signals.llm.error`の**本文**へ依存している箇所はrepo-wide検索でゼロと確認(唯一の参照は`ConciergeClientFull.tsx`のdebug panel内`.llm.used`booleanのみ)。既存backend testの`.llm.error`アサーションも`isinstance(x, str) and x`という型・truthiness判定のみで、content判定はしていない。**API contract変更なし。**

## 5. Synthetic leak tests

新規 `backend/temples/tests/services/test_concierge_llm_error_response_safety.py`(7 tests)。`APIConnectionError`/`APITimeoutError`/`AuthenticationError`/`BadRequestError`/`RateLimitError`/generic `APIStatusError`それぞれについて、synthetic sentinel(`sk-test-secret-do-not-leak` / `PRIVATE_CONSULTATION_SENTINEL` / `PRIVATE_UPSTREAM_BODY_SENTINEL`、実API・実credentialは不使用)が`llm_error`・`signals.llm.error`・captured logのいずれにも出現しないことを検証。全件pass。既存の`test_concierge_llm_signals.py`・`test_concierge_signals_contract.py`は無変更でpass(1005 passed / 13 deselected、非GIS full suite)。

## 6. 新規finding: `_debug.raw_query`は本PRに含めない

このfix作業中に発見した別の問題として、`recs["_debug"]`(`user_state_profile.raw_query` / `interpretation_profile.raw_query`)がユーザーの相談内容を生のまま保持しており、`_build_chat_response`の`data = dict(recs or {})`により**LLM失敗時に限らず常に** `/api/concierge/chat/` のresponse bodyへ到達しうることが判明した。これは本PRが修正するllm_error経路とは完全に別のcode path・別のexposureパターンであり、**本PRには一切含めていない**。別途Emergency Fixが必要(下記J/K参照)。

## Migration Drift

GIS/非GIS双方で`No changes detected`。

## Changed Files

`backend/temples/services/concierge_chat_llm_route.py`、`backend/temples/tests/services/test_concierge_llm_error_response_safety.py`の2ファイルのみ。`build_signals()`/`_build_chat_response()`/Recommendation/scoring/OpenAI request内容/provider選択/retry policy/Web/Mobile/migration/workflowは無変更。

## Commit SHA

`c96eb32e`

## PR URL

(このPR)

## CI Result

PR作成後に確認する。

## J. New Separate Finding

`_debug.raw_query` live response exposure — `recs["_debug"]["user_state_profile"]["raw_query"]` / `recs["_debug"]["interpretation_profile"]["raw_query"]`が、LLM成否に関わらず常にconcierge chatの実responseへ到達しうる。

## K. Follow-up Requirement

**Emergency `_debug` Response Hardening required** — 別Emergency Fix taskとして早急な対応を推奨。

---

PR作成後停止。マージしない。