### PR TITLE
fix: Recommendation候補からテスト神社を除外

### DIFF
--- a/backend/temples/services/concierge_chat_candidates.py
+++ b/backend/temples/services/concierge_chat_candidates.py
@@ -88,6 +88,13 @@ def build_chat_candidates(
     qs = qs.exclude(name_jp__in=noisy_shrine_names)
     qs = qs.exclude(name_jp__startswith="テスト")
     qs = qs.exclude(name_jp__istartswith="test")
+    # 「承認テスト神社」「admin承認テスト神社」「重複検証神社」等、"テスト"接頭辞に
+    # 一致しないQA用fixture命名を除外する。実在神社名にこれらの語が含まれることは
+    # ないことを確認済み（"テスト"は接頭辞以外での混入除去も検討したが、既存test
+    # fixture（例: "距離テスト神社"）との衝突があるため、"承認テスト"と"検証"という
+    # より限定的な部分一致のみを追加する）。
+    qs = qs.exclude(name_jp__icontains="承認テスト")
+    qs = qs.exclude(name_jp__icontains="検証")
 
     qs = qs.select_related("place_ref")
     qs = qs.filter(latitude__isnull=False, longitude__isnull=False)

--- a/backend/temples/tests/services/test_concierge_build_chat_candidates_contract.py
+++ b/backend/temples/tests/services/test_concierge_build_chat_candidates_contract.py
@@ -260,3 +260,55 @@ def test_candidates_knowledge_lookup_does_not_scale_query_count_with_shrine_coun
     assert len(ctx.captured_queries) < 30, (
         f"expected knowledge lookup to avoid N+1, got {len(ctx.captured_queries)} queries"
     )
+
+
+@pytest.mark.django_db
+def test_candidates_exclude_known_qa_fixture_naming_patterns(shrine_factory):
+    """
+    Knowledge Coverage Shadow Audit (audit/knowledge-coverage-shadow-105) で、
+    実DB上のid=101-105（「承認テスト神社」「admin承認テスト神社」「重複検証神社」
+    「重複検証神社（別宮）」）が既存のnoisy_shrine_names / テストprefix除外の
+    いずれにも一致せず、live candidate poolへ混入することを確認した。
+
+    これらは「テスト」で始まらず、「test」でも始まらないため、既存の
+    startswith系除外では捕捉できない。本testはこの実在するfixture命名を
+    再現し、候補から除外されることを保証する。
+    """
+
+    shrine_factory(name="承認テスト神社", latitude=35.0, longitude=139.0)
+    shrine_factory(name="admin承認テスト神社", latitude=35.0, longitude=139.0)
+    shrine_factory(name="重複検証神社", latitude=35.0, longitude=139.0)
+    shrine_factory(name="重複検証神社（別宮）", latitude=35.0, longitude=139.0)
+    shrine_factory(name="実在神社", latitude=35.0, longitude=139.0)
+
+    cands = build_chat_candidates(
+        lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=None, trace_id="test",
+    )
+    names = [c["name"] for c in cands]
+
+    assert "承認テスト神社" not in names
+    assert "admin承認テスト神社" not in names
+    assert "重複検証神社" not in names
+    assert "重複検証神社（別宮）" not in names
+    assert "実在神社" in names
+
+
+@pytest.mark.django_db
+def test_candidates_do_not_over_exclude_shrines_with_mid_name_test_substring(shrine_factory):
+    """
+    修正がid依存や「テスト」の広範な部分一致に頼っていないことを保証する
+    negative guard。「テスト」を名前の途中に含むが実際には除外対象ではない
+    shrine（既存の他test（例: test_candidates_include_distance_m）が使う
+    命名規約と同様）が、誤って除外されないことを確認する。
+    """
+
+    shrine_factory(name="距離テスト神社", latitude=35.0, longitude=139.0)
+    shrine_factory(name="place_idテスト神社", latitude=35.0, longitude=139.0)
+
+    cands = build_chat_candidates(
+        lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=None, trace_id="test",
+    )
+    names = [c["name"] for c in cands]
+
+    assert "距離テスト神社" in names
+    assert "place_idテスト神社" in names


### PR DESCRIPTION
## 目的

Knowledge Coverage Shadow Audit（`audit/knowledge-coverage-shadow-105`）で、`Shrine.objects.count() = 105`のうちid=101〜105が明示的なQA用テストShrineである一方、`build_chat_candidates()`の既存除外条件（`テスト`/`test`のprefix一致）では捕捉されず、live candidate poolへ混入していることを確認した。本PRはテストShrineのみを候補から除外する。

Knowledge Coverage / Recommendation Score / Evidence Gate / Reason V4 / Knowledge Modelには変更を加えていない。

## Root Cause（Phase 1-2）

- id=103-105（重複検証神社×2、重複検証神社（別宮）」）: `temples/management/commands/seed_duplicate_candidate_cases.py`（`duplicate_candidate`の実機確認用seedコマンド）が生成
- id=101-102（承認テスト神社、admin承認テスト神社）: 現行コードに生成元が見当たらず、dev DBへ手動投入されたと推測される孤立データ
- いずれも`name_jp__startswith="テスト"`および`istartswith="test"`に一致しない（"承認"/"admin"/"重複"で始まるため）ため、既存の除外条件をすり抜けていた
- Shrine modelにfixture識別用の専用field/statusは存在しない（Stop Condition A該当なし、model変更不要と判断）

## 修正方法（Phase 3）

`name_jp__icontains="テスト"`のような広い部分一致は採用しなかった。既存test（`test_candidates_include_distance_m`等）が「距離テスト神社」「place_idテスト神社」のような、"テスト"を名前途中に含む正当なfixtureをcandidate結果に期待しているため、この方式では既存contractを壊す（実際に負の対照実験で確認済み、後述）。

代わりに、実在神社名およびtest suite全体で衝突がないことを確認した2つの限定的な部分一致を追加した。

```python
qs = qs.exclude(name_jp__icontains="承認テスト")
qs = qs.exclude(name_jp__icontains="検証")
```

- `id__lte=100`の実在神社100件、および全testファイルのfixture名を横断検索し、いずれも「承認テスト」「検証」を含まないことを確認済み
- idハードコードなし、migration不要

## Regression Test（Phase 4、先にtestを追加し負の対照実験を実施）

- `test_candidates_exclude_known_qa_fixture_naming_patterns`: 修正前コードに対して実行し、実際にFAIL（`承認テスト神社`等がcandidatesに含まれる）することを確認済み
- `test_candidates_do_not_over_exclude_shrines_with_mid_name_test_substring`: 「距離テスト神社」等、名前途中に"テスト"を含む既存fixture契約が壊れていないことを保証するguard test

## QA結果

- 修正後、`test_concierge_build_chat_candidates_contract.py`: 10 passed（新規2件含む）
- Recommendation関連targeted test（candidate_profile/dedupe/duplicate_candidates/candidate_utils/evidence_gate）: 58 passed
- `test_candidate_profile_zero_knowledge_shrine_matches_legacy_output`（zero-Knowledge fallback契約）: pass、維持確認済み
- non-GIS backend full suite: **1007 passed, 1 skipped**（GDAL未導入によるlocal限定skip）, 13 deselected
- `makemigrations --check --dry-run`: `No changes detected`
- `git diff --check`: clean
- local dev DBでのlive確認: 修正後`build_chat_candidates()`が返す候補数が105→**100**へ変化、id=101-105が候補から消え、明治神宮(1)・伊勢神宮(3, zero-Knowledge)は引き続き候補に残ることを確認
- Security/Data Integrity: fixture識別情報の新規API露出なし、debug field追加なし、raw fixture metadataのログ出力なし、production専用IDハードコードなし

## Changed Files

- `backend/temples/services/concierge_chat_candidates.py`（除外条件2行追加のみ）
- `backend/temples/tests/services/test_concierge_build_chat_candidates_contract.py`（regression test 2件追加）

Model/Migration/API/Web/Mobile/docs/workflowへの変更なし。

PR作成後停止。マージしない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>