### PR TITLE
fix: Concierge候補生成のgoriyaku_tags N+1 queryを解消

### DIFF
--- a/backend/temples/services/concierge_chat_candidates.py
+++ b/backend/temples/services/concierge_chat_candidates.py
@@ -79,6 +79,7 @@ def build_chat_candidates(
     qs = exclude_qa_fixture_shrines(qs)
 
     qs = qs.select_related("place_ref")
+    qs = qs.prefetch_related("goriyaku_tags")
     qs = qs.filter(latitude__isnull=False, longitude__isnull=False)
     qs = qs.exclude(address="")
 
@@ -131,7 +132,10 @@ def build_chat_candidates(
                 "visit_style_tags": getattr(s, "visit_style_tags", None),
                 "history_theme": getattr(s, "history_theme", ""),
                 "astro_priority": getattr(s, "astro_priority", None),
-                "goriyaku_tag_ids": list(s.goriyaku_tags.values_list("id", flat=True))
+                # .values_list()はprefetch_relatedのcacheを使わず新規queryを発行するため、
+                # .all()経由でPython側抽出する（N+1回避、shrine_meaning_composer.py
+                # の_read_goriyaku_tags()と同じ理由）。
+                "goriyaku_tag_ids": [tag.id for tag in s.goriyaku_tags.all()]
                 if hasattr(s, "goriyaku_tags")
                 else [],
                 "popular_score": getattr(s, "popular_score", None),

--- a/backend/temples/services/shrine_meaning_composer.py
+++ b/backend/temples/services/shrine_meaning_composer.py
@@ -404,9 +404,12 @@ def _read_value(source: Any, *keys: str) -> Any:
 def _read_goriyaku_tags(source: Any) -> tuple[str, ...]:
     raw = _read_value(source, "goriyakuTags", "goriyaku_tags")
 
-    if hasattr(raw, "values_list"):
+    if hasattr(raw, "all"):
+        # .values_list()はprefetch_relatedのcacheを使わず新規queryを発行するため、
+        # .all()経由でPython側抽出する（prefetch済みなら追加queryなし、
+        # 未prefetchなら従来同様1回のqueryで済む）。
         try:
-            return _clean_str_list(list(raw.values_list("name", flat=True)))
+            return _clean_str_list([tag.name for tag in raw.all()])
         except Exception:
             return ()
 


### PR DESCRIPTION
## Summary

`build_chat_candidates()`の候補生成で、per-shrine loop内の2箇所が`goriyaku_tags`（M2M）へ`.values_list()`で個別queryを発行しており、候補数に比例してquery数が増加するN+1が存在した。前回のFact Integrity Audit（構造監査のみ、実装なし）で発見した箇所の修正。

## Root Cause（実測で確認）

`CaptureQueriesContext`で実測した結果:

| limit | pool size | query数（修正前） |
|---|---:|---:|
| 10 | 50 | 105 |
| 20 | 100 | 205 |
| 40 | 100 | 205 |

候補数が増えるとquery数が線形に増加していた。原因は2箇所:

1. `concierge_chat_candidates.py:134`（当時） — `s.goriyaku_tags.values_list("id", flat=True)`
2. `shrine_meaning_composer.py::_read_goriyaku_tags()` — `raw.values_list("name", flat=True)`（`compose_shrine_meaning_payload()`経由で同じloop内から呼ばれる）

## Fix

`prefetch_related("goriyaku_tags")`を追加するだけでは直らないことを実測で確認した（推測で決めない、という指示に従い先に検証）。

```
prefetch_related + .values_list()維持 → 5 queries / 5 shrines（直っていない）
prefetch_related + .all()経由でPython側抽出 → 0 query / 5 shrines
```

`.values_list()`は`prefetch_related`のcacheを使わず新規queryを発行するため、上記2箇所を`.all()`経由のPython側抽出（`[tag.id for tag in s.goriyaku_tags.all()]`等）へ変更した。

## 効果（実測）

| limit | pool size | query数（修正後） |
|---|---:|---:|
| 10 | 50 | 6 |
| 20 | 100 | 6 |
| 40 | 100 | 6 |

候補数に依存しない定数queryになった（Knowledge selector側と同じ挙動）。

## Functional Regression（実データで確認）

- `goriyaku_tag_ids`: 修正前後で完全一致（100候補、diff無し）
- 候補の順序: 完全一致
- pool size: 100（変化なし）
- fixture（id 101-105）除外: 維持
- Knowledge-backed 19社: 全件pool内に維持
- `goriyakuTags`名抽出（`compose_shrine_meaning_payload`経由）: 正しく動作（例: 三峯神社→['仕事運', '厄除け', '開運']）

## Test plan
- [x] candidate関連test（51 passed）
- [x] Evidence Gate関連test（50 passed）
- [x] backend full suite（1025 passed, 9 skipped=GDAL/PostGIS未導入、既存・無関係）
- [x] `makemigrations --check --dry-run`: No changes detected
- [x] `git diff --check`

## Scope Guard
- Score・Ranking・Recommendation Readiness・Knowledge Model・APIは変更していない
- candidate selection結果・filtering条件・fixture exclusionは変更していない（実データ比較で確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)