### PR TITLE
temples 0091をProduction schema driftでも安全に適用できるよう修正

### DIFF
--- a/backend/temples/migrations/0091_fill_missing_local_shrine_reason_facts.py
+++ b/backend/temples/migrations/0091_fill_missing_local_shrine_reason_facts.py
@@ -1,4 +1,35 @@
 from django.db import migrations
+from django.db.models import F
+
+# Only the columns this migration actually reads/writes. In particular this
+# excludes `location`: on production the column is a legacy `text` field
+# (pre-PostGIS import path), while the historical model state for this
+# migration declares it as a PostGIS `PointField`. Selecting it triggers the
+# GeometryField converter on every row fetch and raises GEOSException before
+# any row is ever touched, even though this migration never reads or writes
+# location. `.only()` keeps it out of the generated SELECT entirely.
+SHRINE_LOOKUP_FIELDS = ("id", "name_jp", "history_theme", "goriyaku", "place_ref_id", "updated_at")
+
+
+def _resolve_target_shrine(Shrine, name):
+    """Find the single canonical shrine row for `name`.
+
+    A few shrine names (including both names this migration targets) have
+    accidental duplicate rows: the original catalog row (no `place_ref_id`)
+    plus a later row created by the map "resolve"/Google Places flow (always
+    has a `place_ref_id`). `Shrine.Meta.ordering` is `-updated_at`, so a bare
+    `.first()` deterministically but silently picks the *duplicate* (more
+    recently touched) row instead of the catalog row this migration is meant
+    to enrich. Ordering explicitly by `place_ref_id IS NULL` first, then `id`,
+    selects the original catalog row when a duplicate exists, and is a no-op
+    when it doesn't (single match either way).
+    """
+    return (
+        Shrine.objects.filter(name_jp=name)
+        .only(*SHRINE_LOOKUP_FIELDS)
+        .order_by(F("place_ref_id").asc(nulls_first=True), "id")
+        .first()
+    )
 
 
 def fill_missing_local_shrine_reason_facts(apps, schema_editor):
@@ -21,7 +52,7 @@ def fill_missing_local_shrine_reason_facts(apps, schema_editor):
     ]
 
     for item in updates:
-        shrine = Shrine.objects.filter(name_jp=item["name"]).first()
+        shrine = _resolve_target_shrine(Shrine, item["name"])
         if shrine is None:
             continue
 
@@ -43,7 +74,11 @@ def reverse_fill_missing_local_shrine_reason_facts(apps, schema_editor):
 
     tags = list(GoriyakuTag.objects.filter(name__in=tag_names))
 
-    for shrine in Shrine.objects.filter(name_jp__in=names):
+    for name in names:
+        shrine = _resolve_target_shrine(Shrine, name)
+        if shrine is None:
+            continue
+
         shrine.history_theme = ""
         shrine.goriyaku = ""
         shrine.save(update_fields=["history_theme", "goriyaku", "updated_at"])
@@ -53,7 +88,6 @@ def reverse_fill_missing_local_shrine_reason_facts(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("temples", "0090_add_rest_healing_tag_to_silent_shrines"),
     ]

--- a/backend/temples/tests/test_gis_migration_0091_shrine_reason_facts.py
+++ b/backend/temples/tests/test_gis_migration_0091_shrine_reason_facts.py
@@ -1,0 +1,282 @@
+# backend/temples/tests/test_gis_migration_0091_shrine_reason_facts.py
+"""Regression tests for temples.0091_fill_missing_local_shrine_reason_facts.
+
+Production has a schema drift: the historical model state this migration's
+RunPython runs against declares `Shrine.location` as a PostGIS `PointField`,
+but the actual production column is a legacy `text` column. A bare
+`Shrine.objects.filter(...).first()` selects every column (including
+`location`), so Django's GeometryField converter tries to parse the text
+value as WKB and raises `GEOSException` before any row is touched
+(confirmed against a restored production dump; see
+docs/audit/temples-0091-production-remediation.md).
+
+Separately, two of the migration's target shrine names each have an
+accidental duplicate row in production (the original catalog row plus a
+later row created by the map "resolve"/Google Places flow, which always has
+a `place_ref_id`). `Shrine.Meta.ordering = ["-updated_at"]` means a bare
+`.first()` deterministically picks the *duplicate* row, not the catalog row
+this migration is meant to enrich.
+
+These tests only run under GIS (module-level skip below): under
+`USE_GIS=0` the `temples` app uses `temples.migrations_nogis`, a squashed
+migration set that does not contain this migration as a separate step, and
+`location` there is a genuine `TextField` with no drift to reproduce.
+"""
+
+import os
+
+import pytest
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+if os.getenv("USE_GIS") != "1":
+    pytest.skip("GIS disabled by env", allow_module_level=True)
+
+PRE_0091 = [("temples", "0090_add_rest_healing_tag_to_silent_shrines")]
+AT_0091 = [("temples", "0091_fill_missing_local_shrine_reason_facts")]
+HEAD = [("temples", "0093_shrine_knowledge_model_foundation")]
+
+NAME_A = "長太稲荷神社"
+NAME_B = "給田六所神社"
+HISTORY_THEME = "守り"
+GORIYAKU_A = "地域に根ざした稲荷社として、商売繁盛や五穀豊穣、日々の暮らしの安定を願う神社。"
+GORIYAKU_B = "地域の氏神として、暮らしや家内安全、日々の無事を見守る神社。"
+TAGS_A = ["商売繁盛", "五穀豊穣", "地域安泰"]
+TAGS_B = ["地域安泰", "家内安全"]
+
+
+def _executor() -> MigrationExecutor:
+    executor = MigrationExecutor(connection)
+    executor.loader.build_graph()
+    return executor
+
+
+def _migrate(executor: MigrationExecutor, target):
+    executor.migrate(target)
+    executor.loader.build_graph()
+
+
+@pytest.fixture
+def pre_0091():
+    """Reverse temples to 0090 (0091 unapplied) and restore the full chain afterwards."""
+    executor = _executor()
+    _migrate(executor, PRE_0091)
+    try:
+        yield executor
+    finally:
+        _migrate(executor, HEAD)
+
+
+def _historical_models(executor: MigrationExecutor):
+    state = executor.loader.project_state(PRE_0091[0])
+    Shrine = state.apps.get_model("temples", "Shrine")
+    GoriyakuTag = state.apps.get_model("temples", "GoriyakuTag")
+    PlaceRef = state.apps.get_model("temples", "PlaceRef")
+    return Shrine, GoriyakuTag, PlaceRef
+
+
+def _create_duplicate_shrine(Shrine, PlaceRef, name_jp, place_id, **extra):
+    """Create a shrine row with a resolved `place_ref`, matching how the
+    real map "resolve" flow creates duplicate rows in production (see
+    docs/audit/temples-0091-production-remediation.md, Phase 3)."""
+    place_ref = PlaceRef.objects.create(place_id=place_id, name=name_jp)
+    return Shrine.objects.create(name_jp=name_jp, kind="shrine", place_ref_id=place_ref.pk, **extra)
+
+
+def _raw_shrine_row(name_jp):
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT id, history_theme, goriyaku, updated_at FROM temples_shrine "
+            "WHERE name_jp = %s ORDER BY id",
+            [name_jp],
+        )
+        cols = [c[0] for c in cur.description]
+        return [dict(zip(cols, row, strict=True)) for row in cur.fetchall()]
+
+
+def _raw_tag_names_for_shrine(shrine_id):
+    with connection.cursor() as cur:
+        cur.execute(
+            "SELECT t.name FROM temples_shrine_goriyaku_tags gt "
+            "JOIN temples_goriyakutag t ON t.id = gt.goriyakutag_id "
+            "WHERE gt.shrine_id = %s ORDER BY t.name",
+            [shrine_id],
+        )
+        return [row[0] for row in cur.fetchall()]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_geos_exception_avoided_under_text_location_drift(pre_0091):
+    """Test A: 0091 must not raise GEOSException when the physical `location`
+    column is `text` (the confirmed production drift condition), even though
+    the historical model declares it as a PostGIS PointField."""
+    executor = pre_0091
+    Shrine, _GoriyakuTag, _PlaceRef = _historical_models(executor)
+    shrine = Shrine.objects.create(name_jp=NAME_A, kind="shrine", place_ref_id=None)
+
+    with connection.cursor() as cur:
+        # The GiST index on `location` has no default operator class for
+        # `text`, so it must be dropped before the type change (and rebuilt
+        # after) to simulate the drift without an unrelated index error.
+        cur.execute(
+            "SELECT indexname FROM pg_indexes "
+            "WHERE tablename = 'temples_shrine' AND indexdef ILIKE '%% USING gist (location)%%'"
+        )
+        gist_index_names = [row[0] for row in cur.fetchall()]
+        for index_name in gist_index_names:
+            cur.execute(f'DROP INDEX "{index_name}";')
+
+        cur.execute('ALTER TABLE temples_shrine ALTER COLUMN "location" TYPE text USING NULL;')
+        cur.execute(
+            'UPDATE temples_shrine SET "location" = %s WHERE id = %s;',
+            ["not-a-valid-wkb-value", shrine.id],
+        )
+
+    try:
+        _migrate(executor, AT_0091)
+    finally:
+        with connection.cursor() as cur:
+            cur.execute(
+                'ALTER TABLE temples_shrine ALTER COLUMN "location" TYPE geometry(Point,4326) '
+                "USING NULL;"
+            )
+            for index_name in gist_index_names:
+                cur.execute(f'CREATE INDEX "{index_name}" ON temples_shrine USING gist (location);')
+
+    rows = _raw_shrine_row(NAME_A)
+    assert len(rows) == 1
+    assert rows[0]["history_theme"] == HISTORY_THEME
+    assert rows[0]["goriyaku"] == GORIYAKU_A
+
+
+@pytest.mark.django_db(transaction=True)
+def test_b_only_canonical_duplicate_is_updated(pre_0091):
+    """Test B: when a name has a duplicate (original catalog row + later
+    place-resolved row), only the canonical (no place_ref_id) row is updated."""
+    executor = pre_0091
+    Shrine, _GoriyakuTag, PlaceRef = _historical_models(executor)
+
+    canonical = Shrine.objects.create(name_jp=NAME_A, kind="shrine", place_ref_id=None)
+    duplicate = _create_duplicate_shrine(Shrine, PlaceRef, NAME_A, "ChIJdummyplaceref0001")
+    # Duplicate is the more recently touched row, matching the real production
+    # pattern (resolve-created rows are newer) and proving `.first()`'s
+    # implicit `-updated_at` ordering is not what selects the target.
+    Shrine.objects.filter(pk=duplicate.pk).update(name_jp=NAME_A)
+
+    _migrate(executor, AT_0091)
+
+    canonical.refresh_from_db()
+    duplicate.refresh_from_db()
+
+    assert canonical.history_theme == HISTORY_THEME
+    assert canonical.goriyaku == GORIYAKU_A
+    assert duplicate.history_theme == ""
+    assert duplicate.goriyaku in ("", None)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_c_non_target_duplicate_left_completely_unchanged(pre_0091):
+    """Test C: the untouched duplicate keeps its original field values and
+    gets no goriyaku_tags relations, even though a tag matching its name
+    exists and would apply if it were (incorrectly) selected."""
+    executor = pre_0091
+    Shrine, GoriyakuTag, PlaceRef = _historical_models(executor)
+
+    for name in TAGS_A:
+        GoriyakuTag.objects.get_or_create(name=name)
+
+    canonical = Shrine.objects.create(name_jp=NAME_A, kind="shrine", place_ref_id=None)
+    duplicate = _create_duplicate_shrine(
+        Shrine,
+        PlaceRef,
+        NAME_A,
+        "ChIJdummyplaceref0002",
+        history_theme="",
+        goriyaku="",
+    )
+
+    _migrate(executor, AT_0091)
+
+    duplicate.refresh_from_db()
+    assert duplicate.history_theme == ""
+    assert duplicate.goriyaku in ("", None)
+    assert _raw_tag_names_for_shrine(duplicate.id) == []
+
+    canonical.refresh_from_db()
+    assert canonical.history_theme == HISTORY_THEME
+    assert sorted(_raw_tag_names_for_shrine(canonical.id)) == sorted(TAGS_A)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_d_missing_tag_is_silently_skipped_without_blocking_field_updates(pre_0091):
+    """Test D: when a requested tag ("地域安泰", matching production) does not
+    exist in GoriyakuTag, the migration must not error, must still set
+    history_theme/goriyaku, and must attach only the tags that do exist."""
+    executor = pre_0091
+    Shrine, GoriyakuTag, _PlaceRef = _historical_models(executor)
+
+    # "地域安泰" intentionally not created, matching production's confirmed gap.
+    GoriyakuTag.objects.get_or_create(name="商売繁盛")
+    GoriyakuTag.objects.get_or_create(name="五穀豊穣")
+    GoriyakuTag.objects.get_or_create(name="家内安全")
+    assert not GoriyakuTag.objects.filter(name="地域安泰").exists()
+
+    shrine_a = Shrine.objects.create(name_jp=NAME_A, kind="shrine", place_ref_id=None)
+    shrine_b = Shrine.objects.create(name_jp=NAME_B, kind="shrine", place_ref_id=None)
+
+    _migrate(executor, AT_0091)
+
+    shrine_a.refresh_from_db()
+    shrine_b.refresh_from_db()
+
+    assert shrine_a.history_theme == HISTORY_THEME
+    assert shrine_a.goriyaku == GORIYAKU_A
+    assert sorted(_raw_tag_names_for_shrine(shrine_a.id)) == ["五穀豊穣", "商売繁盛"]
+
+    assert shrine_b.history_theme == HISTORY_THEME
+    assert shrine_b.goriyaku == GORIYAKU_B
+    assert _raw_tag_names_for_shrine(shrine_b.id) == ["家内安全"]
+
+
+@pytest.mark.django_db(transaction=True)
+def test_e_reverse_migration_undoes_only_the_canonical_row(pre_0091):
+    """Test E: reversing 0091 clears history_theme/goriyaku and removes the
+    tag relations it added, again touching only the canonical row (not any
+    duplicate), and without raising GEOSException."""
+    executor = pre_0091
+    Shrine, GoriyakuTag, PlaceRef = _historical_models(executor)
+
+    for name in TAGS_A:
+        GoriyakuTag.objects.get_or_create(name=name)
+
+    canonical = Shrine.objects.create(name_jp=NAME_A, kind="shrine", place_ref_id=None)
+    duplicate = _create_duplicate_shrine(Shrine, PlaceRef, NAME_A, "ChIJdummyplaceref0003")
+
+    _migrate(executor, AT_0091)
+    canonical.refresh_from_db()
+    assert canonical.history_theme == HISTORY_THEME
+    assert sorted(_raw_tag_names_for_shrine(canonical.id)) == sorted(TAGS_A)
+
+    _migrate(executor, PRE_0091)
+
+    canonical.refresh_from_db()
+    duplicate.refresh_from_db()
+    assert canonical.history_theme == ""
+    assert canonical.goriyaku in ("", None)
+    assert _raw_tag_names_for_shrine(canonical.id) == []
+    assert duplicate.history_theme == ""
+
+
+@pytest.mark.django_db(transaction=True)
+def test_f_fresh_db_migration_chain_0090_to_0091_succeeds():
+    """Test F: on a fresh migration graph with no pre-existing shrine data
+    (nothing named 長太稲荷神社/給田六所神社 exists), 0090 -> 0091 applies and
+    reverses cleanly with exit-equivalent success (no exception raised)."""
+    executor = _executor()
+    try:
+        _migrate(executor, PRE_0091)
+        _migrate(executor, AT_0091)
+        assert _raw_shrine_row(NAME_A) == []
+        assert _raw_shrine_row(NAME_B) == []
+    finally:
+        _migrate(executor, HEAD)

--- a/docs/audit/temples-0091-production-remediation.md
+++ b/docs/audit/temples-0091-production-remediation.md
@@ -1,0 +1,382 @@
+> **Status: `TEMPLES_0091_REMEDIATION_READY`。**
+>
+> `temples 0091`（`0091_fill_missing_local_shrine_reason_facts`）のProduction
+> 実行失敗（`docs/audit/production-migration-local-execution-runbook.md`の
+> 「Execution Record — Stage 3」、`TEMPLES_0091_EXECUTION_STOP`）を受けて、
+> root cause再現・duplicate shrine identity確定・安全な修正設計・
+> regression test・Production相当restore DBでの実測を行った記録である。
+>
+> **本ドキュメント作成のセッションではProduction migrationを一切実行して
+> いない。** `temples 0091`のProduction再実行・`temples 0092`/`0093`の実行は
+> 一切行っていない。Production DBへのwriteは0件。Production retryの
+> 可否はMother Ship判断待ち。
+
+# temples 0091 Production Remediation
+
+## 1. develop SHA
+
+作業開始時点: `6e5fac58`（PR #2336 反映済み、`origin/develop`と同期済み、
+working tree clean）。
+
+---
+
+## 2. Root Cause Reproduction
+
+### 2.1 手法
+
+Production実dump（`temples 0090`適用済み・`0091`未適用の状態で、Stage 3
+実行直前に取得したfresh backup）を、ローカルの隔離されたPostgreSQL 18 +
+PostGIS 3.6インスタンスへ復元した（`createdb`で新規作成した専用DB、
+Productionへは一切接続していない）。
+
+復元後に確認したbaseline（Stage 3 Execution Recordの事前実測と完全一致）:
+
+| 項目 | 値 |
+|---|---|
+| `temples`最新migration | `0090_add_rest_healing_tag_to_silent_shrines` |
+| `users`最新migration | `0006_userprofile_birth_profile_fields` |
+| `shrine`件数 | 105 |
+| `goriyaku_relation`件数 | 280 |
+| `temples_shrine.location`列の実際の型 | `text` |
+| 対象2神社の重複 | 長太稲荷神社: id=21, id=103／給田六所神社: id=22, id=101 |
+
+### 2.2 実行結果
+
+修正前の`0091`をこの復元DBに対して実行したところ、Production記録と
+完全に同一のtraceback・同一の失敗行で`GEOSException`が再現した。
+
+```
+Applying temples.0091_fill_missing_local_shrine_reason_facts...ERROR django.contrib.gis: GEOS_ERROR:
+...
+File ".../temples/migrations/0091_fill_missing_local_shrine_reason_facts.py", line 24, in fill_missing_local_shrine_reason_facts
+    shrine = Shrine.objects.filter(name_jp=item["name"]).first()
+...
+File ".../django/contrib/gis/db/backends/postgis/operations.py", line 424, in converter
+    return None if value is None else GEOSGeometryBase(read(value), geom_class)
+...
+django.contrib.gis.geos.error.GEOSException: Error encountered checking Geometry returned from GEOS C function "GEOSWKBReader_readHEX_r".
+```
+
+`exit=1`、`django_migrations`に`0091`のレコードなし（atomic rollback）、
+`shrine`/`goriyaku_relation`件数・対象4神社の`history_theme`/`goriyaku`/
+`updated_at`いずれも実行前と完全一致——Production Stage 3の記録と
+すべて一致した。
+
+### 2.3 型不整合の直接確認
+
+`MigrationLoader.project_state(("temples", "0090_..."))`から取得した
+historical model stateで`Shrine._meta.get_field("location")`を確認したところ、
+`django.contrib.gis.db.models.fields.PointField`（PostGIS geometry field）
+であることを確認した。
+
+一方、`Shrine.objects.filter(...)`が生成する実際のSELECT文は`location`列を
+含む全カラムを取得する（`.only()`/`.defer()`未使用）:
+
+```sql
+SELECT "temples_shrine"."id", ..., "temples_shrine"."location", ...
+FROM "temples_shrine" WHERE "temples_shrine"."name_jp" = 長太稲荷神社
+ORDER BY "temples_shrine"."updated_at" DESC
+```
+
+Production実DBの`temples_shrine.location`列は実際には`text`型
+（`migrations_nogis`由来のレガシー列。`\d temples_shrine`で実測確認）。
+ORMが`location`の生値（text）をGEOS geometry objectへ変換しようとして
+`GEOSException`が発生する。
+
+### 2.4 分類
+
+**`PRODUCTION_SCHEMA_MODEL_MISMATCH_CONFIRMED`**
+
+---
+
+## 3. 0091 Intent Audit
+
+### 3.1 目的
+
+`docs/audit/reason-facts-coverage-after-classification-policy.md`
+（PR #1859より前の監査）が特定した、Recommendation Reason v4のevidenceが
+不足している実運用神社2社（長太稲荷神社・給田六所神社）に対し、
+`history_theme`・`goriyaku`・`goriyaku_tags`を補完するdata-only migration
+（PR #1859、`c5f2b3d5`、2026-07-04）。
+
+### 3.2 対象・更新内容
+
+| 神社 | history_theme | goriyaku | 追加tag候補 |
+|---|---|---|---|
+| 長太稲荷神社 | 守り | 地域に根ざした稲荷社として、商売繁盛や五穀豊穣、日々の暮らしの安定を願う神社。 | 商売繁盛・五穀豊穣・地域安泰 |
+| 給田六所神社 | 守り | 地域の氏神として、暮らしや家内安全、日々の無事を見守る神社。 | 地域安泰・家内安全 |
+
+### 3.3 missing tag時の挙動
+
+`GoriyakuTag.objects.filter(name__in=item["tags"])`で存在するtagのみを
+取得し、`if tags: shrine.goriyaku_tags.add(*tags)`——**1件も存在しなくても
+migration自体はエラーにならず、`history_theme`/`goriyaku`は無条件に
+更新される。** 一部のみ存在する場合も、存在する分だけ付与される
+（all-or-nothingではない）。Production実測では`地域安泰`tagが存在しない
+ことを確認済み（Stage 3事前調査）。
+
+### 3.4 `.first()`採用理由
+
+migration作成時点（2026-07-04）では`name_jp`が実質的に一意という前提
+だったと推測される（明示的なunique制約はなく、当時この2神社に重複が
+存在したかは不明だが、コード上は単純な「存在すれば1件取得」という
+意図のみが読み取れる）。**identity選択のための意図的なordering指定では
+ない**——`Shrine.Meta.ordering = ["-updated_at"]`という既存のmodel-levelの
+デフォルト順序に暗黙に依存しているだけであり、これは後述のとおり
+偶然にも誤ったレコードを選択してしまう。
+
+### 3.5 reverse function
+
+`history_theme`/`goriyaku`を空文字へ戻し、対象tagを除去する対称的な
+実装。ただし修正前は`Shrine.objects.filter(name_jp__in=names)`（`.first()`
+ではなく全件ループ）で実装されており、forward側が1件のみ更新するのに
+対しreverse側は**名前が一致する全レコード（重複含む）を対象にしてしまう
+非対称なバグ**があった（4.4節参照）。
+
+### 3.6 dependency
+
+`temples.0090_add_rest_healing_tag_to_silent_shrines`のみ。cross-app
+dependencyなし。
+
+---
+
+## 4. Duplicate Shrine Identity Audit
+
+### 4.1 対象データの実測比較
+
+Production復元DBで対象4行を全カラム比較した。
+
+| id | name_jp | created_at | location格納形式 | place_ref_id | astro_elements | visit_style_tags |
+|---|---|---|---|---|---|---|
+| 21 | 長太稲荷神社 | 2026-06-11 14:49:02 | WKB (real geometry write) | (空) | `["火"]` | `["urban"]` |
+| 22 | 給田六所神社 | 2026-06-11 14:49:02 | WKB (real geometry write) | (空) | `["土"]` | `["urban"]` |
+| 101 | 給田六所神社 | 2026-06-11 16:18:01 | JSON文字列（text列への直接書き込み） | `ChIJl-MEepfxGGAR1Eo44p__GaE` | `[]` | `[]` |
+| 103 | 長太稲荷神社 | 2026-06-11 17:00:18 | JSON文字列（text列への直接書き込み） | `ChIJX19mq8nxGGARsA2kP4gX90M` | `[]` | `[]` |
+
+id=21/22は`backend/temples/seed_data/shrines_initial.json`の**21番目・22番目**
+のエントリと住所・緯度経度が完全一致し、生成順（`created_at`が20ms差で
+連番）から、当初の100件シード投入（`ids 1-100`）の一部であることを確認した。
+
+id=101/103は`temples_shrinecandidate`テーブルに対応するレコードが存在し、
+`raw`列に`{"via": "resolve", "shrine_id": 101}`のようなGoogle Places解決
+フロー（地図クリックからshrine候補を解決・登録する機能）由来である
+ことが明示されている。`temples_shrineinteractionlog`にはこれら2行の
+作成直後（+4秒）に`detail_view`ログが存在し、実行者は本番の唯一の
+ユーザー（`id=1`, username=`test`, superuser, `date_joined`=2026-06-11
+14:58:42）——つまり実顧客トラフィックではなく、開発者/QA担当による
+map機能の手動テストと判断できる。
+
+同じセッション内（`id`連番101〜105）に、名前が明らかにテスト目的である
+`id=102 "テスト確認神社 20260611"`・`id=105 "広島市"`が挟まっており、
+101/103がこの手動テストセッションの副産物であることを補強する。
+
+さらに、同一パターンの重複が**他に1件存在する**ことも確認した
+（`富岡八幡宮`: id=49（seed, place_ref_id空）／id=104（resolve由来,
+place_ref_idあり、created_at=翌日10:31））——0091の対象外だが、
+「resolve機能が既存shrineと名寄せせずに重複行を作成する」という
+根本原因が0091固有ではなくsystem-wideの既知パターンであることを裏付ける。
+
+### 4.2 Engagement/FK参照の確認
+
+`temples_favorite`/`temples_visit`/`temples_goshuin`/`temples_shrine_deities`/
+`temples_actionevent`/`temples_conciergethread.main_shrine_id`のいずれにも
+id=21/22/101/103への参照は0件。`temples_shrineinteractionlog`のみ
+id=101/103に1件ずつ（上記の手動テストクリック由来）。実質的な
+ユーザーengagementはいずれの行にも存在しない。
+
+### 4.3 判断
+
+- **canonical**: id=21（長太稲荷神社）, id=22（給田六所神社）
+  — 元々の100件シードデータの一部、`shrines_initial.json`の該当位置と
+  完全一致、`astro_elements`/`visit_style_tags`がseed時点で正しく設定済み
+- **duplicate**: id=101, id=103
+  — 単一のtest/superuserアカウントによる地図resolve機能の手動テストで
+  偶発的に作成された重複行。`place_ref_id`あり、seed由来の付随データ
+  （`astro_elements`/`visit_style_tags`）が欠落
+
+複数の独立した証拠（seed fileの位置一致、id範囲の生成波、
+`place_ref_id`の有無、`astro_elements`/`visit_style_tags`の有無、
+同一セッション内の明示的テストshrine名との時系列近接、
+他の重複ペア`富岡八幡宮`での同一パターン再現）が収束しており、
+推測ではなく実測に基づく判断である。
+
+### 4.4 `.first()`は意図的な選択だったか
+
+**偶然である。** `Shrine.Meta.ordering = ["-updated_at"]`により、`.first()`
+は「最も最近更新された行」を選ぶ。対象2ペアではid=101/103が
+duplicateでありながら`updated_at`がより新しいため、**もし
+GEOSExceptionが発生していなければ、0091は誤ってduplicate行
+（id=101/103）を更新し、本来enrichすべきcanonical行（id=21/22）は
+未着手のまま残っていたはずである。** これはGEOS crashとは独立した、
+より深刻な潜在的正しさのバグであり、スキーマ不整合による偶発的な
+「クラッシュによる回避」がなければ気づかれずにProductionへ誤データを
+書き込んでいた可能性が高い。
+
+同様に、修正前のreverse関数は`name_jp__in=names`で全件（duplicateも
+含む）を対象にしており、forward/reverseの非対称性というバグも
+併存していた。
+
+### 4.5 分類
+
+**`CANONICAL_IDENTITY_CONFIRMED`**
+
+---
+
+## 5. Remediation Candidate Comparison
+
+| 候補 | GEOS回避 | migration意図維持 | duplicate解決 | 備考 |
+|---|---|---|---|---|
+| A: `.only()` + 明示的`order_by` | ○ | ○ | ○ | 最小の変更、model instance/M2M managerをそのまま使える |
+| B: `.values()` | ○ | △ | ○ | dictを返すため`.save()`/`goriyaku_tags.add()`が使えず、`update()`とM2M throughテーブル操作を別途実装する必要があり複雑化 |
+| C: raw SQL | ○ | △ | ○ | M2M through tableのschemaをmigration外で決め打ちする必要があり、ORMのhistorical model stateが持つ正しい情報を捨てることになる。portability/保守性で劣る |
+| D: 過去migrationの再構成（新migration追加等） | — | — | — | Phase 7で不要と判断（5節参照）。fake migration/手動`django_migrations`更新/Production ALTER/UPDATEは候補から除外（絶対禁止事項） |
+
+**選定: Candidate A。** 最小の差分で、GEOS回避とduplicate解決の両方を
+同時に満たし、ORM/M2M managerの既存セマンティクスをそのまま維持できる。
+
+---
+
+## 6. Historical Migration Edit Risk
+
+- **Production**: `0091`は一度も成功appliedになっていない
+  （`django_migrations`にレコードなし、atomic rollback）。既存の
+  committed効果はゼロであり、in-place編集による「他環境で既に適用済み
+  との乖離」リスクはProductionに関しては存在しない。
+- **CI**: `.github/workflows/backend-tests.yml`の`unit`/`integration`
+  jobはいずれもephemeralな`postgres`serviceコンテナを毎回新規作成し、
+  そこへ全migrationを新規適用する。永続DBが存在しないため、CI側にも
+  乖離リスクはない。
+- **local dev**: `backend/db.sqlite3`は既に`0091`（旧コード）を適用済み
+  （`django_migrations`で確認）。migrationファイルを編集しても、
+  Djangoはfile checksumをDBへ保存しないため**このsqliteに対して0091が
+  再実行されることはない**——つまりこの開発者ローカルの状態は編集の
+  影響を受けず、単に「ローカルの適用履歴が現在のファイル内容と
+  食い違う」という静的な事実が残るのみ（新規`migrate`実行時に
+  影響はない）。
+
+**結論: `0091`のin-place編集は安全。** データ変更のみのmigrationであり
+schema変更を伴わないため、リスクは限定的。
+
+---
+
+## 7. Safe Patch Design
+
+`backend/temples/migrations/0091_fill_missing_local_shrine_reason_facts.py`
+を以下の方針で修正した（要件はすべて満たす）:
+
+- **`location`列を読み込まない**: `.only("id", "name_jp", "history_theme",
+  "goriyaku", "place_ref_id", "updated_at")`で明示的に列を絞り込み
+- **migration本来の更新内容は不変**: `updates`リスト（対象名・
+  history_theme・goriyaku・tags候補）は一切変更していない
+- **canonical shrineを安定して選択**: `order_by(F("place_ref_id")
+  .asc(nulls_first=True), "id")` — `place_ref_id`が`NULL`（=resolve機能を
+  経由していない、元のカタログ行）を優先し、次点で`id`昇順。重複が
+  存在しない環境では単純に唯一の一致行を返す（no-op的に安全）
+- **`.first()`の暗黙orderingに非依存**: 上記の明示的`order_by`により、
+  `Shrine.Meta.ordering`（`-updated_at`）に依存しなくなった
+- **missing tagの既存guardを保持**: `if tags: shrine.goriyaku_tags.add(*tags)`
+  はそのまま維持
+- **id hardcodeなし**: production固有のid値（21/22/101/103等）は
+  コード中に一切登場しない。`place_ref_id`の有無という一般的な
+  識別ルールのみを使用
+- **reverse behaviorを維持**: reverse関数も同じ`_resolve_target_shrine`
+  helperを使うよう修正し、forward/reverseの対称性を回復
+  （旧実装の「reverseは重複行も含めて全件処理してしまう」という
+  非対称バグも同時に修正）
+
+差分: [0091_fill_missing_local_shrine_reason_facts.py](../../backend/temples/migrations/0091_fill_missing_local_shrine_reason_facts.py)
+
+---
+
+## 8. Regression Tests
+
+`backend/temples/tests/test_gis_migration_0091_shrine_reason_facts.py`
+（新規、`USE_GIS=1`時のみ実行——GISが無効な環境では`temples`アプリが
+`temples.migrations_nogis`という別の squashed migration setを使うため、
+このmigration自体が独立したstepとして存在せず、テストの前提が
+成立しない）。
+
+| Test | 内容 | 修正前migrationでの結果 |
+|---|---|---|
+| A | `location`列が実際に`text`型（GiST indexを一時的に外して型変更し、非WKB値を挿入）でも`GEOSException`が起きないこと | **FAIL**（実際に同一の`GEOSException`を再現） |
+| B | duplicate（`place_ref_id`あり・`updated_at`がより新しい）が存在してもcanonical行のみ更新される | **FAIL**（誤った行を更新） |
+| C | 対象外のduplicate行が完全に無変更のまま（tag付与も含め）であること | **FAIL** |
+| D | `地域安泰`tagが存在しない状態でもmigrationがエラーにならず、存在するtagのみ付与されること | PASS（元々このケースは重複と無関係のため旧実装でも成立） |
+| E | reverse migrationがcanonical行のみを対象に正しく取り消すこと | **FAIL**（旧reverseは重複行も対象にしてしまう） |
+| F | shrineデータが存在しないfresh DBで`0090`→`0091`のchainが例外なく成立すること | PASS |
+
+**修正前のコードに対して意図的に再実行し、A/B/C/Eが実際に失敗する
+（D/Fはduplicateやexisting dataと無関係なため元々成立する）ことを
+確認した——テストが実際にこの2つのバグ（GEOS crash・誤ったidentity
+selection）を検出できることを検証済み。** 修正後は6件すべてPASS。
+
+---
+
+## 9. Production-Equivalent Restore Test
+
+2節で復元したProduction実dump相当の隔離DB（`temples 0090`適用済み・
+`0091`未適用）に対し、**修正後**の`0091`を適用した。
+
+| 項目 | 結果 |
+|---|---|
+| exit status | `0` |
+| `GEOSException` | 発生せず |
+| id=21（長太稲荷神社） | `history_theme="守り"`、`goriyaku`=想定文言、tag: `商売繁盛`・`五穀豊穣`（`地域安泰`はProductionに存在しないため付与されず、既存guard通り） |
+| id=22（給田六所神社） | `history_theme="守り"`、`goriyaku`=想定文言、tag: `家内安全`のみ（同上） |
+| id=101, id=103（duplicate） | `history_theme`/`goriyaku`とも空のまま、`updated_at`も無変更——**完全に無変更** |
+| aggregate: `shrine` | 105 → 105（不変） |
+| aggregate: `goriyaku_relation` | 280 → 283（Stage 3事前予測どおり+3） |
+| aggregate: `auth_user`/`userprofile`/`visit` | 不変 |
+| その他shrine（id=21/22以外）の`history_theme` | 変化なし（0件） |
+| `users`側migration state | `0006`のまま不変（regressionなし） |
+| `django_migrations`記録 | `temples 0091`が正しくapplied記録される |
+| `0092`/`0093` | **実行していない**（絶対禁止事項として厳守） |
+
+Stage 3記録に残っていた事前予測（「id=103/101がduplicateの`.first()`で
+誤って選ばれ、`goriyaku_relation`が280→283になるはず」という**旧実装
+前提の予測**）とは対象行が入れ替わったが、件数（283）自体は一致した
+——正しい行（canonical）に対して同じ内容が適用された結果であり、
+migration本来の意図（実運用2神社のreason facts補完）がようやく
+正しく実現されたことを意味する。
+
+---
+
+## 10. Limitations
+
+- Production baseline（`favorite`件数）について、
+  `production-migration-local-execution-runbook.md`のStage 0〜3記録では
+  `favorite=0`と記載されているが、今回参照した4つのProduction dump
+  （Stage 0〜Stage 3直前のいずれも）を直接確認したところ実際には
+  一貫して`favorite=3`だった。これは既存ドキュメントの記載誤り
+  （おそらく初期の誤記がそのままコピーされ続けた）と考えられ、
+  今回のPhase 8検証は同一dump内でのpre/post比較（3→3、不変）に
+  基づいているため本修正の正しさには影響しない。念のため記録する。
+- 同一パターンの重複（`富岡八幡宮` id=49/104等）が他にも存在する
+  可能性があり、resolve機能自体の名寄せロジック改善は本Gateの
+  scope外（Stage 3記録が既に指摘済みの別途点検事項）。
+- `pytest`/`pytest-dotenv`のCLIオプション競合（`--envfile`の二重登録、
+  `pytest-env`と`pytest-dotenv`の間の既知衝突）は本修正の対象外。
+  ローカル実行では`-p no:dotenv`で回避し、実行可能なテスト経路
+  （`temples`アプリ全体、1026 passed / 9 skipped、うちskipはGDAL/PostGIS
+  ローカル環境起因で本修正と無関係）を最大限使用した。
+
+---
+
+## 11. Final Classification
+
+**`TEMPLES_0091_REMEDIATION_READY`**
+
+根拠:
+- root cause再現済み（`PRODUCTION_SCHEMA_MODEL_MISMATCH_CONFIRMED`）
+- canonical identity確定済み（`CANONICAL_IDENTITY_CONFIRMED`）
+- safe patch実装済み（Candidate A、id hardcodeなし、意図維持）
+- regression test 6件すべてPASS（修正前は該当4件が実際に失敗することも確認済み）
+- Production相当restore DBで`0091`単体がexit 0、期待効果と完全一致、
+  意図しない変更ゼロ
+- `makemigrations --check --dry-run` / `manage.py check` / ruff lint
+  すべてPASS
+- `temples`アプリ全体のtest suite: 1026 passed, 9 skipped（既存環境起因、
+  本修正と無関係）
+
+**Production retryはMother Ship判断待ち。** 本セッションではProduction
+migrationを一切実行していない。


### PR DESCRIPTION
## Summary

- Production migration `temples 0091` (`0091_fill_missing_local_shrine_reason_facts`) failed with `GEOSException` on real attempt (see `docs/audit/production-migration-local-execution-runbook.md`, Stage 3, `TEMPLES_0091_EXECUTION_STOP`). Root cause reproduced against a restored production dump in an isolated local PostGIS instance (never touching production): the migration's historical model state declares `Shrine.location` as a PostGIS `PointField`, but the actual production column is a legacy `text` column. A bare `.filter().first()` selects all columns, triggering the GeometryField converter on the drifted text value.
- While investigating, found that the two target shrine names each have an accidental duplicate row (original seed catalog row vs. a later row created by the map "resolve"/Google Places flow during manual QA testing). `Shrine.Meta.ordering = ["-updated_at"]` meant `.first()` would have silently selected the *wrong* (duplicate, non-catalog) row had the schema drift not caused a crash first — a latent correctness bug independent of the GEOS issue.
- Fix: `.only()` excludes `location` from the generated SELECT, and an explicit `order_by(F("place_ref_id").asc(nulls_first=True), "id")` deterministically selects the canonical (non-duplicate) row instead of relying on implicit `-updated_at` ordering. Applied the same identity-selection logic to the reverse function, which previously had a forward/reverse asymmetry bug (reverse touched *all* matching rows including duplicates).
- No production-specific values are hardcoded; the migration's original intent (fields, target shrine names, tag list, missing-tag guard) is unchanged.

## Verification

- Reproduced the exact production `GEOSException` traceback against a restored production dump in an isolated local DB.
- Applied the fixed migration to the same restored dump: exit 0, canonical rows (id=21/22) updated as intended, duplicate rows (id=101/103) completely untouched, aggregate counts consistent with the pre-migration audit's prediction (`goriyaku_relation` 280→283).
- Added `backend/temples/tests/test_gis_migration_0091_shrine_reason_facts.py` (6 tests, GIS-only). Confirmed 4 of them fail against the original code with the actual bugs (GEOS crash, wrong-row targeting) and all 6 pass with the fix.
- `manage.py makemigrations --check --dry-run` / `manage.py check`: clean.
- `ruff check` / `ruff format --check`: clean.
- Full `temples` test suite: 1026 passed, 9 skipped (pre-existing, GDAL/PostGIS unavailable locally — unrelated to this change).
- Full findings, evidence, and candidate comparison: `docs/audit/temples-0091-production-remediation.md`.

**Production migration was not executed in this work.** `temples 0091` retry, `0092`, and `0093` were not run against production. This PR only prepares the fix for Mother Ship's review/approval before any production retry.

## Test plan

- [x] Reproduced failure against restored production dump (isolated DB)
- [x] Applied fix against same restored dump, verified expected effect and no unintended changes
- [x] New regression tests pass with fix, fail meaningfully without it
- [x] `makemigrations --check --dry-run`, `manage.py check`, ruff lint clean
- [x] Full `temples` test suite green
- [ ] CI green (pending)
- [ ] Mother Ship review and production retry approval (out of scope for this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)