### PR TITLE
feat: Shrine Detail PR-D2 Saved/Favorite Semantic Tokenを部分適用

### DIFF
--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -87,14 +87,18 @@ export default function ShrineSaveButton({
       ? `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-2.5 text-xs font-semibold transition
           ${
             fav
-              ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+              ? /* border-emerald-200: subtle variant固有の値。default variantの
+                   border-emerald-300とTokenが分裂しているため(MULTI_VARIANT_VALUE_SPLIT)、
+                   --kt-color-saved-border(=emerald-300)を流用せずliteralのまま維持する。
+                   docs/audit/design-token-stage4-mother-ship-decisions.md 参照 */
+                "border-emerald-200 bg-[var(--kt-color-saved-background)] text-[var(--kt-color-saved-text)]"
               : "border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-muted)] hover:bg-[var(--kt-color-background-subtle)] hover:text-[var(--kt-color-text-secondary)]"
           }
           disabled:opacity-60`
       : `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold transition
           ${
             fav
-              ? "border-emerald-300 bg-emerald-50 text-emerald-700"
+              ? "border-[var(--kt-color-saved-border)] bg-[var(--kt-color-saved-background)] text-[var(--kt-color-saved-text)]"
               : "border-[var(--kt-color-border-strong)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-primary)] hover:bg-[var(--kt-color-background-subtle)]"
           }
           disabled:opacity-60`;

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -105,6 +105,23 @@
   --kt-color-surface-emphasis: var(--color-slate-800);
   --kt-color-surface-emphasis-hover: var(--color-slate-900);
 
+  /* ---- Semantic Token: saved (Saved / Favorite) ---- */
+  /* Web現行: ShrineSaveButton.tsx の fav=true 状態
+     (bg-emerald-50 text-emerald-700、border は variant により emerald-200/300)。
+     docs/audit/design-token-stage4-mother-ship-decisions.md で新設決定済み。
+     Selection・Status successとは別責務のため、それらのTokenを流用しない。
+     background/textは両variantで完全一致するためToken化した。
+     borderはsubtle variant(emerald-200)とdefault variant(emerald-300)で
+     実値が分裂している(MULTI_VARIANT_VALUE_SPLIT)。--kt-color-saved-border は
+     default variantの値(emerald-300)のみを表し、subtle variantの
+     border-emerald-200 は今回Token化せずliteralのまま維持する
+     (Blocked by current variant value split)。
+     fav=true状態には現行hoverが存在しないため、--kt-color-saved-hover は
+     実値を捏造しないよう今回追加しない。 */
+  --kt-color-saved-background: var(--color-emerald-50);
+  --kt-color-saved-text: var(--color-emerald-700);
+  --kt-color-saved-border: var(--color-emerald-300);
+
   /* ================================================================
    * Spacing (Primitiveは Tailwind の --spacing 基準値を係数計算で使用)
    * Web現行頻出値: p-4(107回)/px-4(91回)≒16px, px-3(121回)/p-3(53回)≒12px,


### PR DESCRIPTION
## Summary

`docs/audit/design-token-stage4-mother-ship-decisions.md`のSaved/Favorite Decisionに基づき、`--kt-color-saved-background`/`-text`/`-border`を追加し、`ShrineSaveButton.tsx`のfav=true状態へ部分適用した。

## 実装内容

- `--kt-color-saved-background`（`emerald-50`）・`--kt-color-saved-text`（`emerald-700`）: subtle/default両variantで値が完全一致するため適用
- `--kt-color-saved-border`（`emerald-300`）: **default variantのみ**適用。subtle variantの`border-emerald-200`は現行値がdefaultと分裂している（`MULTI_VARIANT_VALUE_SPLIT`）ため、Tokenを流用せずliteralのまま維持した（`Blocked by current variant value split`、コード内コメントに明記）
- `--kt-color-saved-hover`は追加しない: fav=true状態に現行hoverが存在せず、値を捏造することになるため

## Phase 6 — Repo-wide Guard（確認のみ、適用なし）

Saved/Favorite機能を持つ他6ファイルを確認したが、値clusterが`ShrineSaveButton.tsx`と一致しないため、今回の適用範囲には含めていない。

| ファイル | 確認結果 |
|---|---|
| `ranking/page.tsx` | emerald系の色literalなし |
| `FavoritesSection.tsx` | `border-emerald-700/20 bg-emerald-800 hover:bg-emerald-900`— 別クラスタ（dark CTA寄り） |
| `ShrineCard.tsx` | 色ではなく`★`/`☆`のglyph切替で表現、比較対象の色literalが存在しない |
| `ShrineCardLite.tsx` / `ShrineConciergeCard.tsx` / `ShrineSaveToggle.tsx` | emerald系literalなし |

同一Semantic責務（favorite/saved）ではあるが、視覚表現が統一されていないことを確認した。別PRでの検討対象として記録するに留める。

## Scope Guard
- 変更ファイルは`tokens.css`と`ShrineSaveButton.tsx`のみ
- `saved-hover`追加なし
- subtle variantのborder変更なし
- Selection/Status/Action Tokenの流用なし
- D3対象ファイルへの変更なし
- click handler・save/favorite API・optimistic state・Analytics・Copy・icon・disabled挙動・layout・radius/shadowは変更なし

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run src/components/shrine`（15 files / 102 tests）
- [x] `pnpm test:run`（115 files / 731 tests、フルスイート）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] `--kt-color-saved-background`/`-text`/`-border`のcomputed styleが`emerald-50`/`emerald-700`/`emerald-300`と完全一致することを確認。`saved-border`が意図的に`emerald-200`（subtle variant）とは一致しないことも確認
- [ ] 実際のShrine Detail画面での375/390/430/desktop目視確認 — 開発環境にbackendが立っておらず実データでの到達ができなかったため、computed style一致による検証のみ実施

## 判定
`PR_D2_SAVED_FAVORITE_PARTIAL_MIGRATION_COMPLETE`

残課題:
- subtle variantのborder（`emerald-200`）— 値統一するかvariant別Tokenを追加するかは別途Product判断
- repo-wideのSaved/Favorite展開（6ファイル、視覚表現の統一有無を含めて別PR）
- hover UX（別Product task）

🤖 Generated with [Claude Code](https://claude.com/claude-code)