### PR TITLE
docs: Production Migration Execution Gate preflightを記録(EXECUTION_BLOCKED_BACKUP_GATE)

### DIFF
--- a/docs/audit/production-migration-execution-gate.md
+++ b/docs/audit/production-migration-execution-gate.md
@@ -1,0 +1,177 @@
+> **Status: Active — Phase 0/1完了、Phase 1でSTOP（Backup GateがPASS相当でない）**
+>
+> **Classification: `EXECUTION_BLOCKED_BACKUP_GATE`**
+>
+> 本ドキュメントはProduction Migration Execution Gateの最終preflight監査
+> 記録である。**Production migrate・makemigrations・DB write・restore・
+> reverse migration・Environment変更・deploy・新規signupはいずれも
+> 一切実行していない。** これはExecutionではなく、Backup Gateの結果を
+> 反映したGate判定の記録である。
+
+# Production Migration Execution Gate — Final Preflight Audit
+
+## Phase 0 — Base State
+
+| 項目 | 結果 |
+|---|---|
+| develop checkout | 完了（既に`develop`ブランチ） |
+| `git fetch` + `git merge --ff-only origin/develop` | 完了（実行時点で既にup to date） |
+| working tree | clean |
+| develop HEAD SHA | `bf762d4b...`（指示で示された値と完全一致。ユーザー確認済みの値からの変化なし） |
+| HEADの進み | **なし**。ユーザー提示の`bf762d4b`がそのまま最新であることを確認した。migration関連の新規変更は入っていない |
+
+`bf762d4b`はPR #2325（`docs/audit/production-manual-backup-restore-gate.md`
+のsquash merge commit）である。この時点でPhase 0のSTOP条件
+（`EXECUTION_GATE_BASE_STATE_CHANGED`）には該当しない。
+
+---
+
+## Phase 1 — Backup Gate Import
+
+`docs/audit/production-manual-backup-restore-gate.md`を実際に読み、
+記載されている結果のみを転記する（推測での再構築は行っていない）。
+
+| 抽出項目 | 正本記載値 |
+|---|---|
+| 最終Classification | **`MANUAL_BACKUP_BLOCKED_CREDENTIAL_ACCESS`** |
+| manual dump方式 | 候補B（Supabase CLI `supabase db dump`）を設計上の推奨候補として選定のみ。未インストール |
+| dump成功/失敗 | **未実施**（credential access blockedのため着手前でSTOP） |
+| isolated restore成功/失敗 | **未実施** |
+| migration state一致/不一致 | **未評価**（dump取得前のため比較不能） |
+| schema一致/不一致 | **未評価** |
+| aggregate data一致/不一致 | **未評価** |
+| Recovery Runbook検証範囲 | Phase 9に設計案のみ記載。全手順`UNVERIFIED`（実機未検証） |
+| remaining risks | 安全に利用可能なProduction接続情報が本セッションに一切存在しないこと自体が最大のrisk。次にGateへ戻る際はMother Ship側でread-only credentialを用意するか、Mother Ship自身がdumpを取得して非秘密ファイルのみを共有する必要がある |
+
+### 判定
+
+**Backup GateはPASS相当ではない。**`MANUAL_BACKUP_BLOCKED_CREDENTIAL_ACCESS`は
+「dump/restoreの実効性が一度も実証されていない」状態であり、指示の
+Phase 1ルール「Backup GateがProduction migration前提としてPASS相当で
+ない場合、即STOP。Production migration runbookを『実行可能』と分類
+しない。」に該当する。
+
+**したがって本監査はここでSTOPする。** Phase 2（Target Migration
+Audit）〜Phase 11（Rollback / Recovery Decision Tree）は、いずれも
+「実行可能なRunbookを組み立てる」ことを前提としたPhaseであり、
+その前提自体が満たされないまま実施すると「実行準備が整っているように
+見える文書」を作ってしまうリスクがある。これは指示の意図
+（Backup Gate未通過ならrunbookを実行可能と分類しない）に反するため、
+Phase 2以降は**すべて未着手のまま保留する。**
+
+---
+
+## Phase 2〜11 — 未着手
+
+Backup Gateのblockingにより、以下はいずれも実施していない:
+
+- Phase 2 — Target Migration Audit（`users 0006`・`temples 0090-0093`の
+  最新developとの一致確認）
+- Phase 3 — Dependency / Ordering Audit（migration graph実測）
+- Phase 4 — Production Migration State Read-only Recheck
+- Phase 5 — Pre-Migration Backup Procedure確定
+- Phase 6 — Execution Strategy Comparison（Candidate A〜D）
+- Phase 7 — Exact Command Audit
+- Phase 8 — Stepwise Verification Design
+- Phase 9 — Application Runtime Verification Design
+- Phase 10 — Failure Boundaries明文化
+- Phase 11 — Rollback / Recovery Decision Tree
+
+これらはBackup Gateが`MANUAL_BACKUP_RESTORE_PASS`
+（または`BACKUP_READY`相当）まで前進した後、本Gateへ再度戻って着手する
+対象として保留する。
+
+なお、参考情報として、`users 0006`・`temples 0090-0093`の内容自体は
+既存監査（`docs/audit/production-all-app-migration-state-audit.md`・
+`docs/audit/production-migration-0090-0093-safety.md`）で既にlocal実測
+済みであり、developのコード自体に変更が入っていないこと（Phase 0で
+HEAD SHAが指示値と一致することを確認済み）から、**それらの結論自体が
+古くなっているとは考えていない。** ただし「今回のExecution Gateとして
+Phase 2を正式に再実施したか」という意味では、Backup Gateのblockingに
+より本セッションでは実施していない。
+
+---
+
+## Phase 12 — Go / No-Go Classification
+
+**`EXECUTION_BLOCKED_BACKUP_GATE`**
+
+理由: Phase 1でimportした`docs/audit/production-manual-backup-restore-gate.md`
+の最終Classificationが`MANUAL_BACKUP_BLOCKED_CREDENTIAL_ACCESS`であり、
+Production migration実行前提としてPASS相当ではないため。
+
+**Production migration execution runbookは「実行可能」と分類しない。**
+
+---
+
+## Stop Conditions（該当確認）
+
+- [ ] `EXECUTION_GATE_BASE_STATE_CHANGED` → 非該当（Phase 0でHEAD SHA一致確認済み）
+- [x] `EXECUTION_BLOCKED_BACKUP_GATE` → **該当（本監査の結論）**
+- [ ] `PRODUCTION_MIGRATION_STATE_CHANGED` → 未評価（Phase 4未着手のため）
+- [ ] `TARGET_MIGRATION_CHANGED` → 未評価（Phase 2未着手のため。ただしHEAD SHA一致から変更なしと推定されるが、正式なmigration file単位の再監査はしていない）
+- [ ] `PRODUCTION_STATE_RECHECK_BLOCKED` → 未評価（Phase 4未着手のため）
+- [ ] `EXECUTION_METHOD_UNRESOLVED` → 未評価（Phase 6/7未着手のため）
+- [ ] `RECOVERY_PLAN_INSUFFICIENT` → 未評価（Phase 11未着手のため。ただしBacking Gate側のRecovery Runbookが全件`UNVERIFIED`であることは既知）
+
+---
+
+## 明示的禁止事項の遵守確認
+
+- [x] Production migrate禁止（遵守）
+- [x] Production makemigrations禁止（遵守）
+- [x] Production DB write禁止（遵守、接続自体していない）
+- [x] Production restore禁止（遵守）
+- [x] Production reverse migration禁止（遵守）
+- [x] Supabase Environment変更禁止（遵守）
+- [x] Render Environment変更禁止（遵守）
+- [x] Production deploy禁止（遵守）
+- [x] Production新規signup禁止（遵守）
+- [x] Batch 8開始禁止（遵守）
+- [x] credential要求禁止（遵守。本監査ではcredentialに一切触れていない）
+- [x] credential commit禁止（遵守）
+- [x] dump commit禁止（遵守）
+- [x] PR merge禁止（本監査ではPR作成のみ行い、mergeはしない）
+
+---
+
+## Mother Shipへの最終報告
+
+1. **develop SHA**: `bf762d4b...`（指示値と一致、変化なし）
+2. **Backup Gate classification**: `MANUAL_BACKUP_BLOCKED_CREDENTIAL_ACCESS`（`docs/audit/production-manual-backup-restore-gate.md`より転記）
+3. **Production users latest migration**: `0005`（Mother Ship提供値を引き継ぎ。本監査では未再確認——Phase 4未着手）
+4. **Production temples latest migration**: `0089`（同上、未再確認）
+5. **target migrations changed / unchanged**: **未評価**（Phase 2未着手。ただしHEAD SHAが変化していないことから、migration file自体に変更が入っている可能性は低いと考えられる）
+6. **cross-app dependency有無**: **未評価**（Phase 3未着手）
+7. **推奨execution order**: **未確定**（Phase 6未着手）
+8. **Production execution method**: **未確定**（Phase 7未着手）
+9. **migration直前backup手順**: **未確定**（Backup Gate自体がblocked状態のため、この項目こそが今回のボトルネック）
+10. **`users 0006`後verification**: **未設計**（Phase 8未着手）
+11. **`temples 0090-0093`後verification**: **未設計**（Phase 8未着手）
+12. **failure時STOP条件**: **未設計**（Phase 10未着手）
+13. **recovery strategy**: **未設計**（Phase 11未着手。Backup Gate側のRecovery Runbookは全件`UNVERIFIED`）
+14. **Execution Gate classification**: **`EXECUTION_BLOCKED_BACKUP_GATE`**
+15. **remaining risks**: 最大のriskはBackup Gateが未通過のまま。仮に今後Phase 2〜11を進めてExecution Runbookを完成させても、**migration直前に安全に復元できるbackupが存在しない状態でProduction migrationを実行することは推奨しない**（本監査の一貫した立場）
+16. **PR番号**: 本セクションはPR作成後に更新する
+17. **CI状態**: 本セクションはCI確認後に更新する
+
+## 次にMother Shipが用意すべきもの
+
+`docs/audit/production-manual-backup-restore-gate.md`の「次にMother Ship
+が用意すべきもの」節と同一:
+
+- Mother Ship自身のローカル環境でSupabase CLI（`supabase db dump`）を
+  実行し、`roles.sql`/`schema.sql`/`data.sql`を取得した上で、
+  それらのファイル（秘密情報を含まないことを確認した上で）を安全な
+  方法でこのセッションの作業領域へ持ち込む
+- または、read-only権限に限定したProduction DB接続情報を、チャットに
+  貼る以外の安全な方法で本セッションが利用できるようにする
+
+上記が満たされ、Backup Gateが`MANUAL_BACKUP_RESTORE_PASS`
+（または`BACKUP_READY`相当）へ前進した時点で、本Execution Gateの
+Phase 2〜11を再開する。
+
+## Repository Changes
+
+- `docs/audit/production-migration-execution-gate.md`: 本ドキュメント（新規）
+- 上記以外の変更なし


### PR DESCRIPTION
## Summary
- Phase 0: base state確認。develop HEADが指示値`bf762d4b`と完全一致、変化なし
- Phase 1: `docs/audit/production-manual-backup-restore-gate.md`（正本）をimport。最終Classificationは`MANUAL_BACKUP_BLOCKED_CREDENTIAL_ACCESS`（dump/restore/comparisonいずれも未実施）
- Backup GateがPASS相当でないため、指示のPhase 1ルールに従い即STOP。Phase 2(Target Migration Audit)〜Phase 11(Rollback/Recovery Decision Tree)は未着手のまま保留
- Phase 12 Classification: `EXECUTION_BLOCKED_BACKUP_GATE`
- Production migration execution runbookは「実行可能」と分類していない

## Test plan
- [x] `git diff --check`
- [x] docs-only(`docs/audit/production-migration-execution-gate.md`のみ、コード変更なし)
- [x] pre-push hook: OpenAPI lint pass
- [x] pre-push hook: Web契約テスト 731 passed
- [x] Production migrate/makemigrations/DB write/restore/reverse migration/Environment変更/deploy/新規signupはすべて未実施(Stop Conditions遵守)

🤖 Generated with [Claude Code](https://claude.com/claude-code)