### PR TITLE
feat: Recommendation UI PR-C3 ConciergeCardへSemantic Tokenを適用

### DIFF
--- a/apps/web/src/components/ConciergeCard.tsx
+++ b/apps/web/src/components/ConciergeCard.tsx
@@ -19,7 +19,7 @@ function Chevron({ open }: { open: boolean }) {
     <svg
       viewBox="0 0 20 20"
       aria-hidden="true"
-      className={cn("size-4 text-neutral-500 transition-transform duration-200", open ? "rotate-180" : "rotate-0")}
+      className={cn("size-4 text-[var(--kt-color-text-muted)] transition-transform duration-200", open ? "rotate-180" : "rotate-0")}
     >
       <path
         d="M5.5 7.5 10 12l4.5-4.5"
@@ -62,11 +62,11 @@ export default function ConciergeCard(props: BaseCardProps) {
   const CardInner = (
     <div
       className={cn(
-        "overflow-hidden rounded-2xl bg-white ring-1 ring-neutral-200/70",
-        "shadow-sm transition",
-        isPrimary && "shadow-md ring-neutral-200",
+        "overflow-hidden rounded-[var(--kt-radius-card)] bg-[var(--kt-color-surface-default)] ring-1 ring-neutral-200/70",
+        "shadow-[var(--kt-shadow-medium)] transition",
+        isPrimary && "shadow-md ring-[var(--kt-color-border-default)]",
         detailHref && "cursor-pointer hover:shadow-md",
-        isHero && "ring-2 ring-emerald-200 shadow-lg",
+        isHero && "ring-2 ring-emerald-200 shadow-[var(--kt-shadow-high)]",
       )}
     >
       <div className={cn("relative w-full", isHero ? "h-40" : "h-36")}>
@@ -95,11 +95,11 @@ export default function ConciergeCard(props: BaseCardProps) {
                 <span
                   key={badge}
                   className={cn(
-                    "inline-flex shrink-0 items-center rounded-full px-2.5 py-1",
+                    "inline-flex shrink-0 items-center rounded-[var(--kt-radius-pill)] px-2.5 py-1",
                     "text-[11px] font-medium",
                     isHero
                       ? "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200"
-                      : "bg-neutral-100/80 text-neutral-500 ring-1 ring-inset ring-neutral-200/60",
+                      : "bg-neutral-100/80 text-[var(--kt-color-text-muted)] ring-1 ring-inset ring-neutral-200/60",
                   )}
                 >
                   {badge}
@@ -119,7 +119,7 @@ export default function ConciergeCard(props: BaseCardProps) {
           {!hideLeftMark ? (
             <div
               className={cn(
-                "mt-0.5 flex size-9 items-center justify-center rounded-full",
+                "mt-0.5 flex size-9 items-center justify-center rounded-[var(--kt-radius-pill)]",
                 "bg-neutral-100 ring-1 ring-inset ring-neutral-200/60",
               )}
               aria-hidden="true"
@@ -131,28 +131,28 @@ export default function ConciergeCard(props: BaseCardProps) {
           ) : null}
 
           <div className="min-w-0 flex-1">
-            {isHero && sub ? <p className="mb-1 text-[18px] font-bold leading-8 text-neutral-950">{sub}</p> : null}
+            {isHero && sub ? <p className="mb-1 text-[18px] font-bold leading-8 text-[var(--kt-color-text-primary)]">{sub}</p> : null}
 
             {!isHero && sub ? (
-              <p className="text-[15px] font-semibold leading-6 text-neutral-900 line-clamp-2">{sub}</p>
+              <p className="text-[15px] font-semibold leading-6 text-[var(--kt-color-text-primary)] line-clamp-2">{sub}</p>
             ) : null}
 
             <h3
               className={cn(
                 "mt-1 font-semibold leading-snug",
-                isHero ? "text-[14px] text-neutral-700" : "text-[15px] text-neutral-700",
+                isHero ? "text-[14px] text-[var(--kt-color-text-secondary)]" : "text-[15px] text-[var(--kt-color-text-secondary)]",
               )}
             >
               {title}
             </h3>
 
-            {address ? <p className="mt-1 truncate text-xs text-neutral-500">{address}</p> : null}
+            {address ? <p className="mt-1 truncate text-xs text-[var(--kt-color-text-muted)]">{address}</p> : null}
 
             {desc ? (
               <p
                 className={cn(
                   "mt-2 leading-6",
-                  isHero ? "text-[13px] text-neutral-700" : "text-[13px] text-neutral-600 line-clamp-2",
+                  isHero ? "text-[13px] text-[var(--kt-color-text-secondary)]" : "text-[13px] text-neutral-600 line-clamp-2",
                 )}
               >
                 {desc}
@@ -164,7 +164,11 @@ export default function ConciergeCard(props: BaseCardProps) {
                 href={detailHref}
                 prefetch={false}
                 className={cn(
-                  "mt-4 inline-flex min-h-[44px] w-full items-center justify-center rounded-xl px-3 py-2",
+                  "mt-4 inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] px-3 py-2",
+                  /* bg-neutral-900/hover:bg-neutral-800: Dark Surface Contract Group A候補だが、
+                     --kt-color-surface-emphasis(slate-800/900)とcomputed colorが一致しないため
+                     今回は適用しない(Blocked by Contract)。
+                     詳細は docs/audit/design-token-stage3-dark-surface-decision.md */
                   "text-sm font-semibold bg-neutral-900 text-white",
                   "ring-1 ring-inset ring-black/10 transition active:scale-[0.99] hover:bg-neutral-800",
                   "focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400",
@@ -195,7 +199,7 @@ export default function ConciergeCard(props: BaseCardProps) {
             }}
             className={cn(
               "flex w-full items-center justify-between px-4 py-3 text-left",
-              "transition hover:bg-neutral-50",
+              "transition hover:bg-[var(--kt-color-background-subtle)]",
               "focus:outline-none focus-visible:ring-2 focus-visible:ring-neutral-400",
             )}
             aria-expanded={open}


### PR DESCRIPTION
## Summary

Stage 3最後のPR-Cファイル、`apps/web/src/components/ConciergeCard.tsx` を実装。

- 同一palette厳密一致: `radius-card`/`radius-panel`/`radius-pill`、`shadow-medium`/`shadow-high`、`surface-default`
- Option Bによるneutral→slateの意味Fold: `text-primary`/`text-secondary`/`text-muted`、`border-default`(flatな`ring-neutral-200`のみ)、`background-subtle`(flatな`hover:bg-neutral-50`のみ)
- `text-neutral-950`（Heroと同じ理由のnormalization）→ `text-primary`

## Phase 2 — Live Consumer再確認（blast radius）

| Consumer | 実際の到達経路 | 分類 |
|---|---|---|
| `PrimaryRecommendationCard.tsx` | repo内どこからもimportされていない | 未使用（dead code）、visual影響なし |
| `ShrineConciergeCard.tsx` → `ConciergeShrineCard.tsx` | `/debug/concierge-fixture`（debugルート）経由のみ | debug-only、本番Shrine Detail画面への到達経路は現状ない |
| `PlaceShrineCard.tsx` | `ConciergeSectionsRenderer.tsx`内（`未登録`扱いの神社カード） | **Recommendation実trafficあり**、今回の主な検証対象 |

## Phase 4 — Dark Surface Guard: STOP、Blocked by Contractとして継続

詳細リンクボタン（`bg-neutral-900 hover:bg-neutral-800`）はPR-C2の`ConciergeSectionsRenderer.tsx`と同一literalで、`--kt-color-surface-emphasis`（`slate-800`/`slate-900`）とcomputed colorが一致しないことを確認済み（PR #2287参照）。**token値・Contract側の値を変更せず、literalのまま維持**。該当箇所のradiusのみ`--kt-radius-panel`へtoken化し、色literal部分にBlocked by Contractのコードコメントを追加した。

## neutral-100 / ring-neutral-200 の扱い

- `ring-neutral-200`（alpha付き、カード外枠・バッジ・icon-mark circle、計3箇所）: alpha modifier付きのためPR-C1/C2と同じ理由で今回は対象外（`ring-[var(--kt-color-x)]/NN`の組み合わせをこのリポジトリで導入した前例がなく、Tailwind側の挙動未検証のため）
- `ring-neutral-200`（flatな1箇所、`isPrimary`時の強調リング）: `border-default`へ意味確認の上でtoken化（カードの既定枠線と同じ役割と判断）
- `bg-neutral-100`（icon-mark circle、flat）: 既にmerge済みのDark Surface Contract（`docs/audit/design-token-stage3-dark-surface-decision.md`）で「Light Surface 100系はKEEP_LITERAL_FOR_NOW」と決定済みのため、**機械統合せずliteralのまま維持**
- `bg-neutral-100/80`（バッジ背景、alpha付き）: 同上、alpha付きのため対象外

## Deferred by Contract

- `bg-neutral-900`/`hover:bg-neutral-800`（Dark Surface、上記の通り値不一致でStop）
- `bg-neutral-100`（icon-mark circle）、`bg-neutral-100/80`（バッジ背景）（Light Surface 100系）

## No Semantic Match

- `text-neutral-600`/`text-neutral-800`（600/800 shadeのtext tokenが未定義）
- `bg-emerald-50`/`text-emerald-700`/`ring-emerald-200`（isHeroバッジ）— 値としてはstatus-successトークンと一致するが、本バッジは「成功状態」ではなく強調タグ表示のため、責務の異なるTokenを流用しない
- `shadow-md`（`isPrimary`/`hover`）— 対応するshadow tier tokenが未定義（medium=sm、high=lgのみ、mdは未定義）
- alpha modifier付きliteral全般（`ring-neutral-*/N`、`bg-neutral-*/N`、`bg-gradient-*`、`ring-black/*`）— PR-C1/C2と同じ理由で今回は対象外
- focus-visible関連リング色（`ring-neutral-400`）— 既存のFocus責務未整理のため対象外

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run`（115 files / 731 tests）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] 適用した同一palette token（`radius-card`/`radius-panel`/`radius-pill`/`shadow-medium`/`shadow-high`/`surface-default`）がcomputed styleで対応Primitiveと完全一致することを確認
- [x] Dark Surface Guard: `neutral-900`とtoken値のcomputed colorを再確認し、不一致を確認した上でliteral維持を継続（PR #2287と同一の結論）
- [x] `/debug/concierge-fixture`（`ConciergeCard.tsx`を実際にレンダリングする、backend不要で到達可能なルート）で375px/390px/430px/desktopの目視確認、および主要要素（icon-mark circle、詳細リンクボタン、バッジ、タイトル、住所）のcomputed styleを直接検証し、token化箇所は新値、deferred箇所は旧値のまま変化していないことを確認

## Scope guard
- 変更ファイルは `ConciergeCard.tsx` のみ（`tokens.css`・PR-C1/C2対象ファイルは変更なし）
- 新規Semantic Token追加なし、`surface-emphasis`の既存値変更なし
- props/state/handlers/API/Analytics/copy/shared component責務変更なし（className文字列のみ）

判定: `PR_C3_PARTIAL_MIGRATION_COMPLETE`。Stage 3全体はPR-A/PR-B/PR-C1/PR-C2/PR-C3を通じ、依然 `PARTIALLY_DONE`（Dark Surface・Light Surface 100系・一部shade/badge責務が未解決のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)