### PR TITLE
docs: Knowledge Pilotを基にRecommendation Readiness Contractを設計

### DIFF
--- a/docs/core/recommendation-readiness.md
+++ b/docs/core/recommendation-readiness.md
@@ -366,16 +366,177 @@ Recommendation Readiness は
 
 ---
 
+# Implementation Status
+
+本書のReadiness Level・Coverageは、本書作成時点から現在まで**設計のみで、Backend実装は存在しない**（`readiness_level`/`recommendation_readiness`等の名称でrepo全体を検索しても実装ゼロ）。
+
+一方、本書が前提としていた`deity`/`shrine_history`/`source_url`/`verified_at`は、本書作成後に`ShrineDeity`/`ShrineHistory`/`ShrineKnowledgeSource`という別Model構造として実装された（`docs/knowledge/shrine-knowledge-contract.md`、PR #2221）。Level2の必要項目名は現在もこの実装と対応しているが、`source_url`という単一Field名は現在の実装では`ShrineKnowledgeSource`という関連Modelに置き換わっている。
+
+---
+
+# Evidence Gate Boundary
+
+Recommendation Readiness（本書）とEvidence Gate（`temples.services.evidence_gate`、実装済み）は別責務であり、混同しない。
+
+| | Evidence Gate | Recommendation Readiness |
+|---|---|---|
+| 判定単位 | Fact 1件（`ShrineDeity`/`ShrineHistory`の各レコード） | Shrine全体 |
+| 判定内容 | この1件のFactをRecommendation Reason/Detail表示へ使ってよいか | この神社はどこまでRecommendation/Action/Reflectionに利用できるか |
+| 実装状況 | 実装済み（`decide_fact_usability()`、Evidence Gate test 50件で検証済み） | 未実装（本書は設計のみ） |
+| 出力 | `usable: bool` / `display_mode` / `reason_strength` | Level0〜3（本書が定義する分類） |
+
+Evidence GateがFact単位で「使えるFactが1つもない」と判定した場合でも、Shrine自体は依然としてLevel0（表示可能）やLevel1（`place_context AND (history_theme OR goriyaku_tags)`を満たせば推薦可能）でありうる。Evidence Gateの判定結果を集約したものがLevel2以降の判定材料の一部になりうるが、両者は独立した別レイヤーである。
+
+---
+
+# Pilot Evidence
+
+`docs/audit/shrine-knowledge-pilot-5-result.md`（明治神宮・品川神社・三峯神社・神田神社・給田六所神社の5社）の実データを用いて、本書のLevel定義を検証した。**DBへの分類保存は行っていない（design simulationのみ）。**
+
+## Five-Shrine Simulation
+
+| Shrine | Level0 | Level1 | Level2 | Level3（multiple_sources以外） |
+|---|---|---|---|---|
+| 明治神宮 | PASS | PASS | PASS | `shrine_feature`/`action_source`/`reflection_source`該当なし |
+| 品川神社 | PASS | PASS | PASS | 同上 |
+| 三峯神社 | PASS | PASS | PASS | 同上 |
+| 神田神社 | PASS | PASS | PASS | 同上 |
+| 給田六所神社 | PASS | PASS | PASS | 同上 |
+
+**`INSUFFICIENT_NEGATIVE_CASES`**: Pilot 5社は全て`place_context`/`goriyaku_tags`/`history_theme`を既存のLegacy Fieldとして持ち（Level1は自動的に満たす）、かつ全社が`deity`・`shrine_history`・出典URL付きSource・`verified_at`を持つ（Level2も満たす）。5社すべてが同一Levelへ到達するため、本Pilotデータのみでは**Level1とLevel2の境界がどこで実際に機能するかを検証できていない**（`deity`/`shrine_history`が本当に無い神社、`place_context`はあるが`history_theme`も`goriyaku_tags`もない神社等のnegative caseがPilotに含まれない）。
+
+## multiple_sources（Level3の一部）は観測された
+
+`shrine_knowledge-pilot-5-result.md`の実データ再確認の結果、`multiple_sources`（Level3の追加項目）に該当する事実（Fact 1件に2件以上のSourceが紐づく）は、明治神宮・品川神社・給田六所神社で観測された（deity 7件、history 3件）。三峯神社・神田神社の新規投入分は1 Fact = 1 Sourceのみ。
+
+## Level3の他項目は現行Modelに存在しない
+
+`shrine_feature`・`action_source`・`reflection_source`という3項目は、現行`ShrineDeity`/`ShrineHistory`/`ShrineKnowledgeSource` modelのいずれにも対応するFieldが存在しない。Pilot 5社を含め、これらは本書作成時点から一貫して`NOT_OBSERVED_IN_PILOT`（Pilotで観測しようがない、Model自体が持たない）である。§Contract Gapsで分離記録する。
+
+---
+
+# Contract Scenarios（CONTRACT_SCENARIO_ONLY）
+
+以下はPilotで未観測のケースについて、Contract検討用に設計したシナリオである。**実Factとして捏造・登録していない。**
+
+| Scenario | 現行Modelで表現可能か | Level影響（想定） |
+|---|---|---|
+| deityなし・shrine_historyなし | 可能（該当レコードを作らないだけ） | Level1どまり（Level2未達） |
+| Sourceなし | 可能 | Evidence Gateで`usable=False`、Level2の`verified_at`要件も未達 |
+| draft Sourceのみ | 可能（`verification_status=draft`） | Evidence Gateで`usable=False` |
+| disputed factのみ | 可能（`verification_status=disputed`、Evidence Gate test済み） | Evidence Gateで`usable=False`、断定表現禁止 |
+| low confidenceのみ | 可能（`confidence=low`） | Evidence Gateのusable判定には影響しないが、Reason V4側で`suppressed`表現へ |
+| legacy fieldsのみ（`Shrine.sajin`/`description`はあるが新Model未登録） | 可能（現状Pilot前の全105件がこの状態） | Level1相当だがLevel2未達 |
+| place_contextのみ | 可能 | Level1未達（`history_theme`/`goriyaku_tags`いずれも無ければLevel0止まり） |
+| goriyakuのみ | 可能 | Level1到達（`place_context`が別途あれば） |
+
+---
+
+# Threshold Policy
+
+Level1の閾値（`place_context AND (history_theme OR goriyaku_tags)`）は本書に既に数値として存在するが、**Pilot 5社の実データだけではこの閾値の妥当性を検証できていない**（§Pilot Evidence参照、全社が閾値を大きく上回る状態のため）。
+
+Level2・Level3について、「`deity`が何件以上必要か」「Source何件必要か」等の**具体的なcount thresholdは本書に存在しない**（現状は「存在するかしないか」の二値条件のみ）。
+
+分類: **`THRESHOLD_EVIDENCE_INSUFFICIENT`**
+
+Pilotが最良ケース中心（5社中5社がLevel1・Level2を満たす）であるため、本書はLevel1の既存閾値を維持しつつ、Level2以降の具体的なcount threshold策定は行わない。`Threshold: TBD after 105-shrine shadow evaluation`として残す。
+
+---
+
+# Aliases Contract Gap（Readiness観点）
+
+`docs/audit/shrine-knowledge-pilot-5-result.md`で記録された`CONTRACT_GAP_ALIASES_FIELD`（`ShrineDeity`に専用aliases fieldが存在しない）をReadiness観点で再評価する。
+
+- aliasesがないことでReadiness判定（Level0〜3のいずれか）が不能になることはない。Level判定は`deity`エントリの有無・件数のみを見るため、別名の有無は影響しない
+- `note`運用でLevel判定には十分
+- Recommendation Reason品質（表記の一貫性）には影響しうるが、これは本書の責務外（Reason V4側の責務）
+
+分類: **`NON_BLOCKING_FOR_READINESS`**
+
+---
+
+# 105-Shrine Rollout Boundary
+
+Pilot → Readiness → Rolloutの依存関係について、以下2案を提示する。最終選択は母艦判断とする。
+
+**案A（実装確定型）**
+
+```text
+Knowledge Pilot 5社
+↓
+Readiness Contract確定（本書、count threshold含む）
+↓
+Readiness backend実装
+↓
+105社 coverage audit
+↓
+Data rollout
+```
+
+**案B（観測先行型）**
+
+```text
+Knowledge Pilot 5社
+↓
+Readiness Contract（本書、count thresholdはTBDのまま）
+↓
+105社 shadow evaluation（現行Legacy Field基準のみでLevel0/1を計算し、実際のLevel分布を観測）
+↓
+観測結果を踏まえてLevel2/3のcount threshold確定
+↓
+Readiness実装
+```
+
+§Threshold Policyの`THRESHOLD_EVIDENCE_INSUFFICIENT`判定を踏まえると、案Bの方が根拠に基づく閾値設計に近づく可能性があるが、これも母艦判断とする。
+
+---
+
+# Known Unknowns
+
+- Level2・Level3の具体的なcount threshold（§Threshold Policy）
+- Level1〜3をRecommendation candidate poolのどの段階で実際に接続するか（`docs/core/recommendation-architecture.md`のEligibility Filter段階が候補だが未実装）
+- `shrine_feature`/`action_source`/`reflection_source`（Level3項目）に対応する実装が今後追加されるか、または本書側でField名を現行Modelに合わせて改定するか
+- 105件中、実際にどの程度がLevel1未達（`place_context`はあるが`history_theme`も`goriyaku_tags`もない）になるかは未計測
+
+---
+
+# Mother Ship Decisions Required
+
+- Readinessを何段階にするか（既存Level0〜3を維持するか、簡略化するか）
+- Level2・Level3のcount thresholdをいつ・どう確定するか（105社shadow evaluation先行か、実装先行か）
+- Readinessをcandidate filteringへ接続するか（`recommendation-architecture.md`のEligibility Filter案の採否）、Reason生成のみに使うか、Admin用途のみに留めるか
+- Readinessをuser-facingへ表示するか（例:「情報充実度」）、internal/admin onlyに留めるか
+- `shrine_feature`/`action_source`/`reflection_source`をLevel3要件から外すか、実装するか
+- aliases field追加を別途行うか（`NON_BLOCKING_FOR_READINESS`のため急ぎではないと判断）
+
+---
+
+# Implementation PR Plan（実装しない。後続PR分割案）
+
+| PR | 目的 | Scope | Out of Scope | Recommended AI |
+|---|---|---|---|---|
+| PR-R1 | Readiness pure classifier | Level0〜3判定ロジックのみ（既存Legacy Field + 新Knowledge Model参照、DB書き込みなし） | candidate pool接続、UI表示 | Codex |
+| PR-R2 | Readiness API/Admin露出 | Shrine詳細APIまたはAdminへLevel表示を追加 | candidate filtering変更 | Codex |
+| PR-R3 | Recommendation統合 | Eligibility Filter段階への接続（Level1未達を候補から除外） | Score計算式変更 | Codex |
+| PR-R4 | 105社 shadow evaluation | 全105件のLevel分布を計測、count threshold確定の材料収集 | 実データ投入・Rollout実施 | ChatGPT（分析）+ Codex（計測実装） |
+
+各PRの着手順序は母艦判断とする。
+
+---
+
 # 他ドキュメントとの関係
 
 | ドキュメント | 責務 |
 |--------------|------|
 | docs/knowledge/shrine-profile-spec.md | 神社プロフィール定義 |
 | docs/knowledge/shrine-data-guide.md | データ入力基準 |
+| docs/knowledge/shrine-knowledge-contract.md | Knowledge Model（deity/shrine_history/Source）の値の意味・出典・確認状態・Evidence Gate要件の正本 |
+| docs/core/recommendation-architecture.md | Recommendationパイプライン全体の正本。本書のLevel1判定は同書のEligibility Filter段階に対応 |
 | docs/core/meaning-layer.md | Meaning Layer |
-| docs/core/recommendation-readiness.md | Recommendation品質判定 |
 | docs/product/visit-reflection-flow.md | 参拝導線 |
 | docs/product/action_suggestion_v4.md | Action契約 |
+| docs/audit/shrine-knowledge-pilot-5-result.md | Pilot 5社の実データ監査結果（本書§Pilot Evidenceの根拠） |
 
 ---
 


### PR DESCRIPTION
## 重要な前提の訂正

作業開始時のタスク定義は「新規文書の候補: `docs/core/recommendation-readiness.md`」としていたが、**このファイルは既に`Status: Active`で存在していた**（Level0〜3・Coverage・Stored/Derived/Runtime/Governance・Responsibility Boundaryまで既に設計済み、`docs/core/README.md`のActive一覧にも登録済み）。Phase 19「Contract Document Location Audit」の結果、判定は`CREATE`ではなく**`MERGE_EXISTING`**（既存ファイルへの追記）とした。既存のLevel/Coverage/Boundary定義は書き換えず、Pilot実データで検証した結果と、Evidence Gate/現行実装との境界という不足していた情報を追加した。

## Pilot Evidence Summary

`docs/audit/shrine-knowledge-pilot-5-result.md`（明治神宮・品川神社・三峯神社・神田神社・給田六所神社）を5社ともシミュレーション（design simulation、DB保存なし）した結果、**5社全てが既存のLevel0/1/2を満たす**ことを確認した。これは`INSUFFICIENT_NEGATIVE_CASES`（Pilotが最良ケース中心で、Level1/2の境界を実際に試す欠損データがない）を意味する。一方、Level3の`multiple_sources`は既存2社と給田六所神社で実際に観測できたが、`shrine_feature`/`action_source`/`reflection_source`は現行Knowledge Modelにフィールド自体が存在せず、Pilotでは観測しようがないことを確認した。

## Evidence Gate Boundary

Evidence Gate（`temples.services.evidence_gate`、実装済み、Fact 1件単位でusable判定）とRecommendation Readiness（Shrine全体単位、未実装）は別レイヤーであることをコードで確認し、既存文書に不足していたこの境界を明記した。Evidence GateがFactを1件も使えないと判定しても、Shrine自体はLevel0/1でありうる。

## Recommendation Score Boundary

`docs/core/recommendation-architecture.md`のScoring節（`data_confidence_score`は未実装）を確認し、既存の「Responsibility Boundary」（Score/Ranking等は責務外）と矛盾しないことを確認した。Score計算式・candidate ranking自体は本PRで変更していない。

## Threshold Evidence

`THRESHOLD_EVIDENCE_INSUFFICIENT`と判定した。Level1の既存閾値（`place_context AND (history_theme OR goriyaku_tags)`）はPilot全社が大きく上回るため据え置き、Level2・Level3の具体的なcount thresholdはPilotだけでは確定できないため、数値を創作せず`Threshold: TBD after 105-shrine shadow evaluation`として残した。

## Aliases Gap

Pilotで記録された`CONTRACT_GAP_ALIASES_FIELD`をReadiness観点で再評価し、`NON_BLOCKING_FOR_READINESS`と判定した（Level判定は`deity`エントリの有無・件数のみを見るため、別名の有無は影響しない）。

## 105-Shrine Rollout Boundary

案A（実装確定型: Contract確定→実装→105社audit→rollout）と案B（観測先行型: Contract→105社shadow evaluation→threshold確定→実装）の2案を提示。開始時期・どちらを採るかは確定していない。

## Mother Ship Decisions Required

- Readinessを何段階にするか（既存Level0〜3を維持するか）
- Level2・Level3のcount thresholdをいつ・どう確定するか
- Readinessをcandidate filteringへ接続するか、Reason生成のみに使うか、Admin用途のみに留めるか
- Readinessをuser-facingへ表示するか
- `shrine_feature`/`action_source`/`reflection_source`をLevel3要件から外すか、実装するか
- aliases field追加を別途行うか

## Implementation PR Plan

PR-R1（pure classifier）〜PR-R4（105社shadow evaluation）の4分割案を提示。着手順序・実装は本PRのスコープ外。

## Changed Files

- `docs/core/recommendation-readiness.md`（既存Active正本への追記のみ。既存のLevel/Coverage/Boundary定義は変更していない）

副次的に、同ファイル内の「他ドキュメントとの関係」表にあった既存の自己参照バグ（本書が本書自身を「他ドキュメント」として列挙していた）も、追記のついでに修正した。

## QA

- Duplication Guard: Evidence Gateの再定義なし、閾値の新規確定なし、105件Rolloutを開始扱いにしていないことを確認
- `git diff --check`: clean、docs-only diff（1ファイルのみ）
- model/migration/serializer/Recommendation Score/candidate pool/Web/Mobile: 変更なし
- pre-push hook（OpenAPI lint + Web契約テスト 731/731）: pass
- README Navigation: `docs/core/README.md`は既に本書をActive一覧・読む順番へ登録済みのため変更不要

PR作成後停止。マージしない。Backend実装には進まない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>