### PR TITLE
Add Knowledge Batch 8 seed preflight

### DIFF
--- a/backend/temples/data/knowledge_seeds/batch_8_seed.json
+++ b/backend/temples/data/knowledge_seeds/batch_8_seed.json
@@ -1,0 +1,373 @@
+{
+  "schema_version": "1.0",
+  "sources": [
+    {
+      "key": "batch8-fuji-official",
+      "source_type": "shrine_official",
+      "title": "御由緒｜富士山本宮浅間大社",
+      "publisher": "富士山本宮浅間大社",
+      "url": "https://fuji-hongu.or.jp/sengen/history/index.html",
+      "bibliography": "",
+      "accessed_at": "2026-08-10",
+      "verified_at": "2026-08-10T08:30:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "御祭神、起源、山宮鎮座、大宮遷座の各節を直接確認。"
+    },
+    {
+      "key": "batch8-tsukuba-official",
+      "source_type": "shrine_official",
+      "title": "由緒｜筑波山神社",
+      "publisher": "筑波山神社",
+      "url": "https://tsukubasanjinja.jp/history/",
+      "bibliography": "",
+      "accessed_at": "2026-08-10",
+      "verified_at": "2026-08-10T08:35:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "由緒、御祭神、鎮座地を直接確認。"
+    },
+    {
+      "key": "batch8-keta-official",
+      "source_type": "shrine_official",
+      "title": "由緒・気多の神々｜氣多大社",
+      "publisher": "氣多大社",
+      "url": "https://keta.jp/history/",
+      "bibliography": "",
+      "accessed_at": "2026-08-10",
+      "verified_at": "2026-08-10T08:40:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "本殿祭神と8世紀以降の文献記録を直接確認。"
+    },
+    {
+      "key": "batch8-tsubaki-official",
+      "source_type": "shrine_official",
+      "title": "椿大神社について｜椿大神社",
+      "publisher": "椿大神社",
+      "url": "https://tsubaki.or.jp/about/",
+      "bibliography": "",
+      "accessed_at": "2026-08-10",
+      "verified_at": "2026-08-10T08:45:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "主神、相殿、配祀および御創立の由来を直接確認。"
+    },
+    {
+      "key": "batch8-enoshima-deity-official",
+      "source_type": "shrine_official",
+      "title": "ご祭神｜江島神社",
+      "publisher": "江島神社",
+      "url": "https://enoshimajinja.or.jp/gosaijin/",
+      "bibliography": "",
+      "accessed_at": "2026-08-10",
+      "verified_at": "2026-08-10T08:50:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "奥津宮・中津宮・辺津宮の三女神を直接確認。"
+    },
+    {
+      "key": "batch8-enoshima-history-official",
+      "source_type": "shrine_official",
+      "title": "辺津宮｜江島神社",
+      "publisher": "江島神社",
+      "url": "https://enoshimajinja.or.jp/hetsumiya/",
+      "bibliography": "",
+      "accessed_at": "2026-08-10",
+      "verified_at": "2026-08-10T08:55:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "辺津宮の創建・再建・改修記録を直接確認。"
+    }
+  ],
+  "shrines": [
+    {
+      "shrine_ref": {
+        "name_jp": "富士山本宮浅間大社",
+        "address": "静岡県富士宮市宮町1-1"
+      },
+      "deities": [
+        {
+          "display_name": "木花之佐久夜毘売命",
+          "canonical_name": "木花之佐久夜毘売命",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:30:00+00:00",
+          "note": "公式別称は浅間大神。",
+          "source_keys": ["batch8-fuji-official"]
+        },
+        {
+          "display_name": "瓊々杵尊",
+          "canonical_name": "瓊々杵尊",
+          "role": "enshrined",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:30:00+00:00",
+          "note": "公式表記は相殿神。",
+          "source_keys": ["batch8-fuji-official"]
+        },
+        {
+          "display_name": "大山祇神",
+          "canonical_name": "大山祇神",
+          "role": "enshrined",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:30:00+00:00",
+          "note": "公式表記は相殿神。",
+          "source_keys": ["batch8-fuji-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "浅間大神奉斎の起源伝承",
+          "content": "『富士本宮浅間社記』によれば、富士山噴火後の荒廃を憂えた垂仁天皇が、その御代3年に浅間大神を山足の地に祀って山霊を鎮めたことが当大社の起源と伝えられている。",
+          "period_text": "垂仁天皇3年（社記による）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:30:00+00:00",
+          "note": "公式Sourceが社記に基づく伝承として記すため、history_type=traditionとし確定年代として扱わない。",
+          "source_keys": ["batch8-fuji-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "大宮への遷座",
+          "content": "富士山本宮浅間大社の公式由緒は、大同元年（806）、坂上田村麿が平城天皇の勅命を受け、現在の大宮の地に社殿を造営して山宮から遷座したと記している。",
+          "period_text": "大同元年（806）",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:30:00+00:00",
+          "note": "公式由緒の大宮遷座節に基づく。",
+          "source_keys": ["batch8-fuji-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "筑波山神社",
+        "address": "茨城県つくば市筑波1"
+      },
+      "deities": [
+        {
+          "display_name": "伊弉諾尊",
+          "canonical_name": "伊弉諾尊",
+          "role": "enshrined",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:35:00+00:00",
+          "note": "筑波男大神として男体山に祀るとの公式記載。",
+          "source_keys": ["batch8-tsukuba-official"]
+        },
+        {
+          "display_name": "伊弉冊尊",
+          "canonical_name": "伊弉冊尊",
+          "role": "enshrined",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:35:00+00:00",
+          "note": "筑波女大神として女体山に祀るとの公式記載。",
+          "source_keys": ["batch8-tsukuba-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "筑波一族による奉仕の伝承",
+          "content": "公式由緒は、崇神天皇の御代に筑波命が筑波国造に命じられ、以来、筑波一族が祭政一致で筑波山神社に奉仕したと伝えている。",
+          "period_text": "崇神天皇の御代（公式由緒による）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:35:00+00:00",
+          "note": "古代の年代を確定日へ変換せず、公式由緒の伝承表現を保持。",
+          "source_keys": ["batch8-tsukuba-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "氣多大社",
+        "address": "石川県羽咋市寺家町ク1-1"
+      },
+      "deities": [
+        {
+          "display_name": "大己貴神",
+          "canonical_name": "大己貴神",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:40:00+00:00",
+          "note": "公式由緒の本殿祭神表記に基づく。",
+          "source_keys": ["batch8-keta-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "historical_event",
+          "title": "8世紀の文献記録",
+          "content": "氣多大社の公式由緒は、神護景雲2年（768）に封戸二十戸と田二町が寄進されたことを『続日本紀』に基づいて記している。",
+          "period_text": "神護景雲2年（768）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:40:00+00:00",
+          "note": "公式Sourceが文献名を明記する歴史記録。",
+          "source_keys": ["batch8-keta-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "椿大神社",
+        "address": "三重県鈴鹿市山本町1871"
+      },
+      "deities": [
+        {
+          "display_name": "猿田彦大神",
+          "canonical_name": "猿田彦大神",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:45:00+00:00",
+          "note": "公式表記は主神。",
+          "source_keys": ["batch8-tsubaki-official"]
+        },
+        {
+          "display_name": "瓊々杵尊",
+          "canonical_name": "瓊々杵尊",
+          "role": "enshrined",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:45:00+00:00",
+          "note": "公式表記は相殿。",
+          "source_keys": ["batch8-tsubaki-official"]
+        },
+        {
+          "display_name": "栲幡千々姫命",
+          "canonical_name": "栲幡千々姫命",
+          "role": "enshrined",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:45:00+00:00",
+          "note": "公式表記は相殿。",
+          "source_keys": ["batch8-tsubaki-official"]
+        },
+        {
+          "display_name": "天之鈿女命",
+          "canonical_name": "天之鈿女命",
+          "role": "enshrined",
+          "sort_order": 3,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:45:00+00:00",
+          "note": "公式表記は配祀。",
+          "source_keys": ["batch8-tsubaki-official"]
+        },
+        {
+          "display_name": "木花咲耶姫命",
+          "canonical_name": "木花咲耶姫命",
+          "role": "enshrined",
+          "sort_order": 4,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:45:00+00:00",
+          "note": "公式表記は配祀。",
+          "source_keys": ["batch8-tsubaki-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "道別大神の社奉斎伝承",
+          "content": "椿大神社の公式由緒は、垂仁天皇27年秋、倭姫命の御神託により、この地に『道別大神の社』として社殿が奉斎されたと伝えている。",
+          "period_text": "垂仁天皇27年秋（公式由緒による）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:45:00+00:00",
+          "note": "公式の創立伝承として保持し、西暦の確定日へ変換しない。",
+          "source_keys": ["batch8-tsubaki-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "江島神社",
+        "address": "神奈川県藤沢市江の島2-3-8"
+      },
+      "deities": [
+        {
+          "display_name": "多紀理比賣命",
+          "canonical_name": "多紀理比賣命",
+          "role": "enshrined",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:50:00+00:00",
+          "note": "奥津宮に祀るとの公式記載。",
+          "source_keys": ["batch8-enoshima-deity-official"]
+        },
+        {
+          "display_name": "市寸島比賣命",
+          "canonical_name": "市寸島比賣命",
+          "role": "enshrined",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:50:00+00:00",
+          "note": "中津宮に祀るとの公式記載。",
+          "source_keys": ["batch8-enoshima-deity-official"]
+        },
+        {
+          "display_name": "田寸津比賣命",
+          "canonical_name": "田寸津比賣命",
+          "role": "enshrined",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:50:00+00:00",
+          "note": "辺津宮に祀るとの公式記載。",
+          "source_keys": ["batch8-enoshima-deity-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "historical_event",
+          "title": "辺津宮の創建",
+          "content": "江島神社の公式サイトは、辺津宮が建永元年（1206）に当時の将軍・源実朝によって創建されたと記している。",
+          "period_text": "建永元年（1206）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-10T08:55:00+00:00",
+          "note": "江島神社全体の創建ではなく、辺津宮に限定した歴史Fact。",
+          "source_keys": ["batch8-enoshima-history-official"]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/audit/knowledge-batch8-seed-preflight.md
+++ b/docs/audit/knowledge-batch8-seed-preflight.md
@@ -1,0 +1,132 @@
+# Knowledge Batch 8 Seed Preflight — Mother Ship Report
+
+## Executive Summary
+
+- Execution date: 2026-08-10
+- Base: `develop` / `deed42907b2f7ab55f1a83c3851944f1cf3d0d14`
+- PR #2347 merge commit: present in `develop`
+- Final target: five canonical, zero-Knowledge shrines
+- Seed delta: Source 6, Deity 14, History 6, Knowledge shrine +5
+- Local validate/import/idempotency: PASS
+- Production-equivalent aggregate regression: PASS
+- Production validate-only/dry-run: PASS; expected CREATE 6/14/6
+- Production Knowledge writes: **0**
+- Batch 8 Production import executions: **0**
+- Mother Ship recommendation: **`GO_RECOMMENDED_PENDING_EXPLICIT_PRODUCTION_WRITE_APPROVAL`**
+
+This report is a technical Go recommendation only. It does not authorize a
+Production write. The Production import must remain stopped until Mother Ship
+issues an explicit, separate write approval.
+
+## 1. Phase 0 — Base and source of truth
+
+`develop` was fast-forwarded from `origin/develop`. PR #2347 is present, HEAD
+was recorded as `deed42907b2f7ab55f1a83c3851944f1cf3d0d14`, and the working tree
+was clean before Batch 8 files were created. The canonical Target Selection
+Contract was read fresh.
+
+The existing local database was reused as the Production-equivalent baseline
+because its read-only coverage snapshot exactly matched the canonical
+Production snapshot: total 105, audit target 100, Knowledge 41, complete 39,
+scoped Source 59. No destructive restore was necessary.
+
+## 2. Phase 1 — Final target contract
+
+| Shrine | Canonical address | Deity | History | Source |
+| --- | --- | ---: | ---: | ---: |
+| 富士山本宮浅間大社 | 静岡県富士宮市宮町1-1 | 3 | 2 | 1 |
+| 筑波山神社 | 茨城県つくば市筑波1 | 2 | 1 | 1 |
+| 氣多大社 | 石川県羽咋市寺家町ク1-1 | 1 | 1 | 1 |
+| 椿大神社 | 三重県鈴鹿市山本町1871 | 5 | 1 | 1 |
+| 江島神社 | 神奈川県藤沢市江の島2-3-8 | 3 | 1 | 2 |
+
+The two partial shrines, 香取神宮 and 阿佐ヶ谷神明宮, remain excluded and
+must pass their separate repair/evidence gate. Every selected identity resolves
+exactly once by `name_jp` + address; ambiguous identity count is zero. Numeric
+database IDs are not present in the seed.
+
+## 3. Phases 2–4 — Evidence and canonical seed
+
+All six Sources are classified `shrine_official`, with
+`verification_status=source_confirmed`, `confidence=high`, access date,
+verification timestamp, publisher, title, and URL. Traditional accounts are
+expressed as traditions rather than promoted to unqualified historical fact.
+
+| Shrine | Official evidence |
+| --- | --- |
+| 富士山本宮浅間大社 | `https://fuji-hongu.or.jp/sengen/history/index.html` |
+| 筑波山神社 | `https://tsukubasanjinja.jp/history/` |
+| 氣多大社 | `https://keta.jp/history/` |
+| 椿大神社 | `https://tsubaki.or.jp/about/` |
+| 江島神社 | `https://enoshimajinja.or.jp/gosaijin/`, `https://enoshimajinja.or.jp/hetsumiya/` |
+
+Canonical seed:
+`backend/temples/data/knowledge_seeds/batch_8_seed.json`
+
+Schema validation passes. The final structure is Source 6, shrine 5, Deity 14,
+History 6, Deity–Source relations 14, and History–Source relations 6. Thus every
+fact has at least one Source relation and source-less fact count is zero.
+
+## 4. Phases 5–6 — Local import and aggregate regression
+
+Local validate-only and dry-run passed. The first local import created Source 6,
+Deity 14, and History 6. A second dry-run produced only `SKIP_EXISTS`: Source 6,
+Deity 14, History 6, with zero CREATE actions. This verifies same-seed
+idempotency.
+
+The post-import Production-equivalent report is:
+
+| Metric | Baseline | Batch 8 local | Expected delta |
+| --- | ---: | ---: | ---: |
+| Audit target shrine | 100 | 100 | 0 |
+| Knowledge coverage | 41 | 46 | +5 |
+| Both Deity and History | 39 | 44 | +5 |
+| Scoped Source | 59 | 65 | +6 |
+| Fact-ready facts | 188 | 208 | +20 |
+
+All five exact target identities remain single rows. No Knowledge was attached
+to duplicate, QA fixture, or unresolved identities; duplicate contamination is
+zero. The focused importer, GIS identity, command, and coverage regression suite
+passed: **33 passed**.
+
+## 5. Phase 7 — Production read-only preflight
+
+Only `--validate-only` and `--dry-run` were run against Production. Validation
+passed and the deterministic plan is:
+
+- CREATE Source: 6
+- CREATE Deity: 14
+- CREATE History: 6
+- SKIP/ERROR: 0
+
+Neither command wrote to Production. The apply/import command was not run.
+
+One importer limitation is recorded explicitly: existence planning identifies
+natural-key collisions as `SKIP_EXISTS` but does not compare all persisted field
+values for semantic drift. This Batch 8 Production plan has no collision because
+all proposed records are CREATE, and same-seed local idempotency passed. Any
+future plan containing unexpected `SKIP_EXISTS` must stop for a field-level
+conflict audit.
+
+## 6. Phase 8 — Runtime QA contract after an authorized import
+
+| QA case | Shrine | Expected Detail payload |
+| --- | --- | --- |
+| Simple | 氣多大社 | Deity 1, History 1, Source 1 |
+| Multi-deity | 椿大神社 | Deity 5, History 1, Source 1 |
+| Multi-history | 富士山本宮浅間大社 | Deity 3, History 2, Source 1 |
+| Multi-source | 江島神社 | Deity 3, History 1, Source 2 |
+
+For each case, Shrine Detail must return HTTP 200, exact canonical identity,
+the counts above, the expected official Source titles/URLs, and no duplicate
+facts. Runtime QA is defined here but was not executed against Production,
+because doing so before import cannot validate the future payload.
+
+## 7. Phase 9 — Mother Ship Go/No-Go
+
+**Technical decision: GO recommended, pending explicit Production write
+approval.** Identity, evidence, traceability, schema, local import, idempotency,
+aggregate regression, and Production read-only planning gates pass with the
+expected 6/14/6 create delta. The execution boundary remains closed: no
+Production Knowledge write, Batch 8 import, Score/Ranking change, Source UI, or
+`PER_FACT_RENDERING` work was performed.


### PR DESCRIPTION
## Summary

- add the canonical Knowledge Batch 8 seed for five shrines
- add six official sources, fourteen deity facts, and six history facts
- document local import/idempotency, Production-equivalent regression, and Production validate-only/dry-run results
- define post-import Runtime QA expectations and the Mother Ship execution boundary

## Why

Batch 8 needs a reproducible, evidence-backed seed and a recorded preflight before any separately authorized Production write.

## Validation

- final committed-diff secret/credential/connection-string/private-host scan: clean
- focused backend regression suite: 33 passed
- pre-push OpenAPI lint: passed
- pre-push Web contract tests: 731 passed
- local validate/import/second dry-run idempotency: passed
- Production validate-only/dry-run: passed; expected CREATE Source 6 / Deity 14 / History 6

## Safety

No Production Knowledge write or Batch 8 Production import was performed. This PR must not be merged by this workflow. Final classification remains `GO_RECOMMENDED_PENDING_EXPLICIT_PRODUCTION_WRITE_APPROVAL`.