### PR TITLE
feat: Knowledge Coverageのread-only集計commandを追加

### DIFF
--- a/backend/temples/management/commands/knowledge_coverage_report.py
+++ b/backend/temples/management/commands/knowledge_coverage_report.py
@@ -1,0 +1,81 @@
+"""Knowledge Coverageのread-only集計command。
+
+Knowledge Pilot / Rollout Batch 1 / Batch 2で繰り返し手動実行してきた
+Coverage集計クエリ（`docs/audit/shrine-knowledge-rollout-batch-2.md`
+§O「同種の集計クエリを今回で通算7回目程度手動実行」参照）を置き換える。
+
+DBへの書き込みは一切行わない。Recommendation Score / Candidate / Ranking /
+Evidence Gate contract / Reason V4のいずれも変更しない。
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.core.management.base import BaseCommand
+
+from temples.services.knowledge_coverage_report import build_knowledge_coverage_report
+
+
+def _format_count(entry: dict) -> str:
+    return f"{entry['count']} ({entry['percentage']}%)"
+
+
+def render_text_report(report: dict) -> str:
+    lines: list[str] = []
+    lines.append("Knowledge Coverage Report")
+    lines.append("=" * 40)
+    lines.append(f"Total DB Shrines: {report['total_db_shrines']}")
+    lines.append(f"Audit Target Shrines: {report['audit_target_shrines']}")
+    lines.append(f"Excluded Test Shrines: {report['excluded_test_shrines']}")
+    lines.append("")
+    lines.append(f"Knowledge Coverage: {_format_count(report['knowledge_coverage'])}")
+    lines.append(f"Zero Knowledge: {_format_count(report['zero_knowledge'])}")
+    lines.append(f"Deity Coverage: {_format_count(report['deity_coverage'])}")
+    lines.append(f"History Coverage: {_format_count(report['history_coverage'])}")
+    lines.append(f"Source Coverage: {_format_count(report['source_coverage'])}")
+    lines.append(
+        f"Both Deity and History Coverage: "
+        f"{_format_count(report['both_deity_and_history_coverage'])}"
+    )
+    lines.append("")
+    fact_ready = report["fact_ready_coverage"]
+    lines.append("Fact-ready Coverage:")
+    lines.append(f"  Deity: {_format_count(fact_ready['fact_ready_deity_shrines'])}")
+    lines.append(f"  History: {_format_count(fact_ready['fact_ready_history_shrines'])}")
+    lines.append(f"  Any: {_format_count(fact_ready['fact_ready_any_shrines'])}")
+    lines.append("")
+    lines.append(f"Verified Source Count: {report['verified_source_count']}")
+    lines.append(f"Total Source Count: {report['total_source_count']}")
+    lines.append("")
+    lines.append(f"Deity Count Distribution: {report['deity_count_distribution']}")
+    lines.append(f"History Count Distribution: {report['history_count_distribution']}")
+    lines.append(f"Source Count Distribution: {report['source_count_distribution']}")
+    lines.append(
+        f"Verification Status Distribution: {report['verification_status_distribution']}"
+    )
+    lines.append(f"Confidence Distribution: {report['confidence_distribution']}")
+    lines.append(f"Source Type Distribution: {report['source_type_distribution']}")
+    return "\n".join(lines)
+
+
+class Command(BaseCommand):
+    help = (
+        "Knowledge Coverageのread-only集計レポートを表示する。"
+        "DB書き込みは一切行わない。"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="出力形式。text（既定、人間可読）またはjson。",
+        )
+
+    def handle(self, *args, **options):
+        report = build_knowledge_coverage_report()
+        if options["format"] == "json":
+            self.stdout.write(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        else:
+            self.stdout.write(render_text_report(report))

--- a/backend/temples/services/concierge_chat_candidates.py
+++ b/backend/temples/services/concierge_chat_candidates.py
@@ -20,6 +20,7 @@ from temples.services.shrine_knowledge_selector import (
     fetch_fact_ready_knowledge_deities,
     fetch_fact_ready_knowledge_histories,
 )
+from temples.services.shrine_qa_fixture_exclusion import exclude_qa_fixture_shrines
 
 log = logging.getLogger(__name__)
 
@@ -73,28 +74,9 @@ def build_chat_candidates(
             | Q(name_romaji__icontains=area)
         )
 
-    noisy_shrine_names = [
-        "x",
-        "x2",
-        "noaddr",
-        "住所なし神社",
-        "test神社",
-        "テスト候補神社",
-        "テスト神社",
-        "テスト神社2",
-        "テスト神社-1770895174",
-    ]
-
-    qs = qs.exclude(name_jp__in=noisy_shrine_names)
-    qs = qs.exclude(name_jp__startswith="テスト")
-    qs = qs.exclude(name_jp__istartswith="test")
-    # 「承認テスト神社」「admin承認テスト神社」「重複検証神社」等、"テスト"接頭辞に
-    # 一致しないQA用fixture命名を除外する。実在神社名にこれらの語が含まれることは
-    # ないことを確認済み（"テスト"は接頭辞以外での混入除去も検討したが、既存test
-    # fixture（例: "距離テスト神社"）との衝突があるため、"承認テスト"と"検証"という
-    # より限定的な部分一致のみを追加する）。
-    qs = qs.exclude(name_jp__icontains="承認テスト")
-    qs = qs.exclude(name_jp__icontains="検証")
+    # QA用fixture Shrineの除外条件は shrine_qa_fixture_exclusion.py を正本とし、
+    # Knowledge Coverage集計（knowledge_coverage_report command）と共有する。
+    qs = exclude_qa_fixture_shrines(qs)
 
     qs = qs.select_related("place_ref")
     qs = qs.filter(latitude__isnull=False, longitude__isnull=False)

--- a/backend/temples/services/knowledge_coverage_report.py
+++ b/backend/temples/services/knowledge_coverage_report.py
@@ -1,0 +1,198 @@
+"""Knowledge Coverage集計（read-only）。
+
+Knowledge Pilot（`docs/audit/shrine-knowledge-pilot-5-result.md`）、
+Rollout Batch 1/2（`docs/audit/shrine-knowledge-rollout-batch-1.md`、
+`shrine-knowledge-rollout-batch-2.md`）で繰り返し手動実行してきたCoverage
+集計クエリを、`knowledge_coverage_report` management commandから呼び出す
+唯一の計算ロジックとしてまとめる。
+
+このモジュールは以下を再実装しない。
+
+- Fact usable判定（`temples.services.evidence_gate.decide_fact_usability`へ委譲）
+- QA fixture Shrineの除外条件
+  （`temples.services.shrine_qa_fixture_exclusion.exclude_qa_fixture_shrines`へ委譲）
+- Knowledge Fact取得の候補条件
+  （`temples.services.shrine_knowledge_selector`へ委譲）
+
+DBへの書き込みは一切行わない。`docs/core/recommendation-readiness.md`の
+Governance Coverage契約・`docs/knowledge/shrine-knowledge-contract.md`の
+Evidence Gate契約を再定義せず、既存契約の集計結果を表示するのみ。
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any
+
+from django.db.models import Count, Q, QuerySet
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services import evidence_gate
+from temples.services.shrine_knowledge_selector import (
+    fetch_fact_ready_knowledge_deities,
+    fetch_fact_ready_knowledge_histories,
+)
+from temples.services.shrine_qa_fixture_exclusion import exclude_qa_fixture_shrines
+
+
+def _audit_target_shrine_ids() -> list[int]:
+    return list(exclude_qa_fixture_shrines(Shrine.objects.all()).values_list("id", flat=True))
+
+
+def _per_shrine_fact_counts(queryset: QuerySet, shrine_ids: list[int]) -> dict[int, int]:
+    """shrine_id毎のFact件数を1クエリで取得する（shrine数に比例したN+1を発生させない）。"""
+    counted = dict(
+        queryset.values("shrine_id").annotate(n=Count("id")).values_list("shrine_id", "n")
+    )
+    return {sid: counted.get(sid, 0) for sid in shrine_ids}
+
+
+def _count_distribution(counts_by_shrine: dict[int, int]) -> dict[str, int]:
+    histogram = Counter(counts_by_shrine.values())
+    return {str(k): v for k, v in sorted(histogram.items())}
+
+
+def _source_counts_by_shrine(shrine_ids: list[int]) -> dict[int, int]:
+    """shrine毎の（deity/history経由の）distinct Source件数を2クエリで取得する。"""
+    pairs: set[tuple[int, int]] = set()
+    for shrine_id, source_id in ShrineDeity.objects.filter(
+        shrine_id__in=shrine_ids, sources__isnull=False
+    ).values_list("shrine_id", "sources__id"):
+        pairs.add((shrine_id, source_id))
+    for shrine_id, source_id in ShrineHistory.objects.filter(
+        shrine_id__in=shrine_ids, sources__isnull=False
+    ).values_list("shrine_id", "sources__id"):
+        pairs.add((shrine_id, source_id))
+
+    counts = Counter(shrine_id for shrine_id, _ in pairs)
+    return {sid: counts.get(sid, 0) for sid in shrine_ids}
+
+
+def _shrines_with_source(shrine_ids: list[int]) -> set[int]:
+    return {sid for sid, count in _source_counts_by_shrine(shrine_ids).items() if count > 0}
+
+
+def _audit_scoped_sources_queryset(shrine_ids: list[int]) -> QuerySet:
+    return ShrineKnowledgeSource.objects.filter(
+        Q(deities__shrine_id__in=shrine_ids) | Q(histories__shrine_id__in=shrine_ids)
+    ).distinct()
+
+
+def build_knowledge_coverage_report() -> dict[str, Any]:
+    """Knowledge Coverageのread-only集計結果をdictで返す。
+
+    件数（count）に加え、audit_target_shrinesに対する割合（percentage、
+    小数点1桁）も併記する。現在のDB実測値をhardcodeせず、呼び出し時点の
+    DB状態から毎回計算する。
+    """
+
+    total_db_shrines = Shrine.objects.count()
+    audit_target_ids = _audit_target_shrine_ids()
+    audit_target_shrines = len(audit_target_ids)
+    excluded_test_shrines = total_db_shrines - audit_target_shrines
+
+    deity_counts = _per_shrine_fact_counts(
+        ShrineDeity.objects.filter(shrine_id__in=audit_target_ids), audit_target_ids
+    )
+    history_counts = _per_shrine_fact_counts(
+        ShrineHistory.objects.filter(shrine_id__in=audit_target_ids), audit_target_ids
+    )
+    source_counts = _source_counts_by_shrine(audit_target_ids)
+
+    deity_shrine_ids = {sid for sid, n in deity_counts.items() if n > 0}
+    history_shrine_ids = {sid for sid, n in history_counts.items() if n > 0}
+    source_shrine_ids = {sid for sid, n in source_counts.items() if n > 0}
+    any_knowledge_ids = deity_shrine_ids | history_shrine_ids
+    both_deity_history_ids = deity_shrine_ids & history_shrine_ids
+
+    fact_ready_deities = fetch_fact_ready_knowledge_deities(audit_target_ids)
+    fact_ready_histories = fetch_fact_ready_knowledge_histories(audit_target_ids)
+    fact_ready_deity_ids = {sid for sid, facts in fact_ready_deities.items() if facts}
+    fact_ready_history_ids = {sid for sid, facts in fact_ready_histories.items() if facts}
+    fact_ready_any_ids = fact_ready_deity_ids | fact_ready_history_ids
+
+    audit_sources_qs = _audit_scoped_sources_queryset(audit_target_ids)
+    verified_source_count = audit_sources_qs.filter(
+        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
+    ).count()
+    total_source_count = audit_sources_qs.count()
+
+    verification_status_counter = Counter(
+        ShrineDeity.objects.filter(shrine_id__in=audit_target_ids).values_list(
+            "verification_status", flat=True
+        )
+    ) + Counter(
+        ShrineHistory.objects.filter(shrine_id__in=audit_target_ids).values_list(
+            "verification_status", flat=True
+        )
+    )
+    confidence_counter = Counter(
+        ShrineDeity.objects.filter(shrine_id__in=audit_target_ids).values_list(
+            "confidence", flat=True
+        )
+    ) + Counter(
+        ShrineHistory.objects.filter(shrine_id__in=audit_target_ids).values_list(
+            "confidence", flat=True
+        )
+    )
+    source_type_counter = Counter(audit_sources_qs.values_list("source_type", flat=True))
+
+    def pct(count: int) -> float:
+        if audit_target_shrines == 0:
+            return 0.0
+        return round(count * 100 / audit_target_shrines, 1)
+
+    return {
+        "total_db_shrines": total_db_shrines,
+        "audit_target_shrines": audit_target_shrines,
+        "excluded_test_shrines": excluded_test_shrines,
+        "knowledge_coverage": {
+            "count": len(any_knowledge_ids),
+            "percentage": pct(len(any_knowledge_ids)),
+        },
+        "zero_knowledge": {
+            "count": audit_target_shrines - len(any_knowledge_ids),
+            "percentage": pct(audit_target_shrines - len(any_knowledge_ids)),
+        },
+        "deity_coverage": {
+            "count": len(deity_shrine_ids),
+            "percentage": pct(len(deity_shrine_ids)),
+        },
+        "history_coverage": {
+            "count": len(history_shrine_ids),
+            "percentage": pct(len(history_shrine_ids)),
+        },
+        "source_coverage": {
+            "count": len(source_shrine_ids),
+            "percentage": pct(len(source_shrine_ids)),
+        },
+        "both_deity_and_history_coverage": {
+            "count": len(both_deity_history_ids),
+            "percentage": pct(len(both_deity_history_ids)),
+        },
+        "fact_ready_coverage": {
+            "fact_ready_deity_shrines": {
+                "count": len(fact_ready_deity_ids),
+                "percentage": pct(len(fact_ready_deity_ids)),
+            },
+            "fact_ready_history_shrines": {
+                "count": len(fact_ready_history_ids),
+                "percentage": pct(len(fact_ready_history_ids)),
+            },
+            "fact_ready_any_shrines": {
+                "count": len(fact_ready_any_ids),
+                "percentage": pct(len(fact_ready_any_ids)),
+            },
+        },
+        "verified_source_count": verified_source_count,
+        "total_source_count": total_source_count,
+        "deity_count_distribution": _count_distribution(deity_counts),
+        "history_count_distribution": _count_distribution(history_counts),
+        "source_count_distribution": _count_distribution(source_counts),
+        "verification_status_distribution": dict(sorted(verification_status_counter.items())),
+        "confidence_distribution": dict(sorted(confidence_counter.items())),
+        "source_type_distribution": dict(sorted(source_type_counter.items())),
+    }
+
+
+__all__ = ["build_knowledge_coverage_report"]

--- a/backend/temples/services/shrine_qa_fixture_exclusion.py
+++ b/backend/temples/services/shrine_qa_fixture_exclusion.py
@@ -1,0 +1,48 @@
+"""QA fixture Shrine除外契約。
+
+PR2271（audit/knowledge-coverage-shadow-105、id=101-105の「承認テスト神社」
+「重複検証神社」等）で確立した、Recommendation candidate pool
+（temples.services.concierge_chat_candidates.build_chat_candidates）と
+Knowledge Coverage集計（temples.management.commands.knowledge_coverage_report）
+の両方が共有すべき「テスト/QA用fixture Shrineの除外」条件を一箇所にまとめる。
+
+この関数は「どのShrineが実在神社（audit対象）か」を判定する唯一の正本であり、
+呼び出し側は本関数の結果をそのまま使い、除外条件を独自に再実装しない。
+name_jpの命名規約にのみ依存し、id範囲のhardcodeは行わない
+（新しいfixtureがid=106以降に追加されても、同じ命名規約に従う限り
+再定義なしで機能する）。
+"""
+
+from __future__ import annotations
+
+from django.db.models import QuerySet
+
+_NOISY_SHRINE_NAMES = [
+    "x",
+    "x2",
+    "noaddr",
+    "住所なし神社",
+    "test神社",
+    "テスト候補神社",
+    "テスト神社",
+    "テスト神社2",
+    "テスト神社-1770895174",
+]
+
+
+def exclude_qa_fixture_shrines(queryset: QuerySet) -> QuerySet:
+    """QA用fixture Shrineをquerysetから除外する。
+
+    Recommendation candidate pool（concierge_chat_candidates.build_chat_candidates）
+    と同一の除外条件を適用する。地理座標・住所の有無等、Candidate固有のfilterは
+    ここに含めない（Coverage集計等、Candidate以外の用途で母集団が変わらないため）。
+    """
+    qs = queryset.exclude(name_jp__in=_NOISY_SHRINE_NAMES)
+    qs = qs.exclude(name_jp__startswith="テスト")
+    qs = qs.exclude(name_jp__istartswith="test")
+    qs = qs.exclude(name_jp__icontains="承認テスト")
+    qs = qs.exclude(name_jp__icontains="検証")
+    return qs
+
+
+__all__ = ["exclude_qa_fixture_shrines"]

--- a/backend/temples/tests/services/test_knowledge_coverage_report.py
+++ b/backend/temples/tests/services/test_knowledge_coverage_report.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+import pytest
+from django.utils import timezone
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services.knowledge_coverage_report import build_knowledge_coverage_report
+
+
+def _shrine(name: str) -> Shrine:
+    return Shrine.objects.create(name_jp=name, address="東京都千代田区", popular_score=0.0)
+
+
+def _source(verification_status: str = "source_confirmed", source_type: str = "shrine_official") -> ShrineKnowledgeSource:
+    kwargs = dict(source_type=source_type, title="出典", verification_status=verification_status)
+    if verification_status in ("source_confirmed", "reviewed"):
+        kwargs["verified_at"] = timezone.now()
+    return ShrineKnowledgeSource.objects.create(**kwargs)
+
+
+@pytest.mark.django_db
+def test_empty_knowledge_db_reports_zero_coverage():
+    _shrine("神社A")
+    _shrine("神社B")
+
+    report = build_knowledge_coverage_report()
+
+    assert report["audit_target_shrines"] == 2
+    assert report["knowledge_coverage"] == {"count": 0, "percentage": 0.0}
+    assert report["zero_knowledge"] == {"count": 2, "percentage": 100.0}
+    assert report["verified_source_count"] == 0
+
+
+@pytest.mark.django_db
+def test_one_knowledge_shrine_is_counted():
+    shrine = _shrine("知識あり神社")
+    _shrine("知識なし神社")
+    source = _source()
+
+    deity = ShrineDeity.objects.create(
+        shrine=shrine, display_name="祭神A", sort_order=0,
+        verification_status="source_confirmed", verified_at=timezone.now(),
+    )
+    deity.sources.add(source)
+
+    report = build_knowledge_coverage_report()
+
+    assert report["audit_target_shrines"] == 2
+    assert report["knowledge_coverage"] == {"count": 1, "percentage": 50.0}
+    assert report["zero_knowledge"] == {"count": 1, "percentage": 50.0}
+    assert report["deity_coverage"]["count"] == 1
+    assert report["source_coverage"]["count"] == 1
+
+
+@pytest.mark.django_db
+def test_fact_ready_deity_and_history_are_counted_via_evidence_gate():
+    shrine = _shrine("Fact-ready神社")
+    source = _source("source_confirmed")
+
+    deity = ShrineDeity.objects.create(
+        shrine=shrine, display_name="祭神A", sort_order=0,
+        verification_status="source_confirmed", verified_at=timezone.now(),
+    )
+    deity.sources.add(source)
+
+    history = ShrineHistory.objects.create(
+        shrine=shrine, history_type="tradition", title="由緒A", content="内容A",
+        period_text="", sort_order=0,
+        verification_status="source_confirmed", verified_at=timezone.now(),
+    )
+    history.sources.add(source)
+
+    report = build_knowledge_coverage_report()
+    fact_ready = report["fact_ready_coverage"]
+
+    assert fact_ready["fact_ready_deity_shrines"]["count"] == 1
+    assert fact_ready["fact_ready_history_shrines"]["count"] == 1
+    assert fact_ready["fact_ready_any_shrines"]["count"] == 1
+
+
+@pytest.mark.django_db
+def test_unusable_fact_is_excluded_from_fact_ready_but_counted_in_raw_coverage():
+    """draft状態のFactは Evidence Gate で usable=False。
+    raw coverage（knowledge_coverage/deity_coverage）には含まれるが、
+    fact_ready_coverageには含まれないことを確認する。
+    """
+    shrine = _shrine("Draft神社")
+    source = _source("source_confirmed")
+
+    deity = ShrineDeity.objects.create(
+        shrine=shrine, display_name="下書き祭神", sort_order=0,
+        verification_status="draft",
+    )
+    deity.sources.add(source)
+
+    report = build_knowledge_coverage_report()
+
+    assert report["knowledge_coverage"]["count"] == 1
+    assert report["deity_coverage"]["count"] == 1
+    assert report["fact_ready_coverage"]["fact_ready_deity_shrines"]["count"] == 0
+    assert report["verification_status_distribution"].get("draft") == 1
+
+
+@pytest.mark.django_db
+def test_qa_fixture_shrines_are_excluded_from_audit_target():
+    # conftest.py の `_ensure_shrine_exists`（autouse）が pk=1 の「テスト神社」を
+    # 自動生成するため、絶対件数ではなくbaselineからの差分で検証する。
+    baseline = build_knowledge_coverage_report()
+
+    _shrine("実在神社")
+    _shrine("承認テスト神社")
+    _shrine("重複検証神社")
+    _shrine("テスト神社")
+
+    report = build_knowledge_coverage_report()
+
+    assert report["total_db_shrines"] == baseline["total_db_shrines"] + 4
+    assert report["audit_target_shrines"] == baseline["audit_target_shrines"] + 1
+    assert report["excluded_test_shrines"] == baseline["excluded_test_shrines"] + 3
+
+
+@pytest.mark.django_db
+def test_source_type_and_confidence_distribution():
+    shrine = _shrine("分布確認神社")
+    source_official = _source("source_confirmed", source_type="shrine_official")
+    source_cultural = _source("source_confirmed", source_type="cultural_property")
+
+    deity = ShrineDeity.objects.create(
+        shrine=shrine, display_name="祭神A", sort_order=0, confidence="high",
+        verification_status="source_confirmed", verified_at=timezone.now(),
+    )
+    deity.sources.add(source_official)
+
+    history = ShrineHistory.objects.create(
+        shrine=shrine, history_type="historical_event", title="出来事A", content="内容A",
+        period_text="", sort_order=0, confidence="medium",
+        verification_status="source_confirmed", verified_at=timezone.now(),
+    )
+    history.sources.add(source_cultural)
+
+    report = build_knowledge_coverage_report()
+
+    assert report["source_type_distribution"] == {
+        "cultural_property": 1,
+        "shrine_official": 1,
+    }
+    assert report["confidence_distribution"] == {"high": 1, "medium": 1}
+
+
+@pytest.mark.django_db
+def test_report_does_not_write_to_database():
+    _shrine("書き込みなし確認神社")
+
+    before = list(Shrine.objects.values_list("id", "name_jp"))
+    build_knowledge_coverage_report()
+    after = list(Shrine.objects.values_list("id", "name_jp"))
+
+    assert before == after
+    assert ShrineDeity.objects.count() == 0
+    assert ShrineHistory.objects.count() == 0
+    assert ShrineKnowledgeSource.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_orphan_source_with_no_fact_relation_is_excluded_from_scoped_counts():
+    """shrine/factのいずれにも紐付かないSourceは、audit-target-scoped集計に含めない
+    （PR実装時に実DBで発見した実例: id=999002「テスト神社公式サイト」相当のケース）。
+    """
+    _shrine("神社A")
+    _source("source_confirmed")  # どのDeity/Historyにもattachしない
+
+    report = build_knowledge_coverage_report()
+
+    assert report["verified_source_count"] == 0
+    assert report["total_source_count"] == 0

--- a/backend/temples/tests/services/test_shrine_qa_fixture_exclusion.py
+++ b/backend/temples/tests/services/test_shrine_qa_fixture_exclusion.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from temples.models import Shrine
+from temples.services.shrine_qa_fixture_exclusion import exclude_qa_fixture_shrines
+
+
+def _shrine(name: str) -> Shrine:
+    return Shrine.objects.create(name_jp=name, address="東京都千代田区", popular_score=0.0)
+
+
+@pytest.mark.django_db
+def test_excludes_known_qa_fixture_naming_patterns():
+    _shrine("実在神社")
+    _shrine("承認テスト神社")
+    _shrine("admin承認テスト神社")
+    _shrine("重複検証神社")
+    _shrine("重複検証神社（別宮）")
+    _shrine("テスト神社")
+    _shrine("test神社")
+
+    remaining = list(
+        exclude_qa_fixture_shrines(Shrine.objects.exclude(pk=1)).values_list("name_jp", flat=True)
+    )
+
+    assert remaining == ["実在神社"]
+
+
+@pytest.mark.django_db
+def test_does_not_over_exclude_mid_name_test_substring():
+    _shrine("距離テスト神社")
+    _shrine("place_idテスト神社")
+
+    remaining = set(
+        exclude_qa_fixture_shrines(Shrine.objects.exclude(pk=1)).values_list("name_jp", flat=True)
+    )
+
+    assert "距離テスト神社" in remaining
+    assert "place_idテスト神社" in remaining

--- a/backend/temples/tests/test_knowledge_coverage_report_command.py
+++ b/backend/temples/tests/test_knowledge_coverage_report_command.py
@@ -1,0 +1,60 @@
+import io
+import json
+
+import pytest
+from django.core.management import call_command
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+
+
+@pytest.mark.django_db
+def test_command_text_output_contains_expected_labels():
+    out = io.StringIO()
+    call_command("knowledge_coverage_report", stdout=out)
+    text = out.getvalue()
+
+    assert "Knowledge Coverage Report" in text
+    assert "Total DB Shrines:" in text
+    assert "Audit Target Shrines:" in text
+    assert "Knowledge Coverage:" in text
+    assert "Zero Knowledge:" in text
+    assert "Fact-ready Coverage:" in text
+    assert "Verified Source Count:" in text
+
+
+@pytest.mark.django_db
+def test_command_json_output_is_valid_and_has_expected_shape():
+    out = io.StringIO()
+    call_command("knowledge_coverage_report", "--format", "json", stdout=out)
+    payload = json.loads(out.getvalue())
+
+    assert "total_db_shrines" in payload
+    assert "audit_target_shrines" in payload
+    assert "excluded_test_shrines" in payload
+    assert set(payload["knowledge_coverage"].keys()) == {"count", "percentage"}
+    assert set(payload["zero_knowledge"].keys()) == {"count", "percentage"}
+    fact_ready = payload["fact_ready_coverage"]
+    assert set(fact_ready.keys()) == {
+        "fact_ready_deity_shrines",
+        "fact_ready_history_shrines",
+        "fact_ready_any_shrines",
+    }
+    assert isinstance(payload["deity_count_distribution"], dict)
+    assert isinstance(payload["source_type_distribution"], dict)
+
+
+@pytest.mark.django_db
+def test_command_does_not_write_to_database():
+    shrine_count_before = Shrine.objects.count()
+    deity_count_before = ShrineDeity.objects.count()
+    history_count_before = ShrineHistory.objects.count()
+    source_count_before = ShrineKnowledgeSource.objects.count()
+
+    out = io.StringIO()
+    call_command("knowledge_coverage_report", stdout=out)
+    call_command("knowledge_coverage_report", "--format", "json", stdout=out)
+
+    assert Shrine.objects.count() == shrine_count_before
+    assert ShrineDeity.objects.count() == deity_count_before
+    assert ShrineHistory.objects.count() == history_count_before
+    assert ShrineKnowledgeSource.objects.count() == source_count_before


### PR DESCRIPTION
## Summary

- `python manage.py knowledge_coverage_report`（`--format text|json`）を追加。DB書き込みは一切行わない
- Pilot/Batch1/Batch2で7回程度手動実行してきたCoverage集計クエリ（Knowledge/Zero-Knowledge/Deity/History/Source coverage、Fact-ready coverage、verification/confidence/source_type分布等）を一本化
- Fact usable判定は既存の`evidence_gate.decide_fact_usability()` / `shrine_knowledge_selector`へ委譲し、判定ロジックを複製していない
- QA fixture Shrineの除外条件を`temples/services/shrine_qa_fixture_exclusion.py`へ抽出し、`build_chat_candidates()`と本commandの両方が同一の正本を共有（id範囲のhardcodeなし、name_jp命名規約のみに依存）
- `build_chat_candidates()`は抽出後も既存テスト（fixture除外・mid-name非過剰除外を含む）で挙動変更なしを確認済み

## Golden Comparison（実DB確認）

`docs/audit/shrine-knowledge-rollout-batch-2.md`記載の値と一致:
- Total DB Shrines: 105 / Audit Target: 100 / Excluded: 5
- Knowledge Coverage: 14/100 (14.0%) / Zero Knowledge: 86/100 (86.0%)

一点、既存one-off集計との差分を発見: `verified_source_count`が27（本command、shrine紐付けでscope）に対し、過去の手動集計は28（shrine非scopeのglobal count）だった。差分の原因は、どのDeity/Historyにも紐付いていない孤立Source（id=999002「テスト神社公式サイト」、Fact関係0件）が手動集計では混入していたため。本commandはaudit対象shrineに実際に紐付くSourceのみを数えるため、こちらがより正確な値。過去のBatch文書（Archive済み）は遡って修正していない。

## Scope

変更: management command / service module（`knowledge_coverage_report.py`） / 共有helper（`shrine_qa_fixture_exclusion.py`、既存の`build_chat_candidates()`をこのhelper呼び出しへ置換） / テスト3ファイル

変更なし: models / migrations / serializers / API / Candidate選定ロジック / Score / Ranking / Evidence Gate contract / Reason V4 / Web / Mobile

## Test plan

- [x] `knowledge_coverage_report` service tests（empty DB / one shrine / fact-ready / unusable fact / fixture除外 / source_type・confidence分布 / DB非書き込み / orphan source除外）8件 PASS
- [x] `shrine_qa_fixture_exclusion` tests 2件 PASS
- [x] management command tests（text/JSON出力・DB非書き込み）3件 PASS
- [x] `build_chat_candidates()`既存contract test 10件（fixture除外を含む）PASS — helper抽出後も挙動不変を確認
- [x] full backend suite: 1025 passed, 9 skipped（GIS、ローカル環境起因）
- [x] `makemigrations --check --dry-run` — No changes detected
- [x] `git diff --check` — 問題なし
- [x] query count確認: 100 shrine規模で17クエリ、shrine数に依存しないN+1なし構造
- [x] pre-push guard（OpenAPI lint + Web contract tests 731/731）PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)