### PR TITLE
docs: Traceability Metric Correctionを記録(URL-backed Source Rateの誤判定を訂正)

### DIFF
--- a/docs/audit/traceability-metric-correction.md
+++ b/docs/audit/traceability-metric-correction.md
@@ -1,0 +1,77 @@
+> **Status: Decided（KPI定義を正本化、コード実装は伴わない）**
+>
+> 本ドキュメントは、Batch 7 Closure確認時に発覚した「Internal Traceability」指標の
+> 誤判定を訂正し、`docs/knowledge/shrine-knowledge-contract.md`へTraceability Contractを
+> 追記した記録である。**コード変更は一切行っていない。**
+
+# Traceability Metric Correction
+
+## 発端: Batch 7 Closure時の誤判定
+
+Batch 7 Closure確認の中で、DB全体のFact traceabilityを再測定したところ、2件の
+"trace-unable Fact"（明治天皇・昭憲皇太后、`ShrineDeity` id=1,2、明治神宮）を検出した。
+これはBatch 7の新規投入分（17 Fact）には含まれない、Batch 1以前（最初のKnowledge Pilot）
+由来のFactだった。
+
+### 誤判定の原因
+
+当時使用した測定ロジックは、「Factに紐づく**全て**のSourceが`url`を持つこと」を
+traceabilityの条件としていた。しかし該当2 Factを直接確認したところ、実際には
+以下のように**2件のSourceが紐づいており、そのうち1件はURLを持つ**ことが判明した。
+
+```
+明治天皇 -> sources:
+  (999005, shrine_official, 'https://www.meijijingu.or.jp/about/')  # URLあり
+  (999004, user_observation, '')                                     # URLなし（現地観察の補強Source）
+```
+
+「全てのSourceがURLを持つこと」という条件は誤りであり、正しくは「**少なくとも1件の
+Sourceが到達可能であること**」または「Fact自体がSource relationを持つこと」を基準に
+すべきだった。`user_observation`（現地観察）は、Web出典と並行して補強的に付与される
+ケースがあり、これ自体はFact Integrity上まったく問題のない構成である。
+
+## Traceability Contractの追記
+
+`docs/knowledge/shrine-knowledge-contract.md`のSource契約へ、以下を追記した。
+
+- **Fact → Source relation到達を必須条件とする**（URLの有無を問わない）。これは
+  Evidence Gateが既に強制している要件と一致する。
+- **Source typeごとのtraceability要件**を定義した。`shrine_official`等はURL必須を
+  基本とし、`user_observation`・書籍等の`local_history`はURLなしを許容する代わりに
+  `title`/`source_type`/`verification_status`（`user_observation`の場合）または
+  `bibliography`/`publisher`（書籍等の場合）を必須とする。
+- **3つのKPIを再定義し、混同しないことを明記した**:
+  - **Internal Source Traceability Rate** = Source relationへ逆引き可能なFact数 ÷ 対象Fact数
+  - **URL-backed Source Rate** = URLを持つSourceに紐づくFact数 ÷ 対象Fact数
+  - **Offline Source-backed Fact Rate** = `user_observation`・書籍等のoffline Sourceに紐づくFact数 ÷ 対象Fact数
+
+## 再測定結果（develop HEAD `694f422d`時点、DB全体188 Fact）
+
+新しい定義でDB全体を再測定した。
+
+| KPI | 値 |
+|---|---|
+| Internal Source Traceability Rate | 188/188（100.0%） |
+| URL-backed Source Rate | 188/188（**100.0%**、訂正前の186/188という誤った値を修正） |
+| Offline Source-backed Fact Rate | 2/188（1.1%、明治天皇・昭憲皇太后が`shrine_official`のURL付きSourceに加え`user_observation`の補強Sourceも持つことを示す） |
+
+`user_observation` Source（id=999004）自体が新しい per-source-type要件を満たすことも
+確認した（`title`/`source_type`/`verification_status`いずれも設定済み、Fact relationも存在）。
+
+**訂正: 前回のBatch 7 Closure確認で報告した「DB-wide traceability 186/188（98.9%）」は
+誤りであり、正しくは新しいURL-backed Source Rate定義で100%である。** Internal Source
+Traceability Rate（Source relation存在の有無のみを問う、最も基本的な指標）は、訂正前も
+訂正後も一貫して100%であり、この点に誤りはなかった。
+
+## Repository Changes
+
+- `docs/knowledge/shrine-knowledge-contract.md`: Source契約へ「Traceability Contract」節を追記
+- `docs/audit/traceability-metric-correction.md`: 本ドキュメント（新規）
+- 上記以外の変更なし（Model/Service/Test/Migration/API contract/Score/Ranking/DB書き込み: すべて変更なし）
+
+## Stop
+
+- Batch 8はまだ開始していない
+- Score/Ranking codeは変更していない
+- PER_FACT_RENDERINGは変更していない
+- Source UIは変更していない

--- a/docs/knowledge/shrine-knowledge-contract.md
+++ b/docs/knowledge/shrine-knowledge-contract.md
@@ -477,6 +477,47 @@ Web出典のみを前提にしない。以下を扱えるようにする。
 > - **Source confidence**（`ShrineKnowledgeSource.confidence`）: PR-C1時点で以下のいずれにも使わないと確定する。Evidence usable判定、Recommendation Reason表現強度、Score/Ranking。Source confidenceからFact confidenceへの自動変換も行わない（上表の「Source typeによる基準値」「複数Source一致度から算出」「複合方式」はいずれも未採用のままの候補であり、Source confidence自体をどう算出・利用するかは引き続き未確定）。
 > - 上表の「利用先」のうち、`data_confidence_score`（Score軸）は今回も対象外のまま。数値閾値も導入していない（PR-Bはcategorical値(high/medium/low)をそのままReason表現強度へ対応させており、数値閾値を持たない）。
 
+### Traceability Contract（Batch 7 Closure、2026-08-08追加）
+
+> **Status**: 契約確定のみ。コード実装（`knowledge_coverage_report`等への組み込み）は伴わない。
+
+これまでのAudit（Batch 4-7）では、「Internal Traceability」を単一の指標
+（`Fact → Source → URL`まで逆引きできるか）として扱ってきたが、`user_observation`
+（現地観察）のようにURLを持たないことが仕様上正当なSource種別が存在するため、
+「URLの有無」と「Source Traceabilityそのもの」を同一視すると誤った異常判定を招く
+（Batch 7 Closureで実際にこの誤判定が発生した）。本節でこれを分離する。
+
+**Fact → Source relation到達を必須条件とする。** URLの有無に関わらず、すべての
+Fact（`ShrineDeity`/`ShrineHistory`）は最低1件の`ShrineKnowledgeSource`への
+Relationを持たなければならない。これはEvidence Gate（`decide_fact_usability()`）が
+既に強制している要件であり、Traceability Contractもこれを土台とする。
+
+#### Source typeごとのtraceability要件
+
+| source_type | URL | 必須項目 |
+|---|---|---|
+| `shrine_official` / `government` / `cultural_property` / `academic` / `museum_or_archive` / `tourism_official` / `secondary_editorial` | **必須を基本とする** | `url` |
+| `user_observation` | **なしを許容** | `title`・`source_type`・`verification_status`・Note等で観察内容を識別可能であること（`bibliography`等の代替識別情報でも可）・Fact relation |
+| `local_history`（書籍・郷土資料等）／URLを持たない`academic`等 | **なしを許容** | `bibliography`・`publisher`等の書誌情報・Fact relation |
+
+`internal_research`・`ai_generated_draft`は上記のいずれにも該当しない特殊区分として、
+本節では扱わない（`ai_generated_draft`はSourceとして独立した信頼性を持たない、
+既存記載の通り）。
+
+#### KPI再定義（3指標を混ぜない）
+
+| KPI | 定義 | 用途 |
+|---|---|---|
+| **Internal Source Traceability Rate** | Source relationへ逆引き可能なFact数 ÷ 対象Fact数 | Fact Integrityの根幹指標。Evidence Gateの必須要件（Source relation存在）と対応する。URLの有無を問わない |
+| **URL-backed Source Rate** | URLを持つSourceに紐づくFact数 ÷ 対象Fact数 | Web上で直接検証可能なFactの割合。ユーザー向けSource表示（将来のTrust UX検討）の実現可能範囲を示す |
+| **Offline Source-backed Fact Rate** | `user_observation`・書籍等のoffline Sourceに紐づくFact数 ÷ 対象Fact数 | URLを持たないことが仕様上正当なFactの割合。「URL-backed Rateが100%でない」ことが直ちに異常を意味しないことを示すための補助指標 |
+
+**Internal Source Traceability Rateは、Fact Integrityが健全かどうかの判定に使う。
+URL-backed Source Rateは、それより狭い「Web直接検証可能性」の指標であり、
+100%未満であることは`user_observation`等のoffline Sourceが正当に存在する限り
+異常ではない。** 今後のAuditでは、この3指標を区別して報告し、単一の
+「Traceability」という語で両者を混同しない。
+
 ### 情報矛盾時
 
 - 矛盾するSourceを削除せず保持する（片方を消して整合性があるように見せない）


### PR DESCRIPTION
## Summary

Batch 7 Closure確認時に報告した「DB-wide traceability 186/188（98.9%）」が誤りだったことを訂正し、`docs/knowledge/shrine-knowledge-contract.md`へTraceability Contractを追記した。**コード変更は一切行っていない。**

## 誤判定の原因

測定ロジックが「Factに紐づく**全て**のSourceがURLを持つこと」を条件としていたが、実際には明治天皇・昭憲皇太后（`ShrineDeity` id=1,2、明治神宮、Batch 1以前のKnowledge Pilot由来）は`shrine_official`（URLあり）と`user_observation`（URLなし、現地観察による補強）の2件のSourceを持ち、**少なくとも1件はURLを持つ**ため本来traceableだった。

## Traceability Contractの追記

- Fact → Source relation到達を必須条件とする（URLの有無を問わない、Evidence Gateの既存要件と一致）
- Source typeごとのtraceability要件を定義（`shrine_official`等はURL必須、`user_observation`/`local_history`はURLなし許容だが代替識別情報必須）
- 3 KPIを再定義し混同しないことを明記: **Internal Source Traceability Rate** / **URL-backed Source Rate** / **Offline Source-backed Fact Rate**

## 再測定結果（DB全体188 Fact）

| KPI | 値 |
|---|---|
| Internal Source Traceability Rate | 188/188（100.0%） |
| URL-backed Source Rate | 188/188（**100.0%**、訂正前の186/188という誤った値を修正） |
| Offline Source-backed Fact Rate | 2/188（1.1%） |

## Test plan

- [x] docs-only diff（新規1件・既存contractへの追記1件）
- [x] 新KPI定義でDB全体を実測し、`user_observation` Sourceが新しいper-type要件を満たすことを確認
- [x] バックエンド全1031テスト再実行、0 failure確認
- [x] pre-push hook（OpenAPI lint / Web contract test 731件）通過

## Stop

Batch 8・Score/Ranking code変更・PER_FACT_RENDERING・Source UIのいずれにも進んでいない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)