### PR TITLE
feat: Migration safety tooling(allow-list guard付きbackup/restore)を追加

### DIFF
--- a/docs/audit/migration-safety-tooling.md
+++ b/docs/audit/migration-safety-tooling.md
@@ -1,0 +1,227 @@
+> **Status: Implementation + local verification complete.
+> Production DBは一切変更していない。Production migrate/restore/DB write/
+> Environment変更は一切行っていない。Production操作を自動実行するコードは
+> 作っていない。**
+
+# Migration Safety Tooling — Implementation & Verification Record
+
+本ドキュメントは、今後のmigration（`users 0006`・`temples 0090-0093`、
+および将来のmigration一般）で再利用できる安全な変更・復旧ルートの実装と、
+そのローカル検証結果の記録である。
+
+対象コード: `scripts/migration_safety/`（Runbookは
+[`scripts/migration_safety/README.md`](../../scripts/migration_safety/README.md)
+を参照）。
+
+---
+
+## 実装したもの
+
+| ファイル | 内容 |
+|---|---|
+| `scripts/migration_safety/guard.py` | 純粋関数のみのPython safety guard。DB接続・ネットワークコードは一切含まない。restore先の許可判定（allow-list方式）、dump出力先のrepo境界チェック、credential redaction |
+| `scripts/migration_safety/dump_readonly.sh` | 明示的に渡されたURLのみをdumpするread-only script。デフォルト接続先を持たない |
+| `scripts/migration_safety/restore_isolated.sh` | `guard.py`のrestore-target判定を通過した場合のみ動作するrestore script |
+| `scripts/migration_safety/sql/migration_state.sql`ほか2件 | SELECT-onlyのmigration state / snapshot / verification クエリ |
+| `scripts/migration_safety/tests/test_guard.py` | `guard.py`の単体テスト（DB不要） |
+| `scripts/migration_safety/tests/test_backup_restore_e2e.sh` | ローカル隔離DBのみを使ったbackup/restore end-to-endテスト |
+
+いずれもProduction操作を自動実行しない。すべてのscriptは呼び出し側が
+明示的に渡した接続先文字列のみを操作対象とし、デフォルト値・環境変数
+フォールバックによる暗黙のProduction接続経路は存在しない。
+
+---
+
+## 安全設計の核心: allow-list方式のrestore guard
+
+`guard.py`の`is_safe_restore_target()`は、「Productionっぽいものを
+検出してblockする」deny-list方式ではなく、「ローカル隔離DBとして
+明確なものだけを許可する」allow-list方式を採用した。理由は、本セッションが
+Productionの実際のhostnameを知らないため、deny-listは構造的に不完全
+にしかなり得ないためである。許可条件は以下すべてを満たす場合のみ:
+
+- hostが`localhost`/`127.0.0.1`/`::1`のいずれか
+- database名が既存local dev DB（`jinja_db`/`jinja_app_dev`/`jinja_test`等）と一致しない
+- database名に`audit`/`restore_test`/`migration_safety`のいずれかが含まれる
+
+それ以外（実際のProduction hostnameがどのような値であっても）はすべて
+デフォルトでblockされる。
+
+---
+
+## テスト結果
+
+### 単体テスト（`test_guard.py`、DB不要）
+
+```
+backend/.venv/bin/python3 -m pytest scripts/migration_safety/tests/test_guard.py -v
+```
+
+**結果: 18 passed in 0.04s**（全件pass）。カバー範囲:
+- 非localhost（Supabase風hostname・Render風hostname含む）を正しくblock
+- 既存local dev DB名（`jinja_db`・`jinja_app_dev`）を正しくblock
+- isolation marker（`audit`/`restore_test`/`migration_safety`）を含む
+  localhost URLを正しく許可
+- query stringにmarkerを紛れ込ませてもdbname本体で判定されるため
+  誤って許可しないことを確認
+- repo内へのdump path出力を正しくblock、repo外は正しく許可
+- credential redactionがuser/passwordを確実にマスクすることを確認
+
+### End-to-endテスト（`test_backup_restore_e2e.sh`、ローカル隔離DBのみ使用）
+
+**結果: PASS（exit code 0）。**
+
+このテストは以下を実施した（すべてローカル、Productionへは一切接続
+していない）:
+
+1. `guard.py`の否定テスト4件（非localhost host拒否・既存dev DB拒否・
+   隔離target許可・repo内dump path拒否）をすべて確認
+2. 一時DB `jinja_migration_safety_source_<timestamp>` を新規作成し、
+   `contenttypes 0002` → `auth 0012` → `admin 0003` → `sessions 0001` →
+   `token_blacklist 0013` → `users 0005` → `favorites 0002` →
+   `temples 0089`（migration 89件、PostGIS込み）を適用し、Production
+   相当のbaseline schemaを再現
+3. User/UserProfileの実データを1件ずつ投入
+4. `dump_readonly.sh`でこのDBをdump（`roles.sql`/`schema.sql`/
+   `data.sql`）
+5. 別の一時DB `jinja_migration_safety_restore_test_<timestamp>` を
+   新規作成し、`restore_isolated.sh`でguard判定を通過させた上でrestore
+6. restore後のaggregate件数（`auth_user`/`users_userprofile`/
+   `temples_shrine`）がsource側と完全一致することを確認
+7. restore後の`django_migrations`最新状態が`users=0005`/`temples=0089`
+   と一致することを確認
+8. **restoreされた側（sourceでもProductionでもない）に対してのみ**
+   `users 0006`・`temples 0090-0093`を適用し、成功を確認
+9. 新規カラム4件・新規Knowledge table 5件の存在、aggregate件数不変を確認
+10. `temples 0089`・`users 0005`へのrollbackが成功することを確認
+11. 使用した一時DB・dumpファイルをすべて削除（`trap ... EXIT`により
+    テスト失敗時も確実に削除される）
+
+### テスト中に発見した実際の不具合（設計段階の文書レビューだけでは
+見つからなかったもの）
+
+1. **`pg_dumpall`のバージョン不一致拒否**: ローカルPostgres serverは
+   `18.0`だが、`PATH`上のデフォルト`pg_dump`/`pg_dumpall`は`16.10`
+   （Homebrewの一般シンボリックリンク）。`pg_dumpall`はバージョン
+   不一致時に警告ではなく即エラーで停止する。`PG_DUMP_BIN`/
+   `PG_DUMPALL_BIN`/`PSQL_BIN`のオーバーライドをscriptへ追加して解消。
+   **実際のProduction dump実行前には、Supabase側のPostgresバージョンを
+   確認し、一致するクライアントを使う必要がある。**
+2. **`--schema=public`のdumpに含まれる`CREATE SCHEMA public;`が、
+   新規作成直後のtarget DBに既に存在する`public`schemaと衝突する**。
+   restore前にその1行を除去することで解消（`restore_isolated.sh`内で
+   `grep -v`により対処）。
+3. **PostGIS/pg_trgm型がrestore先で未定義**: `--schema=public`限定の
+   dumpにはextension object自体が含まれない（Supabaseはextensionを
+   `public`以外のschemaへインストールする設計のため）。restore前に
+   `CREATE EXTENSION IF NOT EXISTS postgis;`/`pg_trgm;`をtargetへ
+   実行することで解消。
+
+これら3件はいずれも`restore_isolated.sh`内で既に対処済みだが、実際の
+Production dump/restoreを試みる際は、Supabase側のPostgresバージョン・
+extension配置がローカル環境と異なる可能性がある点を「既知の未検証事項」
+として`README.md`「Known gaps」節に明記した。
+
+---
+
+## Phase別チェックリスト結果
+
+### Phase 0 — Contract確認
+- [x] 既存Backup Gate文書（`docs/audit/production-manual-backup-restore-gate.md`）を読んだ
+- [x] Migration Safety Audit（`docs/audit/production-migration-0090-0093-safety.md`・`docs/audit/production-all-app-migration-state-audit.md`）を読んだ
+- [x] Production Execution Gate（`docs/audit/production-migration-execution-gate.md`）を読んだ
+- [x] `users 0006`/`temples 0090-0093`の既知状態を確認した（既存監査の結論を再利用、再実施はしていない）
+
+### Phase 1 — Backup Route
+- [x] manual dump手順をRunbook化（`README.md`「Runbook: Manual Backup Route」）
+- [x] dump保存先をrepo外に固定（`guard.py`の`is_safe_dump_path`で強制）
+- [x] credential非露出チェックを入れる（`redact_url`、scriptはURLを平文でechoしない）
+- [x] dump file存在/size確認手順を作る（`dump_readonly.sh`が自動で各ファイルのサイズを表示・0バイト時警告）
+
+### Phase 2 — Restore Verification Route
+- [x] isolated PostgreSQL作成手順を作る
+- [x] Production誤接続防止チェックを入れる（`guard.py`のallow-list、`restore_isolated.sh`から強制呼び出し）
+- [x] restore手順をRunbook化
+- [x] migration state比較SQLを用意（`sql/migration_state.sql`）
+- [x] schema比較SQLを用意（`sql/post_migration_verification.sql`内）
+- [x] aggregate count比較SQLを用意（`sql/pre_migration_snapshot.sql`・`sql/post_migration_verification.sql`）
+
+### Phase 3 — Pre-Migration Checklist
+- [x] Production migration state確認手順を用意（`sql/migration_state.sql`、実行自体はMother Ship側）
+- [x] manual backup完了確認手順を用意
+- [x] backup timestamp記録手順を用意
+- [x] users/temples baseline確認手順を用意
+- [x] STOP条件を明文化（`README.md`「Pre-Migration Checklist」）
+
+### Phase 4 — Migration Execution Runbook
+- [x] `users 0006`適用候補コマンドを定義（`migrate users 0006 --noinput`）
+- [x] users適用後QAを定義（`sql/post_migration_verification.sql`）
+- [x] `temples 0090-0093`適用候補を定義（`migrate temples 0093 --noinput`）
+- [x] temples適用後QAを定義
+- [x] 全app一括migrateを無条件採用しない（`README.md`に明記。`docs/audit/migration-execution-method-reality-audit.md`・`docs/audit/production-all-app-migration-state-audit.md`で確認済みの「app指定なしmigrateは`users 0006`も巻き込む」を踏襲）
+
+### Phase 5 — Recovery Route
+- [x] migration失敗時のSTOP条件（`README.md`のPre-Migration Checklist、既存execution gate docのFailure boundariesを参照）
+- [x] reverse migration候補整理（`migrate temples 0089`/`migrate users 0005`、E2Eテストで実際に成功を確認）
+- [x] backup restore判断条件（既存`docs/audit/production-manual-backup-restore-gate.md`のRestore開始条件を踏襲）
+- [x] restore後QAを定義（`sql/post_migration_verification.sql`と同じクエリを再利用可能）
+- [ ] service再開条件を定義 — **`UNVERIFIED`**。Renderのmaintenance機能有無が未確認のため（`docs/audit/migration-execution-method-reality-audit.md`で既に指摘済みの既知gap）
+
+### Phase 6 — Safety Guard
+- [x] Production hostname検出時の確認処理 → allow-list方式で実装（デザイン上の理由は上述）
+- [x] destructive commandを自動実行しない（scriptはいずれも明示的な引数なしでは何もしない。デフォルト接続先なし）
+- [x] dry-run/read-onlyをデフォルトにする（`dump_readonly.sh`はread-onlyのみ、書き込み系操作は`restore_isolated.sh`のみで、かつguard必須）
+- [x] credentialをログ出力しない（`redact_url`使用、E2Eテストでも実際にログへ`***`が出ることを確認済み）
+- [x] dumpをGit対象外にする（`is_safe_dump_path`で強制。加えて一時dumpは`/tmp`配下、テスト終了時に削除）
+
+### Phase 7 — Test
+- [x] local isolated DBでbackup/restore再現（E2Eテストで実施、PASS）
+- [x] `users 0005`状態再現（E2Eテストで実施）
+- [x] `temples 0089`状態再現（E2Eテストで実施、GIS込み89件のmigrationを再現）
+- [x] restore後データ一致確認（aggregate件数・migration state両方を実測比較）
+- [x] migration後QA手順を検証（restoreされたコピーに対して`users 0006`・`temples 0090-0093`を適用し、新規column/table・件数不変・rollbackまで実測）
+
+---
+
+## 完了条件チェック
+
+- [x] 本番変更前に戻せる手順が文書化されている（`README.md`、SQL定義済み）
+- [x] localで復旧ルートを再現できる（E2Eテストで実測PASS）
+- [x] Production操作は自動実行されない（全script、デフォルト接続先なし。CI testpathsにも含まれない）
+- [ ] Mother ShipがGo/No-Goを判断できる → 本ドキュメント・README・PRで判断材料を提供。**ただし実際のProductionに対して一度もdump/restoreを試みていない**ため、最終的なGo判定（Backup Gateの`MANUAL_BACKUP_BLOCKED_CREDENTIAL_ACCESS`解消）はMother Ship側でのcredential提供が必要
+- [x] PR作成まで
+
+---
+
+## Stop Conditions（遵守確認）
+
+- [x] Production migrate禁止（遵守。すべての`migrate`実行はローカル一時DB上のみ）
+- [x] Production restore禁止（遵守。restoreはローカル隔離DB間のみ）
+- [x] Production DB write禁止（遵守。Productionへは一切接続していない）
+- [x] Environment変更禁止（遵守）
+- [x] Production操作を自動実行するコードを作らない（遵守。全scriptはDATABASE_URL等を明示引数として要求し、デフォルト値・環境変数フォールバックによる暗黙のProduction接続経路を持たない。CI wiring もしていない）
+
+---
+
+## Repository Changes
+
+- `scripts/migration_safety/guard.py`: 新規
+- `scripts/migration_safety/dump_readonly.sh`: 新規
+- `scripts/migration_safety/restore_isolated.sh`: 新規
+- `scripts/migration_safety/sql/migration_state.sql`: 新規
+- `scripts/migration_safety/sql/pre_migration_snapshot.sql`: 新規
+- `scripts/migration_safety/sql/post_migration_verification.sql`: 新規
+- `scripts/migration_safety/tests/test_guard.py`: 新規
+- `scripts/migration_safety/tests/test_backup_restore_e2e.sh`: 新規
+- `scripts/migration_safety/README.md`: 新規（Runbook）
+- `docs/audit/migration-safety-tooling.md`: 本ドキュメント（新規）
+- 既存コード（`backend/`アプリケーションコード）への変更: **なし**
+- Production DB・Environment・deploy設定への変更: **なし**
+
+## 次にMother Shipが用意すべきもの
+
+`docs/audit/production-manual-backup-restore-gate.md`と同一の結論のまま
+変わらない: 本ツールがそのまま使えるようになるには、Mother Ship側で
+read-only Production接続情報を、チャット以外の安全な経路で用意する
+必要がある。用意できた時点で、`scripts/migration_safety/README.md`の
+Runbookに従い、Phase 1（Manual Backup Route）から実際に実行できる。

--- a/scripts/migration_safety/README.md
+++ b/scripts/migration_safety/README.md
@@ -1,0 +1,236 @@
+# Migration Safety Tooling — Backup / Restore Runbook
+
+Tooling to make Production migrations (starting with `users 0006` and
+`temples 0090-0093`) safely reversible. Everything here is read-only with
+respect to Production, or operates only on local/isolated databases.
+
+**This tooling never runs a command against Production automatically.**
+Every script here requires a `DATABASE_URL`-style argument explicitly —
+there is no default, no ambient credential lookup, and nothing is wired
+into CI or a deploy pipeline. A human decides when and against what to
+run these, every time.
+
+Background reading (read in this order):
+
+1. [`docs/audit/supabase-backup-capability-gate.md`](../../docs/audit/supabase-backup-capability-gate.md) — why Supabase's Free plan has no native backup/PITR
+2. [`docs/audit/production-manual-backup-restore-gate.md`](../../docs/audit/production-manual-backup-restore-gate.md) — why manual dump/restore was chosen, and the credential-access block that stopped it from being exercised against real Production
+3. [`docs/audit/production-migration-execution-gate.md`](../../docs/audit/production-migration-execution-gate.md) — why Production migration execution stays paused until this Gate passes
+4. [`docs/audit/production-all-app-migration-state-audit.md`](../../docs/audit/production-all-app-migration-state-audit.md) — the `users 0006` / `temples 0090-0093` content this tooling protects
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `guard.py` | Pure-Python safety guard. Allow-list (not deny-list) check for restore targets; repo-boundary check for dump output paths; credential redaction for logging. No DB/network code. |
+| `dump_readonly.sh` | Read-only logical dump (`pg_dumpall --roles-only` + `pg_dump --schema-only` + `pg_dump --data-only`, `public` schema only) of a URL you pass explicitly. |
+| `restore_isolated.sh` | Restores a dump into a target URL, but only after `guard.py` confirms the target is a disposable local database. Refuses otherwise. |
+| `sql/migration_state.sql` | SELECT-only. Per-app latest applied migration. |
+| `sql/pre_migration_snapshot.sql` | SELECT-only. Run immediately before a backup/migration attempt; records the baseline to compare against later. |
+| `sql/post_migration_verification.sql` | SELECT-only. Run after migration; every value must match the pre-migration snapshot except the two migrations you intentionally applied. |
+| `tests/test_guard.py` | Unit tests for `guard.py`. No DB required. |
+| `tests/test_backup_restore_e2e.sh` | End-to-end local test: builds a `users=0005`/`temples=0089` local database, dumps it, restores it into a second isolated database through the actual guarded scripts, verifies they match, applies `users 0006` + `temples 0090-0093` to the restored copy, verifies again, rolls back. Never touches Production. |
+
+## The core safety property
+
+`guard.py`'s restore-target check is an **allow-list**, not a deny-list of
+"things that look like Production." This tooling does not know
+Production's real hostname, so guessing at patterns to block would be
+incomplete by construction. Instead, a restore target must satisfy *all*
+of:
+
+- host is `localhost`, `127.0.0.1`, or `::1`
+- database name is not one of the protected existing local databases
+  (`jinja_db`, `jinja_app_dev`, `jinja_test`, `postgres`, ...)
+- database name contains `audit`, `restore_test`, or `migration_safety`
+
+Anything else — including every real Production hostname, whatever it
+turns out to be — is blocked by default. `restore_isolated.sh` calls this
+check before touching the target and aborts with a non-zero exit if it
+fails.
+
+The dump-path check works the other way: a dump's *output path* must
+resolve outside the git repository, so a Production dump can never end up
+staged for commit.
+
+## Running the tests
+
+```bash
+# Unit tests (fast, no DB):
+backend/.venv/bin/python3 -m pytest scripts/migration_safety/tests/test_guard.py -v
+
+# End-to-end local drill (needs local PostgreSQL with postgis available,
+# ~1-2 minutes — it replays temples migrations 0001-0093):
+scripts/migration_safety/tests/test_backup_restore_e2e.sh
+```
+
+Both are safe to run repeatedly and clean up everything they create
+(`test_backup_restore_e2e.sh` uses a `trap ... EXIT` that drops its temp
+databases and dump directory even on failure).
+
+Neither test is wired into any CI workflow's `testpaths`
+(`backend/pytest.ini` only scopes `temples/tests`, `users/tests`,
+`tests`) — they are standalone tooling, run manually. Wiring the unit
+tests into CI would be a reasonable follow-up but is out of scope here
+and wasn't requested.
+
+## Runbook: Manual Backup Route (Phase 1)
+
+1. Obtain a read-only-capable Production connection string. **Never paste
+   it into chat with an AI assistant; never commit it.** Export it into
+   your own shell as `SOURCE_DATABASE_URL`.
+2. Confirm your local `pg_dump`/`pg_dumpall` major version matches
+   Production's Postgres version (check via Supabase Dashboard → Database
+   settings, or `SELECT version();`). If they don't match, set
+   `PG_DUMP_BIN` / `PG_DUMPALL_BIN` to a matching Homebrew install (e.g.
+   `postgresql@18`) — mismatched major versions make `pg_dumpall` refuse
+   to run at all (`server version mismatch`); this was hit and fixed
+   during development of this tooling, see `dump_readonly.sh` comments.
+3. Pick an output directory **outside this repository**, e.g.
+   `~/kami-musubi-backups/$(date +%Y%m%d%H%M%S)/`.
+4. Run:
+   ```bash
+   scripts/migration_safety/dump_readonly.sh "$SOURCE_DATABASE_URL" ~/kami-musubi-backups/<timestamp>/
+   ```
+5. Confirm all three files (`roles.sql`, `schema.sql`, `data.sql`) exist
+   and have non-zero size (the script prints sizes; it also warns on any
+   zero-byte file).
+6. Record the timestamp and file sizes in the execution gate document —
+   this becomes the "backup timestamp" referenced by the pre-migration
+   checklist.
+
+Supabase's own CLI (`supabase db dump`) remains the officially recommended
+tool for a real Production dump against Supabase specifically (see the
+Backup Capability Gate doc) — it handles Supabase-managed schema/extension
+placement automatically. `dump_readonly.sh` here uses plain `pg_dump`
+because that's what could actually be exercised end-to-end without
+Supabase CLI installed; it needed two fixes to work at all (server-version
+mismatch, and `public`-schema-only dumps needing `postgis`/`pg_trgm`
+extensions pre-created on restore — see "What broke during testing"
+below). If Supabase CLI is used for a real Production dump instead, the
+resulting `roles.sql`/`schema.sql`/`data.sql` files are restored the same
+way, through `restore_isolated.sh`.
+
+## Runbook: Restore Verification Route (Phase 2)
+
+1. Create a disposable target database whose name contains `audit`,
+   `restore_test`, or `migration_safety` — e.g.:
+   ```bash
+   createdb kami_musubi_migration_safety_$(date +%Y%m%d%H%M%S)
+   ```
+2. Restore into it:
+   ```bash
+   scripts/migration_safety/restore_isolated.sh ~/kami-musubi-backups/<timestamp>/ \
+     "postgres://$(whoami)@localhost:5432/<the db you just created>"
+   ```
+   If `guard.py` rejects the target, the script exits non-zero before
+   touching the database at all — fix the naming/host, don't work around
+   the check.
+3. Run `sql/migration_state.sql` against the restored DB and compare to
+   what you expect (`users=0005`, `temples=0089` before any migration has
+   been applied to the restore source).
+4. Run the aggregate-count queries in `sql/pre_migration_snapshot.sql`
+   against both the original Production values you recorded and the
+   restored copy; they must match.
+5. Only after 3-4 both check out is the backup considered verified.
+
+## Runbook: Pre-Migration Checklist (Phase 3)
+
+Before ever running a real migration command against Production:
+
+- [ ] Run `sql/migration_state.sql` against Production (read-only) —
+      confirm `users=0005`, `temples=0089`, and that no other app's state
+      has drifted from the last audit
+- [ ] Complete the Manual Backup Route above against Production
+- [ ] Complete the Restore Verification Route above against the resulting
+      dump
+- [ ] Record the backup timestamp, dump file sizes, and restore
+      verification result in the execution gate document
+- [ ] Re-run `sql/migration_state.sql` against Production one more time
+      immediately before migrating — if it has changed since step 1,
+      **stop** (`PRODUCTION_MIGRATION_STATE_CHANGED`, see the execution
+      gate doc)
+
+**How fresh must the backup be?** No fixed number is asserted here
+without a real timing measurement. As a starting point: treat a backup as
+stale if more than the time it took to *also* complete the restore
+verification route has passed since it was taken — i.e., don't sit on a
+verified-good dump for hours before migrating. Mother Ship should set an
+explicit staleness threshold once real Production dump/restore timing is
+known; this hasn't been measured against Production and is marked
+`UNVERIFIED` accordingly.
+
+## Runbook: Migration Execution Candidates (Phase 4) — reference only, not endorsement
+
+These commands are documented for completeness; **do not run them without
+completing the Pre-Migration Checklist first, and only with Mother Ship's
+explicit go-ahead.** This tooling does not execute them.
+
+```bash
+# users first (smaller, independently reversible):
+python manage.py migrate users 0006 --noinput
+
+# then temples:
+python manage.py migrate temples 0093 --noinput
+```
+
+Deliberately **not** `python manage.py migrate` with no app name — that
+form applies every pending migration across every app, which is exactly
+the confounding risk documented in
+`docs/audit/migration-execution-method-reality-audit.md` Phase 4 and
+confirmed to actually apply here (`users 0006` is pending, not just
+`temples`) in `docs/audit/production-all-app-migration-state-audit.md`.
+
+After each command: run `sql/post_migration_verification.sql` before
+proceeding to the next one. If `users 0006` verification fails, do not
+run the `temples` migration.
+
+## What broke during local testing (keep this — it's the point of testing)
+
+Building `tests/test_backup_restore_e2e.sh` surfaced three real problems
+that a design-only Runbook would not have caught:
+
+1. **`pg_dumpall` refuses cross-major-version connections.** The local
+   Postgres *server* here is 18.0; the default `pg_dump`/`pg_dumpall` on
+   `PATH` is 16.10 (Homebrew's generic symlink). `pg_dumpall` hard-fails
+   with "server version mismatch" rather than degrading. Fixed by adding
+   `PG_DUMP_BIN`/`PG_DUMPALL_BIN`/`PSQL_BIN` overrides to the scripts.
+   **Before a real Production dump, confirm the Postgres major version
+   Supabase reports and use a matching client — do not assume the
+   default `pg_dump` on any machine matches.**
+2. **A `--schema=public` dump's `CREATE SCHEMA public;` collides with a
+   freshly-created target database**, which already has an empty
+   `public` schema by default. Fixed by stripping that one line before
+   restoring (a fresh `createdb` target always has this collision; it is
+   not a sign of a bad dump).
+3. **PostGIS/pg_trgm types are undefined on the restore target** unless
+   those extensions are created there first — a `--schema=public`-only
+   dump does not carry extension objects (Supabase installs extensions
+   outside `public` by design). Fixed by running
+   `CREATE EXTENSION IF NOT EXISTS postgis;` /
+   `... pg_trgm;` on the target before applying `schema.sql`.
+
+All three are now handled inside `restore_isolated.sh` — a real restore
+drill should not hit any of them. But they are exactly the kind of thing
+a paper Runbook would have missed, which is why Phase 7 required actually
+running this end-to-end rather than just describing it.
+
+## Known gaps (be honest about these)
+
+- Every fix above was validated against a **local** Postgres 18 instance,
+  not against Supabase's actual Postgres version or its actual extension
+  layout. Supabase may install `postgis`/`pg_trgm` in a schema other than
+  what a plain local install uses, or may already have them present in
+  every project by default — this needs to be confirmed once a real
+  Production dump is attempted with Mother Ship's own credentials.
+- `roles.sql` restore is treated as best-effort (`|| continue on error`)
+  because roles like the local Unix user commonly already exist on a dev
+  machine. Against a truly fresh restore target this may hide a real
+  roles-restore failure — inspect its output, don't just trust the
+  "continuing" message.
+- No timing data exists for how long a real Production dump/restore
+  takes. The "backup freshness" guidance above is a placeholder, not a
+  measured number.
+- This tooling was never run against Production, because no Production
+  credential is available to this environment (see the Manual Backup
+  Restore Gate doc). Everything above is proven against a local
+  simulation of Production's known shape, not against Production itself.

--- a/scripts/migration_safety/dump_readonly.sh
+++ b/scripts/migration_safety/dump_readonly.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Take a read-only logical dump (roles/schema/data, public schema only) of
+# a PostgreSQL database, using plain pg_dump.
+#
+# This script never has a default DATABASE_URL. It only ever dumps a URL
+# you pass in explicitly, and only ever runs SELECT-equivalent (read-only)
+# pg_dump commands — no destructive statement is possible via this script.
+#
+# Usage:
+#   scripts/migration_safety/dump_readonly.sh <SOURCE_DATABASE_URL> <OUTPUT_DIR>
+#
+# Output: <OUTPUT_DIR>/roles.sql, schema.sql, data.sql
+#
+# pg_dump/pg_dumpall refuse to talk to a server whose major version is
+# newer than the client (a real risk: Homebrew's default `pg_dump` may not
+# match the target server's version — this bit us during local testing,
+# see docs/audit/migration-safety-tooling.md). Override the binaries used
+# via PG_DUMP_BIN / PG_DUMPALL_BIN if the default `pg_dump`/`pg_dumpall`
+# on PATH don't match the source server's version, e.g.:
+#   PG_DUMP_BIN=/opt/homebrew/opt/postgresql@18/bin/pg_dump \
+#   PG_DUMPALL_BIN=/opt/homebrew/opt/postgresql@18/bin/pg_dumpall \
+#     scripts/migration_safety/dump_readonly.sh ...
+#
+# Safety:
+#   - OUTPUT_DIR is checked with guard.py and rejected if it resolves
+#     inside this git repository (prevents an accidental `git add`).
+#   - The URL is never echoed or logged; only its redacted form is.
+#   - Dump is scoped to `--schema=public` only (see docs/audit/
+#     production-manual-backup-restore-gate.md Phase 2 for why).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ $# -ne 2 ]; then
+  echo "[dump_readonly] usage: $0 <SOURCE_DATABASE_URL> <OUTPUT_DIR>" >&2
+  exit 2
+fi
+
+SOURCE_DATABASE_URL="$1"
+OUTPUT_DIR="$2"
+
+PG_DUMP_BIN="${PG_DUMP_BIN:-pg_dump}"
+PG_DUMPALL_BIN="${PG_DUMPALL_BIN:-pg_dumpall}"
+
+REDACTED_URL="$(python3 "${SCRIPT_DIR}/guard.py" redact "${SOURCE_DATABASE_URL}")"
+echo "[dump_readonly] source: ${REDACTED_URL}"
+
+if ! python3 "${SCRIPT_DIR}/guard.py" check-dump-path "${OUTPUT_DIR}" "${REPO_ROOT}"; then
+  echo "[dump_readonly] BLOCKED: output dir must be outside the repository. Aborting." >&2
+  exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "[dump_readonly] dumping roles (read-only)..."
+"${PG_DUMPALL_BIN}" --dbname="${SOURCE_DATABASE_URL}" --roles-only --no-role-passwords \
+  > "${OUTPUT_DIR}/roles.sql"
+
+echo "[dump_readonly] dumping schema (read-only, public schema only)..."
+"${PG_DUMP_BIN}" --dbname="${SOURCE_DATABASE_URL}" --schema-only --schema=public --no-owner --no-privileges \
+  > "${OUTPUT_DIR}/schema.sql"
+
+echo "[dump_readonly] dumping data (read-only, public schema only)..."
+"${PG_DUMP_BIN}" --dbname="${SOURCE_DATABASE_URL}" --data-only --schema=public --no-owner --no-privileges \
+  > "${OUTPUT_DIR}/data.sql"
+
+for f in roles.sql schema.sql data.sql; do
+  size=$(wc -c < "${OUTPUT_DIR}/${f}" | tr -d ' ')
+  if [ "${size}" -eq 0 ]; then
+    echo "[dump_readonly] WARNING: ${f} is empty (size=0)" >&2
+  fi
+  echo "[dump_readonly] ${f}: ${size} bytes"
+done
+
+echo "[dump_readonly] done. Files never leave ${OUTPUT_DIR} automatically — do not commit them."

--- a/scripts/migration_safety/guard.py
+++ b/scripts/migration_safety/guard.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Safety guard for manual Production backup/restore drills.
+
+This module contains no network or DB code. It only answers two yes/no
+questions from a connection URL/path, using an allow-list (not a deny-list):
+
+- is a RESTORE target safe to write to? (must look like a disposable local
+  isolation DB, never anything that could plausibly be Production)
+- is a DUMP output path safe to write to? (must be outside this repository,
+  so a Production dump can never end up committed)
+
+An allow-list is used instead of a "does this look like production"
+deny-list because this tooling does not know Production's real hostname.
+A deny-list of guessed patterns would be incomplete by construction; an
+allow-list of known-safe local targets fails closed instead.
+
+No function here executes a command, opens a socket, or reads a secret
+from a file. Callers (shell scripts) are responsible for actually running
+pg_dump/psql; this module only decides whether that's safe to attempt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from urllib.parse import urlparse
+
+# Only these hosts are ever treated as "local" for restore purposes.
+ALLOWED_RESTORE_HOSTS = {"localhost", "127.0.0.1", "::1"}
+
+# Existing local databases that real developers rely on. Restoring into one
+# of these would clobber someone's work, so they are blocked even though
+# they're local.
+PROTECTED_LOCAL_DB_NAMES = {
+    "jinja_db",
+    "jinja_app_dev",
+    "jinja_test",
+    "postgres",
+    "template0",
+    "template1",
+}
+
+# A restore target's database name must contain one of these markers.
+# This is what makes a target "obviously disposable" rather than a
+# same-named collision with something real.
+REQUIRED_ISOLATION_MARKERS = ("audit", "restore_test", "migration_safety")
+
+# A dump file's *contents* must never contain the connection string used to
+# produce it. This redaction is defense in depth for anything that logs the
+# URL a script was invoked with (e.g. `set -x` output, error messages).
+_CREDENTIAL_RE = re.compile(r"://([^:/@]+)(:([^@/]*))?@")
+
+
+def redact_url(url: str) -> str:
+    """Return `url` with any userinfo (user:password) replaced by '***'."""
+    return _CREDENTIAL_RE.sub("://***@", url)
+
+
+def is_safe_restore_target(database_url: str) -> tuple[bool, str]:
+    """Return (ok, reason). ok is True only for a disposable local DB."""
+    try:
+        parsed = urlparse(database_url)
+    except ValueError as exc:
+        return False, f"could not parse URL: {exc}"
+
+    host = (parsed.hostname or "").lower()
+    dbname = (parsed.path or "").lstrip("/")
+
+    if host not in ALLOWED_RESTORE_HOSTS:
+        return False, f"host {host!r} is not in the local allow-list {sorted(ALLOWED_RESTORE_HOSTS)}"
+
+    if not dbname:
+        return False, "database name is empty"
+
+    if dbname.lower() in PROTECTED_LOCAL_DB_NAMES:
+        return False, f"database name {dbname!r} is a protected existing local database"
+
+    if not any(marker in dbname.lower() for marker in REQUIRED_ISOLATION_MARKERS):
+        return False, (
+            f"database name {dbname!r} does not contain a required isolation "
+            f"marker {REQUIRED_ISOLATION_MARKERS}; refusing to restore into "
+            "a database that wasn't clearly created for this drill"
+        )
+
+    return True, "ok"
+
+
+def is_safe_dump_path(path: str, repo_root: str) -> tuple[bool, str]:
+    """Return (ok, reason). ok is True only if `path` is outside `repo_root`."""
+    abs_path = os.path.realpath(path)
+    abs_repo_root = os.path.realpath(repo_root)
+
+    if abs_path == abs_repo_root or abs_path.startswith(abs_repo_root + os.sep):
+        return False, f"{abs_path} is inside the repository ({abs_repo_root}); refusing to write a dump there"
+
+    return True, "ok"
+
+
+def _cli() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_restore = sub.add_parser("check-restore-target", help="Exit 0 if URL is a safe restore target, else 1")
+    p_restore.add_argument("database_url")
+
+    p_dump = sub.add_parser("check-dump-path", help="Exit 0 if path is outside the repo, else 1")
+    p_dump.add_argument("path")
+    p_dump.add_argument("repo_root")
+
+    p_redact = sub.add_parser("redact", help="Print URL with credentials masked")
+    p_redact.add_argument("database_url")
+
+    args = parser.parse_args()
+
+    if args.command == "check-restore-target":
+        ok, reason = is_safe_restore_target(args.database_url)
+        print(f"{'SAFE' if ok else 'BLOCKED'}: {reason}", file=sys.stderr)
+        return 0 if ok else 1
+
+    if args.command == "check-dump-path":
+        ok, reason = is_safe_dump_path(args.path, args.repo_root)
+        print(f"{'SAFE' if ok else 'BLOCKED'}: {reason}", file=sys.stderr)
+        return 0 if ok else 1
+
+    if args.command == "redact":
+        print(redact_url(args.database_url))
+        return 0
+
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/scripts/migration_safety/restore_isolated.sh
+++ b/scripts/migration_safety/restore_isolated.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Restore a dump produced by dump_readonly.sh into an isolated PostgreSQL
+# database. Refuses to run unless guard.py confirms the target is a
+# disposable local database — never Production, never an existing local
+# dev database.
+#
+# Usage:
+#   scripts/migration_safety/restore_isolated.sh <DUMP_DIR> <TARGET_DATABASE_URL>
+#
+# TARGET_DATABASE_URL must point at a database that:
+#   - has host in {localhost, 127.0.0.1, ::1}
+#   - has a name containing "audit", "restore_test", or "migration_safety"
+#   - is not one of the protected existing local dev DB names
+# (see guard.py for the exact allow-list — deny-by-default).
+#
+# This script does NOT create the target database. Create it first with
+# `createdb <name>` so the intent to make a disposable DB is explicit and
+# visible in your shell history, separate from this script's guard check.
+#
+# Override PSQL_BIN if the default `psql` on PATH doesn't match the
+# target server's major version (see dump_readonly.sh for why this matters).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ $# -ne 2 ]; then
+  echo "[restore_isolated] usage: $0 <DUMP_DIR> <TARGET_DATABASE_URL>" >&2
+  exit 2
+fi
+
+DUMP_DIR="$1"
+TARGET_DATABASE_URL="$2"
+
+PSQL_BIN="${PSQL_BIN:-psql}"
+
+REDACTED_URL="$(python3 "${SCRIPT_DIR}/guard.py" redact "${TARGET_DATABASE_URL}")"
+echo "[restore_isolated] target: ${REDACTED_URL}"
+
+if ! python3 "${SCRIPT_DIR}/guard.py" check-restore-target "${TARGET_DATABASE_URL}"; then
+  echo "[restore_isolated] BLOCKED: target failed the isolation-target guard. Aborting. See stderr above for reason." >&2
+  exit 1
+fi
+
+for f in roles.sql schema.sql data.sql; do
+  if [ ! -s "${DUMP_DIR}/${f}" ]; then
+    echo "[restore_isolated] BLOCKED: ${DUMP_DIR}/${f} is missing or empty. Aborting." >&2
+    exit 1
+  fi
+done
+
+echo "[restore_isolated] applying roles.sql (best-effort; roles may already exist)..."
+"${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" --file="${DUMP_DIR}/roles.sql" --quiet || \
+  echo "[restore_isolated] roles.sql had non-fatal errors (likely pre-existing roles); continuing"
+
+echo "[restore_isolated] ensuring required extensions exist (postgis, pg_trgm — a --schema=public dump omits extension objects, since Supabase installs extensions outside public; this app's migrations only ever require these two, see backend/temples/migrations/0001_initial.py, 0027, 0036)..."
+"${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" --variable ON_ERROR_STOP=1 --quiet \
+  --command "CREATE EXTENSION IF NOT EXISTS postgis; CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+
+echo "[restore_isolated] applying schema.sql (dropping the redundant 'CREATE SCHEMA public;' line — a fresh target DB already has an empty public schema from createdb, so re-issuing it would error)..."
+grep -v '^CREATE SCHEMA public;$' "${DUMP_DIR}/schema.sql" | "${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" \
+  --single-transaction --variable ON_ERROR_STOP=1 --quiet
+
+echo "[restore_isolated] applying data.sql..."
+"${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" --single-transaction --variable ON_ERROR_STOP=1 \
+  --command "SET session_replication_role = replica;" \
+  --file="${DUMP_DIR}/data.sql" --quiet
+
+echo "[restore_isolated] done."

--- a/scripts/migration_safety/sql/migration_state.sql
+++ b/scripts/migration_safety/sql/migration_state.sql
@@ -1,0 +1,5 @@
+-- SELECT-only. Safe to run against Production. Reports the latest applied
+-- migration per app.
+SELECT app, name, applied
+FROM django_migrations
+ORDER BY app, applied DESC;

--- a/scripts/migration_safety/sql/post_migration_verification.sql
+++ b/scripts/migration_safety/sql/post_migration_verification.sql
@@ -1,0 +1,40 @@
+-- SELECT-only. Safe to run against Production.
+-- Run after applying migrations. Compare every result against the values
+-- recorded by pre_migration_snapshot.sql.
+
+-- 1. Confirm the target migrations are now applied.
+SELECT app, name, applied FROM django_migrations
+WHERE (app = 'users' AND name = '0006_userprofile_birth_profile_fields')
+   OR (app = 'temples' AND name = '0093_shrine_knowledge_model_foundation');
+-- Expected: 2 rows.
+
+-- 2. UserProfile's 4 new columns must now exist.
+SELECT column_name FROM information_schema.columns
+WHERE table_name = 'users_userprofile'
+AND column_name IN ('birthday', 'birth_time', 'birth_place', 'worship_style');
+-- Expected: 4 rows.
+
+-- 3. Knowledge tables + M2M relation tables must now exist.
+SELECT table_name FROM information_schema.tables
+WHERE table_schema = 'public'
+AND table_name IN (
+  'temples_shrineknowledgesource', 'temples_shrinedeity', 'temples_shrinehistory',
+  'temples_shrinedeity_sources', 'temples_shrinehistory_sources'
+);
+-- Expected: 5 rows.
+
+-- 4. Aggregate row counts must be unchanged from the pre-migration snapshot.
+SELECT
+  (SELECT COUNT(*) FROM auth_user) AS auth_user_count,
+  (SELECT COUNT(*) FROM users_userprofile) AS userprofile_count,
+  (SELECT COUNT(*) FROM temples_shrine) AS shrine_count,
+  (SELECT COUNT(*) FROM favorites_favorite) AS favorite_count,
+  (SELECT COUNT(*) FROM temples_visit) AS visit_count,
+  (SELECT COUNT(*) FROM temples_shrine_goriyaku_tags) AS shrine_goriyaku_relation_count;
+
+-- 5. New Knowledge tables should be empty (no import has happened yet).
+SELECT
+  (SELECT COUNT(*) FROM temples_shrineknowledgesource) AS source_count,
+  (SELECT COUNT(*) FROM temples_shrinedeity) AS deity_count,
+  (SELECT COUNT(*) FROM temples_shrinehistory) AS history_count;
+-- Expected: all 0 (Knowledge import is a separate, later gate).

--- a/scripts/migration_safety/sql/pre_migration_snapshot.sql
+++ b/scripts/migration_safety/sql/pre_migration_snapshot.sql
@@ -1,0 +1,48 @@
+-- SELECT-only. Safe to run against Production.
+-- Run this immediately before taking a manual backup / applying migrations.
+-- Record every result (and the time you ran this) in the execution gate doc.
+
+-- 1. Confirm the target migrations are not already applied.
+SELECT
+  EXISTS (
+    SELECT 1 FROM django_migrations
+    WHERE app = 'users' AND name = '0006_userprofile_birth_profile_fields'
+  ) AS users_0006_applied,
+  EXISTS (
+    SELECT 1 FROM django_migrations
+    WHERE app = 'temples' AND name = '0093_shrine_knowledge_model_foundation'
+  ) AS temples_0093_applied;
+-- Expected: both false. If either is true, STOP — the known state has
+-- changed since the last audit; do not proceed on stale assumptions.
+
+-- 2. Aggregate row counts (no personal data, counts only).
+SELECT
+  (SELECT COUNT(*) FROM auth_user) AS auth_user_count,
+  (SELECT COUNT(*) FROM users_userprofile) AS userprofile_count,
+  (SELECT COUNT(*) FROM temples_shrine) AS shrine_count,
+  (SELECT COUNT(*) FROM favorites_favorite) AS favorite_count,
+  (SELECT COUNT(*) FROM temples_visit) AS visit_count,
+  (SELECT COUNT(*) FROM temples_shrine_goriyaku_tags) AS shrine_goriyaku_relation_count;
+
+-- 3. Knowledge tables must not exist yet (temples 0093 not applied).
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+AND table_name IN (
+  'temples_shrineknowledgesource',
+  'temples_shrinedeity',
+  'temples_shrinehistory',
+  'temples_shrinedeity_sources',
+  'temples_shrinehistory_sources'
+);
+-- Expected: 0 rows.
+
+-- 4. UserProfile's 4 new columns must not exist yet (users 0006 not applied).
+SELECT column_name FROM information_schema.columns
+WHERE table_name = 'users_userprofile'
+AND column_name IN ('birthday', 'birth_time', 'birth_place', 'worship_style');
+-- Expected: 0 rows. If any exist, this is a migration-history/schema
+-- mismatch — classify separately, do not treat as a normal pending state.
+
+-- 5. Record wall-clock time of this snapshot.
+SELECT now() AS snapshot_taken_at;

--- a/scripts/migration_safety/tests/test_backup_restore_e2e.sh
+++ b/scripts/migration_safety/tests/test_backup_restore_e2e.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# End-to-end local verification of the backup/restore drill.
+#
+# This test does NOT touch Production. It builds a local "source" database
+# that reproduces Production's known shape (users=0005, temples=0089),
+# dumps it with dump_readonly.sh, restores the dump into a second isolated
+# database with restore_isolated.sh (going through the same guard.py check
+# a real drill would), compares the two, then applies users 0006 and
+# temples 0090-0093 to the restored copy and verifies the result — exactly
+# mirroring docs/audit/production-all-app-migration-state-audit.md and
+# docs/audit/production-migration-0090-0093-safety.md, but chained through
+# the actual dump/restore tooling instead of just `migrate`.
+#
+# Requires: local PostgreSQL with postgis available, backend/.venv set up.
+# Safe to run repeatedly; all databases it creates are dropped at the end
+# (including on failure, via the trap below).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGSAFE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${MIGSAFE_DIR}/../.." && pwd)"
+BACKEND_DIR="${REPO_ROOT}/backend"
+PY="${BACKEND_DIR}/.venv/bin/python"
+
+STAMP="$(date +%Y%m%d%H%M%S)"
+SOURCE_DB="jinja_migration_safety_source_${STAMP}"
+RESTORE_DB="jinja_migration_safety_restore_test_${STAMP}"
+DUMP_DIR="$(mktemp -d /tmp/migration_safety_dump.XXXXXX)"
+
+SOURCE_URL="postgres://$(whoami)@localhost:5432/${SOURCE_DB}"
+RESTORE_URL="postgres://$(whoami)@localhost:5432/${RESTORE_DB}"
+
+cleanup() {
+  echo "[e2e] cleanup: dropping ${SOURCE_DB}, ${RESTORE_DB}, removing ${DUMP_DIR}"
+  dropdb --if-exists "${SOURCE_DB}" || true
+  dropdb --if-exists "${RESTORE_DB}" || true
+  rm -rf "${DUMP_DIR}"
+}
+trap cleanup EXIT
+
+export USE_GIS=1
+export DEBUG=0
+export SECRET_KEY="migration-safety-e2e-key-not-used-in-prod"
+
+# The local Postgres *server* here may be newer than the default `pg_dump`/
+# `psql` on PATH (this happened during development: server 18, PATH client
+# 16.10). Auto-detect a version-matched Homebrew client if the default one
+# would refuse to talk to the server, so this test is reproducible across
+# machines without hardcoding a version.
+SERVER_MAJOR="$(psql -d postgres -tAc "SHOW server_version_num" | cut -c1-2)"
+if command -v brew >/dev/null 2>&1 && [ -d "/opt/homebrew/opt/postgresql@${SERVER_MAJOR}/bin" ]; then
+  export PG_DUMP_BIN="/opt/homebrew/opt/postgresql@${SERVER_MAJOR}/bin/pg_dump"
+  export PG_DUMPALL_BIN="/opt/homebrew/opt/postgresql@${SERVER_MAJOR}/bin/pg_dumpall"
+  export PSQL_BIN="/opt/homebrew/opt/postgresql@${SERVER_MAJOR}/bin/psql"
+  echo "[e2e] using version-matched client binaries from postgresql@${SERVER_MAJOR}"
+fi
+
+echo "[e2e] === guard.py negative-test sanity check (must fail) ==="
+if python3 "${MIGSAFE_DIR}/guard.py" check-restore-target "postgres://user:pw@db.example.supabase.co:5432/postgres"; then
+  echo "[e2e] FAIL: guard allowed a non-local host as a restore target" >&2
+  exit 1
+fi
+echo "[e2e] guard correctly blocked a non-local restore target"
+
+if python3 "${MIGSAFE_DIR}/guard.py" check-restore-target "postgres://$(whoami)@localhost:5432/jinja_db"; then
+  echo "[e2e] FAIL: guard allowed restoring into the protected jinja_db" >&2
+  exit 1
+fi
+echo "[e2e] guard correctly blocked the protected local dev database"
+
+if ! python3 "${MIGSAFE_DIR}/guard.py" check-restore-target "${RESTORE_URL}"; then
+  echo "[e2e] FAIL: guard blocked our own isolated restore target ${RESTORE_DB}" >&2
+  exit 1
+fi
+echo "[e2e] guard correctly allowed the isolated restore target"
+
+if python3 "${MIGSAFE_DIR}/guard.py" check-dump-path "${REPO_ROOT}/docs/audit/dump.sql" "${REPO_ROOT}"; then
+  echo "[e2e] FAIL: guard allowed a dump path inside the repo" >&2
+  exit 1
+fi
+echo "[e2e] guard correctly blocked an in-repo dump path"
+
+echo "[e2e] === building source DB (${SOURCE_DB}), simulating Production shape ==="
+createdb "${SOURCE_DB}"
+
+cd "${BACKEND_DIR}"
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate contenttypes 0002 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate auth 0012 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate admin 0003 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate sessions 0001 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate token_blacklist 0013 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate users 0005 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate favorites 0002 --noinput
+DATABASE_URL="${SOURCE_URL}" "${PY}" manage.py migrate temples 0089 --noinput
+
+echo "[e2e] seeding realistic baseline data via raw SQL (bypasses the known users/apps.py signal mismatch — see docs/audit/production-all-app-migration-state-audit.md)"
+psql -d "${SOURCE_DB}" <<'SQL'
+INSERT INTO auth_user (password, last_login, is_superuser, username, first_name, last_name, email, is_staff, is_active, date_joined)
+VALUES ('x', NULL, false, 'e2e_user_1', '', '', 'e2e1@example.com', false, true, now());
+
+INSERT INTO users_userprofile (nickname, is_public, bio, icon, created_at, user_id, current_period_end, stripe_customer_id, stripe_price_id, stripe_subscription_id, subscription_status, updated_at)
+SELECT 'E2Eユーザー', true, 'end-to-end test bio', '', now(), id, NULL, '', '', '', 'inactive', now()
+FROM auth_user WHERE username = 'e2e_user_1';
+SQL
+
+SOURCE_SNAPSHOT="$(psql -d "${SOURCE_DB}" -tAc "
+SELECT (SELECT COUNT(*) FROM auth_user) || ',' || (SELECT COUNT(*) FROM users_userprofile) || ',' || (SELECT COUNT(*) FROM temples_shrine)
+")"
+echo "[e2e] source aggregate snapshot (auth_user,userprofile,shrine): ${SOURCE_SNAPSHOT}"
+
+echo "[e2e] === dumping source via dump_readonly.sh ==="
+"${MIGSAFE_DIR}/dump_readonly.sh" "${SOURCE_URL}" "${DUMP_DIR}"
+
+echo "[e2e] === creating isolated restore target (${RESTORE_DB}) ==="
+createdb "${RESTORE_DB}"
+
+echo "[e2e] === restoring via restore_isolated.sh (guarded) ==="
+"${MIGSAFE_DIR}/restore_isolated.sh" "${DUMP_DIR}" "${RESTORE_URL}"
+
+echo "[e2e] === comparing restored DB against source snapshot ==="
+RESTORE_SNAPSHOT="$(psql -d "${RESTORE_DB}" -tAc "
+SELECT (SELECT COUNT(*) FROM auth_user) || ',' || (SELECT COUNT(*) FROM users_userprofile) || ',' || (SELECT COUNT(*) FROM temples_shrine)
+")"
+echo "[e2e] restored aggregate snapshot (auth_user,userprofile,shrine): ${RESTORE_SNAPSHOT}"
+
+if [ "${SOURCE_SNAPSHOT}" != "${RESTORE_SNAPSHOT}" ]; then
+  echo "[e2e] FAIL: source/restore aggregate mismatch (${SOURCE_SNAPSHOT} != ${RESTORE_SNAPSHOT})" >&2
+  exit 1
+fi
+echo "[e2e] PASS: aggregate counts match"
+
+RESTORE_MIGRATION_STATE="$(psql -d "${RESTORE_DB}" -tAc "
+SELECT string_agg(app || '=' || name, ';' ORDER BY app)
+FROM (SELECT DISTINCT ON (app) app, name FROM django_migrations ORDER BY app, applied DESC) t
+WHERE app IN ('users','temples')
+")"
+echo "[e2e] restored latest migration state (users,temples): ${RESTORE_MIGRATION_STATE}"
+case "${RESTORE_MIGRATION_STATE}" in
+  *"temples=0089_actionevent"*"users=0005_userprofile_current_period_end_and_more"*) : ;;
+  *) echo "[e2e] FAIL: restored migration state does not match expected users=0005/temples=0089" >&2; exit 1 ;;
+esac
+echo "[e2e] PASS: restored migration state matches users=0005/temples=0089"
+
+echo "[e2e] === applying users 0006 + temples 0090-0093 to the RESTORED copy (never to source, never to Production) ==="
+DATABASE_URL="${RESTORE_URL}" "${PY}" manage.py migrate users 0006 --noinput
+DATABASE_URL="${RESTORE_URL}" "${PY}" manage.py migrate temples 0093 --noinput
+
+POST_COLUMNS="$(psql -d "${RESTORE_DB}" -tAc "
+SELECT count(*) FROM information_schema.columns
+WHERE table_name='users_userprofile' AND column_name IN ('birthday','birth_time','birth_place','worship_style')
+")"
+POST_TABLES="$(psql -d "${RESTORE_DB}" -tAc "
+SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name IN
+('temples_shrineknowledgesource','temples_shrinedeity','temples_shrinehistory','temples_shrinedeity_sources','temples_shrinehistory_sources')
+")"
+POST_SNAPSHOT="$(psql -d "${RESTORE_DB}" -tAc "
+SELECT (SELECT COUNT(*) FROM auth_user) || ',' || (SELECT COUNT(*) FROM users_userprofile) || ',' || (SELECT COUNT(*) FROM temples_shrine)
+")"
+
+echo "[e2e] post-migration: new UserProfile columns=${POST_COLUMNS} (expect 4), new Knowledge tables=${POST_TABLES} (expect 5), aggregate=${POST_SNAPSHOT}"
+
+if [ "${POST_COLUMNS// /}" != "4" ] || [ "${POST_TABLES// /}" != "5" ] || [ "${POST_SNAPSHOT}" != "${SOURCE_SNAPSHOT}" ]; then
+  echo "[e2e] FAIL: post-migration verification did not match expected values" >&2
+  exit 1
+fi
+echo "[e2e] PASS: post-migration schema and data verification succeeded on the restored (never-Production) copy"
+
+echo "[e2e] === rollback check on the restored copy ==="
+DATABASE_URL="${RESTORE_URL}" "${PY}" manage.py migrate temples 0089 --noinput
+DATABASE_URL="${RESTORE_URL}" "${PY}" manage.py migrate users 0005 --noinput
+echo "[e2e] PASS: rollback to 0089/0005 succeeded on the restored copy"
+
+echo ""
+echo "[e2e] ==================================================="
+echo "[e2e] ALL CHECKS PASSED. Production was never touched."
+echo "[e2e] ==================================================="

--- a/scripts/migration_safety/tests/test_guard.py
+++ b/scripts/migration_safety/tests/test_guard.py
@@ -1,0 +1,114 @@
+"""Pure unit tests for scripts/migration_safety/guard.py.
+
+No database, no network, no Django. Run with:
+    python3 -m pytest scripts/migration_safety/tests/test_guard.py -v
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from guard import is_safe_dump_path, is_safe_restore_target, redact_url  # noqa: E402
+
+
+class TestIsSafeRestoreTarget:
+    def test_allows_localhost_with_isolation_marker(self):
+        ok, _ = is_safe_restore_target("postgres://morietsu@localhost:5432/jinja_migration_audit_users_temp")
+        assert ok is True
+
+    def test_allows_127_0_0_1_with_migration_safety_marker(self):
+        ok, _ = is_safe_restore_target("postgres://user:pw@127.0.0.1:5432/kami_musubi_migration_safety_20260810")
+        assert ok is True
+
+    def test_allows_restore_test_marker(self):
+        ok, _ = is_safe_restore_target("postgres://user@localhost/some_restore_test_db")
+        assert ok is True
+
+    def test_blocks_non_local_host_even_with_marker(self):
+        ok, reason = is_safe_restore_target(
+            "postgres://user:pw@db.abcdefgh.supabase.co:5432/postgres_audit_restore_test"
+        )
+        assert ok is False
+        assert "allow-list" in reason
+
+    def test_blocks_render_internal_hostname(self):
+        ok, _ = is_safe_restore_target("postgres://user:pw@dpg-abc123-a.oregon-postgres.render.com/audit_restore_test")
+        assert ok is False
+
+    def test_blocks_protected_existing_dev_db_jinja_db(self):
+        ok, reason = is_safe_restore_target("postgres://morietsu@localhost:5432/jinja_db")
+        assert ok is False
+        assert "protected" in reason
+
+    def test_blocks_protected_existing_dev_db_jinja_app_dev(self):
+        ok, reason = is_safe_restore_target("postgres://morietsu@localhost:5432/jinja_app_dev")
+        assert ok is False
+        assert "protected" in reason
+
+    def test_blocks_localhost_without_isolation_marker(self):
+        ok, reason = is_safe_restore_target("postgres://morietsu@localhost:5432/some_random_db")
+        assert ok is False
+        assert "isolation marker" in reason
+
+    def test_blocks_empty_database_name(self):
+        ok, reason = is_safe_restore_target("postgres://morietsu@localhost:5432/")
+        assert ok is False
+        assert "empty" in reason
+
+    def test_blocks_postgres_default_db_even_with_marker_in_query(self):
+        # dbname is parsed from the path, not the query string — a marker
+        # tacked on as a query param must not count.
+        ok, _ = is_safe_restore_target("postgres://morietsu@localhost:5432/postgres?comment=audit_restore_test")
+        assert ok is False
+
+    def test_blocks_unparseable_url(self):
+        ok, reason = is_safe_restore_target("not a url at all ://[[[")
+        assert ok is False
+        assert reason
+
+
+class TestIsSafeDumpPath:
+    def test_blocks_path_inside_repo_root(self, tmp_path):
+        repo_root = str(tmp_path)
+        inside = os.path.join(repo_root, "docs", "audit", "dump.sql")
+        ok, reason = is_safe_dump_path(inside, repo_root)
+        assert ok is False
+        assert "inside the repository" in reason
+
+    def test_blocks_repo_root_itself(self, tmp_path):
+        ok, _ = is_safe_dump_path(str(tmp_path), str(tmp_path))
+        assert ok is False
+
+    def test_allows_path_outside_repo_root(self, tmp_path):
+        repo_root = str(tmp_path / "repo")
+        os.makedirs(repo_root, exist_ok=True)
+        outside = str(tmp_path / "elsewhere" / "dump.sql")
+        ok, reason = is_safe_dump_path(outside, repo_root)
+        assert ok is True
+        assert reason == "ok"
+
+    def test_blocks_sneaky_relative_path_that_resolves_inside_repo(self, tmp_path):
+        repo_root = str(tmp_path)
+        sneaky = os.path.join(repo_root, "..", os.path.basename(repo_root), "dump.sql")
+        ok, _ = is_safe_dump_path(sneaky, repo_root)
+        assert ok is False
+
+
+class TestRedactUrl:
+    def test_masks_user_and_password(self):
+        redacted = redact_url("postgres://myuser:supersecret@db.example.com:5432/mydb")
+        assert "supersecret" not in redacted
+        assert "myuser" not in redacted
+        assert "db.example.com" in redacted
+        assert "mydb" in redacted
+
+    def test_masks_user_only_no_password(self):
+        redacted = redact_url("postgres://myuser@localhost:5432/mydb")
+        assert "myuser" not in redacted
+        assert "localhost" in redacted
+
+    def test_leaves_url_without_credentials_unchanged_in_shape(self):
+        redacted = redact_url("postgres://localhost:5432/mydb")
+        assert "localhost" in redacted
+        assert "mydb" in redacted


### PR DESCRIPTION
## Summary
- 今後のmigration(`users 0006`・`temples 0090-0093`および将来のmigration一般)を安全に適用・復旧できるread-onlyツール群を`scripts/migration_safety/`へ追加
- `guard.py`: allow-list方式のsafety guard(deny-listではない — 本セッションはProductionの実hostnameを知らないため、deny-listは構造的に不完全になる)。restore先はlocalhost/127.0.0.1かつisolation marker付きDB名のみ許可、既存local dev DBは保護、dump出力先はrepo外のみ許可
- `dump_readonly.sh`/`restore_isolated.sh`: 明示的に渡されたURLのみを操作。デフォルト接続先なし、Production操作を自動実行しない
- `sql/`: migration state・pre/post migration snapshotのSELECT-onlyクエリ
- `tests/test_guard.py`: guard.pyの単体テスト18件、すべてpass(DB不要)
- `tests/test_backup_restore_e2e.sh`: ローカル隔離DBのみを使うend-to-endテスト。`users=0005`/`temples=0089`相当のsource DBを構築→dump→別の隔離DBへrestore→一致確認→restoreされたコピーにのみ`users 0006`+`temples 0090-0093`を適用→検証→rollback、まで実行しPASS。**Productionには一切接続していない**
- テスト実行中に実際の不具合3件を発見・修正(pg_dumpallのserver version mismatch、`CREATE SCHEMA public`衝突、PostGIS/pg_trgm extension未定義) — 詳細は`docs/audit/migration-safety-tooling.md`

## Test plan
- [x] `git diff --check`
- [x] `backend/.venv/bin/python3 -m pytest scripts/migration_safety/tests/test_guard.py -v` — 18 passed
- [x] `scripts/migration_safety/tests/test_backup_restore_e2e.sh` — PASS (ローカル隔離DBのみ、Production未接続)
- [x] `shellcheck` — 新規shell script 3件、warning/error なし
- [x] `ruff check` — 新規Python 2件、All checks passed
- [x] pre-push hook: OpenAPI lint pass
- [x] pre-push hook: Web契約テスト 731 passed
- [x] Production migrate/restore/DB write/Environment変更は一切実施していない
- [x] Production操作を自動実行するコードは含まれない(全script、デフォルト接続先なし、CI testpathsにも含まれない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)