### PR TITLE
feat: Recommendation UIのMessage・Selection Semantic Tokenを追加

### DIFF
--- a/apps/web/src/features/concierge/components/MessageList.tsx
+++ b/apps/web/src/features/concierge/components/MessageList.tsx
@@ -25,7 +25,9 @@ export default function MessageList({ messages }: Props) {
             <div
               className={[
                 "inline-block max-w-[80%] rounded-2xl px-3 py-2 text-[13px] leading-relaxed",
-                isUser ? "bg-gray-900 text-white" : "bg-white text-gray-900 border border-gray-200",
+                isUser
+                  ? "bg-[var(--kt-color-message-own-background)] text-[var(--kt-color-message-own-text)]"
+                  : "bg-white text-gray-900 border border-gray-200",
               ].join(" ")}
             >
               {m.content}

--- a/apps/web/src/features/concierge/components/ThreadListItem.tsx
+++ b/apps/web/src/features/concierge/components/ThreadListItem.tsx
@@ -11,7 +11,9 @@ export default function ThreadListItem({ thread, selected, onClick }: Props) {
   const lastMessageAtText = thread.last_message_at ? new Date(thread.last_message_at).toLocaleString("ja-JP") : "";
 
   const baseClass = "w-full rounded-md border px-3 py-2 text-left transition-colors hover:bg-gray-50";
-  const selectedClass = selected ? " border-blue-500 bg-blue-50" : " border-gray-200 bg-white";
+  const selectedClass = selected
+    ? " border-[var(--kt-color-selection-border)] bg-[var(--kt-color-selection-background)]"
+    : " border-gray-200 bg-white";
 
   return (
     <li>

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -77,6 +77,21 @@
      不統一だったため、より広く使われているbg-black/50相当を採用) */
   --kt-color-overlay-default: rgb(0 0 0 / 0.5);
 
+  /* ---- Semantic Token: message-own ---- */
+  /* Web現行: bg-gray-900 text-white (MessageList.tsx、自分側メッセージ)。
+     docs/audit/design-token-stage3-neutral-semantic-decision.md で新設決定済み。
+     Dark Surface / Premiumとは別責務のため統合しない。 */
+  --kt-color-message-own-background: var(--color-gray-900);
+  --kt-color-message-own-text: var(--color-white);
+
+  /* ---- Semantic Token: selection ---- */
+  /* Web現行: border-blue-500 bg-blue-50 (ThreadListItem.tsx、選択中のリスト項目)。
+     docs/audit/design-token-stage3-neutral-semantic-decision.md で新設決定済み。
+     Action Token (emerald) とは別責務のため、blueをemeraldへ置換しない。
+     selection-textは現状専用textが無いため未追加 (必要性が確認され次第追加判断)。 */
+  --kt-color-selection-background: var(--color-blue-50);
+  --kt-color-selection-border: var(--color-blue-500);
+
   /* ================================================================
    * Spacing (Primitiveは Tailwind の --spacing 基準値を係数計算で使用)
    * Web現行頻出値: p-4(107回)/px-4(91回)≒16px, px-3(121回)/p-3(53回)≒12px,


### PR DESCRIPTION
## Summary
- `--kt-color-message-own-background` / `--kt-color-message-own-text` を新設し、`MessageList.tsx` の自分側メッセージ（`bg-gray-900 text-white`）をToken参照に置換
- `--kt-color-selection-background` / `--kt-color-selection-border` を新設し、`ThreadListItem.tsx` の選択中スレッド（`border-blue-500 bg-blue-50`）をToken参照に置換
- 実値はすべて既存Tailwind Primitive（`--color-gray-900`, `--color-white`, `--color-blue-50`, `--color-blue-500`）を参照するのみで、新しい色は作らない
- Action Token（emerald）への統合、neutral palette統合、`selection-text`の先行追加は行っていない（`docs/audit/design-token-stage3-neutral-semantic-decision.md`のContractに準拠）

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run`（115 files / 731 tests, 全て通過）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] ブラウザでToken解決値と旧literal値のcomputed colorが完全一致することを確認（`--kt-color-message-own-background` == `--color-gray-900`、`--kt-color-selection-background` == `--color-blue-50`、`--kt-color-selection-border` == `--color-blue-500`）
- [x] repo-wide grep で `bg-gray-900` / `border-blue-500` / `bg-blue-50` が対象コンポーネントから消えたことを確認（他画面での同literal使用なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)