### PR TITLE
feat: Shrine Detail PR-D1 低リスクcomponentへexact match Semantic Tokenを適用

### DIFF
--- a/apps/web/src/components/shrine/DetailSection.tsx
+++ b/apps/web/src/components/shrine/DetailSection.tsx
@@ -5,20 +5,20 @@ import * as React from "react";
 export type DetailSectionVariant = "primary" | "secondary" | "tertiary";
 
 const SECTION_CLASS: Record<DetailSectionVariant, string> = {
-  primary: "rounded-2xl border border-slate-300 bg-white p-6 shadow-lg",
-  secondary: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm",
-  tertiary: "rounded-2xl border border-slate-200 bg-slate-50 p-4",
+  primary: "rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-strong)] bg-[var(--kt-color-surface-default)] p-6 shadow-[var(--kt-shadow-high)]",
+  secondary: "rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-5 shadow-[var(--kt-shadow-medium)]",
+  tertiary: "rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] p-4",
 };
 
 const TITLE_CLASS: Record<DetailSectionVariant, string> = {
-  primary: "text-base font-semibold text-slate-900",
-  secondary: "text-sm font-semibold text-slate-900",
-  tertiary: "text-xs font-semibold text-slate-500",
+  primary: "text-base font-semibold text-[var(--kt-color-text-primary)]",
+  secondary: "text-sm font-semibold text-[var(--kt-color-text-primary)]",
+  tertiary: "text-xs font-semibold text-[var(--kt-color-text-muted)]",
 };
 
 const RIGHT_CLASS: Record<DetailSectionVariant, string> = {
-  primary: "text-xs text-slate-500",
-  secondary: "text-xs text-slate-500",
+  primary: "text-xs text-[var(--kt-color-text-muted)]",
+  secondary: "text-xs text-[var(--kt-color-text-muted)]",
   tertiary: "text-[11px] text-slate-400",
 };
 

--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -88,14 +88,14 @@ export default function ShrineSaveButton({
           ${
             fav
               ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-              : "border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-muted)] hover:bg-slate-50 hover:text-slate-700"
+              : "border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-muted)] hover:bg-[var(--kt-color-background-subtle)] hover:text-[var(--kt-color-text-secondary)]"
           }
           disabled:opacity-60`
       : `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold transition
           ${
             fav
               ? "border-emerald-300 bg-emerald-50 text-emerald-700"
-              : "border-[var(--kt-color-border-strong)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-primary)] hover:bg-slate-50"
+              : "border-[var(--kt-color-border-strong)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-primary)] hover:bg-[var(--kt-color-background-subtle)]"
           }
           disabled:opacity-60`;
 

--- a/apps/web/src/components/shrine/detail/PublicGoshuinSection.tsx
+++ b/apps/web/src/components/shrine/detail/PublicGoshuinSection.tsx
@@ -40,16 +40,16 @@ export default function PublicGoshuinSection({
         !isEmpty ? (
           <div className="relative z-50 flex flex-wrap items-center justify-end gap-2">
             {hasMore && seeAllHref ? (
-              <Link href={seeAllHref} className="text-xs font-semibold text-slate-700 hover:underline">
+              <Link href={seeAllHref} className="text-xs font-semibold text-[var(--kt-color-text-secondary)] hover:underline">
                 {seeAllLabel}
-                {moreCount > 0 ? <span className="ml-1 text-slate-500">（他{moreCount}件）</span> : null}
+                {moreCount > 0 ? <span className="ml-1 text-[var(--kt-color-text-muted)]">（他{moreCount}件）</span> : null}
               </Link>
             ) : null}
 
             {addGoshuinHref ? (
               <Link
                 href={addGoshuinHref}
-                className="relative z-50 rounded-lg bg-emerald-600 px-3 py-1.5 text-xs font-semibold text-white"
+                className="relative z-50 rounded-lg bg-[var(--kt-color-action-primary)] px-3 py-1.5 text-xs font-semibold text-[var(--kt-color-action-primary-text)]"
               >
                 この神社に御朱印を残す
               </Link>
@@ -58,19 +58,19 @@ export default function PublicGoshuinSection({
         ) : null
       }
     >
-      <p className="text-xs text-slate-500">お気に入りの御朱印を、この神社に残せます。</p>
+      <p className="text-xs text-[var(--kt-color-text-muted)]">お気に入りの御朱印を、この神社に残せます。</p>
 
-      {sendingLabel ? <p className="mt-2 text-xs text-slate-500">{sendingLabel}</p> : null}
+      {sendingLabel ? <p className="mt-2 text-xs text-[var(--kt-color-text-muted)]">{sendingLabel}</p> : null}
 
       {isEmpty ? (
-        <div className="mt-3 rounded-xl border bg-emerald-50 p-5 text-center">
-          <p className="text-sm font-semibold text-slate-700">この神社、まだ誰も御朱印を残していません</p>
-          <p className="mt-1 text-xs text-slate-500">あなたが最初の御朱印を残せます。</p>
+        <div className="mt-3 rounded-[var(--kt-radius-panel)] border bg-emerald-50 p-5 text-center">
+          <p className="text-sm font-semibold text-[var(--kt-color-text-secondary)]">この神社、まだ誰も御朱印を残していません</p>
+          <p className="mt-1 text-xs text-[var(--kt-color-text-muted)]">あなたが最初の御朱印を残せます。</p>
 
           {addGoshuinHref ? (
             <Link
               href={addGoshuinHref}
-              className="mt-4 inline-flex items-center justify-center rounded-lg bg-emerald-600 px-5 py-2.5 text-sm font-semibold text-white"
+              className="mt-4 inline-flex items-center justify-center rounded-lg bg-[var(--kt-color-action-primary)] px-5 py-2.5 text-sm font-semibold text-[var(--kt-color-action-primary-text)]"
             >
               この神社に御朱印を残す
             </Link>
@@ -85,8 +85,8 @@ export default function PublicGoshuinSection({
               <div
                 key={g.id}
                 className={[
-                  "overflow-hidden rounded-xl border bg-white",
-                  isLead ? "col-span-2 border-slate-200 shadow-sm" : "border-slate-200/80",
+                  "overflow-hidden rounded-[var(--kt-radius-panel)] border bg-[var(--kt-color-surface-default)]",
+                  isLead ? "col-span-2 border-[var(--kt-color-border-default)] shadow-[var(--kt-shadow-medium)]" : "border-slate-200/80",
                 ].join(" ")}
               >
                 <div
@@ -112,7 +112,9 @@ export default function PublicGoshuinSection({
                 <div className={isLead ? "p-3" : "p-2"}>
                   <p
                     className={
-                      isLead ? "truncate text-sm font-semibold text-slate-800" : "truncate text-xs text-slate-700"
+                      isLead
+                        ? "truncate text-sm font-semibold text-slate-800"
+                        : "truncate text-xs text-[var(--kt-color-text-secondary)]"
                     }
                   >
                     {(g.title ?? "").trim() || "（タイトルなし）"}
@@ -120,7 +122,9 @@ export default function PublicGoshuinSection({
                   {g.created_at ? (
                     <p
                       className={
-                        isLead ? "mt-1 truncate text-xs text-slate-500" : "truncate text-[11px] text-slate-500"
+                        isLead
+                          ? "mt-1 truncate text-xs text-[var(--kt-color-text-muted)]"
+                          : "truncate text-[11px] text-[var(--kt-color-text-muted)]"
                       }
                     >
                       {g.created_at}


### PR DESCRIPTION
## Summary

`docs/audit/design-token-stage4-mother-ship-decisions.md`（PR #2292）に基づき、Stage 4のうち既存Semantic Tokenで安全に表現できる箇所（PR-D1）を先行移行した。

## 対象・分類

### `DetailSection.tsx` — D1_READY（ほぼ全件）
- `text-slate-900`→`text-primary`、`text-slate-500`→`text-muted`（全3 variant）
- `border-slate-300`→`border-strong`、`border-slate-200`→`border-default`
- `bg-white`→`surface-default`、`bg-slate-50`→`background-subtle`
- `rounded-2xl`→`radius-card`、`shadow-lg`→`shadow-high`、`shadow-sm`→`shadow-medium`
- `text-slate-400`（tertiary variantの`right`表示）のみ対応Tokenが存在せずliteral維持

### `PublicGoshuinSection.tsx` — D1_READY（部分）
- text/border/surface/radius/shadowの exact match箇所を適用
- 同一要素でbg/textが揃う`bg-emerald-600`+`text-white`→`action-primary`/`action-primary-text`（2箇所）
- **`bg-slate-100`（Light Surface 100系）は今回対象外、Blocked by Contractとしてliteral維持**
- `text-slate-400`/`text-slate-800`（対応Tokenなし）、`border-slate-200/80`（alpha付き）もliteral維持
- 空状態バナーの`bg-emerald-50`は「まだ誰も御朱印を残していない」という空/prompt表現であり`status-success`の意味とは異なるため、値が一致するだけの理由でtoken化しなかった

### `ShrineSaveButton.tsx` — D1_READY（favorite=false側のみ）
- `hover:bg-slate-50`→`background-subtle`、`hover:text-slate-700`→`text-secondary`（favorite=false分岐のみ）
- **favorite=true側（`border-emerald-*`/`bg-emerald-50`/`text-emerald-700`）は一切変更していない**（Saved/Favorite Contract、PR-D2の責務）

## Scope Guard
- 変更ファイルはこの3つのみ。`tokens.css`は変更なし
- `ShrineSaveButton.tsx`のfavorite=true分岐はdiff上でも変更なしであることを確認
- Saved/Favorite・Dark Surface・Light Surface 100系のToken追加は行っていない
- state判定ロジック・props・API・Analytics・Copyは変更していない

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run src/components/shrine`（15 files / 102 tests）
- [x] `pnpm test:run`（115 files / 731 tests、フルスイート）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] 適用した全token（radius-card/panel、shadow-medium/high、border-default/strong、surface-default、background-subtle、text-primary/secondary/muted、action-primary/-text）がcomputed styleで対応Primitiveと完全一致することを確認
- [ ] 実際のShrine Detail画面での375/390/430/desktop目視確認 — 開発環境にbackendが立っておらず実データでの到達ができなかったため、computed style一致による検証のみ実施

## 判定
`PR_D1_EXACT_MATCH_MIGRATION_COMPLETE`

残存literalの分類:
- `BLOCKED_BY_CONTRACT`: `bg-slate-100`（Light Surface 100系）
- `D2`: `ShrineSaveButton.tsx`のfavorite=true側全体
- `KEEP_LITERAL_FOR_NOW` / 対応Tokenなし: `text-slate-400`/`text-slate-800`、alpha付き`border-slate-200/80`、空状態バナーの`bg-emerald-50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)