### PR TITLE
fix: Recommendation ReasonのTradition Confidence Gapを解消(TRADITION_ALWAYS_HEDGED)

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -375,6 +375,21 @@ def _pick_primary_knowledge_history_confidence(knowledge_histories: Any) -> str 
     return str(item.get("confidence") or "").strip() or None
 
 
+def _pick_primary_knowledge_history_type(knowledge_histories: Any) -> str | None:
+    """`_pick_primary_knowledge_history_content()`が採用するのと同じHistory 1件の
+    history_typeを返す。別Historyのhistory_typeを混ぜない（PR-B契約と同じ選定基準）。
+
+    history_typeはconfidenceとは別軸の情報（Source信頼度ではなく、その記述が
+    伝承かどうかという記述種別）であり、TRADITION_ALWAYS_HEDGED契約
+    （docs/core/recommendation-reason-contract.md）でRecommendation Reason V4側の
+    表現強度判定に使われる。ここでは値の受け渡しのみを行い、判定はしない。
+    """
+    item = _pick_primary_knowledge_history_item(knowledge_histories)
+    if item is None:
+        return None
+    return str(item.get("history_type") or "").strip() or None
+
+
 def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
     meaning_payload = rec.get("meaning_payload") if isinstance(rec.get("meaning_payload"), dict) else {}
     source = meaning_payload.get("source") if isinstance(meaning_payload.get("source"), dict) else {}
@@ -399,6 +414,14 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
         if knowledge_history_content is not None
         else None
     )
+    # TRADITION_ALWAYS_HEDGED契約: history_typeはconfidenceと同じ選定基準（同一History）
+    # から取る。Legacy fallback時はKnowledge history_type概念が存在しないためNone
+    # （confidence同様、PR-B契約に合わせる）。
+    shrine_history_type = (
+        _pick_primary_knowledge_history_type(rec.get("knowledge_histories"))
+        if knowledge_history_content is not None
+        else None
+    )
 
     return {
         "shrine_id": rec.get("shrine_id") or rec.get("id") or source.get("shrineId"),
@@ -416,6 +439,7 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
         "deity_confidence": deity_confidence,
         "shrine_history": knowledge_history_content if knowledge_history_content is not None else (rec.get("description") or source.get("description")),
         "shrine_history_confidence": shrine_history_confidence,
+        "shrine_history_type": shrine_history_type,
         "place_context": rec.get("address") or source.get("address"),
         "place_id": rec.get("place_id"),
         "behavior_signals": rec.get("behavior_signals") if isinstance(rec.get("behavior_signals"), dict) else {},

--- a/backend/temples/services/recommendation_reason_v4.py
+++ b/backend/temples/services/recommendation_reason_v4.py
@@ -166,6 +166,28 @@ def _reason_strength_from_confidence(confidence: Any) -> str:
     return "assertive"
 
 
+# TRADITION_ALWAYS_HEDGED契約（docs/core/recommendation-reason-contract.md）:
+# confidenceはSourceへの信頼度であり、history_type（記述がその出来事を確定した
+# 史実として書いているか、伝承として書いているか）とは責務が別の軸である。
+# confidence=highは「Sourceは信頼できる」ことしか意味せず、「記述内容が史実として
+# 確定している」ことは意味しない。history_type="tradition"のFactは、Source信頼度に
+# 関わらず断定表現(assertive)を出してはならない。
+_TRADITION_HISTORY_TYPE = "tradition"
+
+
+def _apply_tradition_hedge_floor(reason_strength: str, history_type: Any) -> str:
+    """history_type="tradition"のFactについて、reason_strengthの下限をweakenedに引き上げる。
+
+    confidence由来で既にsuppressedと判定されているFactはそのまま
+    suppressed（最も安全側）を維持し、ここでは書き戻さない。assertiveのみを
+    weakenedへ引き下げる。content本文が手動でhedge表現を含んでいるかには依存しない
+    （_build_fact_text()のテンプレート選択自体を強制する設計）。
+    """
+    if history_type == _TRADITION_HISTORY_TYPE and reason_strength == "assertive":
+        return "weakened"
+    return reason_strength
+
+
 def _build_fact(
     candidate_profile: dict[str, Any], meaning_translation: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, str]]:
@@ -188,6 +210,9 @@ def _build_fact(
 
     deity_reason_strength = _reason_strength_from_confidence(candidate_profile.get("deity_confidence"))
     shrine_history_reason_strength = _reason_strength_from_confidence(candidate_profile.get("shrine_history_confidence"))
+    shrine_history_reason_strength = _apply_tradition_hedge_floor(
+        shrine_history_reason_strength, candidate_profile.get("shrine_history_type")
+    )
 
     # confidence=low(suppressed)のKnowledge Factは、Recommendation Reason
     # （fact/evidence/used_fact/quality監査を含む）へ一切使用しない。

--- a/backend/temples/tests/services/test_tradition_output_contract.py
+++ b/backend/temples/tests/services/test_tradition_output_contract.py
@@ -1,0 +1,116 @@
+"""TRADITION_ALWAYS_HEDGED契約の回帰テスト。
+
+docs/core/recommendation-reason-contract.md「Tradition Output Contract」に従い、
+history_type="tradition"のShrineHistory Factは、confidence（Source信頼度）に
+関わらずassertive表現（断定的な言い回し）を出してはならない。
+
+confidenceとhistory_typeは責務が別軸であることを確認するため、各テストは
+知識としての確度（confidence）を固定し、記述種別（history_type）だけを
+変えて出力文体（weakened/assertive）が変わることを確認する。
+
+deityの存在は_build_fact_text()の優先順位でshrine_history文を上書きするため、
+ここでは全テストでknowledge_deitiesを空にし、shrine_history表現だけを
+単独で観測できるようにする。
+"""
+
+from __future__ import annotations
+
+from temples.services.concierge_chat import _build_score_v3_candidate_profile
+from temples.services.recommendation_reason_v4 import build_recommendation_reason_v4
+
+
+def _rec_with_single_history(*, history_type: str, confidence: str) -> dict:
+    return {
+        "shrine_id": 900,
+        "name": "検証神社",
+        "knowledge_deities": [],
+        "knowledge_histories": [
+            {
+                "history_type": history_type,
+                "title": "検証用由緒",
+                "content": "検証神社は古くからこの地にあったという由緒を持つ。",
+                "period_text": "不詳",
+                "sort_order": 0,
+                "confidence": confidence,
+            }
+        ],
+    }
+
+
+def test_tradition_high_confidence_is_hedged_not_assertive():
+    """tradition + high: confidenceが高くても断定表現を出してはならない(新契約)。"""
+    rec = _rec_with_single_history(history_type="tradition", confidence="high")
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["shrine_history_type"] == "tradition"
+    assert profile["shrine_history_confidence"] == "high"
+    assert "伝えられています" in result["reason_text"]
+    assert "という背景があります" not in result["reason_text"]
+
+
+def test_tradition_medium_confidence_is_hedged():
+    """tradition + medium: 既存のconfidence由来hedgeと同じ表現のまま(回帰なし)。"""
+    rec = _rec_with_single_history(history_type="tradition", confidence="medium")
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert "伝えられています" in result["reason_text"]
+    assert "という背景があります" not in result["reason_text"]
+
+
+def test_historical_event_high_confidence_stays_assertive():
+    """tradition以外のhistory_typeはfloorの対象外(高confidenceなら現行通り断定表現)。"""
+    rec = _rec_with_single_history(history_type="historical_event", confidence="high")
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert "という背景があります" in result["reason_text"]
+    assert "伝えられています" not in result["reason_text"]
+
+
+def test_founding_high_confidence_keeps_current_contract():
+    """founding(祭神と対の由緒として既存Pilotで使われてきた種別)はfloor対象外のまま。"""
+    rec = _rec_with_single_history(history_type="founding", confidence="high")
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert "という背景があります" in result["reason_text"]
+    assert "伝えられています" not in result["reason_text"]
+
+
+def test_tradition_low_confidence_stays_suppressed_not_upgraded_to_hedged():
+    """tradition + low: floorはassertiveをweakenedへ引き下げるだけで、
+    suppressed(低confidenceによる非表示)をweakenedへ引き上げはしない。
+    """
+    rec = _rec_with_single_history(history_type="tradition", confidence="low")
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["shrine_history_type"] == "tradition"
+    assert result["fact"]["shrine_history"] is None
+    assert "検証神社は古くからこの地にあった" not in result["reason_text"]
+
+
+def test_legacy_fallback_history_has_no_history_type_and_is_unaffected():
+    """Legacy(description)フォールバック時はKnowledge history_type概念が存在しないため
+    shrine_history_typeはNoneになり、floorは一切作用しない(PR-B契約と同じ扱い)。
+    """
+    rec = {
+        "shrine_id": 901,
+        "name": "レガシー神社",
+        "description": "レガシーの由緒文",
+    }
+
+    profile = _build_score_v3_candidate_profile(rec)
+    result = build_recommendation_reason_v4(candidate_profile=profile)
+
+    assert profile["shrine_history_type"] is None
+    assert profile["shrine_history_confidence"] is None
+    assert "レガシーの由緒文という背景があります" in result["reason_text"]
+    assert "伝えられています" not in result["reason_text"]

--- a/docs/audit/tradition-output-contract-fix.md
+++ b/docs/audit/tradition-output-contract-fix.md
@@ -1,0 +1,173 @@
+> **Status: Active**
+>
+> 本ドキュメントは`docs/audit/recommendation-fact-integrity-negative-pilot.md`のPhase 12「Mother Ship Decisions Required」で提起された`RECOMMENDATION_REASON_CONTRACT_GAP`（Tradition Confidence Gap）への対応記録である。契約自体の正本は`docs/core/recommendation-reason-contract.md`「Fact表現強度（confidence / history_type）」を参照する。
+
+# Tradition Output Contract Fix
+
+## 背景
+
+前回のReal Negative Evidence Pilotで、`recommendation_reason_v4.py`の
+confidence→表現強度変換は`history_type`を一切見ていないことをコードレベルで確認した。
+`history_type="tradition"`（Source自身が伝承と明記した記述）のFactでも、
+`confidence=high`であれば断定表現（assertive）テンプレートが適用され、
+伝承が確定史実であるかのように出力される可能性がある。この時点では
+`content`本文を手動でhedge表現込みに執筆することで回避していたが、
+執筆規律への依存であり、システムによる保証ではなかった。
+
+## Mother Ship Gate
+
+以下は母艦から固定されたDecisionであり、本Auditでは変更しない。
+
+- Phase 1: `TRADITION_ALWAYS_HEDGED` — `history_type="tradition"`はconfidenceに関わらず断定表現禁止
+- Phase 5: `KEEP_FULL_SUPPRESSION_FOR_NOW` — `CONFIDENCE_MIXED`の現行挙動（全suppression）は変更しない
+- Phase 6: `KEEP_CURRENT_EVIDENCE_LEVEL` — 阿佐ヶ谷神明宮の`secondary_editorial`祭神のconfidenceは変更しない
+
+## Phase 2 — Runtime Audit（実施結果）
+
+`history_type`がRecommendation Reason V4まで渡っているかを追跡した結果:
+
+| 層 | history_typeの扱い | 結果 |
+|---|---|---|
+| `shrine_knowledge_selector.fetch_fact_ready_knowledge_histories()` | dictへ含めて返す | 保持されている |
+| `concierge_chat._pick_primary_knowledge_history_content/_confidence()` | `content`/`confidence`のみ抽出 | **ここで消失** |
+| `concierge_chat._build_score_v3_candidate_profile()` | `shrine_history`/`shrine_history_confidence`のみ設定 | history_type未設定 |
+| `recommendation_reason_v4._build_fact()` | `shrine_history_confidence`のみ参照 | history_typeを受け取る手段自体が無かった |
+
+情報が失われる層は`concierge_chat.py`（selector→candidate_profile変換部）であり、
+`shrine_knowledge_selector.py`自体は改修不要と判明した。
+
+## Phase 3 — Implementation Design
+
+候補A（Fact payloadへhistory_type保持）は既にselector層で満たされていたため対象外。
+候補B（selector段階でtradition flagへ変換）は、selector側へ「表現戦略の判断」という
+Reason生成の責務を混入させることになり、Fact取得責務（selectorのdocstringが明記する
+「Factを使えるか判断する責務はevidence_gateへ一本化」という既存分離）と衝突するため不採用。
+
+**候補C（Reason builderへ明示的にhistory_typeを渡す）を採用した。**
+理由:
+
+- Fact責務を維持: selector/candidate_profile builderは値の受け渡しのみを行い、
+  「tradition→hedge」の判断はこれまでconfidence→strength変換を行ってきた
+  `recommendation_reason_v4.py`内に閉じる（既存の責務境界と一致する）
+- Source/raw metadataをReasonへ露出しない: `history_type`はFact自身のenum値であり
+  Source metadataではない。既にShrine Detail APIでも公開されている情報。
+- existing deity pathを壊さない: `deity`にはhistory_type概念が無く無関係
+- migration不要: `history_type`はモデルに既存のfield、新規列は追加していない
+- Score/Rankingへ影響しない: `recommendation_reason_v4.py`はReason生成専用であり、
+  スコアリング・ランキングを一切扱わない
+
+具体的な変更:
+
+- `backend/temples/services/concierge_chat.py`: `_pick_primary_knowledge_history_type()`を追加し、
+  `candidate_profile["shrine_history_type"]`として（confidenceと同一選定基準のHistory 1件から）値を渡す
+- `backend/temples/services/recommendation_reason_v4.py`: `_apply_tradition_hedge_floor()`を追加し、
+  `history_type == "tradition"`かつ`reason_strength == "assertive"`の場合のみ`"weakened"`へ引き下げる
+  （`suppressed`は最も安全側のためそのまま維持し、引き上げはしない）
+
+`_build_fact_text()`自体は変更していない。既存の`weakened`分岐（「〜と伝えられています」）が
+そのまま使われるため、テンプレート文言の追加・変更は不要だった。
+
+## Phase 4 — Regression Tests
+
+新規: `backend/temples/tests/services/test_tradition_output_contract.py`（6件、全てPASS）
+
+| ケース | 結果 |
+|---|---|
+| tradition + high → hedged | PASS（新規で保護） |
+| tradition + medium → hedged | PASS（既存契約のまま、回帰なし） |
+| historical_event + high → assertive可 | PASS（floor対象外、回帰なし） |
+| founding + high → 現行契約維持 | PASS（floor対象外と明示、回帰なし） |
+| tradition + low → suppressed維持（weakenedへ引き上げない） | PASS（floorの片方向性を確認） |
+| Legacy fallback → history_type概念自体が無くfloor不作用 | PASS（PR-B契約と同じ扱い） |
+
+既存回帰（disputed/sourceなし→suppression、deity high/medium現状維持）は
+`test_reason_strength_pilot_and_regression.py`・`test_reason_strength_mixed_confidence.py`
+含むバックエンド全1031テストで再確認済み（0 failure、9 skip[PostGIS/GDAL未導入起因のみ]）。
+
+## Phase 5 — CONFIDENCE_MIXED（Decision: KEEP_FULL_SUPPRESSION_FOR_NOW）
+
+現行挙動を変更していない。実データfixtureとして再確認した結果:
+
+```
+阿佐ヶ谷神明宮: deity = 天照大神、月読命、須佐之男命 / confidence = __mixed__
+  → fact.deity = None（suppressed、reason_textはgenericフォールバックへ）
+```
+
+DB全体で複数Deityかつconfidence不一致のshrineは1件（阿佐ヶ谷神明宮のみ）。
+high subsetのpartial assertionは別Audit候補として送る（本Auditでは実装しない）。
+Score/Rankingは変更していない。
+
+## Phase 6 — Secondary Deity（Decision: KEEP_CURRENT_EVIDENCE_LEVEL）
+
+阿佐ヶ谷神明宮の月読命・須佐之男命（`secondary_editorial`/`medium`）はconfidenceを変更していない。
+公式Sourceが見つかるまで`high`へ格上げしない。Fact削除もしていない。
+mixed suppression回避を目的としたconfidence変更は行っていない。
+
+## Phase 7 — KPI再計測
+
+対象: `build_chat_candidates()`が返す全100件（QA fixture除外後の監査対象Shrine）。
+
+| KPI | 値 |
+|---|---|
+| Knowledge Coverage | 21/100（21.0%） |
+| Verified Source Count | 36 |
+| Unsupported Claim Rate | 0/100（0%） — 全Fact-ready出力がKnowledge selectorまたはLegacy由来であることを確認 |
+| Tradition Misstatement Rate（fix後） | 0/13（0%） — Fact-ready tradition History 13件、全てassertiveへ到達しないことを確認 |
+| Disputed Fact Usage Rate | 0%（Evidence Gate仕様上、disputedはFact-ready集合に含まれない。既存テストで保証） |
+| Source-less Fact Usage Rate | 0%（Evidence Gate仕様上、Source未確認のFactはusable=Falseで除外。既存テストで保証） |
+| Mixed Confidence Suppression Rate | 1/1（100%） — 複数confidence混在Deityを持つShrine 1件中1件がsuppressedになることを確認（阿佐ヶ谷神明宮） |
+| Zero-Knowledge Fallback成功率 | 79/79（100%） — Knowledge未登録79件全てでreason_text生成が例外なく成功 |
+
+### Tradition Misstatement Rateの実測（fix前後比較）
+
+fix前のロジック（`_reason_strength_from_confidence()`のみ、`history_type`未参照）で
+同じ100件を再計算したところ、以下5件が実際に`assertive`（断定表現）に該当していたことを確認した。
+
+```
+三峯神社 / 出雲大社 / 妙義神社 / 武蔵御嶽神社 / 鹿島神宮（いずれもconfidence=high, history_type=tradition）
+```
+
+この5件はいずれも同じShrineに`deity` Factも存在するため、`_build_fact_text()`の
+deity優先ルールにより`reason_text`上には実際には出力されていなかった（結果的に無事故）。
+ただし`fact.shrine_history`（構造化出力、`recommendation_reason_v4_detail.fact.shrine_history`
+としてAPIにも露出する）自体は`content`そのままであり、deity非存在のshrineが将来1件でも
+Fact-readyになれば、reason_text上に断定表現として出力されるリスクが現実だった。
+今回の修正によりこの5件を含む全13件のtradition Factが、confidenceに関わらずhedge表現の
+対象になることを確認した（deityの有無に依存しない構造的な保証へ変わった）。
+
+## Phase 8 — Final Classification
+
+`FACT_INTEGRITY_READY_WITH_LIMITATIONS`
++ `TRADITION_OUTPUT_CONTRACT_FIXED`（前回の`RECOMMENDATION_REASON_CONTRACT_GAP`を解消）
++ `MIXED_CONFIDENCE_POLICY_DEFERRED`（high subset partial assertionは未着手のまま、別Audit候補）
+
+Fact Integrityの構造的な安全性（Evidence Gate、Source-less/disputed排除、
+CONFIDENCE_MIXED suppression、Tradition hedge floor）は確認できたが、
+以下は依然として未解決であり「Ready for Rollout」への昇格条件ではない。
+
+- `low confidence`/`disputed`の実データ実例がDB全体でゼロ
+- Mixed Confidence partial assertionポリシー自体が未確定
+- Knowledge Coverageは21/100に留まる（Batch 4以降は本Audit範囲外）
+
+## Phase 9 — Stop
+
+本Auditでは以下へ進まない。
+
+- Batch 4着手
+- 81社一括投入
+- Mixed confidence partial assertion実装
+- user-facing Source citation UI
+- confidence UI
+- Score/Ranking変更
+- Readiness candidate gateへの接続
+
+## Repository Changes
+
+- `backend/temples/services/concierge_chat.py`: `_pick_primary_knowledge_history_type()`追加、`candidate_profile["shrine_history_type"]`追加
+- `backend/temples/services/recommendation_reason_v4.py`: `_apply_tradition_hedge_floor()`追加、`_build_fact()`内で適用
+- `backend/temples/tests/services/test_tradition_output_contract.py`: 新規（6テスト）
+- `docs/core/recommendation-reason-contract.md`: 「Fact表現強度（confidence / history_type）」節追加、禁止事項に1件追加
+- `docs/knowledge/shrine-knowledge-contract.md`: 3軸分離節へRecommendation Reason側強制への相互参照を追加
+- `docs/audit/tradition-output-contract-fix.md`: 本ドキュメント（新規）
+- Model/Migration/Serializer/Evidence Gate判定ロジック/API contract/Score/Ranking: 変更なし
+- DB書き込み: なし（本Auditは既存local DBデータの読み取り測定のみ）

--- a/docs/core/recommendation-reason-contract.md
+++ b/docs/core/recommendation-reason-contract.md
@@ -71,6 +71,40 @@ Stored情報を根拠として付与されたMeaning情報である。
 
 Factはユーザー状態の診断や行動提案を行わない。
 
+### Fact表現強度（confidence / history_type）
+
+Recommendation Reasonが`shrine_history`（および`deity`）をどの強度の文体で
+表示するかは、Knowledge Fact側の2つの独立した軸から決まる。
+
+- `confidence`（`temples.models.KNOWLEDGE_CONFIDENCE_CHOICES`）: そのFactを
+  裏付けるSourceへの信頼度。「情報がどれだけ確からしいSourceに基づくか」を表す。
+- `history_type`（`temples.models.ShrineHistory.history_type`）: そのFactが
+  何を記述しているかの種別（`official_origin` / `founding` / `historical_event` /
+  `tradition` / `regional_context` / `editorial_summary`）。「記述内容が確定した
+  史実として書かれているか、伝承として書かれているか」を表す。
+
+**両者は責務が別であり、どちらか一方だけでは他方を代替しない。**
+`confidence=high`は「Sourceは信頼できる」ことしか意味せず、
+「記述内容が史実として確定している」ことは意味しない。
+
+**Tradition Output Contract（TRADITION_ALWAYS_HEDGED）**:
+`history_type="tradition"`のFactは、`confidence`の値に関わらず断定表現
+（assertive）を出してはならない。confidenceがどれだけ高くても、伝承として
+書かれた内容は伝承としての文体（例:「〜と伝えられています」）で表示する。
+
+この制御はKnowledge Fact`content`本文が手動でhedge表現を含んでいるかには
+依存しない。`history_type="tradition"`である事実だけで、Reason生成側
+（`backend/temples/services/recommendation_reason_v4.py`の
+`_apply_tradition_hedge_floor()`）が表現強度の下限を強制する。
+これにより、執筆者が`content`のhedge表現を書き忘れた場合でも
+伝承が史実であるかのように出力される事故を構造的に防ぐ。
+
+`history_type="founding"`は既存Pilot（Score v3以前）から現行文体
+（confidenceに応じたassertive/weakened/suppressed）のまま維持し、
+本契約の対象に含めない。`founding`は「創建の一次的な由緒」という
+既存の意味合いで使われており、`tradition`（Source自身が伝承と明記した記述）
+とは別カテゴリとして扱う。両者を混同して`history_type`を選択しない。
+
 ### Interpretation
 
 相談内容をどのような文脈として受け取ったかを説明する。
@@ -352,6 +386,7 @@ Action Suggestion全体と同一ではない。
 - Snapshotを後から暗黙に再計算する
 - 方位一致をRecommendation Reasonの主理由として表示する
 - 「吉方位なので行くべき」「必ず良い結果になる」「運気が上がる」「願いが叶う」と断定する
+- `history_type="tradition"`のFactを、confidenceに関わらず断定表現(assertive)で出す
 
 ## 互換維持方針
 

--- a/docs/knowledge/shrine-knowledge-contract.md
+++ b/docs/knowledge/shrine-knowledge-contract.md
@@ -636,6 +636,8 @@ Detailで`disputed`のFactを扱う場合は、各Factを**独立したFactと�
 - `official_origin` ≠ `source_confirmed`（公式由緒に分類されていることと、確認済み状態であることは別概念。公式由緒であっても`draft`のまま未確認の場合がある）
 - `founding` ≠ historical certainty（創建情報に分類されていることは、その内容が史実として確定していることを意味しない。確定性は`verification_status`/`confidence`側で表現する）
 
+> **Recommendation Reason側での強制（TRADITION_ALWAYS_HEDGED）**: 上記の3軸分離はModel/Data Entry契約であり、Recommendation Reason生成側が`confidence=high`の`tradition`分類Factを断定表現で出力しないことまでは、本節単独では保証しない。Reason生成側での強制（`history_type="tradition"`ならconfidenceに関わらずhedge表現を使う）は`docs/core/recommendation-reason-contract.md`「Fact表現強度（confidence / history_type）」を正本とする。
+
 ### Multiple Fact保持方針
 
 現行Modelでは、複数の`ShrineHistory`/`ShrineDeity`を別レコードとして保持できる（`unique_together`等の一意制約は存在しない）。各Factは以下を独立して保持できる。


### PR DESCRIPTION
## Summary

前回のReal Negative Evidence Pilot（[docs/audit/recommendation-fact-integrity-negative-pilot.md](../blob/develop/docs/audit/recommendation-fact-integrity-negative-pilot.md)）で発見した`RECOMMENDATION_REASON_CONTRACT_GAP`（Tradition Confidence Gap）を、母艦Gate（Phase 1: `TRADITION_ALWAYS_HEDGED`）に従い構造的に修正した。

`history_type="tradition"`（Source自身が伝承と明記した記述）のFactは、`confidence`（Source信頼度）が`high`でも断定表現を出してはならない、という契約を新設し、Reason生成側で強制するようにした。

## Root cause（Phase 2監査）

`history_type`は`shrine_knowledge_selector.py`では保持されていたが、`concierge_chat.py`の`candidate_profile`変換時に`content`/`confidence`のみ抽出され消失していた。`recommendation_reason_v4.py`はそもそも`history_type`を受け取る手段自体を持っていなかった。

## Fix（Phase 3設計・実装）

選定基準（Fact責務維持・Source raw metadata非露出・deity path非破壊・migration不要・Score/Ranking非影響）に基づき「Reason builderへ明示的にhistory_typeを渡す」方式を採用。

- `backend/temples/services/concierge_chat.py`: `candidate_profile["shrine_history_type"]`を追加
- `backend/temples/services/recommendation_reason_v4.py`: `_apply_tradition_hedge_floor()`を追加。`history_type=="tradition"`かつ`reason_strength=="assertive"`の場合のみ`"weakened"`へ引き下げる片方向floor（`suppressed`は引き上げない）

## 実データでの影響確認

DB全体（Fact-ready History 13件）を実測したところ、fix前ロジックでは以下5件が実際に`assertive`（断定表現）扱いになっていた。

```
三峯神社 / 出雲大社 / 妙義神社 / 武蔵御嶽神社 / 鹿島神宮
```

いずれも同一shrineに`deity` Factが存在するため`_build_fact_text()`のdeity優先ルールにより`reason_text`には結果的に出力されていなかったが、`fact.shrine_history`（`recommendation_reason_v4_detail`としてAPI露出する構造化出力）自体は無防備だった。今回の修正で、deityの有無に関わらず全13件のtradition Factがconfidenceに関係なくhedge対象になることを構造的に保証した。

## Mother Ship Decisions（変更なし・記録のみ）

- Phase 5 `KEEP_FULL_SUPPRESSION_FOR_NOW`: `CONFIDENCE_MIXED`挙動は変更していない（阿佐ヶ谷神明宮1件で再確認）
- Phase 6 `KEEP_CURRENT_EVIDENCE_LEVEL`: secondary deityのconfidenceは変更していない

## Final Classification

`FACT_INTEGRITY_READY_WITH_LIMITATIONS` + `TRADITION_OUTPUT_CONTRACT_FIXED` + `MIXED_CONFIDENCE_POLICY_DEFERRED`

詳細（KPI再計測含む）は[docs/audit/tradition-output-contract-fix.md](../blob/develop/docs/audit/tradition-output-contract-fix.md)参照。

## 禁止事項の遵守

- [x] Score/Ranking変更なし
- [x] Readiness/candidate exclusion接続なし
- [x] Evidence Gate判定ロジック変更なし
- [x] Migration不要（既存fieldの受け渡しのみ）
- [x] Batch 4 / 81社一括投入 / Mixed confidence partial assertion / user-facing citation UI / confidence UIには着手していない

## Test plan

- [x] 新規回帰テスト6件（`test_tradition_output_contract.py`）全PASS
- [x] バックエンド全1031テスト PASS（9 skip: PostGIS/GDAL未導入起因のみ）
- [x] 実DBデータでの`shrine_history_type`伝播・reason_text出力を鹿島神宮/阿佐ヶ谷神明宮の実データで直接確認
- [x] pre-push hook（OpenAPI lint / Web contract test 731件）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)