### PR TITLE
feat: Recommendation UI PR-C1 ConciergeEntryCardへSemantic Tokenを適用

### DIFF
--- a/apps/web/src/features/concierge/components/ConciergeEntryCard.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeEntryCard.tsx
@@ -64,10 +64,10 @@ export default function ConciergeEntryCard({
     <>
       <div className="space-y-1.5 rounded-3xl border border-stone-200/10 bg-stone-50/30 px-4 py-4">
         <div>
-          <p className="text-[9px] font-normal tracking-[0.24em] text-stone-500 opacity-70">KAMI MUSUBI GUIDE</p>
-          <h1 className="mt-1.5 text-lg font-medium leading-7 text-stone-900">相談から、向かう神社を見つける</h1>
+          <p className="text-[9px] font-normal tracking-[0.24em] text-[var(--kt-color-text-muted)] opacity-70">KAMI MUSUBI GUIDE</p>
+          <h1 className="mt-1.5 text-lg font-medium leading-7 text-[var(--kt-color-text-primary)]">相談から、向かう神社を見つける</h1>
         </div>
-        <p className="text-sm leading-6 text-stone-500 opacity-85">
+        <p className="text-sm leading-6 text-[var(--kt-color-text-muted)] opacity-85">
           {displayName
             ? `${displayLabel}さんの相談をもとに、今向かいやすい神社との出会いを整えます。`
             : "相談をもとに、今向かいやすい神社との出会いを整えます。"}
@@ -77,7 +77,7 @@ export default function ConciergeEntryCard({
       <div className="mt-4">
         <label
           htmlFor="concierge-entry-nickname"
-          className="mb-0.5 block text-[11px] font-medium text-stone-500 opacity-65"
+          className="mb-0.5 block text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-65"
         >
           呼び名（任意）
         </label>
@@ -87,25 +87,25 @@ export default function ConciergeEntryCard({
           value={sessionState.sessionNickname ?? ""}
           onChange={(e) => setSessionNickname(e.target.value)}
           placeholder="例: なまえ"
-          className="w-full rounded-2xl border border-stone-200/30 bg-stone-50/25 px-2.5 py-1.5 text-sm text-stone-900 placeholder:text-stone-400 placeholder:opacity-60"
+          className="w-full rounded-2xl border border-stone-200/30 bg-stone-50/25 px-2.5 py-1.5 text-sm text-[var(--kt-color-text-primary)] placeholder:text-stone-400 placeholder:opacity-60"
           maxLength={20}
         />
       </div>
 
       {!canSaveConciergeThread && !isUiPaywall ? (
-        <div className="mt-3 rounded-xl border border-amber-200/50 bg-amber-50/50 px-3 py-2 text-xs text-amber-800 opacity-85">
+        <div className="mt-3 rounded-[var(--kt-radius-panel)] border border-amber-200/50 bg-amber-50/50 px-3 py-2 text-xs text-amber-800 opacity-85">
           <p>未ログインでも相談できます。保存にはログインが必要です。</p>
           <div className="mt-2 flex gap-2">
             <button
               type="button"
-              className="rounded-lg bg-slate-800 px-2.5 py-1 text-xs font-medium text-white hover:bg-slate-900"
+              className="rounded-lg bg-[var(--kt-color-surface-emphasis)] px-2.5 py-1 text-xs font-medium text-[var(--kt-color-text-inverse)] hover:bg-[var(--kt-color-surface-emphasis-hover)]"
               onClick={() => redirectToAuth("login")}
             >
               ログイン
             </button>
             <button
               type="button"
-              className="rounded-lg border border-slate-200 bg-stone-50 px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-stone-100"
+              className="rounded-lg border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-stone-100"
               onClick={() => redirectToAuth("register")}
             >
               新規登録
@@ -118,15 +118,15 @@ export default function ConciergeEntryCard({
         <div className="grid gap-3 sm:grid-cols-2">
           <label className="block text-sm font-medium text-stone-600">
             参拝予定日（任意）
-            <input type="date" value={plannedVisitDate} min={new Date().toISOString().slice(0, 10)} onChange={(event) => setPlannedVisitDate(event.target.value)} className="mt-1 min-h-11 w-full rounded-2xl border border-stone-300 bg-stone-50/25 px-3 py-2 text-base text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600" />
+            <input type="date" value={plannedVisitDate} min={new Date().toISOString().slice(0, 10)} onChange={(event) => setPlannedVisitDate(event.target.value)} className="mt-1 min-h-11 w-full rounded-2xl border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-base text-[var(--kt-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600" />
           </label>
           <OriginSelector origin={origin} onChange={onOriginChange} onUseDevice={onUseCurrentLocation} deviceError={locationError} />
         </div>
-        {plannedVisitDate ? <p className="text-xs text-stone-500">予定日の年盤・月盤と、設定した出発地点から神社への方角を補助条件に使います。</p> : null}
+        {plannedVisitDate ? <p className="text-xs text-[var(--kt-color-text-muted)]">予定日の年盤・月盤と、設定した出発地点から神社への方角を補助条件に使います。</p> : null}
         <div>
           <label
             htmlFor="concierge-input"
-            className="mb-0.5 block text-[11px] font-medium text-stone-500 opacity-65"
+            className="mb-0.5 block text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-65"
           >
             必要なら、今の状況を少しだけ書く
           </label>
@@ -136,12 +136,12 @@ export default function ConciergeEntryCard({
             onChange={(e) => setNeedText(e.target.value)}
             placeholder="例: 仕事の迷いを整理したい、少し休みたい"
             rows={4}
-            className="w-full rounded-3xl border border-stone-200/20 bg-stone-50/30 px-3 py-2.5 text-sm leading-7 text-stone-900 outline-none transition placeholder:text-stone-400 placeholder:opacity-60 focus:border-emerald-200/40 focus:ring-1 focus:ring-emerald-100/40"
+            className="w-full rounded-3xl border border-stone-200/20 bg-stone-50/30 px-3 py-2.5 text-sm leading-7 text-[var(--kt-color-text-primary)] outline-none transition placeholder:text-stone-400 placeholder:opacity-60 focus:border-emerald-200/40 focus:ring-1 focus:ring-emerald-100/40"
           />
         </div>
 
         <div>
-          <p className="text-[11px] font-medium text-stone-500 opacity-75">相談テーマ</p>
+          <p className="text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-75">相談テーマ</p>
           <div className="mt-2.5 flex flex-wrap gap-2">
             {feelExamples.map((example) => {
               const isSelected = needText.trim() === example.text;
@@ -150,10 +150,10 @@ export default function ConciergeEntryCard({
                   key={example.label}
                   type="button"
                   className={[
-                    "min-h-11 rounded-full border px-3 py-2 text-sm font-normal transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 active:scale-[0.98]",
+                    "min-h-11 rounded-[var(--kt-radius-pill)] border px-3 py-2 text-sm font-normal transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 active:scale-[0.98]",
                     isSelected
                       ? "border-emerald-200/60 bg-emerald-50/40 text-emerald-700"
-                      : "border-stone-200/35 bg-stone-50/25 text-stone-500 hover:bg-stone-100/30 opacity-65",
+                      : "border-stone-200/35 bg-stone-50/25 text-[var(--kt-color-text-muted)] hover:bg-stone-100/30 opacity-65",
                     "disabled:border-stone-200 disabled:bg-stone-100 disabled:text-stone-400 disabled:opacity-50",
                   ].join(" ")}
                   onClick={() => onPickExample(example)}
@@ -171,7 +171,7 @@ export default function ConciergeEntryCard({
         <div className="flex flex-col gap-1.5 sm:flex-row">
           <button
             type="button"
-            className="min-h-11 w-full rounded-full border border-emerald-300 bg-emerald-50/50 px-3 py-2 text-sm font-medium text-emerald-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-emerald-100/40 disabled:cursor-not-allowed disabled:opacity-40"
+            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-emerald-300 bg-emerald-50/50 px-3 py-2 text-sm font-medium text-emerald-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-emerald-100/40 disabled:cursor-not-allowed disabled:opacity-40"
             disabled={isBusy || !needText.trim() || !canSend}
             onClick={onSubmit}
           >
@@ -180,7 +180,7 @@ export default function ConciergeEntryCard({
 
           <button
             type="button"
-            className="min-h-11 w-full rounded-full border border-stone-300 bg-stone-50/25 px-3 py-2 text-sm font-medium text-stone-700 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-stone-100/30 disabled:cursor-not-allowed disabled:border-stone-200 disabled:bg-stone-100 disabled:text-stone-400 disabled:opacity-40"
+            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-sm font-medium text-[var(--kt-color-text-secondary)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-stone-100/30 disabled:cursor-not-allowed disabled:border-stone-200 disabled:bg-stone-100 disabled:text-stone-400 disabled:opacity-40"
             disabled={isBusy}
             onClick={onClear}
           >

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -92,6 +92,19 @@
   --kt-color-selection-background: var(--color-blue-50);
   --kt-color-selection-border: var(--color-blue-500);
 
+  /* ---- Semantic Token: surface-emphasis (Dark Surface) ---- */
+  /* Web現行: 強調CTA/リンクの濃色背景+反転文字色 (Group A)。
+     docs/audit/design-token-stage3-dark-surface-decision.md で新設決定済み。
+     文字色は専用tokenを作らず --kt-color-text-inverse を再利用する。
+     値はPR-C1で移行する ConciergeEntryCard.tsx のログインボタン
+     (bg-slate-800 hover:bg-slate-900) に合わせた。他のGroup A箇所
+     (billing各画面のbg-slate-900固定、ConciergeCard.tsxのbg-neutral-900
+     hover:bg-neutral-800など、hover方向や値が異なる箇所を含む)は
+     本Contractで機械的に統一しておらず、それらを本tokenへ移行する際は
+     視覚差が出ないか実装PR側で個別に確認すること。 */
+  --kt-color-surface-emphasis: var(--color-slate-800);
+  --kt-color-surface-emphasis-hover: var(--color-slate-900);
+
   /* ================================================================
    * Spacing (Primitiveは Tailwind の --spacing 基準値を係数計算で使用)
    * Web現行頻出値: p-4(107回)/px-4(91回)≒16px, px-3(121回)/p-3(53回)≒12px,


### PR DESCRIPTION
## Summary

Dark Surface Contract（`docs/audit/design-token-stage3-dark-surface-decision.md`、PR #2285）に基づき、PR-C1（`ConciergeEntryCard.tsx`）を実装。

- `apps/web/src/styles/tokens.css` に `--kt-color-surface-emphasis` / `--kt-color-surface-emphasis-hover` を追加（値はこのPRで移行するログインボタンの現行値 `bg-slate-800 hover:bg-slate-900` に合わせた。他のGroup A箇所とは値が異なる場合があり、機械的に統一していない）
- ログインボタンの背景を新Tokenへ、文字色は既存の `--kt-color-text-inverse` を再利用
- 既存Semantic Tokenでexact matchできる箇所をtoken化（`text-primary`/`text-secondary`/`text-muted`、`border-default`/`border-strong`、`background-subtle`、`radius-panel`/`radius-pill`）

## Inventory（Phase 3分類）

| 分類 | 内容 |
|---|---|
| `SURFACE_EMPHASIS` | ログインボタン（`bg-slate-800 hover:bg-slate-900` → `surface-emphasis`/`-hover`、`text-white` → `text-inverse`） |
| `EXACT_MATCH` | 見出し/本文/ラベル系 `text-stone-900`→`text-primary`、`text-stone-500`(opacityは別クラスのため保持)→`text-muted`、`text-stone-700`→`text-secondary`、`border-slate-200`→`border-default`、`border-stone-300`→`border-strong`、`bg-stone-50`(flat)→`background-subtle`、`rounded-xl`→`radius-panel`、`rounded-full`→`radius-pill` |
| `DEFERRED_GUEST_NOTICE` | 未ログイン案内バナーの `amber-200/50` `amber-50/50` `amber-800` |
| `DEFERRED_LIGHT_SURFACE` | `hover:bg-stone-100`系（alpha付きも含む） |
| `DEFERRED_DISABLED` | `disabled:border-stone-200` `disabled:bg-stone-100` `disabled:text-stone-400` |
| `DEFERRED_ACTION_BORDER` | 送信ボタンの `border-emerald-300` `bg-emerald-50/50` `text-emerald-800`、選択中チップの `border-emerald-200/60` `bg-emerald-50/40` `text-emerald-700` |
| `NO_CHANGE_NEEDED` | alpha modifier付きのstone/slateリテラル（`bg-stone-50/25`等、Tailwind arbitrary value + `/alpha`修飾の組み合わせに本リポジトリ内の前例がなく、今回は導入しない）、`text-slate-600`/`text-stone-600`(既存tokenの shadeと一致しない)、focus関連リング色 |

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run`（115 files / 731 tests）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] ブラウザで実際にレンダリングし、`--kt-color-surface-emphasis`(hover含む)・`text-primary`・`text-secondary`・`text-muted`・`border-default`・`border-strong`・`background-subtle`・`text-inverse`・`radius-panel`・`radius-pill` の各tokenが対応するPrimitive（`--color-slate-800/900/700/500/300/200/50`、`--color-white`、`--radius-xl`、`9999px`）と完全一致することをcomputed styleで確認
- [x] 375px/390px/430px/desktopで初期状態・ニックネーム入力・未ログイン案内・ログイン/新規登録ボタン・参拝予定日・相談テーマ選択/非選択・選択後の送信ボタン活性化・クリアボタンを目視確認、Deferred箇所（送信ボタンの emerald outline、無効時の chip 等）が元のリテラル値のまま変化していないことを確認
- [x] scope guard: 変更ファイルは `ConciergeEntryCard.tsx` と `tokens.css` のみ。PR-C2/C3対象ファイル・Guest Notice・Disabled・Action Border・Light Surface 100系のliteralは変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)