### PR TITLE
feat: Shrine Detail PR-D3-1 既存Semantic Tokenとexact matchする箇所を閉域移行

### DIFF
--- a/apps/web/src/components/shrine/DetailDisclosureBlock.tsx
+++ b/apps/web/src/components/shrine/DetailDisclosureBlock.tsx
@@ -44,7 +44,7 @@ export default function DetailDisclosureBlock({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={cn("w-full px-4 py-3 text-left", "flex items-start justify-between gap-3", "hover:bg-slate-50")}
+        className={cn("w-full px-4 py-3 text-left", "flex items-start justify-between gap-3", "hover:bg-[var(--kt-color-background-subtle)]")}
         aria-expanded={open}
       >
         {materials.length ? (

--- a/apps/web/src/components/shrine/ShrineCloseLink.tsx
+++ b/apps/web/src/components/shrine/ShrineCloseLink.tsx
@@ -19,7 +19,7 @@ export default function ShrineCloseLink({ close }: Props) {
     <button
       type="button"
       onClick={() => window.history.back()}
-      className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-slate-700 hover:bg-slate-100"
+      className="inline-flex items-center gap-1 rounded-lg px-2 py-1 text-sm font-semibold text-[var(--kt-color-text-secondary)] hover:bg-slate-100"
     >
       ← {close.label}
     </button>

--- a/apps/web/src/components/shrine/ShrineDetailShell.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailShell.tsx
@@ -101,7 +101,7 @@ export default function ShrineDetailShell({
             {addGoshuinHref ? (
               <Link
                 href={addGoshuinHref}
-                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] border bg-[var(--kt-color-surface-default)] px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-primary)] hover:bg-slate-50"
+                className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] border bg-[var(--kt-color-surface-default)] px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-primary)] hover:bg-[var(--kt-color-background-subtle)]"
               >
                 {LABELS.addGoshuin}
               </Link>

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -683,7 +683,7 @@ export default function ShrineDetailArticle({
               </Link>
 
               {favoriteNoticeState === "saved" ? (
-                <p className="text-xs font-semibold text-emerald-700">{FAVORITE_LABELS.saved}</p>
+                <p className="text-xs font-semibold text-[var(--kt-color-saved-text)]">{FAVORITE_LABELS.saved}</p>
               ) : null}
 
               {favoriteNoticeState === "removed" ? (


### PR DESCRIPTION
## Summary

`docs/audit/design-token-stage4-d3-semantic-decisions.md`のD3-1スコープ（exact match閉域）を実装した。

## 変更内容

- `ShrineDetailShell.tsx`: 御朱印追加リンクの`hover:bg-slate-50`→`background-subtle`
- `ShrineCloseLink.tsx`: `text-slate-700`→`text-secondary`
- `DetailDisclosureBlock.tsx`: `hover:bg-slate-50`→`background-subtle`
- `ShrineDetailArticle.tsx`: `FAVORITE_LABELS.saved`表示テキストの`text-emerald-700`→`saved-text`（Decision 1、`SAVED_TEXT_EXACT_MATCH`）

`ShrineActionSection.tsx`は対象候補だったが、残存literal（`text-amber-950`×2）に対応するTokenが存在しないため変更なし。

## Deferred（今回変更していないもの）

- Dark Surface: `ShrineDetailShell.tsx`の`bg-slate-900 hover:bg-slate-800`
- Light Surface 100系: `ShrineCloseLink.tsx`の`hover:bg-slate-100`、`DetailDisclosureBlock.tsx`の`bg-slate-100`
- Status Success shade差・Tag/Chip・Action variant: `ShrineReflectionPrompt.tsx`（D3-2、Decision 2・3・4によりliteral維持が正式決定済み）
- amber hover（`text-amber-950`等、対応Tokenなし）

## Scope Guard
- 変更ファイルはD3-1対象の4ファイルのみ
- `tokens.css`変更なし
- D3-2対象（`ShrineReflectionPrompt.tsx`・`ShrineSupplementSection.tsx`・`ShrineJudgeSection.tsx`）は未変更
- state logic・API・Analytics・Copyは変更なし

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test:run src/components/shrine`（15 files / 102 tests）
- [x] `pnpm test:run`（115 files / 731 tests、フルスイート）
- [x] `pnpm test:contract`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] 適用した3token（`background-subtle`/`text-secondary`/`saved-text`）がcomputed styleで対応Primitive（`slate-50`/`slate-700`/`emerald-700`）と完全一致することを確認
- [x] Dark Surface・Light Surface 100系・amber-950・`ShrineReflectionPrompt.tsx`の残存literalが変更されていないことを確認
- [ ] 実際のShrine Detail画面での375/390/430/desktop目視確認 — 開発環境にbackendが立っておらず実データでの到達ができなかったため、computed style一致による検証のみ実施

## 判定
`PR_D3_1_EXACT_MATCH_CLOSURE_COMPLETE`

残存:
- `STATUS_SUCCESS_SHADE_GAP`
- `TAG_CHIP_CONTRACT_CANDIDATE`
- `ACTION_VARIANT`
- `DARK_SURFACE`
- `LIGHT_SURFACE_100`
- `AMBER_HOVER`

🤖 Generated with [Claude Code](https://claude.com/claude-code)