### PR TITLE
docs: Mixed Confidence Policy確定記録とBatch 4 Preparationを記録

### DIFF
--- a/docs/audit/mixed-confidence-policy-decision.md
+++ b/docs/audit/mixed-confidence-policy-decision.md
@@ -1,0 +1,84 @@
+> **Status: Decided（技術Policyとして固定）**
+>
+> 本ドキュメントは`docs/audit/mixed-confidence-policy-audit.md`（技術比較監査）の
+> Phase 8「Mother Ship Decision」を確定した記録である。監査自体の正本は
+> `docs/audit/mixed-confidence-policy-audit.md`を参照する。
+
+# Mixed Confidence Policy Decision
+
+## Phase 0 — Closure Base
+
+| 項目 | 値 |
+|---|---|
+| PR #2300（Mixed Confidence Policy Audit） | MERGED（2026-08-08T02:07:27Z、merge commit `6b4a6107`） |
+| develop HEAD | `6b4a6107cb2e7244c79f87bd840d4582c11d7f0a` |
+| working tree | clean |
+| `docs/audit/mixed-confidence-policy-audit.md` | develop反映済み |
+
+本Phaseではコード変更を行っていない。
+
+## Phase 1 — Mother Ship Technical Decision
+
+`docs/audit/mixed-confidence-policy-audit.md` Phase 8の判断材料に基づき、以下を確定する。
+
+- **FULL_SUPPRESSIONを現行Policyとして維持する。** `CONFIDENCE_MIXED`検出時、Deity Fact全体（高confidence Factを含む）をReasonから完全suppressする現行実装（`recommendation_reason_v4._build_fact()`）は変更しない。
+- **HIGH_ONLYは採用しない。** 技術的にはSafe（監査Phase 6で確認済み）だが、現時点で採用へ進む理由（実害の規模）が不足していると判断する。
+- **PRIMARY_ONLYは採用しない。** 監査Phase 6で指摘した通り、`role`を信頼度の代理として扱うことは「roleを勝手に信頼度として扱わない」という既存原則と構造的に矛盾するため、この案自体を採用対象から外す。
+- **PER_FACT_RENDERINGは将来のContract変更候補として記録する。** 直ちに実装しないが、Information Utilizationの観点で最も有望な案として`docs/audit/mixed-confidence-policy-audit.md`のPhase 3/6分析を正本に据え置く。
+- **阿佐ヶ谷神明宮の現行fallback挙動を正常系として維持する。** 天照大神(high)を含む全DeityがsuppressされGenericフォールバック文言（「〜に関する情報があります」）になる現在の出力は、Bugではなく設計通りの安全側動作として扱う。
+
+Score/Ranking/Readiness/confidence値/Fact内容のいずれも変更していない。
+
+## Phase 2 — Deferred Follow-up（PER_FACT_RENDERING再検討条件）
+
+PER_FACT_RENDERINGの検討を再開する条件を以下に固定する。**現時点ではこれらの条件は満たされていないため、実装しない。**
+
+| 条件 | 現状 |
+|---|---|
+| real mixed-confidence shrineがさらに複数件出現 | 現状1件のみ（阿佐ヶ谷神明宮）。Batch 4以降で増える可能性はあるが未確認 |
+| 情報損失がRecommendation品質へ実害を出す | 現時点で定量的な実害（ユーザー影響）は未計測。Recommendation Reason Quality Auditの既存指標では検知範囲外 |
+| Fact単位payloadへの変更範囲を監査できる | `fact.deity`のpublic契約（`recommendation_reason_v4_detail.fact.deity`）変更範囲の監査は未実施 |
+| Web/API contractへの影響を分離できる | Frontend Adapter契約（`docs/product/recommendation-v4-frontend-adapter-contract.md`）への影響分離は未検討 |
+
+4条件すべてが満たされた時点で、別Auditとして再着手を検討する。
+
+## Phase 3 — Fact Integrity Closure（再確認済み）
+
+develop HEAD `6b4a6107`時点で以下を再確認した。
+
+| 項目 | 結果 |
+|---|---|
+| Evidence Gate real negative case確認済み | ○（`docs/audit/recommendation-fact-integrity-negative-pilot.md`、長太稲荷神社/鹿島神宮/阿佐ヶ谷神明宮の実データで確認済み） |
+| Source-less Fact Usage Rate | 0%（Evidence Gate仕様上構造的に不可能。`test_fact_ready_without_source_is_still_unusable_regardless_of_confidence`等で担保） |
+| Disputed Fact Usage Rate | 0%（同上。`test_disputed_high_confidence_is_still_unusable`で担保） |
+| Tradition Misstatement Rate | 0/13（`docs/audit/tradition-output-contract-fix.md`のfix後、Fact-ready tradition History全件で再確認済み） |
+| Mixed Confidenceは安全側に抑止 | ○（本ドキュメントPhase 1でFULL_SUPPRESSION維持を確定） |
+| Candidate N+1解消済み | ○（PR #2297。`test_candidates_knowledge_lookup_does_not_scale_query_count_with_shrine_count`が現在もPASS） |
+| query count定数構造維持 | ○（上記テストを本Closureで再実行し再確認） |
+| Knowledge Coverage 21/100 | ○（`knowledge_coverage_report`で再実測、21.0%） |
+
+バックエンド全1031テストを本Closure時点で再実行し、0 failureを確認した（9 skipはPostGIS/GDAL未導入起因のみ、以前から変化なし）。
+
+## Phase 4 — Final Classification
+
+`FACT_INTEGRITY_READY_WITH_LIMITATIONS`
++ `MIXED_CONFIDENCE_POLICY_CURRENT_SAFE`
++ `PER_FACT_RENDERING_DEFERRED`
+
+Fact Integrityの構造的安全性（Evidence Gate、Tradition hedge floor、Mixed Confidence suppression、N+1解消）はすべて実データ・実測で再確認済みであり、既知の限界（`low`/`disputed`の実データ実例ゼロ、Knowledge Coverage 21/100、Mixed Confidence時の情報損失）を除けば安定している。
+
+`READY_FOR_ROLLOUT`への昇格は、Batch 4以降のCoverage拡大とKnowledge Contractの成熟度次第であり、本Closureでは判断しない。
+
+## 禁止事項の遵守
+
+- コード変更なし
+- confidence値変更なし
+- 阿佐ヶ谷神明宮Fact書き換えなし
+- Score/Ranking変更なし
+- Source追加なし
+- PER_FACT_RENDERINGの実装なし（Deferredとして記録のみ）
+
+## Repository Changes
+
+- `docs/audit/mixed-confidence-policy-decision.md`: 本ドキュメント（新規）
+- 上記以外の変更なし

--- a/docs/audit/shrine-knowledge-batch4-prep.md
+++ b/docs/audit/shrine-knowledge-batch4-prep.md
@@ -1,0 +1,144 @@
+> **Status: Preparation Only — 母艦Gate承認待ち**
+>
+> 本ドキュメントはBatch 4のPreparation記録である。**DB書き込みは一切行っていない。**
+> 実際のデータ投入は、母艦がPhase C「Mother Ship Gate Proposal」を確認・確定した後に、
+> 別セッション（別PR）として実施する。
+
+# Shrine Knowledge Batch 4 Preparation
+
+## 前提
+
+`docs/audit/shrine-knowledge-rollout-batch-1.md`〜`batch-3.md`（19社・49 deity・実データ）に続く、
+Batch 4の候補選定・Source Availability Audit・Fact Sheet起案の記録。
+本Batchの投入順（技術推奨）・最終Gate確定は母艦が行う。
+
+## Phase A — Candidate Population（母集団再取得）
+
+`knowledge_coverage_report`と同じ判定ロジック（`shrine_qa_fixture_exclusion` + Evidence Gate
+Fact-ready判定）で、zero-Knowledge shrineを再取得した。
+
+```
+QA fixture除外後の監査対象: 100件
+Knowledge Coverage: 21件（21.0%）
+Zero-Knowledge: 79件（79.0%）
+```
+
+## Phase A' — Exclusion（既知の除外理由）
+
+| 除外対象 | 理由 | 出典 |
+|---|---|---|
+| 靖國神社(id=58) | Collective deity構造（246万柱、公式が個別列挙という発想自体を採らない）。Model/Contract判断が確定するまでBatch対象候補から除外 | `docs/audit/collective-deity-contract-stress.md`（Mother Ship Decision: 靖國神社=`DEFER`、Batch 4=`CONTINUE`（collective case除外）） |
+| 長太稲荷神社(id=21) | 信頼できるSource（shrine_official/government/cultural_property）が一切確認できず`DO_NOT_ENTER_INSUFFICIENT_EVIDENCE`確定済み | `docs/audit/shrine-knowledge-rollout-batch-2.md`、`docs/audit/recommendation-fact-integrity-negative-pilot.md`（両方で同一結論を再確認済み） |
+
+除外後の候補母集団: **77件**。
+
+護国神社系列（靖國神社と同型の集合的祭神構造を持つ可能性がある神社）に該当する
+shrineは、現在の79件母集団の中には存在しないことを名称確認した（該当0件）。
+
+## Phase B — 候補選定（Batch 4案、5社）
+
+Batch 1-3の技術推奨（「Source構造が単純なケースから開始」）に従い、単一または少数の
+明確な祭神を持つ、公式サイトが安定して存在する著名な神社を優先して5社を選んだ。
+これは提案であり、最終選定は母艦Gateで確定する。
+
+| Shrine | id | 選定理由 |
+|---|---|---|
+| 太宰府天満宮 | 6 | 単一祭神（菅原道真公）、天満宮総本宮、公式サイト安定 |
+| 石清水八幡宮 | 12 | 八幡大神3柱、日本三大八幡宮の一つ、公式サイト安定 |
+| 香取神宮 | 15 | 単一祭神（経津主大神）、既存の鹿島神宮Fact（Negative Pilot投入済み）と対になる関係性、公式サイト安定 |
+| 住吉大社 | 11 | 住吉三神+神功皇后、住吉信仰総本社、公式サイト安定 |
+| 八坂神社 | 56 | 素戔嗚尊中心、祇園信仰総本社、公式サイト安定 |
+
+### 候補差し替えの記録: 宇佐神宮 → 八坂神社
+
+当初、日本三大八幡宮つながりで宇佐神宮(id=8)を候補に含めたが、公式ドメイン
+`usajinguu.com`がTLS証明書不一致（証明書のSAN一覧に自ドメインが含まれない、
+さくらインターネット共用SSLの設定不備と見られる）により直接fetchできなかった。
+Source自体が存在しないケース（長太稲荷神社）とは性質が異なる
+（**`SOURCE_EXISTS_BUT_UNREACHABLE`**として区別する）ため、`INSUFFICIENT_EVIDENCE`
+とは判定せず、単に本Batch候補からは見送り、八坂神社へ差し替えた。
+宇佐神宮は将来のBatchで、公式サイトの復旧確認後に再候補化できる。
+
+## Phase C — Source Availability Audit（5社）
+
+すべて公式サイトへ直接fetchし、内容を確認した（二次情報のみでの登録は行わない）。
+
+### 太宰府天満宮（id=6）
+
+- Source: 御由緒｜太宰府天満宮（`https://www.dazaifutenmangu.or.jp/about/goyuisho`）／shrine_official
+- 御祭神: 菅原道真公
+- 由緒: 昌泰4年（901年）左遷、延喜3年（903年）2月25日逝去（確定的記述）。延喜19年（919年）勅命により社殿造営（確定的記述）。埋葬地選定の経緯として「牛が伏して動かなくなった」逸話が含まれる（**社伝自身が伝承的記述として提示**）。
+
+### 石清水八幡宮（id=12）
+
+- Source: 石清水八幡宮について｜石清水八幡宮（`https://iwashimizu.or.jp/about/`）／shrine_official
+- 御祭神: 中御前=応神天皇（誉田別尊）、西御前=比咩大神（多紀理毘賣命・市寸島姫命・多岐津毘賣命）、東御前=神功皇后（息長帯比賣命）
+- 由緒: 貞観元年（859年）、南都大安寺の僧・行教和尚が宇佐八幡宮での託宣を受け男山に勧請したとする（**社伝自身が伝承的記述として提示**）。
+- **数値差異の記録**: WebSearch要約では「860年（貞観2年）」という表記も見られたが、公式ページを直接fetchした結果は「貞観元年（859年）」であった。公式ページの記述を正としてFact Sheetへ採用する（要約から生じた誤差であり、公式ページ自体に矛盾はない）。
+
+### 香取神宮（id=15）
+
+- Source: 香取神宮について｜御由緒｜香取神宮（`https://katori-jingu.or.jp/about/`、`/about/history/`）／shrine_official
+- 御祭神: 経津主大神（伊波比主命）
+- 由緒: 公式ページ（`/about/history/`）には具体的な創建年（西暦・和暦）の記載がなかった。複数の二次情報（Wikipedia等）は「社伝によれば神武天皇18年（紀元前643年）」と紹介しているが、**この年代を明記した公式ページ自体は今回確認できなかった**。国家鎮護の神・下総国一宮・明治以前の「神宮」称号等、公式ページで確認できる記述は多いが、創建年についてはPending。
+
+### 住吉大社（id=11）
+
+- Source: 住吉大社の由緒｜住吉大社について｜住吉大社（`https://www.sumiyoshitaisha.net/about/origin.html`）／shrine_official
+- 御祭神: 底筒男命・中筒男命・表筒男命（住吉三神）、息長足姫命（神功皇后）
+- 由緒: 神功皇后摂政11年（西暦211年）、新羅遠征からの帰途、住吉大神の神託によりこの地に鎮斎されたとする（**社伝自身が『日本書紀』『古事記』に基づく伝承的記述として提示**）。
+- 大阪市住吉区・摂津国一之宮であることを確認済み（博多の住吉神社とは別法人・別Shrine行）。
+
+### 八坂神社（id=56）
+
+- Source: 御祭神｜八坂神社の歴史｜八坂神社（`https://www.yasaka-jinja.or.jp/about/saijin.html`、`/about/history/`）／shrine_official
+- 御祭神: 素戔嗚尊（主祭神）、櫛稲田姫命（お妃）、八柱御子神（お二人の御子、公式ページが個別列挙せず一括して呼称する集合的名称）
+- 由緒: 公式ページ自身が「社伝としては以下の2つの説が伝わります」と明記した上で2説を提示している。
+  - 説1: 斉明天皇2年（656年）、高麗より来朝した伊利之が新羅国牛頭山の素戔嗚尊をこの地に祀った
+  - 説2: 貞観18年（876年）、南都の僧・円如が堂を建立し、天神が東山麓の祇園林に降り立った
+  - 元慶元年（877年）の疫病鎮静が発展の契機、確定的な初見は祇園御霊会（869年）とされる
+
+## Phase D — Fact Sheet（起案、DB未投入）
+
+Model制約の確認: `role`（primary/enshrined/secondary/unknown）、`history_type`
+（official_origin/founding/historical_event/tradition/regional_context/editorial_summary）、
+`Multiple Fact保持方針`（1つのcontentへ複数説を合成しない）に従い、以下の構成を提案する。
+
+| Shrine | Deity（役割・confidence案） | History（type・confidence案） |
+|---|---|---|
+| 太宰府天満宮 | 菅原道真公(primary, high) | 1件, official_origin, high。901-919の確定的経緯を中心に記述し、埋葬地選定の逸話部分のみ「社伝によれば」等のhedge表現を明示的に含める |
+| 石清水八幡宮 | 応神天皇=誉田別尊(primary, high)／比咩大神(enshrined, high)／神功皇后=息長帯比賣命(enshrined, high) | 1件, **tradition**, high。TRADITION_ALWAYS_HEDGED契約適用（`docs/core/recommendation-reason-contract.md`） |
+| 香取神宮 | 経津主大神(primary, high) | **保留**。公式ページで確認できる範囲（社格・下総国一宮等）に限定するか、創建年について公式ページの別箇所を追加調査するまでHistory登録自体を見送るか、母艦判断が必要 |
+| 住吉大社 | 底筒男命/中筒男命/表筒男命(enshrined, high)、息長足姫命(enshrined, high)、主祭神表記なし（4柱を並列表記する公式記述のためrole=primaryの単独指定は行わない案） | 1件, **tradition**, high。TRADITION_ALWAYS_HEDGED契約適用 |
+| 八坂神社 | 素戔嗚尊(primary, high)／櫛稲田姫命(enshrined, high)／八柱御子神(enshrined, high、collective note付き) | **2件**, **tradition**×2, high。656年説・876年説をそれぞれ別Factとして登録し、1つのcontentへ合成しない |
+
+石清水八幡宮・住吉大社・八坂神社の3社は、社伝自身が伝承として提示する内容を
+`history_type=tradition`で登録することになるため、`docs/audit/tradition-output-contract-fix.md`
+のTRADITION_ALWAYS_HEDGED契約が実データで最も多く適用されるBatchになる見込み。
+
+## Phase E — Mother Ship Gate Proposal（未確定、承認待ち）
+
+以下は提案であり、**本ドキュメントでは確定しない**。母艦の確認後、確定した内容を
+別途Gate記録として残し、その後のみデータ投入へ進む。
+
+| Shrine | 提案Entry Decision |
+|---|---|
+| 太宰府天満宮 | `ENTER_WITH_NOTE`（埋葬地逸話のhedge表現を明示） |
+| 石清水八幡宮 | `ENTER_WITH_NOTE`（tradition分類、3柱individually） |
+| 香取神宮 | `ENTER_WITH_NOTE`（Deityのみ確定投入、Historyは公式ページ追加調査 or 見送り、母艦判断待ち） |
+| 住吉大社 | `ENTER_WITH_NOTE`（tradition分類、4柱role=primary単独指定なし） |
+| 八坂神社 | `ENTER_WITH_NOTE`（History 2件、tradition×2、八柱御子神collective note付き） |
+
+投入順（技術推奨、Source構造が単純なものから）: 太宰府天満宮 → 香取神宮 → 石清水八幡宮 → 住吉大社 → 八坂神社。
+
+## 禁止事項の遵守
+
+- [x] DB書き込みなし
+- [x] confidence値の恣意的な操作なし（すべてSourceに基づく案として提示のみ）
+- [x] 二次情報のみでのFact登録提案なし（全社官公式サイトを直接fetch）
+- [x] Batch全体を一括投入する提案なし（Phase E以降は母艦Gate確定後、別セッションで順次投入する前提）
+
+## Repository Changes
+
+- `docs/audit/shrine-knowledge-batch4-prep.md`: 本ドキュメント（新規）
+- 上記以外の変更なし（Model/Service/Test/Migration/API contract/DB書き込み: すべて変更なし）


### PR DESCRIPTION
## Summary

2つの独立したdocs-onlyトピックをまとめて記録する。**コード変更・DB書き込みは一切行っていない。**

### 1. Mixed Confidence Policy Decision（`docs/audit/mixed-confidence-policy-decision.md`）

[docs/audit/mixed-confidence-policy-audit.md](../blob/develop/docs/audit/mixed-confidence-policy-audit.md)のPhase 8「Mother Ship Decision」を確定した。

- `FULL_SUPPRESSION`を現行Policyとして維持
- `HIGH_ONLY`/`PRIMARY_ONLY`は不採用（PRIMARY_ONLYは「roleを信頼度の代理として扱わない」既存原則と構造的に矛盾するため）
- `PER_FACT_RENDERING`は4条件（real mixed-confidence shrine増加/実害計測/Fact単位payload監査範囲確定/Web-API contract影響分離）を満たすまでDeferred
- Fact Integrity Closureを再実測（バックエンド全1031テスト、N+1 query count定数構造、Knowledge Coverage 21/100）
- Final Classification: `FACT_INTEGRITY_READY_WITH_LIMITATIONS` + `MIXED_CONFIDENCE_POLICY_CURRENT_SAFE` + `PER_FACT_RENDERING_DEFERRED`

### 2. Shrine Knowledge Batch 4 Preparation（`docs/audit/shrine-knowledge-batch4-prep.md`）

zero-Knowledge 79件から、靖國神社（collective deity、Model/Contract判断待ちで`DEFER`確定済み）・長太稲荷神社（`INSUFFICIENT_EVIDENCE`確定済み）を除外した候補母集団77件を確認した上で、太宰府天満宮/石清水八幡宮/香取神宮/住吉大社/八坂神社の5社についてSource Availability Auditを実施した（全社、公式サイトを直接fetchして確認、二次情報のみでの登録提案は行っていない）。

- 宇佐神宮は公式ドメイン（usajinguu.com）のTLS証明書不一致により直接fetchできず、長太稲荷神社型の「Sourceが存在しない」ケースとは性質が異なる（`SOURCE_EXISTS_BUT_UNREACHABLE`）として区別した上で、八坂神社へ差し替えた。
- 石清水八幡宮の創建年について、WebSearch要約（860年）と公式ページ直接fetch結果（859年/貞観元年）に差異があったため、公式ページの記述を正としてFact Sheetへ採用した。
- 石清水八幡宮・住吉大社・八坂神社は、社伝自身が伝承として提示する内容を含むため`history_type=tradition`での登録を提案しており、[TRADITION_ALWAYS_HEDGED契約](../blob/develop/docs/audit/tradition-output-contract-fix.md)が実データで最も多く適用される見込みのBatchになる。
- 香取神宮は、創建年（社伝：神武天皇18年）を明記した公式ページ自体が今回確認できなかったため、Historyの扱いを母艦判断待ちとして保留した。
- Fact Sheet起案・Mother Ship Gate Proposal（Entry Decision案）を記録したが、**実際のデータ投入は本PRでは行っていない**。母艦がGate Proposalを確認・確定した後、別セッション（別PR）として投入する。

## 禁止事項の遵守

- [x] Mixed ConfidenceをBatch 4の途中で変更していない（Policy自体はBatch着手前に確定した）
- [x] confidenceを推薦表示のために書き換えていない
- [x] primary roleを信頼度代わりに使っていない（PRIMARY_ONLY不採用として明記）
- [x] PER_FACT_RENDERINGを本PRで実装していない
- [x] DB書き込みなし

## Test plan

- [x] docs-only diff（新規ファイル2件のみ、`git status --short`で確認）
- [x] バックエンド全1031テスト再実行、0 failure確認
- [x] Knowledge Coverage / Verified Source Countを`knowledge_coverage_report`で再実測
- [x] 5社すべての公式サイトを直接fetchし、二次情報のみに依存していないことを確認
- [x] pre-push hook（OpenAPI lint / Web contract test 731件）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)