### PR TITLE
docs: Stage 3 DONE判定候補Aの前提条件を事実確認する

### DIFF
--- a/docs/audit/design-token-stage3-residual-contract.md
+++ b/docs/audit/design-token-stage3-residual-contract.md
@@ -141,6 +141,25 @@ Premiumではないことは、`ConciergeSectionsRenderer.tsx`の既存コード
 
 どちらを採用するかはGovernance変更を伴う判断であり、母艦の決定を要する。本文書はA/B双方の判断材料を提示するに留め、確定しない。
 
+### 候補Aの前提条件チェック結果（事実確認、2026-08-07時点）
+
+候補Aは自ら4条件を掲げている。このうち3条件は事実として確認できるが、1条件は未達である。
+
+| 条件 | 判定 | 根拠 |
+|---|---|---|
+| 意図的literalが全て分類済み | 達成 | 本文書Phase 2〜8で全カテゴリを分類済み |
+| **accidental remainder 0** | **未達** | `ConciergeFilterPanel.tsx`の`border-emerald-600`/`bg-emerald-50`（Phase 7）が未解消のまま残存している |
+| Contract未定義箇所が明示済み | 達成 | 本文書全体で明示済み |
+| 新規実装で同じ判断を再発明しない | 部分達成 | 分類済みカテゴリについては再発明不要だが、Phase 2〜6自体は依然未決定のため、Stage 4が同一スコープに触れた場合は同じ論点に再度直面する |
+
+**したがって、候補Aは自らの前提条件を満たしておらず、現時点では選択できない。** これは母艦の好みの判断ではなく、候補Aが明記した基準に対する事実確認の結果である。`ConciergeFilterPanel.tsx`の解消（Phase 6のAction Border判断が確定した上でのコード修正）が候補Aの前提として必要になる。
+
+この事実確認の結果として、既存の`docs/design/design-token.md`のDONE定義・`PARTIAL_MIGRATION_ALLOWED`運用は変更せず、Stage 3は`STAGE3_PARTIALLY_DONE`のまま据え置く。これは新たな母艦決定ではなく、既存記述をそのまま維持することを意味する。
+
+### Dark Surface候補Bの前提
+
+Phase 2の候補B（Platform Theme内での吸収）は、`docs/design/design-token.md`の「3層構造」節が定義する「Platform Theme」が現状Web/Mobile差のみを指す概念であることを確認した（同文書37行目「実値の割り当ては各PlatformのTheme層が担う」、62行目以降「3. Platform Theme」）。候補Bを採用するには、この定義をWeb内のコンポーネント間差にも拡張するか否かをまず決める必要があり、これは候補A/Cとは異なり、Token値の決定に先立つ別のGovernance判断を要する。
+
 ## Phase 10 — Stage 4 Handoff
 
 Stage 4（Shrine Detail、`docs/design/design-token.md`のMigration方針 4.）着手時に、以下は既存決定として再利用可能（同じProduct判断を再実施しない）:


### PR DESCRIPTION
## Summary

`docs/audit/design-token-stage3-residual-contract.md`（PR #2289）のPhase 2〜9を再監査し、候補として提示していた各項目を再確認した。

- **Phase 2〜6（Dark Surface variant選択・Light Surface・Guest Notice・Disabled・Action Border）**: いずれも閾値/好みの判断であり、事実だけでは解決できないことを再確認した。値・命名・Token化の可否は今回も確定していない
- **Dark Surface候補B**: `docs/design/design-token.md`の「Platform Theme」定義が現状Web/Mobile差のみを指すことを確認し、候補B採用にはこの定義自体の拡張という、Token値決定に先立つ別のGovernance判断が必要であることを明記した
- **Phase 7**: `ConciergeFilterPanel.tsx`の`border-emerald-600`/`bg-emerald-50`について、同一要素内でborderとbgの値が一致しない（`bg-emerald-50`≠`emerald-600`）ことを再確認。`action-primary`との値一致はあるが同一要素で塗りと縁が一致するケースではないため、既存の「Action Border」責務混同回避の方針に従い`ACCIDENTAL_REMAINDER`のまま維持した
- **Phase 8**: 候補A（`STAGE3_DONE_WITH_DOCUMENTED_LITERAL_EXCEPTIONS`）が自ら掲げる4条件を事実チェックし、「accidental remainder 0」が未達（上記`ConciergeFilterPanel.tsx`が未解消）であることを確認した。**これは母艦の好みではなく候補A自身の基準に対する事実確認であり、この結果に基づき候補Aは現時点で選択できない**。既存のDONE定義・`PARTIAL_MIGRATION_ALLOWED`運用は変更せず、`STAGE3_PARTIALLY_DONE`をそのまま維持する

## 本PRで確定していないこと

- Dark Surface variant選択（A/B/Cのどれか）
- Light Surface 100系のToken化可否
- Guest Notice / Disabled / Action Borderの新規Token化可否
- `ConciergeFilterPanel.tsx`のコード修正（今回未実施）

## design-token.md変更

なし。今回の追記は`design-token-stage3-residual-contract.md`への「候補Aの前提条件チェック結果」「Dark Surface候補Bの前提」の2セクション追加のみ。

## Test plan
- [x] `git diff --check`
- [x] docs-only diff（`tokens.css`・Component変更なし）
- [x] `border-emerald-600`+`bg-emerald-50`の組み合わせが`ConciergeFilterPanel.tsx`以外に存在しないことをrepo全体で再確認
- [x] `design-token.md`の「Platform Theme」定義箇所を再確認し、Web/Mobile差のみを指すことを確認
- [x] pre-push hook（OpenAPI lint / Web contract test）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)