### PR TITLE
feat: Recommendation UI PR-C2 Hero/SectionsRendererへSemantic Tokenを適用

### DIFF
--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -95,10 +95,10 @@ function AstroCard(props: { sunSign?: string; element?: string; reason?: string 
   return (
     <DetailSection title="占星術による選定">
       <div className={conciergeNoticeCardClass}>
-        <div className="text-sm font-semibold text-slate-900">
+        <div className="text-sm font-semibold text-[var(--kt-color-text-primary)]">
           {sunSign || "不明"} / {element || "不明"}
         </div>
-        <div className="mt-2 text-sm leading-7 text-slate-700">{reason || "（理由なし）"}</div>
+        <div className="mt-2 text-sm leading-7 text-[var(--kt-color-text-secondary)]">{reason || "（理由なし）"}</div>
       </div>
     </DetailSection>
   );
@@ -598,7 +598,7 @@ export default function ConciergeSectionsRenderer({
               return (
                 <div key={`filter-${i}-closed`}>
                   <DetailSection title="補助条件を添える">
-                    <p className="mb-2 text-xs text-slate-500">必要なものだけ選んでください</p>
+                    <p className="mb-2 text-xs text-[var(--kt-color-text-muted)]">必要なものだけ選んでください</p>
 
                     <div className="mb-3 flex flex-wrap gap-2">
                       {presets.map((p) => {
@@ -610,8 +610,8 @@ export default function ConciergeSectionsRenderer({
                             className={[
                               "rounded-full border px-3 py-1 text-xs font-semibold transition",
                               active
-                                ? "bg-emerald-600 text-white border-emerald-600"
-                                : "bg-white text-slate-700 hover:bg-slate-50",
+                                ? "bg-[var(--kt-color-action-primary)] text-[var(--kt-color-action-primary-text)] border-[var(--kt-color-action-primary)]"
+                                : "bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-secondary)] hover:bg-[var(--kt-color-background-subtle)]",
                             ].join(" ")}
                             onClick={() => togglePreset(p)}
                           >
@@ -630,7 +630,7 @@ export default function ConciergeSectionsRenderer({
                     {!isEntryRoute ? (
                       <button
                         type="button"
-                        className="mt-2 w-full rounded-xl border px-4 py-3 text-sm font-semibold"
+                        className="mt-2 w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
                         onClick={() => {
                           onAction?.({ type: "back_to_entry" });
                           scrollToConciergeInput();
@@ -643,7 +643,7 @@ export default function ConciergeSectionsRenderer({
 
                     <button
                       type="button"
-                      className="w-full rounded-xl bg-emerald-600 px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
+                      className="w-full rounded-[var(--kt-radius-panel)] bg-[var(--kt-color-action-primary)] px-4 py-3 text-sm font-semibold text-[var(--kt-color-action-primary-text)] disabled:opacity-60"
                       disabled={!canApplyCompatFilter || sending}
                       onClick={() => {
                         onAction?.({ type: "filter_apply" });
@@ -654,7 +654,7 @@ export default function ConciergeSectionsRenderer({
 
                     <button
                       type="button"
-                      className="mt-2 w-full rounded-xl border px-4 py-3 text-sm font-semibold"
+                      className="mt-2 w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
                       onClick={() => onAction?.({ type: "add_condition" })}
                     >
                       もう少し詳しく添える
@@ -728,7 +728,7 @@ export default function ConciergeSectionsRenderer({
                 </div>
 
                 {typeof payload?.meta?.remaining === "number" && payload.meta.remaining > 0 && (
-                  <div className="mb-2 text-xs leading-6 text-slate-500">
+                  <div className="mb-2 text-xs leading-6 text-[var(--kt-color-text-muted)]">
                     あと {payload.meta.remaining}回までは無料で試せます
                   </div>
                 )}
@@ -743,14 +743,18 @@ export default function ConciergeSectionsRenderer({
                   <div className="mt-3 grid grid-cols-2 gap-2">
                     <button
                       type="button"
-                      className="rounded-xl border px-4 py-3 text-sm font-semibold"
+                      className="rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
                       onClick={() => onAction?.({ type: "open_map" })}
                     >
                       近くの神社を静かに見る
                     </button>
                     <button
                       type="button"
-                      className="rounded-xl bg-neutral-900 px-4 py-3 text-sm font-semibold text-white"
+                      /* bg-neutral-900: Dark Surface Contract Group A候補だが、
+                         --kt-color-surface-emphasis(slate-800/900)とcomputed colorが
+                         一致しないため今回は適用しない(Blocked by Contract)。
+                         詳細は docs/audit/design-token-stage3-dark-surface-decision.md */
+                      className="rounded-[var(--kt-radius-panel)] bg-neutral-900 px-4 py-3 text-sm font-semibold text-white"
                       onClick={() => onAction?.({ type: "filter_clear" })}
                     >
                       条件を広げて見直す
@@ -765,7 +769,7 @@ export default function ConciergeSectionsRenderer({
                     <span>{appliedLabel}</span>
                     <button
                       type="button"
-                      className="rounded-md px-2 py-1 font-semibold text-slate-700 hover:bg-slate-100"
+                      className="rounded-[var(--kt-radius-control)] px-2 py-1 font-semibold text-[var(--kt-color-text-secondary)] hover:bg-slate-100"
                       onClick={() => onAction?.({ type: "filter_clear" })}
                     >
                       クリア
@@ -897,7 +901,7 @@ export default function ConciergeSectionsRenderer({
                                     {trustLabels.slice(0, 4).map((label: string) => (
                                       <span
                                         key={label}
-                                        className="rounded-full bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600"
+                                        className="rounded-[var(--kt-radius-pill)] bg-slate-100 px-2 py-0.5 text-[11px] font-semibold text-slate-600"
                                       >
                                         {label}
                                       </span>
@@ -1095,7 +1099,7 @@ export default function ConciergeSectionsRenderer({
                     <div className="pt-4">
                       <button
                         type="button"
-                        className="w-full rounded-xl border px-4 py-3 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+                        className="w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-secondary)] hover:bg-[var(--kt-color-background-subtle)]"
                         onClick={() => {
                           trackCardEvent({
                             event: "save_prompt_click",

--- a/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
@@ -144,7 +144,7 @@ export default function ConciergeTopRecommendationHero({
             <div className="text-xs font-semibold tracking-[0.18em] text-emerald-700">
               {eyebrowLabel ?? "今の相談に近い神社"}
             </div>
-            <h2 className="text-xl font-semibold leading-8 text-slate-950">{name}</h2>
+            <h2 className="text-xl font-semibold leading-8 text-[var(--kt-color-text-primary)]">{name}</h2>
 
             {visibleTrustLabels.length > 0 ? (
               <div className="flex flex-wrap gap-1.5">
@@ -183,7 +183,7 @@ export default function ConciergeTopRecommendationHero({
             data-testid="recommendation-standard-reason"
           >
             <p className="text-[11px] font-semibold tracking-[0.14em] text-slate-600">この神社を選んだ理由</p>
-            <p className="mt-1 text-sm leading-6 text-slate-700">{secondaryReason}</p>
+            <p className="mt-1 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{secondaryReason}</p>
           </div>
         ) : null}
 
@@ -203,7 +203,7 @@ export default function ConciergeTopRecommendationHero({
             data-testid="recommendation-reason-v4-interpretation"
           >
             <p className="text-[11px] font-semibold tracking-[0.14em] text-slate-600">今の相談とのつながり</p>
-            <p className="mt-1 text-sm leading-6 text-slate-700">{interpretationReason}</p>
+            <p className="mt-1 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{interpretationReason}</p>
           </div>
         ) : null}
 


### PR DESCRIPTION
## Summary

PR-A適用済み箇所を除外し、`ConciergeTopRecommendationHero.tsx` / `ConciergeSectionsRenderer.tsx` の残存literalをexact match範囲のみtoken化した。

- `text-primary`/`text-secondary`/`text-muted`、`action-primary`/`action-primary-text`、`surface-default`、`background-subtle`、`radius-panel`/`radius-control`/`radius-pill` を適用
- `text-slate-950`（Hero見出し、単一使用）→ `text-primary` へ統合

## Phase 4 — Dark Surface Guard: STOP、Blocked by Contractとして報告

`ConciergeSectionsRenderer.tsx:753` の `bg-neutral-900`（条件を広げて見直すボタン）について、mergeされた `--kt-color-surface-emphasis`（`slate-800`）/ `--kt-color-surface-emphasis-hover`（`slate-900`）とcomputed colorを実機比較した。

| | lab値 |
|---|---|
| `--color-neutral-900` | `lab(7.782% -0.00001 0)` |
| `--kt-color-surface-emphasis`（slate-800） | `lab(16.132% -0.318 -14.667)`（明度が別段階） |
| `--kt-color-surface-emphasis-hover`（slate-900） | `lab(7.787% 1.823 -15.054)`（明度はほぼ同じだがb軸が0→-15、neutralな灰色→青みがかった灰色へ色相が変化） |

**一致しないため、token値・Contract側の値は変更せず、`bg-neutral-900` はliteralのまま維持した。** 該当ボタンのradiusのみ `--kt-radius-panel` へtoken化し、色literal部分にはBlocked by Contractである旨のコードコメントを追加した。母艦判断が必要な場合は改めて相談する。

## Deferred by Contract（既存Contractで意図的にliteral維持）

- `bg-neutral-900`（Dark Surface、上記の通り値不一致でStop）
- `bg-slate-100`（Light Surface 100系、2箇所）
- `text-amber-900`（`conciergeNoticeCardClass`内、Notice≠Premiumのため既存コメントで明記済みのPremium Token非流用方針を継続）

## No Semantic Match（対応するTokenが未定義、今回の判断範囲外）

- `text-slate-600`/`text-slate-800`（600/800 shadeのtext tokenが未定義）
- `text-emerald-700`/`text-emerald-800`、`bg-amber-800`（hover）（対応するAction/Premiumのhover・shade tokenが未定義）
- `border-emerald-100`/`border-slate-100`、`ring-emerald-100`等（該当shadeのborder/ring tokenが未定義）
- `shadow-{size} shadow-{color}/{alpha}` の組み合わせ全箇所（Hero内の全shadow）— `shadow-[var(--kt-shadow-*)]`へ置換すると `shadow-{color}` modifierとの結合が崩れ、色付きshadowの見た目が変わるリスクがあるため今回は対象外
- `teal-*` 系（`border-teal-100`/`bg-teal-50`/`text-teal-700`）— 対応するSemantic Token・Contractがそもそも存在しない
- alpha modifier付きのliteral全般（`bg-white/70`、`bg-slate-50/70`等）— PR-C1と同じ理由でarbitrary value + `/alpha`修飾の組み合わせを今回は導入しない

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run`（115 files / 731 tests）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] 適用した全token（`text-primary`/`secondary`/`muted`、`action-primary`/`-text`、`surface-default`、`background-subtle`、`radius-panel`/`-control`/`-pill`）がcomputed styleで対応Primitiveと完全一致することを確認
- [x] Dark Surface Guard: `neutral-900` と `surface-emphasis`(hover含む)のcomputed colorを比較し、不一致を確認した上でliteral維持を選択（上記参照）
- [ ] 実データでのHero/SectionsRenderer目視確認 — 開発環境にbackendが立っておらず（`CONCIERGE_CHAT_ERROR 500`）、実際の相談結果画面へ到達できなかったため、今回はcomputed style一致による検証のみ実施。backend接続可能な環境での目視QAを推奨

## Scope guard
- 変更ファイルは `ConciergeSectionsRenderer.tsx` と `ConciergeTopRecommendationHero.tsx` のみ（`tokens.css`・`ConciergeCard.tsx`・PR-C1対象ファイルは変更なし）
- 新規Semantic Token追加なし、`surface-emphasis`の既存値変更なし
- props/state/handlers/API/Analytics/copy/component hierarchy変更なし（className文字列のみ）

判定: `PR_C2_PARTIAL_MIGRATION_COMPLETE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)