### PR TITLE
feat: Production read-only credential bridgeを追加(CREDENTIAL_BRIDGE_BLOCKED_LOCAL_SETUP_REQUIRED)

### DIFF
--- a/docs/audit/production-readonly-credential-bridge.md
+++ b/docs/audit/production-readonly-credential-bridge.md
@@ -1,0 +1,307 @@
+> **Status: Bridge mechanism implemented, tested locally, and ready.
+> Classification: `CREDENTIAL_BRIDGE_BLOCKED_LOCAL_SETUP_REQUIRED`**
+>
+> Production DBへは一切接続していない。credential値は本ドキュメント・
+> commit・PR・consoleのいずれにも一切記載していない。Production
+> migrate/restore/DB write/Environment変更はいずれも行っていない。
+
+# Production Readonly Credential Bridge — Read-only Access Path Audit
+
+## Phase 0 — Base State
+
+| 項目 | 結果 |
+|---|---|
+| develop checkout | 完了（既に`develop`ブランチ） |
+| `git fetch` + `git merge --ff-only origin/develop` | 完了（実行時点で既にup to date） |
+| working tree | clean |
+| develop HEAD SHA | `85562497...`（指示値と完全一致、変化なし） |
+| `docs/audit/real-production-backup-restore-gate.md`反映確認 | 確認済み |
+
+---
+
+## Phase 1 — Existing Secret Handling Audit（存在確認のみ、値は出力せず）
+
+| 確認対象 | 結果 |
+|---|---|
+| `DATABASE_URL_SET_IN_SHELL_ENV` | `0` |
+| `SUPABASE_DB_URL_SET_IN_SHELL_ENV` | `0` |
+| `PRODUCTION_DATABASE_URL_SET_IN_SHELL_ENV` | `0` |
+| `.gitignore`の`.env`系カバレッジ | `.env`/`.env.*`/`.envrc`/`backend/.env`/`backend/.env.*`/`.env*.local`をカバー済み（`!.env.example`で明示的にexampleのみ許可） |
+| `backend/shrine_project/settings.py`の`DATABASE_URL`利用箇所 | `os.getenv("DATABASE_URL")`で読み取り、`dj_database_url.parse()`へ渡す構造のみ確認（値は見ていない） |
+| `scripts/migration_safety/README.md`の既存記述 | Manual Backup Routeが「Export it into your own shell」と書かれていたが、**AI駆動セッションではこの前提が成立しないことが判明**（後述Phase 2） |
+
+---
+
+## Phase 2 — Credential Storage候補比較・実測
+
+### 重要な実測結果: shell state is NOT persisted between Bash calls
+
+Candidate A（shell session env var）を評価する前提として、実際に
+検証した:
+
+```bash
+# 1回目のBash呼び出し
+export TEST_PERSISTENCE_CHECK_VAR="hello"
+```
+```bash
+# 2回目の別Bash呼び出し
+echo "TEST_PERSISTENCE_CHECK_VAR is set: $([ -n "${TEST_PERSISTENCE_CHECK_VAR:-}" ] && echo yes || echo no)"
+# => "TEST_PERSISTENCE_CHECK_VAR is set: no"
+```
+
+**結果: 1回目のBash呼び出しで`export`した変数は、2回目の呼び出しには
+一切引き継がれない。** これはAIエージェント（Claude Code/Codex）が
+個々のshellコマンドを独立プロセスとして実行するためである。したがって
+「ユーザーのshellでexportしてもらう」という素朴なCandidate Aの想定は、
+**AI駆動セッションからは機能しない**（ユーザー自身が対話的terminalで
+手動操作する場合は別）。
+
+### 候補比較（実測を踏まえた最終評価）
+
+| 候補 | 評価 |
+|---|---|
+| A. shell session env var | **AI駆動セッションからは機能しないことを実測で確認**。ユーザー本人の対話的terminal操作でのみ有効 |
+| B. Git管理外のlocal secret file | **採用**。1回のscript呼び出し内で`source`することで、複数のBash呼び出しをまたぐ必要がなくなる。実測で動作確認済み（後述Phase 6/9） |
+| C. OS keychain / secret manager | 不採用（指示通り、新規secret platform導入は目的外） |
+
+---
+
+## Phase 3 — 推奨方式決定
+
+**Candidate B（repo外のlocal secret file）を採用した。**
+
+理由: Candidate Aが実測でAI駆動セッションから機能しないことが判明した
+ため、優先順位表の1位ではなく2位を実質的な最終候補として採用した。
+指示にある「実環境でCodexから参照不能なら、その方式は採用しない」を
+そのまま適用した結果である。
+
+---
+
+## Phase 4 — Secret Fileの安全条件（実装）
+
+採用したpath: `~/.config/kami-musubi/production-db.env`
+
+実施した内容:
+
+- [x] ディレクトリ`~/.config/kami-musubi/`を作成し、`chmod 700`
+- [x] **`production-db.env.example`（テンプレートのみ、実値なし）を配置**。
+      実際の`production-db.env`はユーザー本人がローカルで作成する
+- [x] `guard.py check-dump-path`のロジックを再利用し、このpathがrepo外
+      であることをコードで確認（`SAFE: ok`）
+- [x] スクリプト側（`check_credential_presence.sh`・`readonly_query.sh`）
+      で、対象fileのpermissionが`600`でない場合は即blockする実装
+- [x] shell historyへcredentialが残らない手順（file編集はユーザーの
+      エディタで行い、コマンドライン引数として値を渡さない）を
+      README「Credential Bridge」節に明記
+- [x] 本タスク中にsecret値をcommitしていない（`~/.config/kami-musubi/`
+      はrepo外であり、`git status`にも一切現れない。実測確認済み、
+      Phase 9参照）
+
+---
+
+## Phase 5 — Credential Presence Guard（実装・テスト済み）
+
+`scripts/migration_safety/check_credential_presence.sh`を新規実装した。
+
+許可される確認のみ実施:
+- env varがsetか（`VAR_SET=0/1`）
+- URL schemeがpostgres/postgresqlか（`scheme_is_postgres: bool`）
+- hostnameは一切ログへ出さず、`has_host: bool`のみ
+
+`guard.py`に`describe_url_shape()`を追加し、返す情報を**構造的boolean
+のみ**に限定した（`parses`/`scheme_is_postgres`/`has_host`/`has_port`/
+`has_dbname`/`has_userinfo`）。**credential長（文字数）を含む数値は
+一切返さない・出力しない**（指示のcredential長非表示ルールを反映）。
+
+禁止事項の遵守:
+- `echo $PRODUCTION_DATABASE_URL`相当の操作: 一切行っていない
+- `env | grep DATABASE`相当: 一切行っていない
+- `printenv`でsecret値を出す: 一切行っていない
+- `set -x`/`bash -x`: 全scriptで未使用（`set -euo pipefail`のみ）
+- exception traceでURLを出す: `describe_url_shape()`は例外時も入力値を
+  メッセージに含めない設計（`urlparse`が`ValueError`を出しても
+  `{"parses": False}`を返すのみ）
+
+---
+
+## Phase 6 — Read-only Connection Method（実装・実測済み、ローカルのみ）
+
+`scripts/migration_safety/readonly_query.sh`を新規実装した。
+
+**Production URLをcommand lineへ平文で直接書かない設計**: `guard.py`に
+`pg_env_exports()`を追加し、URIを`PGHOST`/`PGPORT`/`PGUSER`/
+`PGPASSWORD`/`PGDATABASE`/`PGSSLMODE`へ分解し、`eval`経由でsubshell内
+だけにexportする。`psql`はconnection stringを一切argvへ渡さずに起動
+される（libpqが`PG*`環境変数を自動参照する標準機構を利用）。これにより
+`ps`コマンドでの一時的な露出リスクも回避している。
+
+**実測（fake local credentialのみ使用、Productionへは未接続）**:
+
+```
+$ scripts/migration_safety/readonly_query.sh <cred-file> TEST_DATABASE_URL select.sql
+SAFE: ok
+[readonly_query] SQL passed the read-only check. Connecting...
+ ok
+----
+  1
+(1 行)
+[readonly_query] done.
+```
+
+`SELECT 1;`が実際に実行され、結果が返ることを確認した。使用した
+credentialはlocalhost上のfake test値であり、Productionではない。
+
+`SHOW transaction_read_only;`相当の追加確認は、指示通り「実行する
+SQLをSELECT-onlyに限定することでも安全性を担保する」方針のため、
+本bridgeでは必須ステップとせず、Phase 7のSQL allow-list側で担保する
+設計とした。
+
+---
+
+## Phase 7 — Read-only SQL Safety Rules（実装・テスト済み）
+
+`guard.py`に`is_readonly_sql()`を追加した。
+
+許可: `SELECT`/`SHOW`/`EXPLAIN`（`ANALYZE`なし）/`WITH`（CTE）
+拒否: `INSERT`/`UPDATE`/`DELETE`/`MERGE`/`ALTER`/`CREATE`/`DROP`/
+`TRUNCATE`/`GRANT`/`REVOKE`/`VACUUM`/`ANALYZE`/`CALL`/`DO`/`COPY`他
+
+実装方式: SQLをセミコロンで文単位に分割し、各文の先頭keywordが
+許可listに含まれるかを判定する。**「実行するSQLをSELECT-onlyに限定する
+運用」を、`readonly_query.sh`が接続する前に必ず通過する強制チェックと
+して実装した**（Phase 6のコード参照）。
+
+`readonly_query.sh`はこのチェックをcredentialに触れる**前**に実行する
+ため、SQLが1文でも許可listから外れていれば、credentialは一切
+sourceされない。実測で確認済み（Phase 9のE2Eテスト参照）。
+
+`sql/migration_state.sql`・`sql/pre_migration_snapshot.sql`・
+`sql/post_migration_verification.sql`（既存3ファイル）はすべてこの
+チェックを`SAFE: ok`で通過することを確認した。
+
+---
+
+## Phase 8 — Production Identity Confirmation（未実施: ローカル設定待ち）
+
+`~/.config/kami-musubi/production-db.env`（実credential）は**まだ
+存在しない**（テンプレート`.example`のみ配置済み）。
+
+```
+$ scripts/migration_safety/check_credential_presence.sh ~/.config/kami-musubi/production-db.env DATABASE_URL
+VAR_SET=0
+[check_credential_presence] no credential file at that path yet — this is expected before local setup is complete
+```
+
+**したがって、Production identity確認（`current_database()`/
+`current_user`/`version()`）・Production migration state確認
+（`users=0005`/`temples=0089`）のいずれも、本セッションではまだ
+実行できない。** これはbridge機構自体の欠陥ではなく、ユーザー側の
+一度きりのローカル設定（`production-db.env.example`をコピーして
+実値を入れ、`chmod 600`する）が未完了であることによる。
+
+---
+
+## Phase 9 — Credential Leakage Audit
+
+| 確認項目 | 結果 |
+|---|---|
+| `git status --short` | 新規/変更ファイルのみ表示（後述Repository Changes参照）。credential値・実file自体は一切現れない |
+| `git grep -n "postgresql://"`（構造的pattern確認のみ、実credential検索ではない） | 既存の`.env.example`（無関係、pre-existing）のみヒット。新規追加コード内はtest fixture値（`myuser:supersecret@db.example.com`等、明らかなdummy値）のみ |
+| `~/.config/kami-musubi/`のgit追跡確認 | `git status`実行時に`fatal: outside repository`となり、そもそもrepoの管理対象になり得ないことを確認 |
+| test log / CI config | 新規テスト（`test_credential_bridge_e2e.sh`）はfake local credentialのみ使用し、出力にもcredential値は一切含まれないことを目視確認済み |
+
+**End-to-endでの動作確認（fake local credentialのみ、Production未接続）**:
+`scripts/migration_safety/tests/test_credential_bridge_e2e.sh`を新規実装し、
+以下すべてがPASSすることを実測した:
+
+1. presence checkがhostを含まずVAR_SET=1を報告
+2. 存在しないcredential fileに対しVAR_SET=0を報告（エラー扱いにしない）
+3. repo内pathのcredential fileをpresence check・readonly_query.sh
+   いずれも拒否
+4. `SELECT 1;`が実際に接続・実行され結果を返す
+5. `migration_state.sql`相当の複数文read-only queryが成功
+6. `DELETE FROM auth_user;`がcredentialに触れる前に拒否される
+7. `EXPLAIN ANALYZE SELECT 1;`が拒否される
+8. permission`644`のcredential fileが拒否される
+
+---
+
+## Phase 10 — Bridge Classification
+
+**`CREDENTIAL_BRIDGE_BLOCKED_LOCAL_SETUP_REQUIRED`**
+
+（`PRODUCTION_READONLY_CREDENTIAL_BRIDGE_READY`ではない。`CREDENTIAL_BRIDGE_UNSAFE`でもない）
+
+理由: bridge機構自体は実装・ローカルE2Eテストで動作確認済みであり、
+「Git/ログへ露出する方法しか使えない」状態（`UNSAFE`）ではない。
+一方で、実Production credentialがまだユーザー側で設定されていない
+ため、Production接続を伴うPhase 8以降は未実施のままである。これは
+`READY`（即座にProduction接続可能）でも`UNSAFE`（安全な手段がない）
+でもなく、**ユーザー側の一度きりのローカル設定を待っている**状態
+であるため、この分類とした。
+
+---
+
+## Stop Conditions（該当確認）
+
+- [ ] credentialをユーザーへチャットで要求する必要がある → 非該当（要求していない。ユーザーが自発的に設定する前提の仕組みのみ提供した）
+- [ ] secretをechoする必要がある → 非該当
+- [ ] repo内へsecret fileを置く必要がある → 非該当（`~/.config/kami-musubi/`はrepo外）
+- [ ] Productionへwriteが必要 → 非該当
+- [ ] Production migrationが必要 → 非該当
+- [ ] Production restoreが必要 → 非該当
+- [ ] connection methodがsecretをログに出す → 非該当（Phase 5-7で実装・確認済み）
+- [ ] Codexから安全にcredentialを参照できない → **一部該当**。Candidate A（shell env var）は不可と実測確定。Candidate B（file）は実装・動作確認済みで可能
+- [ ] Production migration stateが変わっている → 未評価（Production未接続のため確認不能）
+
+---
+
+## 絶対禁止の遵守確認
+
+- [x] Production migrate禁止（遵守）
+- [x] Production restore禁止（遵守）
+- [x] Production DB write禁止（遵守、接続自体していない）
+- [x] Environment変更禁止（遵守）
+- [x] Render env変更禁止（遵守）
+- [x] Supabase env変更禁止（遵守）
+- [x] credential commit禁止（遵守。テンプレートのみ配置、実値は一切扱っていない）
+- [x] credential PR掲載禁止（遵守）
+- [x] credential docs掲載禁止（遵守。本ドキュメントに実credential値・host名・ユーザー名等は一切記載していない）
+- [x] credential console表示禁止（遵守。全script実行ログを確認したが、値の露出はなし）
+- [x] Production signup禁止（遵守）
+- [x] Batch 8開始禁止（遵守）
+- [x] PR merge禁止（本監査ではPR作成のみ行い、mergeはしない）
+
+---
+
+## Mother Shipへの最終報告
+
+1. **develop SHA**: `85562497`（変化なし）
+2. **採用credential bridge方式**: Candidate B（repo外local secret file、`~/.config/kami-musubi/production-db.env`）。Candidate A（shell env var）はAI駆動セッションから機能しないことを実測で確認したため不採用
+3. **secret保存場所のカテゴリ**: リポジトリ外のユーザーホームディレクトリ配下（`~/.config/`）、permission 600必須
+4. **credential値を表示していないこと**: 確認済み（Phase 5・9）
+5. **Git管理外確認**: 確認済み（`git status`が`fatal: outside repository`を返す、Phase 9）
+6. **Codexから参照成功/失敗**: **成功**（fake local credentialでのend-to-endテストで実証。実Production credentialではまだ未実施）
+7. **SELECT-only接続成功/失敗**: **local fake credentialでは成功**。**Production credentialではまだ未実施**（ユーザー側のローカル設定待ち）
+8. **Production users latest**: 未取得（Production未接続）
+9. **Production temples latest**: 未取得（Production未接続）
+10. **leakage audit結果**: 問題なし（Phase 9）
+11. **classification**: `CREDENTIAL_BRIDGE_BLOCKED_LOCAL_SETUP_REQUIRED`
+12. **Real Production Backup Gate再開可否**: ユーザーが`~/.config/kami-musubi/production-db.env.example`をコピーして実値を設定し`chmod 600`した後、再開可能。設定完了後は`scripts/migration_safety/check_credential_presence.sh`で存在確認してから`docs/audit/real-production-backup-restore-gate.md`のPhase 4以降を再開できる
+13. **remaining risks**: (a) bridge機構自体はローカルでのみ検証済みで、実Production環境（実際のSupabase接続文字列の形式・SSL要件等）との相性は未確認。(b) `roles.sql`のbest-effort restore同様、想定外のURL形式（例: Supabase特有のconnection pooling URL）が来た場合の`pg_env_exports()`の挙動は未検証
+14. **PR番号**: 本セクションはPR作成後に更新する
+15. **CI状態**: 本セクションはCI確認後に更新する
+
+credential値は上記のいずれにも含まれていない。
+
+## Repository Changes
+
+- `scripts/migration_safety/guard.py`: `describe_url_shape()`・`is_readonly_sql()`・`pg_env_exports()`とそのCLIサブコマンドを追加
+- `scripts/migration_safety/check_credential_presence.sh`: 新規
+- `scripts/migration_safety/readonly_query.sh`: 新規
+- `scripts/migration_safety/tests/test_guard.py`: 新規関数のunit test 29件を追加（18件→47件）
+- `scripts/migration_safety/tests/test_credential_bridge_e2e.sh`: 新規（fake local credentialのみ使用）
+- `scripts/migration_safety/README.md`: 「Credential Bridge」節を新規追加、Manual Backup Route手順を更新
+- `docs/audit/production-readonly-credential-bridge.md`: 本ドキュメント（新規）
+- リポジトリ外: `~/.config/kami-musubi/production-db.env.example`（テンプレートのみ、実値なし。リポジトリの一部ではないためgit管理外）
+- 既存の`dump_readonly.sh`/`restore_isolated.sh`本体のロジックへの変更: なし

--- a/scripts/migration_safety/README.md
+++ b/scripts/migration_safety/README.md
@@ -21,14 +21,17 @@ Background reading (read in this order):
 
 | File | Purpose |
 |---|---|
-| `guard.py` | Pure-Python safety guard. Allow-list (not deny-list) check for restore targets; repo-boundary check for dump output paths; credential redaction for logging. No DB/network code. |
+| `guard.py` | Pure-Python safety guard. Allow-list (not deny-list) check for restore targets; repo-boundary check for dump/credential-file paths; credential redaction and structural-shape-only description for logging; read-only SQL statement allow-list; URI → `PG*` env-var export so a credential never needs to appear on a command line. No DB/network code. |
+| `check_credential_presence.sh` | Reports whether a credential file/variable is set and well-formed — booleans only, never the value, host, or length. |
+| `readonly_query.sh` | Runs a SQL file against a database using a credential file outside the repo, after checking every statement is read-only. Connects via `PG*` env vars so the credential never appears in `ps`. See "Credential Bridge" below. |
 | `dump_readonly.sh` | Read-only logical dump (`pg_dumpall --roles-only` + `pg_dump --schema-only` + `pg_dump --data-only`, `public` schema only) of a URL you pass explicitly. |
 | `restore_isolated.sh` | Restores a dump into a target URL, but only after `guard.py` confirms the target is a disposable local database. Refuses otherwise. |
 | `sql/migration_state.sql` | SELECT-only. Per-app latest applied migration. |
 | `sql/pre_migration_snapshot.sql` | SELECT-only. Run immediately before a backup/migration attempt; records the baseline to compare against later. |
 | `sql/post_migration_verification.sql` | SELECT-only. Run after migration; every value must match the pre-migration snapshot except the two migrations you intentionally applied. |
-| `tests/test_guard.py` | Unit tests for `guard.py`. No DB required. |
+| `tests/test_guard.py` | Unit tests for `guard.py`, including the credential-bridge functions (`describe_url_shape`, `is_readonly_sql`, `pg_env_exports`). No DB required. |
 | `tests/test_backup_restore_e2e.sh` | End-to-end local test: builds a `users=0005`/`temples=0089` local database, dumps it, restores it into a second isolated database through the actual guarded scripts, verifies they match, applies `users 0006` + `temples 0090-0093` to the restored copy, verifies again, rolls back. Never touches Production. |
+| `tests/test_credential_bridge_e2e.sh` | End-to-end local test of the credential bridge using a fake local credential (never Production): presence check leaks nothing, a read-only query actually connects, writes/`EXPLAIN ANALYZE`/wrong-permissions/in-repo-path are all refused pre-connection. |
 
 ## The core safety property
 
@@ -52,6 +55,56 @@ The dump-path check works the other way: a dump's *output path* must
 resolve outside the git repository, so a Production dump can never end up
 staged for commit.
 
+## Credential Bridge
+
+**Problem:** an AI assistant (Claude Code / Codex) driving this tooling
+runs each shell command as a *separate* process — `export FOO=bar` in one
+command does not carry over to the next one (verified empirically: it
+doesn't). So "export the credential in your shell" doesn't actually work
+for AI-assisted runs the way it would in a human's interactive terminal.
+The fix used here is a credential **file** that gets sourced fresh inside
+a single script invocation, never split across multiple commands.
+
+**Setup (you do this yourself, once, locally):**
+
+```bash
+mkdir -p ~/.config/kami-musubi
+cp ~/.config/kami-musubi/production-db.env.example ~/.config/kami-musubi/production-db.env
+# edit production-db.env yourself — fill in the real value.
+# Never paste it into a chat with an AI assistant. Never commit it.
+chmod 600 ~/.config/kami-musubi/production-db.env
+```
+
+The file just needs one line: `export DATABASE_URL="postgres://..."` (or
+whatever variable name you choose — you pass the name explicitly to every
+script that uses it, nothing is assumed).
+
+**How an AI session uses it without ever seeing the value:**
+
+```bash
+# Presence check — prints only booleans (VAR_SET, scheme_is_postgres,
+# has_host, has_port, has_dbname, has_userinfo). No host, no length, no value.
+scripts/migration_safety/check_credential_presence.sh ~/.config/kami-musubi/production-db.env DATABASE_URL
+
+# Read-only query — refuses to run anything but SELECT/SHOW/EXPLAIN(no
+# ANALYZE)/WITH, checked BEFORE the credential is ever touched. Connects
+# via PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE/PGSSLMODE (parsed from
+# the URI internally) so the credential never appears in `ps` output —
+# psql is invoked with no connection string on its command line at all.
+scripts/migration_safety/readonly_query.sh ~/.config/kami-musubi/production-db.env DATABASE_URL scripts/migration_safety/sql/migration_state.sql
+```
+
+Both scripts refuse to run if the credential file is inside this
+repository, or if its permissions aren't exactly `600`.
+
+**What this bridge does NOT do:** it doesn't stop a human from misusing
+`psql` directly with the same file, and it doesn't encrypt the file at
+rest (ordinary filesystem permissions only — adequate for a single-user
+laptop, not a shared machine). It also can't verify the connection string
+you put in the file is actually read-only at the database-role level;
+read-only-ness is enforced at the SQL-statement layer by
+`readonly_query.sh`'s allow-list, not by trusting the role's grants.
+
 ## Running the tests
 
 ```bash
@@ -61,13 +114,17 @@ backend/.venv/bin/python3 -m pytest scripts/migration_safety/tests/test_guard.py
 # End-to-end local drill (needs local PostgreSQL with postgis available,
 # ~1-2 minutes — it replays temples migrations 0001-0093):
 scripts/migration_safety/tests/test_backup_restore_e2e.sh
+
+# Credential bridge end-to-end drill (seconds, uses a fake local
+# credential — never Production):
+scripts/migration_safety/tests/test_credential_bridge_e2e.sh
 ```
 
-Both are safe to run repeatedly and clean up everything they create
-(`test_backup_restore_e2e.sh` uses a `trap ... EXIT` that drops its temp
-databases and dump directory even on failure).
+All three are safe to run repeatedly and clean up everything they create
+(both `_e2e.sh` tests use a `trap ... EXIT` that removes temp databases/
+files even on failure).
 
-Neither test is wired into any CI workflow's `testpaths`
+None of these are wired into any CI workflow's `testpaths`
 (`backend/pytest.ini` only scopes `temples/tests`, `users/tests`,
 `tests`) — they are standalone tooling, run manually. Wiring the unit
 tests into CI would be a reasonable follow-up but is out of scope here
@@ -75,9 +132,10 @@ and wasn't requested.
 
 ## Runbook: Manual Backup Route (Phase 1)
 
-1. Obtain a read-only-capable Production connection string. **Never paste
-   it into chat with an AI assistant; never commit it.** Export it into
-   your own shell as `SOURCE_DATABASE_URL`.
+1. Obtain a read-only-capable Production connection string and set up the
+   Credential Bridge above (`~/.config/kami-musubi/production-db.env`,
+   `chmod 600`). **Never paste it into chat with an AI assistant; never
+   commit it.**
 2. Confirm your local `pg_dump`/`pg_dumpall` major version matches
    Production's Postgres version (check via Supabase Dashboard → Database
    settings, or `SELECT version();`). If they don't match, set
@@ -87,10 +145,22 @@ and wasn't requested.
    during development of this tooling, see `dump_readonly.sh` comments.
 3. Pick an output directory **outside this repository**, e.g.
    `~/kami-musubi-backups/$(date +%Y%m%d%H%M%S)/`.
-4. Run:
+4. Run, sourcing the credential file and invoking `dump_readonly.sh` in
+   the *same* command (an AI-driven session can't rely on a separate
+   `export` step persisting — see "Credential Bridge" above; a human
+   typing this directly in their own terminal could instead just
+   `export`/run interactively, but the one-liner below works either way):
    ```bash
-   scripts/migration_safety/dump_readonly.sh "$SOURCE_DATABASE_URL" ~/kami-musubi-backups/<timestamp>/
+   ( set -a; source ~/.config/kami-musubi/production-db.env; set +a; \
+     scripts/migration_safety/dump_readonly.sh "$DATABASE_URL" ~/kami-musubi-backups/<timestamp>/ )
    ```
+   Note `dump_readonly.sh` itself still receives the resolved connection
+   string as an argument (unlike `readonly_query.sh`, it wraps `pg_dump`/
+   `pg_dumpall` directly rather than going through the `PG*` env-var
+   indirection) — this is pre-existing behavior from when the tool was
+   first built and wasn't changed here. It's a strictly read-only dump
+   either way; the credential just briefly appears in that one command's
+   argv on your own machine while it runs.
 5. Confirm all three files (`roles.sql`, `schema.sql`, `data.sql`) exist
    and have non-zero size (the script prints sizes; it also warns on any
    zero-byte file).

--- a/scripts/migration_safety/check_credential_presence.sh
+++ b/scripts/migration_safety/check_credential_presence.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Check whether a Production credential is present and well-formed, WITHOUT
+# ever printing its value, length, host, or any other identifying substring.
+#
+# Usage:
+#   scripts/migration_safety/check_credential_presence.sh <CREDENTIAL_FILE> <VAR_NAME>
+#
+# CREDENTIAL_FILE: a shell-sourceable file (e.g. `export DATABASE_URL="..."`)
+#   living OUTSIDE this repository. Never create this file with a real value
+#   from this tooling — a human sets it up once, locally. See README.md.
+# VAR_NAME: the variable name inside that file to check, e.g. DATABASE_URL.
+#
+# Prints only: VAR_SET=0|1, and if set, a dict of structural booleans
+# (scheme_is_postgres, has_host, has_port, has_dbname, has_userinfo).
+# Never echoes the file, never uses `set -x`, never greps for the value.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ $# -ne 2 ]; then
+  echo "[check_credential_presence] usage: $0 <CREDENTIAL_FILE> <VAR_NAME>" >&2
+  exit 2
+fi
+
+CRED_FILE="$1"
+VAR_NAME="$2"
+
+if ! python3 "${SCRIPT_DIR}/guard.py" check-dump-path "${CRED_FILE}" "${REPO_ROOT}" 2>/dev/null; then
+  echo "[check_credential_presence] BLOCKED: credential file must be outside the repository." >&2
+  exit 1
+fi
+
+if [ ! -f "${CRED_FILE}" ]; then
+  echo "VAR_SET=0"
+  echo "[check_credential_presence] no credential file at that path yet — this is expected before local setup is complete" >&2
+  exit 0
+fi
+
+PERMS="$(stat -f '%OLp' "${CRED_FILE}" 2>/dev/null || stat -c '%a' "${CRED_FILE}" 2>/dev/null)"
+if [ "${PERMS}" != "600" ]; then
+  echo "[check_credential_presence] BLOCKED: file permissions are ${PERMS}, expected 600 (owner read/write only). Run: chmod 600 ${CRED_FILE}" >&2
+  exit 1
+fi
+
+# Source in a throwaway subshell so nothing leaks into this script's own
+# environment beyond the single value we need, and that value never
+# touches argv or stdout directly — only guard.py's boolean-only output does.
+SHAPE_OUTPUT="$(
+  bash -c "
+    set -a
+    # shellcheck disable=SC1090
+    source '${CRED_FILE}'
+    set +a
+    printf '%s' \"\${${VAR_NAME}:-}\"
+  " | python3 "${SCRIPT_DIR}/guard.py" describe-url-shape
+)"
+
+VAR_IS_SET="$(bash -c "
+  set -a
+  # shellcheck disable=SC1090
+  source '${CRED_FILE}'
+  set +a
+  [ -n \"\${${VAR_NAME}:-}\" ] && echo 1 || echo 0
+")"
+
+echo "VAR_SET=${VAR_IS_SET}"
+if [ "${VAR_IS_SET}" = "1" ]; then
+  echo "SHAPE=${SHAPE_OUTPUT}"
+fi

--- a/scripts/migration_safety/guard.py
+++ b/scripts/migration_safety/guard.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 import argparse
 import os
 import re
+import shlex
 import sys
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 # Only these hosts are ever treated as "local" for restore purposes.
 ALLOWED_RESTORE_HOSTS = {"localhost", "127.0.0.1", "::1"}
@@ -88,7 +89,12 @@ def is_safe_restore_target(database_url: str) -> tuple[bool, str]:
 
 
 def is_safe_dump_path(path: str, repo_root: str) -> tuple[bool, str]:
-    """Return (ok, reason). ok is True only if `path` is outside `repo_root`."""
+    """Return (ok, reason). ok is True only if `path` is outside `repo_root`.
+
+    Also used to gate credential *files* (not just dump output) — the same
+    "must not be inside this repository" property is what matters in both
+    cases, so the check is reused rather than duplicated.
+    """
     abs_path = os.path.realpath(path)
     abs_repo_root = os.path.realpath(repo_root)
 
@@ -96,6 +102,100 @@ def is_safe_dump_path(path: str, repo_root: str) -> tuple[bool, str]:
         return False, f"{abs_path} is inside the repository ({abs_repo_root}); refusing to write a dump there"
 
     return True, "ok"
+
+
+def describe_url_shape(database_url: str) -> dict:
+    """Return only structural booleans about a URL — never the value, its
+    length, or any substring (including hostname). Safe to print/log.
+    """
+    try:
+        parsed = urlparse(database_url)
+    except ValueError:
+        return {"parses": False}
+
+    return {
+        "parses": True,
+        "scheme_is_postgres": parsed.scheme in ("postgres", "postgresql"),
+        "has_host": bool(parsed.hostname),
+        "has_port": parsed.port is not None,
+        "has_dbname": bool((parsed.path or "").lstrip("/")),
+        "has_userinfo": bool(parsed.username),
+    }
+
+
+# Statement-start keywords this bridge will ever execute. Anything else is
+# refused. This is a simple lexical check (split on ';', look at the first
+# word), not a real SQL parser — it is deliberately conservative: anything
+# it can't confidently classify as read-only is rejected, not allowed.
+_ALLOWED_SQL_VERBS = {"select", "show", "explain", "with"}
+
+# Explicit deny-list kept too, purely so a caller gets a clear reason
+# ("this is a write verb") instead of a generic "not in the allow-list"
+# message when someone tries something obviously unsafe.
+_FORBIDDEN_SQL_VERBS = {
+    "insert", "update", "delete", "merge", "alter", "create", "drop",
+    "truncate", "grant", "revoke", "vacuum", "analyze", "call", "do",
+    "copy", "refresh", "reindex", "cluster", "lock", "comment", "import",
+    "export", "listen", "notify", "unlisten", "prepare", "execute",
+    "deallocate", "checkpoint", "discard", "load", "security",
+}
+
+
+def _strip_sql_comments(sql_text: str) -> str:
+    no_line_comments = re.sub(r"--[^\n]*", "", sql_text)
+    return re.sub(r"/\*.*?\*/", "", no_line_comments, flags=re.DOTALL)
+
+
+def is_readonly_sql(sql_text: str) -> tuple[bool, str]:
+    """Return (ok, reason). ok is True only if every statement in
+    `sql_text` starts with an allowed read-only verb, and no EXPLAIN
+    statement contains ANALYZE (which actually executes the query and can
+    have side effects for non-SELECT statements).
+    """
+    cleaned = _strip_sql_comments(sql_text)
+    statements = [s.strip() for s in cleaned.split(";")]
+    statements = [s for s in statements if s]
+
+    if not statements:
+        return False, "no SQL statements found"
+
+    for stmt in statements:
+        first_word = stmt.split(None, 1)[0].lower() if stmt.split() else ""
+        if first_word in _FORBIDDEN_SQL_VERBS:
+            return False, f"statement starts with a forbidden write/DDL verb: {first_word!r}"
+        if first_word not in _ALLOWED_SQL_VERBS:
+            return False, f"statement does not start with an allowed read-only verb {sorted(_ALLOWED_SQL_VERBS)}: {first_word!r}"
+        if first_word == "explain" and re.search(r"\banalyze\b", stmt, re.IGNORECASE):
+            return False, "EXPLAIN ANALYZE actually executes the query and is not allowed; use EXPLAIN without ANALYZE"
+
+    return True, "ok"
+
+
+def pg_env_exports(database_url: str) -> str:
+    """Return shell `export` statements (PGHOST/PGPORT/PGUSER/PGPASSWORD/
+    PGDATABASE/PGSSLMODE) for `database_url`, so a caller can `eval` them
+    and then run `psql`/`pg_dump` with NO connection info on the command
+    line at all (libpq reads these automatically). Output is meant to be
+    consumed by `eval "$(...)"` only — never printed to a terminal or log,
+    since it necessarily contains the credential.
+    """
+    parsed = urlparse(database_url)
+    lines = []
+    if parsed.hostname:
+        lines.append(f"export PGHOST={shlex.quote(parsed.hostname)}")
+    if parsed.port:
+        lines.append(f"export PGPORT={shlex.quote(str(parsed.port))}")
+    if parsed.username:
+        lines.append(f"export PGUSER={shlex.quote(parsed.username)}")
+    if parsed.password:
+        lines.append(f"export PGPASSWORD={shlex.quote(parsed.password)}")
+    dbname = (parsed.path or "").lstrip("/")
+    if dbname:
+        lines.append(f"export PGDATABASE={shlex.quote(dbname)}")
+    sslmode = parse_qs(parsed.query).get("sslmode", [None])[0]
+    if sslmode:
+        lines.append(f"export PGSSLMODE={shlex.quote(sslmode)}")
+    return "\n".join(lines)
 
 
 def _cli() -> int:
@@ -112,6 +212,19 @@ def _cli() -> int:
     p_redact = sub.add_parser("redact", help="Print URL with credentials masked")
     p_redact.add_argument("database_url")
 
+    sub.add_parser(
+        "describe-url-shape",
+        help="Read a URL from stdin (never argv), print structural booleans only (no value, length, or host)",
+    )
+
+    p_sql = sub.add_parser("check-readonly-sql", help="Exit 0 if every statement in a SQL file is read-only, else 1")
+    p_sql.add_argument("sql_file")
+
+    sub.add_parser(
+        "pg-env-exports",
+        help="Read a URL from stdin (never argv), print PG* export statements (for eval only — contains the credential)",
+    )
+
     args = parser.parse_args()
 
     if args.command == "check-restore-target":
@@ -126,6 +239,23 @@ def _cli() -> int:
 
     if args.command == "redact":
         print(redact_url(args.database_url))
+        return 0
+
+    if args.command == "describe-url-shape":
+        url = sys.stdin.read().strip()
+        print(describe_url_shape(url))
+        return 0
+
+    if args.command == "check-readonly-sql":
+        with open(args.sql_file, encoding="utf-8") as f:
+            sql_text = f.read()
+        ok, reason = is_readonly_sql(sql_text)
+        print(f"{'SAFE' if ok else 'BLOCKED'}: {reason}", file=sys.stderr)
+        return 0 if ok else 1
+
+    if args.command == "pg-env-exports":
+        url = sys.stdin.read().strip()
+        print(pg_env_exports(url))
         return 0
 
     return 2

--- a/scripts/migration_safety/readonly_query.sh
+++ b/scripts/migration_safety/readonly_query.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Run a SELECT-only SQL file against a Production (or any) database using a
+# credential that lives outside this repo, WITHOUT the connection string
+# ever appearing on the command line (visible via `ps`) or in any output.
+#
+# Usage:
+#   scripts/migration_safety/readonly_query.sh <CREDENTIAL_FILE> <VAR_NAME> <SQL_FILE>
+#
+# Safety, in order:
+#   1. CREDENTIAL_FILE must be outside this repo (guard.py check-dump-path).
+#   2. CREDENTIAL_FILE must have mode 600.
+#   3. SQL_FILE is checked with guard.py check-readonly-sql BEFORE the
+#      credential is ever touched — every statement must start with
+#      SELECT/SHOW/EXPLAIN(no ANALYZE)/WITH, or this refuses to run at all.
+#   4. The credential is parsed into PGHOST/PGPORT/PGUSER/PGPASSWORD/
+#      PGDATABASE/PGSSLMODE and exported inside a subshell via `eval`
+#      (never printed — command substitution output is consumed silently).
+#      `psql` is then invoked with NO connection string argument at all,
+#      so the secret never appears in argv / `ps`.
+#   5. No `set -x`, no echo/printenv of the credential, anywhere in this
+#      script or the subshell it spawns.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ $# -ne 3 ]; then
+  echo "[readonly_query] usage: $0 <CREDENTIAL_FILE> <VAR_NAME> <SQL_FILE>" >&2
+  exit 2
+fi
+
+CRED_FILE="$1"
+VAR_NAME="$2"
+SQL_FILE="$3"
+
+PSQL_BIN="${PSQL_BIN:-psql}"
+
+if ! python3 "${SCRIPT_DIR}/guard.py" check-dump-path "${CRED_FILE}" "${REPO_ROOT}" 2>/dev/null; then
+  echo "[readonly_query] BLOCKED: credential file must be outside the repository." >&2
+  exit 1
+fi
+
+if [ ! -f "${CRED_FILE}" ]; then
+  echo "[readonly_query] BLOCKED: credential file not found at ${CRED_FILE}. See README.md for local setup." >&2
+  exit 1
+fi
+
+PERMS="$(stat -f '%OLp' "${CRED_FILE}" 2>/dev/null || stat -c '%a' "${CRED_FILE}" 2>/dev/null)"
+if [ "${PERMS}" != "600" ]; then
+  echo "[readonly_query] BLOCKED: file permissions are ${PERMS}, expected 600. Run: chmod 600 ${CRED_FILE}" >&2
+  exit 1
+fi
+
+if [ ! -f "${SQL_FILE}" ]; then
+  echo "[readonly_query] BLOCKED: SQL file not found: ${SQL_FILE}" >&2
+  exit 1
+fi
+
+if ! python3 "${SCRIPT_DIR}/guard.py" check-readonly-sql "${SQL_FILE}"; then
+  echo "[readonly_query] BLOCKED: SQL failed the read-only allow-list check (see reason above). Aborting before touching any credential." >&2
+  exit 1
+fi
+
+echo "[readonly_query] SQL passed the read-only check. Connecting..." >&2
+
+(
+  set -a
+  # shellcheck disable=SC1090
+  source "${CRED_FILE}"
+  set +a
+  URL="$(eval "printf '%s' \"\${${VAR_NAME}:-}\"")"
+  if [ -z "${URL}" ]; then
+    echo "[readonly_query] BLOCKED: ${VAR_NAME} is not set in ${CRED_FILE}" >&2
+    exit 1
+  fi
+  eval "$(printf '%s' "${URL}" | python3 "${SCRIPT_DIR}/guard.py" pg-env-exports)"
+  unset URL
+  # shellcheck disable=SC2086
+  unset ${VAR_NAME}
+  "${PSQL_BIN}" --set ON_ERROR_STOP=1 --no-psqlrc -f "${SQL_FILE}"
+)
+
+echo "[readonly_query] done." >&2

--- a/scripts/migration_safety/tests/test_credential_bridge_e2e.sh
+++ b/scripts/migration_safety/tests/test_credential_bridge_e2e.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# End-to-end local verification of the credential bridge
+# (check_credential_presence.sh / readonly_query.sh).
+#
+# Uses a FAKE credential file pointing at the local `postgres` database
+# (never Production) to prove the mechanism itself works: presence check
+# reveals no host/value, a read-only query actually connects and runs, a
+# write statement is refused before the credential is ever touched, and
+# wrong file permissions are refused. No real credential is used or
+# needed for this test.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGSAFE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TEST_DIR="$(mktemp -d /tmp/migration_safety_credtest.XXXXXX)"
+CRED_FILE="${TEST_DIR}/test-db.env"
+
+cleanup() {
+  echo "[cred-e2e] cleanup: removing ${TEST_DIR}"
+  rm -rf "${TEST_DIR}"
+}
+trap cleanup EXIT
+
+printf 'export TEST_DATABASE_URL="postgres://%s@localhost:5432/postgres"\n' "$(whoami)" > "${CRED_FILE}"
+chmod 600 "${CRED_FILE}"
+
+echo "[cred-e2e] === presence check reports VAR_SET=1 and a shape dict, nothing else ==="
+PRESENCE_OUTPUT="$("${MIGSAFE_DIR}/check_credential_presence.sh" "${CRED_FILE}" TEST_DATABASE_URL)"
+echo "${PRESENCE_OUTPUT}"
+echo "${PRESENCE_OUTPUT}" | grep -q '^VAR_SET=1$'
+echo "${PRESENCE_OUTPUT}" | grep -q 'localhost' && { echo "[cred-e2e] FAIL: presence check leaked the host" >&2; exit 1; }
+echo "[cred-e2e] PASS: presence reported, no host leaked"
+
+echo "[cred-e2e] === presence check on a non-existent file reports VAR_SET=0 (not an error) ==="
+MISSING_OUTPUT="$("${MIGSAFE_DIR}/check_credential_presence.sh" "${TEST_DIR}/does-not-exist.env" TEST_DATABASE_URL)"
+echo "${MISSING_OUTPUT}" | grep -q '^VAR_SET=0$'
+echo "[cred-e2e] PASS"
+
+echo "[cred-e2e] === presence check refuses a credential file inside the repo ==="
+if "${MIGSAFE_DIR}/check_credential_presence.sh" "${MIGSAFE_DIR}/README.md" TEST_DATABASE_URL 2>/dev/null; then
+  echo "[cred-e2e] FAIL: should have refused an in-repo path" >&2
+  exit 1
+fi
+echo "[cred-e2e] PASS: in-repo credential path refused"
+
+echo "[cred-e2e] === readonly_query.sh: SELECT succeeds and actually connects ==="
+printf 'SELECT 1 AS ok;\n' > "${TEST_DIR}/select.sql"
+OUTPUT="$("${MIGSAFE_DIR}/readonly_query.sh" "${CRED_FILE}" TEST_DATABASE_URL "${TEST_DIR}/select.sql" 2>&1)"
+echo "${OUTPUT}"
+echo "${OUTPUT}" | grep -q " ok " || { echo "[cred-e2e] FAIL: SELECT 1 did not return expected output" >&2; exit 1; }
+echo "[cred-e2e] PASS: read-only query executed successfully"
+
+echo "[cred-e2e] === readonly_query.sh: multi-statement read-only file (migration_state.sql-shaped) succeeds ==="
+printf 'SELECT current_database();\nSHOW server_version;\n' > "${TEST_DIR}/multi.sql"
+"${MIGSAFE_DIR}/readonly_query.sh" "${CRED_FILE}" TEST_DATABASE_URL "${TEST_DIR}/multi.sql" > /dev/null
+echo "[cred-e2e] PASS"
+
+echo "[cred-e2e] === readonly_query.sh: DELETE is blocked BEFORE the credential is touched ==="
+printf 'DELETE FROM auth_user;\n' > "${TEST_DIR}/bad.sql"
+if "${MIGSAFE_DIR}/readonly_query.sh" "${CRED_FILE}" TEST_DATABASE_URL "${TEST_DIR}/bad.sql" 2>/dev/null; then
+  echo "[cred-e2e] FAIL: DELETE should have been refused" >&2
+  exit 1
+fi
+echo "[cred-e2e] PASS: write statement refused pre-connection"
+
+echo "[cred-e2e] === readonly_query.sh: EXPLAIN ANALYZE is blocked ==="
+printf 'EXPLAIN ANALYZE SELECT 1;\n' > "${TEST_DIR}/explain_analyze.sql"
+if "${MIGSAFE_DIR}/readonly_query.sh" "${CRED_FILE}" TEST_DATABASE_URL "${TEST_DIR}/explain_analyze.sql" 2>/dev/null; then
+  echo "[cred-e2e] FAIL: EXPLAIN ANALYZE should have been refused" >&2
+  exit 1
+fi
+echo "[cred-e2e] PASS: EXPLAIN ANALYZE refused"
+
+echo "[cred-e2e] === readonly_query.sh: wrong permissions (644) are refused ==="
+chmod 644 "${CRED_FILE}"
+if "${MIGSAFE_DIR}/readonly_query.sh" "${CRED_FILE}" TEST_DATABASE_URL "${TEST_DIR}/select.sql" 2>/dev/null; then
+  echo "[cred-e2e] FAIL: should have refused on wrong permissions" >&2
+  exit 1
+fi
+chmod 600 "${CRED_FILE}"
+echo "[cred-e2e] PASS: wrong permissions refused"
+
+echo "[cred-e2e] === readonly_query.sh: credential file inside the repo is refused ==="
+if "${MIGSAFE_DIR}/readonly_query.sh" "${MIGSAFE_DIR}/README.md" TEST_DATABASE_URL "${TEST_DIR}/select.sql" 2>/dev/null; then
+  echo "[cred-e2e] FAIL: should have refused an in-repo credential path" >&2
+  exit 1
+fi
+echo "[cred-e2e] PASS: in-repo credential path refused"
+
+echo ""
+echo "[cred-e2e] ==================================================="
+echo "[cred-e2e] ALL CHECKS PASSED. No real credential was used; Production was never touched."
+echo "[cred-e2e] ==================================================="

--- a/scripts/migration_safety/tests/test_guard.py
+++ b/scripts/migration_safety/tests/test_guard.py
@@ -9,7 +9,14 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from guard import is_safe_dump_path, is_safe_restore_target, redact_url  # noqa: E402
+from guard import (  # noqa: E402
+    describe_url_shape,
+    is_readonly_sql,
+    is_safe_dump_path,
+    is_safe_restore_target,
+    pg_env_exports,
+    redact_url,
+)
 
 
 class TestIsSafeRestoreTarget:
@@ -112,3 +119,163 @@ class TestRedactUrl:
         redacted = redact_url("postgres://localhost:5432/mydb")
         assert "localhost" in redacted
         assert "mydb" in redacted
+
+
+class TestDescribeUrlShape:
+    def test_full_url_reports_all_true(self):
+        shape = describe_url_shape("postgres://myuser:supersecret@db.example.supabase.co:5432/postgres?sslmode=require")
+        assert shape == {
+            "parses": True,
+            "scheme_is_postgres": True,
+            "has_host": True,
+            "has_port": True,
+            "has_dbname": True,
+            "has_userinfo": True,
+        }
+
+    def test_never_contains_the_secret_or_host_substring(self):
+        url = "postgres://myuser:supersecret@db.example.supabase.co:5432/postgres"
+        shape = describe_url_shape(url)
+        rendered = str(shape)
+        assert "supersecret" not in rendered
+        assert "myuser" not in rendered
+        assert "db.example.supabase.co" not in rendered
+        assert "postgres.co" not in rendered  # no partial host leakage either
+
+    def test_never_contains_a_length_field(self):
+        shape = describe_url_shape("postgres://myuser:supersecret@db.example.supabase.co:5432/postgres")
+        assert "length" not in shape
+        assert "len" not in shape
+
+    def test_non_postgres_scheme_reported_false(self):
+        shape = describe_url_shape("mysql://user:pw@host:3306/db")
+        assert shape["scheme_is_postgres"] is False
+
+    def test_missing_dbname_reported_false(self):
+        shape = describe_url_shape("postgres://user@localhost:5432/")
+        assert shape["has_dbname"] is False
+
+    def test_no_userinfo_reported_false(self):
+        shape = describe_url_shape("postgres://localhost:5432/mydb")
+        assert shape["has_userinfo"] is False
+
+
+class TestIsReadonlySql:
+    def test_allows_plain_select(self):
+        ok, _ = is_readonly_sql("SELECT 1;")
+        assert ok is True
+
+    def test_allows_show(self):
+        ok, _ = is_readonly_sql("SHOW transaction_read_only;")
+        assert ok is True
+
+    def test_allows_with_cte_select(self):
+        ok, _ = is_readonly_sql("WITH x AS (SELECT 1) SELECT * FROM x;")
+        assert ok is True
+
+    def test_allows_explain_without_analyze(self):
+        ok, _ = is_readonly_sql("EXPLAIN SELECT * FROM django_migrations;")
+        assert ok is True
+
+    def test_allows_multiple_readonly_statements(self):
+        ok, _ = is_readonly_sql("SELECT 1;\nSHOW server_version;\n")
+        assert ok is True
+
+    def test_allows_information_schema_query(self):
+        ok, _ = is_readonly_sql("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';")
+        assert ok is True
+
+    def test_blocks_explain_analyze(self):
+        ok, reason = is_readonly_sql("EXPLAIN ANALYZE SELECT 1;")
+        assert ok is False
+        assert "ANALYZE" in reason
+
+    def test_blocks_insert(self):
+        ok, reason = is_readonly_sql("INSERT INTO foo VALUES (1);")
+        assert ok is False
+        assert "forbidden" in reason
+
+    def test_blocks_update(self):
+        ok, _ = is_readonly_sql("UPDATE foo SET x = 1;")
+        assert ok is False
+
+    def test_blocks_delete(self):
+        ok, _ = is_readonly_sql("DELETE FROM foo;")
+        assert ok is False
+
+    def test_blocks_drop(self):
+        ok, _ = is_readonly_sql("DROP TABLE foo;")
+        assert ok is False
+
+    def test_blocks_alter(self):
+        ok, _ = is_readonly_sql("ALTER TABLE foo ADD COLUMN bar int;")
+        assert ok is False
+
+    def test_blocks_truncate(self):
+        ok, _ = is_readonly_sql("TRUNCATE foo;")
+        assert ok is False
+
+    def test_blocks_second_statement_being_a_write_even_if_first_is_select(self):
+        ok, reason = is_readonly_sql("SELECT 1; DELETE FROM auth_user;")
+        assert ok is False
+        assert "delete" in reason
+
+    def test_blocks_grant_revoke_vacuum(self):
+        for verb in ("GRANT SELECT ON foo TO bar;", "REVOKE SELECT ON foo FROM bar;", "VACUUM foo;"):
+            ok, _ = is_readonly_sql(verb)
+            assert ok is False, verb
+
+    def test_ignores_sql_line_comments(self):
+        ok, _ = is_readonly_sql("-- this is a comment\nSELECT 1;")
+        assert ok is True
+
+    def test_ignores_sql_block_comments(self):
+        ok, _ = is_readonly_sql("/* block comment */ SELECT 1;")
+        assert ok is True
+
+    def test_empty_sql_is_blocked(self):
+        ok, reason = is_readonly_sql("   \n-- only a comment\n")
+        assert ok is False
+        assert "no SQL" in reason
+
+    def test_unknown_verb_blocked_not_silently_allowed(self):
+        ok, reason = is_readonly_sql("CALL some_procedure();")
+        assert ok is False
+
+
+class TestPgEnvExports:
+    def test_produces_all_expected_vars(self):
+        exports = pg_env_exports("postgres://myuser:supersecret@db.example.supabase.co:5432/postgres?sslmode=require")
+        assert "export PGHOST=db.example.supabase.co" in exports
+        assert "export PGPORT=5432" in exports
+        assert "export PGUSER=myuser" in exports
+        assert "export PGPASSWORD=supersecret" in exports
+        assert "export PGDATABASE=postgres" in exports
+        assert "export PGSSLMODE=require" in exports
+
+    def test_omits_password_var_when_absent(self):
+        exports = pg_env_exports("postgres://myuser@localhost:5432/mydb")
+        assert "PGPASSWORD" not in exports
+        assert "export PGUSER=myuser" in exports
+
+    def test_omits_sslmode_when_not_specified(self):
+        exports = pg_env_exports("postgres://myuser:pw@localhost:5432/mydb")
+        assert "PGSSLMODE" not in exports
+
+    def test_shell_quotes_special_characters_in_password(self):
+        # No '@', ':', '/', or space — those require percent-encoding in a
+        # real URI and would change how urlparse splits the netloc, which
+        # is a separate concern from what this test targets: does
+        # shlex.quote protect the shell metacharacters that ARE valid
+        # unencoded in a password (quotes, $, backticks, parens)?
+        exports = pg_env_exports("postgres://myuser:it's$(touch_pwned)`x`@localhost:5432/mydb")
+        password_line = next(line for line in exports.splitlines() if line.startswith("export PGPASSWORD="))
+        import subprocess
+
+        result = subprocess.run(
+            ["bash", "-c", f"{password_line}; printf '%s' \"$PGPASSWORD\""],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert result.stdout == "it's$(touch_pwned)`x`"


### PR DESCRIPTION
## Summary
- Phase 0-1: base state確認、既存secret handling監査(値は出力せず存在確認のみ)
- Phase 2: 重要な実測 — `export`したshell変数はBash呼び出しをまたいで引き継がれないことを確認。Candidate A(shell env var)はAI駆動セッションから機能しないため不採用、Candidate B(repo外secret file)を採用
- Phase 3-4: `~/.config/kami-musubi/production-db.env`(repo外)を採用方式として確定。`production-db.env.example`(テンプレートのみ、実値なし)を配置
- Phase 5: `check_credential_presence.sh` + `guard.py`の`describe_url_shape()`を追加。返す情報は構造的booleanのみ(host/長さを含む値は一切出力しない)
- Phase 6: `readonly_query.sh` + `guard.py`の`pg_env_exports()`を追加。URIを`PG*`環境変数へ分解しevalすることで、connection stringがpsqlのargvへ一切現れない設計
- Phase 7: `guard.py`の`is_readonly_sql()`を追加。SELECT/SHOW/EXPLAIN(no ANALYZE)/WITHのみ許可し、credentialに触れる前にSQLを検証
- Phase 8: Production credential未設定のため未実施(ユーザー側のローカル設定待ち)
- Phase 9: leakage audit — `git status`/`git grep`/repo外確認いずれも問題なし
- Phase 10 Classification: `CREDENTIAL_BRIDGE_BLOCKED_LOCAL_SETUP_REQUIRED`(機構は実装・検証済みだが実credential未設定)

## Test plan
- [x] `git diff --check`
- [x] `backend/.venv/bin/python3 -m pytest scripts/migration_safety/tests/test_guard.py -v` — 47 passed (18→47、新規29件)
- [x] `scripts/migration_safety/tests/test_backup_restore_e2e.sh` — PASS(既存機能への回帰なし)
- [x] `scripts/migration_safety/tests/test_credential_bridge_e2e.sh` — PASS(fake local credentialのみ使用、presence/read-only query/write拒否/EXPLAIN ANALYZE拒否/permission拒否/repo内path拒否をすべて実測)
- [x] `shellcheck` — 新規/既存shell script全件、warning/error なし
- [x] `ruff check` — 新規/変更Python全件、All checks passed
- [x] pre-push hook: OpenAPI lint pass
- [x] pre-push hook: Web契約テスト 731 passed
- [x] credential commit/PR掲載/docs掲載/console表示は一切なし(実値は一度もこのセッションを通過していない)
- [x] Production migrate/restore/DB write/Environment変更は一切実施していない

🤖 Generated with [Claude Code](https://claude.com/claude-code)