### PR TITLE
docs: Stage 3中立色統合方針・Message-own/Selection Token新設を確定

### DIFF
--- a/docs/audit/design-token-stage3-neutral-semantic-decision.md
+++ b/docs/audit/design-token-stage3-neutral-semantic-decision.md
@@ -1,0 +1,107 @@
+> **Status: Reference**
+>
+> 本文書は、Design Token Migration Stage 3（`docs/design/design-token.md`のMigration方針 3. Recommendation画面適用）の着手前調査で発見した、中立色パレット（slate/gray/neutral/stone）の意味統合方針・未定義Semantic Token（own-message／selected-item）・Premium subtle ringのshade差について、調査事実と決定事項を記録する。
+>
+> 本文書はStage 3着手前の意思決定記録であり、Token名・実値の最終確定はこの後の実装PR（後述「Sub-PR再設計」）で行う。
+
+# Design Token Stage 3 — 中立色統合方針・未定義Semantic Token決定
+
+## 背景
+
+`apps/web/src/features/concierge/`を対象としたStage 3のtoken適用監査で、低リスクと想定していたSub-PR A候補7ファイルが、いずれもslate以外の中立色パレット（neutral/gray/stone）を使用しており、既存の`tokens.css`のSemantic Token（border-default/text-primary等、いずれもslateベース）へ機械的に1:1置換できないことが判明した。これは`docs/design/design-token.md`が「保留事項」として明記していた中立色4系統（slate/stone/gray/neutral）の統合方針が未決定だったことに起因する。
+
+あわせて、既存のSemantic Token体系に該当カテゴリが存在しない2箇所（チャット送信メッセージの背景色、リスト選択状態の色）と、Premium系トークンとの微小なshade差（`ring-amber-100` vs `--kt-color-premium-border: amber-200`）を発見した。
+
+本文書はこれらの調査事実と、確定した決定事項を記録する。
+
+## 調査事実
+
+### 1. 中立色パレットの repo-wide 使用実態
+
+`docs/audit/design-token-phase6-audit.md`（Status: Reference）の既存棚卸しを基礎とし、意味カテゴリ（TEXT/BORDER/SURFACE/DARK_SURFACE/DISABLED/INTERACTIVE/DECORATIVE）別にWeb（`apps/web/src`）全体を再調査した。
+
+| パレット | 規模（phase6監査） | 主な意味カテゴリ |
+|---|---|---|
+| slate | 59ファイル・約400回 | TEXT（700/900）・BORDER（200/300）・SURFACE（50） |
+| stone | 33ファイル・約400回 | TEXT/BORDER/SURFACE全般、INTERACTIVE(hover)の主力 |
+| gray | 約90回 | 主にLogin/Signup等の旧フォーム系。DARK_SURFACE 1件（`MessageList.tsx:bg-gray-900`） |
+| neutral | 約40回 | Concierge・共有`ConciergeCard.tsx`に散発。DARK_SURFACE複数件（`neutral-900/800`） |
+
+**追加発見（DARK_SURFACEの repo横断的不統一）**: `bg-slate-900`（13箇所: billing各画面・`error.tsx`・`plan`・旧concierge debug UI）、`bg-gray-900`（`MessageList.tsx`）、`bg-neutral-900/800`（`ConciergeSectionsRenderer.tsx`・`components/ConciergeCard.tsx`）、`bg-stone-950`（`GoshuinDetailModal.tsx`・`tokens.css`自体）が、4つの異なるパレットで同じ「強調ダークサーフェス」役割を独立に実装していた。`MessageList.tsx`の送信メッセージ色は、チャット固有の概念ではなく、このrepo横断的な不統一パターンの一インスタンスであることを確認した。
+
+### 2. own-message Semantic Tokenの要否
+
+- Web: `bg-gray-900`（自分の発言バブル）
+- Mobile: `apps/mobile/app/consultation-history/[id].tsx:379-384`の`messageBubbleUser`/`messageBubbleAssistant`は、専用色を持たず既存のSurface系（`theme.surfaceSoft`/`theme.surface`）を使い分けているのみ
+
+### 3. selected-item Semantic Tokenの要否
+
+- Web: `ThreadListItem.tsx`の`border-blue-500`/`bg-blue-50`（選択状態）
+- Web内クロスチェック: 同じconcierge feature内の`OriginSelector.tsx`は、同じ「選択中」状態を既にemerald（`border-emerald-500 bg-emerald-50`、既存のAction Tokenと一致）で実装している。`ThreadListItem.tsx`のみblueを使用しており、Web内で選択状態の色表現が2系統に分裂していた
+- Mobile: `apps/mobile/app/profile/index.tsx:222-224`の`chipSelected`は`borderColor: theme.gold`（Mobileの Action/Premiumブランド色）を使用。独立した選択専用色ではなく、既存のブランドAction色を再利用している
+
+### 4. Premium subtle ring
+
+`ring-amber-100`はrepo全体で`ModeBadge.tsx`の1箇所のみ（`ring-amber-*`使用は全体で2件、他方は文脈の異なる`OriginSelector.tsx`の`ring-amber-700`）。一方`--kt-color-premium-border`と一致する`border-amber-200`は13ファイルで反復使用される支配的パターン。
+
+## 決定事項
+
+母艦（Product判断）による確定。
+
+| 項目 | 決定 |
+|---|---|
+| 中立色統合方針 | **Option B採用**: neutral/gray/stone/slateというpalette名をSemantic Token名にせず、意味（text-primary/secondary/muted, border-default, surface-default/subtle/emphasis, disabled, selected, message-own, premium-subtle）で分類し、実色差はPlatform Theme層で吸収する。Option A（slateへ機械統合）は見た目と意味を同時に潰すため不採用 |
+| 移行時の暫定運用 | Option Cを移行中のFallbackとして許容する。既存Tokenで意味が一致する箇所は移行必須、Semantic Token未定義の箇所のみliteralを残してよい |
+| own-message Semantic Token | **追加する**。候補名: `--kt-color-message-own-background`, `--kt-color-message-own-text`（実値・最終命名は実装PR側で確定）。根拠: gray-900は「濃いgray」ではなく「自分側メッセージ」という意味を持つため。Mobile側は既存Surfaceトークンの使い分けで表現しており独立トークンは持たないが、Web側で新設することを妨げない |
+| selected-item Semantic Token | **追加する**。候補名: `--kt-color-selection-background`, `--kt-color-selection-border`, `--kt-color-selection-text`（実値・最終命名は実装PR側で確定）。`ThreadListItem.tsx`のblueをemeraldへ機械的に置換することはしない（意味の独断決定を避けるため、新規Selection Tokenとして切り出す） |
+| premium subtle ring | **KEEP_LITERAL_FOR_NOW**。1箇所のみのため新規Token化を急がず、リテラル(`ring-amber-100`)のまま残す。複数箇所で同じ意味の使用が確認された時点で`--kt-color-premium-ring-subtle`を候補化する |
+| Stage 3 スコープ | ディレクトリ基準（`apps/web/src/features/concierge/**`のみ）から、**Recommendation UI責務基準**へ再定義する。判定基準: (A) Recommendation画面の主要表示責務を持つ (B) Stage 3画面から直接使用される (C) Token未移行が画面全体の整合性に影響する。この基準により`components/ConciergeCard.tsx`（`PrimaryRecommendationCard.tsx`の委譲先で、Recommendation画面の主要カード表示責務を持つ）をStage 3スコープに含める |
+| 部分移行の許容 | **PARTIAL_MIGRATION_ALLOWED**。Semantic Token未定義箇所のみliteral残存を許可する。既存Tokenで意味が一致する箇所は移行必須。残存箇所は「TODO」ではなく「Blocked by Contract」として明記する。Stage 3は本条件下でも「DONE」とは扱わない |
+
+## Sub-PR再設計
+
+前回（視覚リスク階層によるSub-PR A/B/C）の分割案は破棄し、以下の依存関係ベースの分類へ再設計する。
+
+### PR-A: 既存Tokenでexact semantic matchできる箇所
+
+新Token追加を待たずに着手可能。
+
+- `ConciergeConsultationSummary.tsx`
+- `ConciergeFilterPanel.tsx`
+- `PremiumStateDeltaCard.tsx`
+- `ModeBadge.tsx`（`ring-amber-100`はKEEP_LITERAL_FOR_NOWのためliteral残置＝Blocked by Contractと明記）
+- `ConciergeSectionsRenderer.tsx`・`ConciergeTopRecommendationHero.tsx`のslate/emerald/amber部分（neutral-900等のDARK_SURFACE部分・`text-slate-950`部分は対象外、Blocked by Contractと明記）
+
+### PR-B: 新Semantic Token追加後に移行できる箇所
+
+`--kt-color-message-own-*`・`--kt-color-selection-*`の実装（`tokens.css`への追加）を前提PRとし、その後に以下を移行する。
+
+- `MessageList.tsx`（own-message）
+- `ThreadListItem.tsx`（selection）
+- `ThreadList.tsx`（selection関連の可能性があるamber/premium部分はPR-A相当、`text-blue-600`のリンク色は別途Blocked by Contractとして記録し本PRの対象外）
+
+中立色統合（Option B）の具体的なSemantic Token実装（`border-default`等が吸収する対象範囲の確定）も本PRの前提として必要。
+
+- `BreakdownAccordion.tsx` / `MatchChips.tsx` / `NeedChips.tsx` / `DirectionReferenceCard.tsx` / `ChatInput.tsx` / `ChatPanel.tsx` / `ConciergeLayout.tsx` / `OriginSelector.tsx`（stone部分）
+
+### PR-C: 主要Recommendation UI
+
+画面の第一印象・複雑度が高く、最も慎重な視覚QAが必要な範囲。PR-A/PR-Bで確立したToken適用パターンを踏まえた上で最後に着手する。
+
+- `ConciergeEntryCard.tsx`
+- `ConciergeSectionsRenderer.tsx`（残り部分）
+- `ConciergeTopRecommendationHero.tsx`（残り部分）
+- `components/ConciergeCard.tsx`（Stage 3スコープ再定義により新規追加、`PrimaryRecommendationCard.tsx`の委譲先）
+
+`ChatInput.tsx`の送信ボタン（`bg-indigo-500`）は、中立色問題とは別に、確立済みのAction Token（emerald）とのブランド不整合であることも判明している。この扱いは中立色統合とは別軸のProduct判断が必要であり、本文書の決定範囲には含めない。PR-B着手時に別途確認する。
+
+## 関連文書
+
+- `docs/design/design-token.md`（本決定を反映して更新）
+- `docs/audit/design-token-phase6-audit.md`（本調査の基礎データ）
+
+## 品質確認
+
+- [x] 決定事項は全て母艦（Product判断）による確定であり、本文書側で独断していない
+- [x] Token実値・最終命名は本文書で確定させず、実装PR側に委ねた
+- [x] `git diff --check`

--- a/docs/design/design-token.md
+++ b/docs/design/design-token.md
@@ -94,8 +94,14 @@ Phase 6監査で確認した実際の用途分布に基づき、以下のカテ�
 | Premium | Premium機能の強調表現 | `amber-*`系 | `gold`/`borderGold`（`#8A6C32`） |
 | Overlay | モーダル背景等の半透明オーバーレイ | `bg-black/50`と`bg-stone-950/35`が混在（不統一） | `rgba(7, 16, 31, 0.82)`と`rgba(7, 16, 31, 0.72)`が混在（不統一） |
 | Focus | フォーカスリング | `focus:border-emerald-300`, `focus:ring-stone-200`, `focus-visible:ring-neutral-400`が混在 | 明示的なfocus tokenは未確認 |
+| Message-own | チャット等における自分側発言の背景・文字色 | `bg-gray-900`（Concierge）。ただしrepo横断で見ると、billing各画面・error画面・`ConciergeCard.tsx`等が独立にslate-900/neutral-900/stone-950で似た「強調ダークサーフェス」を実装しており、単一のチャット固有概念ではない | 専用色を持たず、既存のSurface系（`surface`/`surfaceSoft`）の使い分けで表現 |
+| Selection | リスト項目等の選択中状態の背景・境界・文字色 | `border-blue-500`/`bg-blue-50`（`ThreadListItem.tsx`）。同一機能内の`OriginSelector.tsx`は同じ「選択中」をemerald（Action Tokenと一致）で実装しており、Web内で表現が2系統に分裂している | `chipSelected`が`theme.gold`（Action/Premiumブランド色）を再利用。独立した選択専用色は持たない |
 
-**統合候補（Phase 6監査で確認した重複、方針は保留事項）**: Webのニュートラル系（slate/stone/gray/neutralの4系統）は、実装上明確な使い分け意図が確認できなかったため、Semantic Token設計時に統合可否を検討する対象とする。
+**中立色統合方針（決定済み、詳細は`docs/audit/design-token-stage3-neutral-semantic-decision.md`）**: Webのニュートラル系（slate/stone/gray/neutralの4系統）は、**Option B**（palette名をSemantic Token名にせず、意味が同じなら同じSemantic Tokenへ吸収し、実色差はPlatform Theme層で吸収する）を正式方針として採用する。Option A（1色への機械統合）は不採用。移行中はOption C（既存Tokenで意味が一致する箇所のみ移行必須とし、Semantic Token未定義の箇所はliteralを残す＝`PARTIAL_MIGRATION_ALLOWED`）を暫定Fallbackとして許容する。残存箇所は「TODO」ではなく「Blocked by Contract」として明記し、対象Migration PRは「DONE」と扱わない。
+
+**Message-own / Selection Semantic Tokenの新設（決定済み）**: 上記2カテゴリはいずれも既存のSemantic Token体系に該当が無いことを確認し、新設することを決定した。候補名（実値・最終命名は実装PRで確定）: `color.message.own.background` / `color.message.own.text`、`color.selection.background` / `color.selection.border` / `color.selection.text`。`ThreadListItem.tsx`のblueをemeraldへ機械的に置換することはしない。
+
+**Premium subtle ring（決定済み）**: `ring-amber-100`（`ModeBadge.tsx`）は repo全体で1箇所のみの使用であることを確認した。新規Token化は急がず、`KEEP_LITERAL_FOR_NOW`（リテラルのまま残す）とする。複数箇所で同じ意味の使用が確認された時点で`color.premium.ring.subtle`相当のTokenを候補化する。
 
 ---
 
@@ -249,10 +255,12 @@ Design Token v1の導入は、以下7段階のPRに分割する。各PRの目的
 ### 3. Recommendation画面適用
 
 - **目的**: Concierge結果画面（Hero/他候補カード等）のColor/Radius/Spacing/Shadowを新Semantic Tokenへ切り替える
-- **変更範囲**: `apps/web/src/features/concierge/**`
+- **変更範囲**: ディレクトリ基準ではなく**Recommendation UI責務基準**で定義する。判定基準: (A) Recommendation画面の主要表示責務を持つ (B) Stage 3画面から直接使用される (C) Token未移行が画面全体の整合性に影響する。`apps/web/src/features/concierge/**`に加え、上記基準に該当する共有UI（例: `apps/web/src/components/ConciergeCard.tsx`）を含める。shared componentであることを理由に一律除外しない
 - **非対象**: Backend・Analytics Event・Score/Ranking（別トラック）
-- **依存関係**: PR 1、可能であればPR 2（共通Button/Card活用のため）
-- **Rollback方針**: featureディレクトリ単位でrevert可能
+- **移行方針**: `PARTIAL_MIGRATION_ALLOWED`。既存Semantic Tokenで意味が一致する箇所は移行必須、未定義の箇所（Message-own/Selection等、新設Token実装待ち）はliteral残置を許容し「Blocked by Contract」と明記する。全箇所のToken化をもって初めて本PRを「DONE」とする
+- **実装順序**: 依存関係に基づき PR-A（既存Tokenでexact match可能な箇所）→ PR-B（Message-own/Selection Token実装後に移行する箇所）→ PR-C（`ConciergeEntryCard`/`ConciergeCard`等、主要Recommendation UI）の順に分割する。詳細は`docs/audit/design-token-stage3-neutral-semantic-decision.md`を参照
+- **依存関係**: PR 1、可能であればPR 2（共通Button/Card活用のため）。PR-B/PR-Cの一部はMessage-own/Selection Semantic Tokenの実装に依存する
+- **Rollback方針**: featureディレクトリ単位、およびPR-A/B/C単位でrevert可能
 
 ### 4. Shrine Detail適用
 
@@ -315,4 +323,5 @@ Design Token v1の導入は、以下7段階のPRに分割する。各PRの目的
 - [x] Token値・ブランド方針は確定させず、保留事項として明記した
 - [x] Web/Mobile差を統一しない前提を設計原則・各カテゴリ表で明記した
 - [x] 実装PR分割を7段階、各々目的/変更範囲/非対象/依存関係/Rollback方針付きで記録した
+- [x] 中立色統合方針（Option B）、Message-own/Selection Semantic Token新設、Premium subtle ring方針、Stage 3スコープ再定義を、母艦決定に基づき反映した（`docs/audit/design-token-stage3-neutral-semantic-decision.md`参照）。Token実値・最終命名は未確定のまま据え置いた
 - [x] `git diff --check`


### PR DESCRIPTION
## Summary
- Design Token Migration Stage 3（`apps/web/src/features/concierge/**`）着手前調査で見つかった、中立色パレット（slate/gray/neutral/stone）の意味統合方針未決定と、既存Semantic Tokenに存在しない2カテゴリ（own-message／selected-item）について、母艦のProduct判断に基づき正式方針を`docs/design/design-token.md`へ反映
- 中立色統合はOption B（意味ベースでSemantic Tokenへ吸収、実色差はPlatform Theme層で吸収）を正式採用、Option Cを移行中の暫定Fallback（`PARTIAL_MIGRATION_ALLOWED`）として許容
- Message-own / Selection Semantic Tokenを新設（候補名のみ、実値・最終命名は後続実装PR）
- Premium subtle ring（`ring-amber-100`）はKEEP_LITERAL_FOR_NOW
- Stage 3のスコープをディレクトリ基準からRecommendation UI責務基準へ再定義し、`components/ConciergeCard.tsx`を対象に含めた
- 調査事実・決定の経緯は新規`docs/audit/design-token-stage3-neutral-semantic-decision.md`に記録（Governance節が要求する監査文書作成要件に対応）

## Scope
- ドキュメントのみ。`tokens.css`・コンポーネント側の実装は含まない（別PR: PR-A/PR-B/PR-Cで対応、詳細は新規audit文書のSub-PR再設計を参照）
- `docs/audit/README.md`は変更しない（同README自身が新規chain索引の追加を後続整理PR-Docs-Bへ委ねる方針のため、対象外）

## Test plan
- [x] `git diff --check`
- [x] pre-push hook: OpenAPI lint 通過
- [x] pre-push hook: Web契約テスト 115ファイル/731件 全通過


🤖 Generated with [Claude Code](https://claude.com/claude-code)