### PR TITLE
docs: Audit navigationとCurrent Source導線を整備

### DIFF
--- a/docs/audit/README.md
+++ b/docs/audit/README.md
@@ -1,0 +1,173 @@
+# KAMI MUSUBI Audit Documents
+
+> **Status: Active（Navigation Only）**
+>
+> `docs/audit/`は時点付きの監査・観測・設計判断履歴を保存する場所であり、現在有効な仕様の正本ではない。現在仕様は各Current Source of Truth（`docs/core/`・`docs/product/`・`docs/knowledge/`・`docs/analytics/`のActive文書）を参照する。
+>
+> 本書は`docs/audit/`配下91文書のnavigationのみを目的とする。個別audit文書の内容・Status変更・削除・移動は本書と同じPRで行っていない。
+
+## 目的
+
+`docs/audit/`配下の監査文書について、以下のみを提供する。
+
+1. `docs/audit/`の読み方の定義
+2. Current Source of Truthへの導線
+3. audit chainの主要入口の整理
+
+古い監査内容の削除・移動・大量Status変更は本書の責務ではない。
+
+---
+
+## `docs/audit/`の性質
+
+- audit文書は原則Current Contract（現在有効な仕様）ではない
+- Archive相当の履歴保存場所としても機能する
+- 古い数値（Coverage件数、shrine件数等）はHistorical Snapshotとしてそのまま残りうる。本書・audit文書のいずれも現在値へ無断更新しない
+- 現在仕様を知りたい場合は、常にCore / Product / Knowledge / AnalyticsのActive正本を先に見る
+- 個別auditからCurrent Source of Truthへの逆引きができるよう、本書は主要3 chainのみを索引化する（下記「Major Audit Chain Index」）
+
+---
+
+## Status Vocabulary Contract
+
+`docs/audit/`配下では現在、Status header記法・語彙が複数混在している（blockquote inline形式、section-header形式、独自語彙等）。本書はREADME上でのみ、今後の分類語彙の契約を以下に定義する。**この契約に基づく91文書全件への一括適用は本PRの対象外**であり、個別文書のStatus変更は行っていない。
+
+| 語彙 | 意味 |
+| --- | --- |
+| `Active Tracking` | 現在進行中の追跡ビュー。ただしCurrent Source of Truthではない（例: Backlogの優先度整理ビュー） |
+| `Reference` | 現在も設計背景として参照価値がある監査 |
+| `Audit / Historical` | ある時点の監査結果・観測snapshot |
+| `Audit / Superseded` | 後続auditまたはCurrent Sourceによって現在仕様としては置換済み。履歴価値は残る |
+| `Archive` | 完了済み・履歴保持のみ |
+| `Review` | 位置づけ未確定。整理監査待ち |
+
+---
+
+## 読み方（Search / Reading Rule）
+
+現在仕様を知りたい場合は、以下の優先順で参照する。
+
+1. Current Source of Truth（各分野のActive正本）
+2. Final / latest audit（chainの最終監査）
+3. Intermediate audit（chain中間の監査）
+4. Historical snapshot（時点記録）
+
+### 例
+
+現在のRecommendation仕様を知りたい
+
+```text
+docs/core/recommendation-architecture.md
+↓（必要なら）
+Recommendation audit chain（下記参照）
+```
+
+現在のKnowledge仕様を知りたい
+
+```text
+docs/knowledge/shrine-knowledge-contract.md
+↓（必要なら）
+Pilot / Rollout audit chain（下記参照）
+```
+
+現在のSecurity仕様を知りたい
+
+```text
+docs/core/runtime-security-baseline.md
+↓（必要なら）
+security-audit-final-2026-08.md
+```
+
+---
+
+## Major Audit Chain Index
+
+今回の監査（`audit/documentation-freshness-2026-08`）で位置づけを確認できた3 chainのみを掲載する。他のaudit文書のchain位置づけは未確認（下記「Statusが付与されていない文書について」参照）。
+
+### Knowledge
+
+Current Source of Truth:
+
+- `docs/knowledge/shrine-knowledge-contract.md`
+- `docs/core/recommendation-readiness.md`
+
+History chain（古い→新しい）:
+
+- `shrine-knowledge-real-data-pilot-1.md`
+- `knowledge-model-pilot-2-shinagawa.md`
+- `shrine-knowledge-pilot-5-result.md`
+- `shrine-knowledge-rollout-batch-1.md`
+- `shrine-knowledge-rollout-batch-2.md`
+- `shrine-knowledge-rollout-batch-3.md`
+
+### Security
+
+Current Source of Truth:
+
+- `docs/core/runtime-security-baseline.md`
+
+History:
+
+- `security-audit-final-2026-08.md`
+
+Tracking view（Current Source of Truthではない。優先度整理・ID付与のためのBacklogビュー）:
+
+- `security-follow-up-backlog.md`
+
+### Recommendation
+
+Current Sources of Truth:
+
+- `docs/core/recommendation-architecture.md`
+- `docs/core/recommendation-readiness.md`
+- `docs/core/recommendation-reason-contract.md`
+
+Historical consolidation（Recommendation関連文書群の統合判断を記録した監査）:
+
+- `recommendation-doc-consolidation-audit.md`
+
+その他のRecommendation関連audit文書（v3/v4系等）は、chain上の位置づけを個別確認する後続整理（PR-Docs-B）で分類する。本書では無理にchainへ含めない。
+
+---
+
+## Statusが付与されていない文書について
+
+`docs/audit/`には、Status headerが付与されていない文書が複数存在する。これらは**Current Sourceとはみなさず、常にCurrent Sourceの確認を優先する**。
+
+ただし、以下は断定しない。
+
+- Statusなし = 古い
+- Statusなし = Superseded
+- Statusなし = Archive
+
+Statusなしは「未分類」を意味するに留まり、内容の陳腐化・妥当性とは独立している。
+
+---
+
+## 本書が扱わないもの
+
+`docs/audit/README.md`はindex / navigationのみを責務とする。以下を本書へ記載しない。
+
+- current API contract
+- current model contract
+- current authentication contract
+- current Knowledge contract
+- current Recommendation contract
+- Product roadmap
+- 運用上のsecret値
+- 具体的なCoverage数値等、Rolloutごとに変化する現在値（数値はRolloutのたびに古くなり、本書自身が新たなstale情報を生む原因になるため。現在値は`knowledge_coverage_report`等の現行toolingから取得する）
+
+---
+
+## 関連ドキュメント
+
+- `../core/README.md`
+- `../product/README.md`
+- `../knowledge/README.md`
+- `../analytics/README.md`
+
+## 更新ルール
+
+- 本書はaudit文書の内容・Status・削除・移動を管理しない
+- 新しいaudit chainを索引化する場合は、Current Source of Truthとの対応関係を確認した上で追加する
+- 91文書全件のStatus一括変更・一括分類は本書の更新では行わない

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -29,6 +29,8 @@ meaning-layer-connection.md
 ↓
 narrative-guideline.md
 ↓
+recommendation-architecture.md
+↓
 recommendation-readiness.md
 ↓
 recommendation-reason-contract.md
@@ -77,6 +79,7 @@ openapi-contract-governance.md
 
 | 文書 | 責務 |
 | --- | --- |
+| `recommendation-architecture.md` | Recommendation全体（相談入力から知識還元まで）のEnd-to-Endフロー、各段階の責務・正本データおよび引き渡し契約 |
 | `recommendation-readiness.md` | 神社Knowledge CoverageのGovernance観測（Runtime candidate除外には接続しない） |
 | `recommendation-reason-contract.md` | Recommendation ReasonのInput / Output / 保存 / 表示 / 互換責務 |
 


### PR DESCRIPTION
## Summary

- `docs/audit/`配下91文書のnavigation問題を確認: Archive/Reference/Active tracking/Statusなしの過去監査/中間snapshot/最終auditが検索上ほぼ同列に見える状態
- Statusなし54件を確認
- Status記法3種類混在を確認（blockquote inline / section-header / 独自語彙「Completed」）
- 今回は一括Status変更しない
- `docs/audit/README.md`を索引として新設（Status Vocabulary Contract定義、読み方ルール、Non-Responsibilities明記）
- Current Sourceを明示（Core/Product/Knowledge/AnalyticsのActive正本への導線）
- Knowledge/Security/Recommendation 3 chainのみ初期index化（他は位置づけ未確認のため含めない）
- `docs/core/recommendation-architecture.md`のcore README索引漏れを修正（Status: Active・自己正本宣言済みだが、Active一覧・読む順番のいずれにも未掲載だった。内容は変更していない。既存の`recommendation-readiness.md`/`recommendation-reason-contract.md`と責務説明が重複しないよう記述）
- 削除0件
- move 0件
- PR-Docs-Bで個別audit文書のSuperseded整理を予定

## Scope

変更: `docs/audit/README.md`（新規）、`docs/core/README.md`（recommendation-architecture.md導線追加のみ）

変更禁止項目の遵守: audit 91ファイルのStatus変更なし、audit文書本文変更なし、core contract本文変更なし、docs移動なし、docs削除なし、archive新設なし、application code変更なし

## Test plan

- [x] `git diff --check` — 問題なし
- [x] 参照先パス全件の存在確認（README内リンク26件、MISSINGなし）
- [x] docs-only diff確認（2ファイルのみ）
- [x] Current Sourceの二重化なし
- [x] `security-follow-up-backlog.md`をSecurity正本と誤表記していないことを確認（Tracking viewと明記）
- [x] `recommendation-doc-consolidation-audit.md`をcurrent Recommendation正本と誤表記していないことを確認（Historical consolidationと明記）
- [x] Knowledge rollout auditをcurrent Knowledge契約と誤表記していないことを確認（History chainと明記）
- [x] `collective-deity-contract-stress.md`は未merge（PR #2276 OPEN）のため導線に含めていない
- [x] READMEに具体的なCoverage数値を含めていない
- [x] pre-push guard（OpenAPI lint + Web contract tests 731/731）PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)