### PR TITLE
Batch 9の既存公式Source再利用と重複検知を改善

### DIFF
--- a/backend/temples/data/knowledge_seeds/batch_9_seed.json
+++ b/backend/temples/data/knowledge_seeds/batch_9_seed.json
@@ -74,16 +74,16 @@
     {
       "key": "batch9-hakone-official",
       "source_type": "shrine_official",
-      "title": "箱根神社の由緒｜箱根神社",
-      "publisher": "箱根神社",
+      "title": "箱根神社・九頭龍神社・箱根元宮の由緒並に宝物と文化財",
+      "publisher": "箱根神社（九頭龍神社）",
       "url": "https://hakonejinja.or.jp/hakone/",
       "bibliography": "",
       "accessed_at": "2026-08-10",
       "verified_at": "2026-08-10T10:25:00+00:00",
       "verification_status": "source_confirmed",
       "confidence": "high",
-      "language": "ja",
-      "note": "箱根大神を構成する御三神と、天平宝字元年の社殿建立記事を直接確認。"
+      "language": "",
+      "note": "Production既存の同一公式URL Sourceと重要metadataを合わせてportableに再利用する。箱根大神を構成する御三神と、天平宝字元年の社殿建立記事を直接確認。"
     }
   ],
   "shrines": [

--- a/backend/temples/management/commands/import_shrine_knowledge.py
+++ b/backend/temples/management/commands/import_shrine_knowledge.py
@@ -35,9 +35,9 @@ from temples.services.knowledge_seed import (
     ParsedSeed,
     find_existing_deity,
     find_existing_history,
-    find_existing_source,
     parse_seed,
     resolve_shrine,
+    resolve_source_identity,
 )
 
 
@@ -46,7 +46,7 @@ class PlanItem:
     kind: str  # "source" | "deity" | "history"
     shrine_name: str
     label: str
-    action: str  # "CREATE" | "SKIP_EXISTS"
+    action: str  # "CREATE" | "REUSE_EXISTING" | "SKIP_EXISTS" | blocking status
     detail: str = ""
 
 
@@ -74,19 +74,17 @@ def _build_plan(parsed: ParsedSeed) -> tuple[Plan, dict[str, ShrineKnowledgeSour
 
     source_existing: dict[str, ShrineKnowledgeSource | None] = {}
     for key, entry in parsed.sources.items():
-        existing = find_existing_source(
-            source_type=entry.source_type,
-            title=entry.title,
-            url=entry.url,
-            bibliography=entry.bibliography,
-        )
+        identity = resolve_source_identity(entry)
+        existing = identity.source
         source_existing[key] = existing
+        if identity.status in ("CONFLICT", "AMBIGUOUS"):
+            errors.append(f"source {key!r}: SOURCE_REUSE_{identity.status} ({identity.detail})")
         items.append(
             PlanItem(
                 kind="source",
                 shrine_name="",
                 label=f"[{key}] {entry.source_type}: {entry.title}",
-                action="SKIP_EXISTS" if existing else "CREATE",
+                action=identity.status,
                 detail=f"matched existing id={existing.pk}" if existing else "",
             )
         )

--- a/backend/temples/services/knowledge_seed.py
+++ b/backend/temples/services/knowledge_seed.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime
 from typing import Any, Literal
+from urllib.parse import urlsplit, urlunsplit
 
 from django.db.models import F
 from temples.models import (
@@ -40,12 +41,20 @@ _VALID_ROLES = {v for v, _ in ShrineDeity.ROLE_CHOICES}
 _VALID_HISTORY_TYPES = {v for v, _ in ShrineHistory.HISTORY_TYPE_CHOICES}
 
 ShrineIdentityStatus = Literal["OK", "OK_CANONICAL_PREFERRED", "NOT_FOUND", "AMBIGUOUS"]
+SourceIdentityStatus = Literal["CREATE", "REUSE_EXISTING", "CONFLICT", "AMBIGUOUS"]
 
 
 @dataclass(frozen=True)
 class ShrineIdentityResult:
     shrine: Shrine | None
     status: ShrineIdentityStatus
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class SourceIdentityResult:
+    source: ShrineKnowledgeSource | None
+    status: SourceIdentityStatus
     detail: str = ""
 
 
@@ -116,26 +125,107 @@ def resolve_shrine(name_jp: str, address: str = "") -> ShrineIdentityResult:
     )
 
 
+def normalize_source_url(url: str) -> str:
+    """Normalize only URL syntax that cannot change the cited document.
+
+    Scheme and host case and default ports are normalized, fragments are
+    removed, and a non-root trailing slash is ignored. Query strings remain
+    byte-for-byte significant, and http/https remain distinct.
+    """
+    value = (url or "").strip()
+    if not value:
+        return ""
+    parts = urlsplit(value)
+    scheme = parts.scheme.lower()
+    hostname = (parts.hostname or "").lower()
+    port = parts.port
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        hostname = f"{hostname}:{port}"
+    path = parts.path or "/"
+    if path != "/":
+        path = path.rstrip("/")
+    return urlunsplit((scheme, hostname, path, parts.query, ""))
+
+
+_SOURCE_REUSE_FIELDS = (
+    "publisher",
+    "verification_status",
+    "confidence",
+    "bibliography",
+    "language",
+)
+
+
+def resolve_source_identity(entry: "SourceEntry") -> SourceIdentityResult:
+    """Resolve a portable Source identity without silently duplicating URLs.
+
+    URL-backed Sources use ``source_type + normalized URL`` as semantic
+    identity. Exactly one matching row is reusable only when important
+    metadata agrees. Multiple matches or metadata drift block the whole
+    import. URL-less Sources retain the original title/bibliography lookup.
+    """
+    normalized_url = normalize_source_url(entry.url)
+    if normalized_url:
+        candidates = [
+            source
+            for source in ShrineKnowledgeSource.objects.filter(source_type=entry.source_type)
+            .exclude(url="")
+            .order_by("id")
+            if normalize_source_url(source.url) == normalized_url
+        ]
+        if len(candidates) > 1:
+            return SourceIdentityResult(
+                None,
+                "AMBIGUOUS",
+                f"{len(candidates)} existing Sources match source_type + normalized URL",
+            )
+        if len(candidates) == 1:
+            source = candidates[0]
+            conflicts = [
+                field
+                for field in _SOURCE_REUSE_FIELDS
+                if str(getattr(source, field) or "").strip()
+                != str(getattr(entry, field) or "").strip()
+            ]
+            if conflicts:
+                return SourceIdentityResult(
+                    None,
+                    "CONFLICT",
+                    "meaningful metadata differs: " + ", ".join(conflicts),
+                )
+            return SourceIdentityResult(source, "REUSE_EXISTING")
+        return SourceIdentityResult(None, "CREATE")
+
+    qs = ShrineKnowledgeSource.objects.filter(
+        source_type=entry.source_type,
+        title=entry.title,
+        url="",
+    )
+    if entry.bibliography:
+        qs = qs.filter(bibliography=entry.bibliography)
+    source = qs.order_by("id").first()
+    return SourceIdentityResult(
+        source,
+        "REUSE_EXISTING" if source is not None else "CREATE",
+    )
+
+
 def find_existing_source(
     *, source_type: str, title: str, url: str = "", bibliography: str = ""
 ) -> ShrineKnowledgeSource | None:
-    """Content-based natural-key lookup for idempotency.
-
-    `ShrineKnowledgeSource` has no dedicated natural-key field (adding one
-    is a schema change and out of scope for this foundation — see the
-    Reproducibility Gap section of the runbook). A Source is treated as
-    "the same" if `source_type` + `title` match, and, when present, `url` or
-    `bibliography` also match (a Source with a URL and one without normally
-    describe different things even under the same title).
-    """
-    qs = ShrineKnowledgeSource.objects.filter(source_type=source_type, title=title)
-    if url:
-        qs = qs.filter(url=url)
-    else:
-        qs = qs.filter(url="")
-    if bibliography:
-        qs = qs.filter(bibliography=bibliography)
-    return qs.order_by("id").first()
+    """Compatibility wrapper for callers that only need a reusable row."""
+    result = resolve_source_identity(
+        SourceEntry(
+            key="",
+            source_type=source_type,
+            title=title,
+            url=url,
+            bibliography=bibliography,
+        )
+    )
+    return result.source if result.status == "REUSE_EXISTING" else None
 
 
 def find_existing_deity(shrine: Shrine, display_name: str) -> ShrineDeity | None:
@@ -418,7 +508,10 @@ def parse_seed(raw: dict) -> ParsedSeed:
 __all__ = [
     "SCHEMA_VERSION",
     "ShrineIdentityResult",
+    "SourceIdentityResult",
     "resolve_shrine",
+    "normalize_source_url",
+    "resolve_source_identity",
     "find_existing_source",
     "find_existing_deity",
     "find_existing_history",

--- a/backend/temples/tests/test_batch9_knowledge_seed.py
+++ b/backend/temples/tests/test_batch9_knowledge_seed.py
@@ -8,10 +8,7 @@ from django.core.management import call_command
 from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
 from temples.services.knowledge_seed import parse_seed
 
-
-SEED_PATH = (
-    Path(__file__).resolve().parents[1] / "data" / "knowledge_seeds" / "batch_9_seed.json"
-)
+SEED_PATH = Path(__file__).resolve().parents[1] / "data" / "knowledge_seeds" / "batch_9_seed.json"
 
 TARGETS = [
     ("宇佐神宮", "大分県宇佐市南宇佐2859"),
@@ -93,7 +90,7 @@ def test_batch9_seed_import_is_idempotent_and_preserves_unrelated_knowledge():
     dry_run = io.StringIO()
     call_command("import_shrine_knowledge", str(SEED_PATH), "--dry-run", stdout=dry_run)
     output = dry_run.getvalue()
-    assert "'source_SKIP_EXISTS': 6" in output
+    assert "'source_REUSE_EXISTING': 6" in output
     assert "'deity_SKIP_EXISTS': 13" in output
     assert "'history_SKIP_EXISTS': 5" in output
     assert "CREATE" not in output

--- a/backend/temples/tests/test_knowledge_seed_import.py
+++ b/backend/temples/tests/test_knowledge_seed_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+from pathlib import Path
 
 import pytest
 from django.core.management import call_command
@@ -233,6 +234,98 @@ def test_import_is_idempotent_on_second_run(tmp_path):
     assert ShrineKnowledgeSource.objects.count() == 1
     assert ShrineDeity.objects.count() == 1
     assert ShrineHistory.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_same_type_and_normalized_url_reuses_source_with_different_title_and_links_facts(tmp_path):
+    Shrine.objects.create(name_jp="テスト対象神社", kind="shrine", address="東京都テスト区1-1-1")
+    existing = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="既存の正式タイトル",
+        publisher="公式神社",
+        url="https://example.jp/source/",
+        verification_status="source_confirmed",
+        verified_at="2025-01-01T00:00:00Z",
+        confidence="high",
+        language="ja",
+    )
+    seed = _minimal_seed()
+    seed["sources"][0].update(
+        {
+            "title": "seed側の異なるタイトル",
+            "publisher": "公式神社",
+            "url": "https://EXAMPLE.jp/source",
+            "language": "ja",
+        }
+    )
+    seed_path = tmp_path / "seed.json"
+    seed_path.write_text(json.dumps(seed), encoding="utf-8")
+
+    out = io.StringIO()
+    call_command("import_shrine_knowledge", str(seed_path), stdout=out)
+
+    assert "source_REUSE_EXISTING" in out.getvalue()
+    assert ShrineKnowledgeSource.objects.count() == 1
+    assert list(ShrineDeity.objects.get().sources.all()) == [existing]
+    assert list(ShrineHistory.objects.get().sources.all()) == [existing]
+
+
+@pytest.mark.django_db
+def test_same_type_and_normalized_url_is_ambiguous_when_multiple_sources_exist(tmp_path):
+    Shrine.objects.create(name_jp="テスト対象神社", kind="shrine", address="東京都テスト区1-1-1")
+    for title, url in (
+        ("既存A", "https://example.jp/source"),
+        ("既存B", "https://example.jp/source/"),
+    ):
+        ShrineKnowledgeSource.objects.create(
+            source_type="shrine_official",
+            title=title,
+            url=url,
+            verification_status="source_confirmed",
+            verified_at="2025-01-01T00:00:00Z",
+            confidence="high",
+        )
+    seed_path = tmp_path / "seed.json"
+    seed = _minimal_seed()
+    seed["sources"][0]["url"] = "https://example.jp/source/"
+    seed_path.write_text(json.dumps(seed), encoding="utf-8")
+
+    with pytest.raises(CommandError, match="import blocked"):
+        call_command("import_shrine_knowledge", str(seed_path), "--dry-run", stdout=io.StringIO())
+
+    assert ShrineKnowledgeSource.objects.count() == 2
+    assert ShrineDeity.objects.count() == 0
+    assert ShrineHistory.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_same_type_and_normalized_url_blocks_meaningful_metadata_conflict(tmp_path):
+    Shrine.objects.create(name_jp="テスト対象神社", kind="shrine", address="東京都テスト区1-1-1")
+    ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="既存タイトル",
+        publisher="別の発行主体",
+        url="https://example.jp/",
+        verification_status="source_confirmed",
+        verified_at="2025-01-01T00:00:00Z",
+        confidence="high",
+    )
+    seed_path = tmp_path / "seed.json"
+    seed_path.write_text(json.dumps(_minimal_seed()), encoding="utf-8")
+
+    with pytest.raises(CommandError, match="import blocked"):
+        call_command("import_shrine_knowledge", str(seed_path), "--dry-run", stdout=io.StringIO())
+
+    assert ShrineKnowledgeSource.objects.count() == 1
+    assert ShrineDeity.objects.count() == 0
+    assert ShrineHistory.objects.count() == 0
+
+
+def test_batch1_to_8_seeds_still_parse_under_source_reuse_contract():
+    seed_dir = Path(__file__).resolve().parents[1] / "data" / "knowledge_seeds"
+    for filename in ("batch_1_7_seed.json", "batch_8_seed.json"):
+        parsed = parse_seed(json.loads((seed_dir / filename).read_text(encoding="utf-8")))
+        assert parsed.errors == [], filename
 
 
 @pytest.mark.django_db

--- a/docs/audit/knowledge-batch9-source-semantic-conflict-remediation.md
+++ b/docs/audit/knowledge-batch9-source-semantic-conflict-remediation.md
@@ -1,0 +1,175 @@
+# Knowledge Batch 9 Source Semantic Conflict Remediation
+
+## Executive Summary
+
+- Date: 2026-08-10
+- Base: `develop` / `9519b7aa04b210eee1b083b59094cd0733c610bf`
+- Conflict: identical official Hakone URL was planned as a second Source because title differed
+- Classification before remediation: `SOURCE_SEMANTIC_DUPLICATE_CONFIRMED`
+- Selected design: unique `source_type + normalized URL` reuse with strict metadata compatibility
+- Revised Production delta: Source +5 / Deity +13 / History +5 / relations +13/+5
+- Production-equivalent: PASS; Hakone URL Source remains one row
+- Production validate-only/dry-run: PASS; CREATE 5, REUSE 1, Deity 13, History 5
+- Final classification: **`BATCH9_SOURCE_REMEDIATION_READY`**
+- Production DB writes: **0**
+- Batch 9 Production import: **NOT_EXECUTED**
+
+## 1. Conflict reproduction
+
+Production read-only inspection found one existing `shrine_official` Source at
+`https://hakonejinja.or.jp/hakone/`. It is titled
+「箱根神社・九頭龍神社・箱根元宮の由緒並に宝物と文化財」 and is already
+related to 九頭龍神社 新宮のDeity「九頭龍大神」とHistory「新宮の建立」。
+
+The original Batch 9 seed used the same URL under title
+「箱根神社の由緒｜箱根神社」. The old importer queried
+`source_type + title + exact URL`, found no row, and planned `CREATE`. This
+would have produced two Source rows for one official Web document.
+
+**Reproduction classification: `SOURCE_SEMANTIC_DUPLICATE_CONFIRMED`.**
+
+## 2. Previous identity behavior
+
+The implementation was read fresh. It had no URL normalization. For a URL-backed
+Source, scheme, host case, trailing slash, query, fragment, and title all had to
+match the stored values exactly. Publisher, verification status, confidence,
+language, and note were not considered by matching. The first title-based match
+was silently selected. This explained both the false CREATE and the inability to
+detect multiple semantic URL matches.
+
+## 3. Design comparison and decision
+
+| Candidate | Result |
+| --- | --- |
+| A — retain old key and align seed title | Fixes only the observed row; future title drift can recreate the bug |
+| B — `source_type + normalized URL` identity | Selected; portable, no schema/PK dependency, detects the whole bug class |
+| C — explicit reuse marker in seed | Rejected for now; introduces a new seed contract and still needs identity resolution |
+| D — stable external key/model field | Deferred; requires schema migration and Production model change |
+
+Candidate B is implemented without schema changes. URL normalization:
+
+- lowercases scheme and host;
+- removes default ports;
+- ignores fragments and a non-root trailing slash;
+- preserves query strings;
+- keeps http and https distinct.
+
+Exactly one same-type normalized-URL match is reusable only when publisher,
+verification status, confidence, bibliography, and language agree after outer
+whitespace trimming. Title, access/verification timestamps, and note do not
+define document identity and are not overwritten.
+
+- unique and compatible: `SOURCE_REUSE_SAFE` / `REUSE_EXISTING`
+- unique but important metadata differs: `SOURCE_REUSE_CONFLICT` / hard stop
+- multiple matches: `SOURCE_REUSE_AMBIGUOUS` / hard stop
+- no match: `CREATE`
+
+URL-less Sources retain the previous `source_type + title + bibliography`
+lookup. Existing rows are never updated.
+
+## 4. Seed remediation and hashes
+
+The Hakone seed Source title, publisher, and language now match the existing
+portable Source metadata. No Production Source PK or environment-specific ID is
+stored.
+
+- Old STOP-state SHA-256:
+  `a4acc276839e8b25937f6a5d7e830365783c7fb787ff5b5d01f29e20dc5116e4`
+- Remediated SHA-256:
+  `8178e49da03ec4d2a1024e3708c2d16c35e549c6c70e3a6aeb439ef156f98be4`
+
+The portable seed still contains six Source descriptions, 13 Deities, five
+Histories, and relation references 13/5. Against current Production, one Source
+is reused, so the write delta is Source +5, Deity +13, History +5, and relations
++13/+5.
+
+## 5. Regression protection
+
+The importer tests now cover:
+
+1. same type + normalized URL + different title reuses rather than creates;
+2. newly created Facts link to the reused Source;
+3. multiple existing semantic matches stop atomically;
+4. meaningful metadata conflict stops atomically;
+5. host case and trailing-slash normalization;
+6. Batch 1–7 and Batch 8 seeds still parse, while the existing importer suite
+   preserves create, validation, ambiguity, atomicity, round-trip, and
+   idempotency behavior.
+
+Focused remediation suite: **27 passed**.
+
+## 6. Disposable local validation
+
+A clean disposable local PostgreSQL database was migrated and populated with
+the five canonical target identities plus one compatible existing Hakone
+Source. Results:
+
+- validate-only: PASS
+- first dry-run: Source CREATE 5 / REUSE 1 / Deity CREATE 13 / History CREATE 5
+- one local import: exit 0; created 5/13/5
+- relations: 13/5
+- source-less Deity/History: 0/0
+- Hakone normalized URL Source count after import: 1
+- second dry-run: Source REUSE 6 / Deity SKIP 13 / History SKIP 5 / CREATE 0
+
+## 7. Fresh Production-equivalent validation
+
+A fresh read-only Production dump was restored into a guard-approved isolated
+local database. The existing Hakone Source and its 九頭龍神社 新宮 relations
+were present before import.
+
+| Metric | Before | After | Delta | Result |
+| --- | ---: | ---: | ---: | --- |
+| Shrine | 105 | 105 | 0 | PASS |
+| Knowledge Shrine | 46 | 51 | +5 | PASS |
+| Source | 65 | 70 | +5 | PASS |
+| Deity | 117 | 130 | +13 | PASS |
+| History | 91 | 96 | +5 | PASS |
+| Deity–Source | 130 | 143 | +13 | PASS |
+| History–Source | 96 | 101 | +5 | PASS |
+| Hakone normalized URL Source | 1 | 1 | 0 | PASS |
+| complete | 44 | 49 | +5 | PASS |
+| partial | 2 | 2 | 0 | PASS |
+| none (105-row operational classification) | 59 | 54 | -5 | PASS |
+
+Source-less Deity/History remained 0/0. Users 1, profiles 1, shrines 105,
+favorites 0, visits 2, and goriyaku relations 283 were unchanged. The second
+dry-run planned Source REUSE 6 and Fact SKIP 18 with no CREATE or error.
+
+## 8. Production read-only validation
+
+Production `--validate-only` passed. Production `--dry-run` planned:
+
+- Source CREATE: 5
+- Source REUSE_EXISTING: 1 (Hakone official Source)
+- Deity CREATE: 13
+- History CREATE: 5
+- UPDATE: 0
+- ambiguous: 0
+- conflict: 0
+- error: 0
+
+No Production import or Source update was executed.
+
+## 9. Remaining risks and execution boundary
+
+- Redirect-equivalent URLs and query-parameter equivalence are not inferred.
+  Query strings deliberately remain identity-significant.
+- The compatibility field set is conservative. A blank/nonblank difference in
+  publisher, status, confidence, bibliography, or language stops reuse and must
+  be reviewed rather than silently enriched.
+- The database has no uniqueness constraint on semantic URL identity. The
+  importer detects multiple matches at planning time, but concurrent creation
+  outside this importer remains a residual risk.
+- Existing Fact `SKIP_EXISTS` still does not compare every Fact field. Any
+  unexpected Fact skip in a future execution gate remains a hard stop.
+
+The next Production Execution Gate must use only remediated hash
+`8178e49d…98be4` and expected Source CREATE 5 + REUSE 1. The old all-Source-
+CREATE expectation and old seed hash are invalid for execution.
+
+**Final classification: `BATCH9_SOURCE_REMEDIATION_READY`.**
+
+- Production DB writes: **0**
+- Batch 9 Production import: **NOT_EXECUTED**
+- Batch 10: **NOT_STARTED**

--- a/docs/audit/knowledge-production-import-foundation.md
+++ b/docs/audit/knowledge-production-import-foundation.md
@@ -182,12 +182,18 @@ schema変更を伴い、Batch 8相当の判断が必要なため）。既存fiel
 
 | Model | 既存行とみなす条件 |
 |---|---|
-| `ShrineKnowledgeSource` | `source_type` + `title` + (`url`があれば`url`一致／なければ`bibliography`一致) |
+| `ShrineKnowledgeSource`（URLあり） | `source_type` + normalized URL。重要metadata一致時だけ一意な既存Sourceを`REUSE_EXISTING` |
+| `ShrineKnowledgeSource`（URLなし） | `source_type` + `title` + (`bibliography`があれば`bibliography`一致) |
 | `ShrineDeity` | `shrine` + `display_name` |
 | `ShrineHistory` | `shrine` + `history_type` + `title` |
 
-**CREATE/UPDATE policy**: 一致する既存行があれば`SKIP_EXISTS`（**silent
-overwriteしない**——内容が古くても上書きしない）。新規のみ`CREATE`。
+URL normalizationはscheme/hostのcase、default port、fragment、非root末尾slash
+のみを正規化する。http/httpsとquery stringは区別する。normalized URL一致が
+複数なら`SOURCE_REUSE_AMBIGUOUS`、publisher/verification_status/confidence/
+bibliography/languageが異なれば`SOURCE_REUSE_CONFLICT`として全importを停止する。
+
+**CREATE/UPDATE policy**: 一致する既存Sourceは`REUSE_EXISTING`、既存Factは
+`SKIP_EXISTS`（**silent overwriteしない**——内容が古くても上書きしない）。新規のみ`CREATE`。
 既存Factの内容修正は本Foundationのimporterでは扱わない
 （Section 12「Limitations」参照、既存のAdmin編集フローを使う）。
 
@@ -354,10 +360,10 @@ error）を確認してから、である。
 1. **既存Fact更新（`--allow-update`）は未実装**: 現状は新規作成のみ。
    既存Factの内容修正はSection 12の手動フロー（Admin編集）に依存する。
    将来のPRで、明示的なdiff表示を伴う更新modeを追加検討できる
-2. **Source natural keyはcontent-based**: 専用field追加はschema変更を
-   伴うため本Foundationのscope外とした。同一Sourceでも`title`の
-   言い回しが変わると別Source扱いになる。seed編集時は既存Sourceの
-   `title`表記を維持することが望ましい
+2. **Source semantic identityはURL依存**: 専用field追加はschema変更を
+   伴うため未実装。URL-backed Sourceは`source_type + normalized URL`で
+   再利用するが、URL自体の恒久的変更・redirect先同一性は自動判定しない。
+   重要metadata差または同一identity複数行はsilent reuseせず停止する
 3. **address一致は完全一致**: 表記ゆれ（全角/半角等）が将来生じた場合、
    `resolve_shrine`は`name_jp`のみでの絞り込みへfallbackし、複数一致
    時は`place_ref_id IS NULL`優先ロジックへ進む。今回の41神社では

--- a/docs/knowledge/shrine-knowledge-contract.md
+++ b/docs/knowledge/shrine-knowledge-contract.md
@@ -429,6 +429,20 @@ Web出典のみを前提にしない。以下を扱えるようにする。
 - 文化財データ
 - 現地観察記録
 
+### Import時のSource semantic identity
+
+URLを持つSourceは、portableなimportにおいて`source_type + normalized URL`を
+semantic identityとして扱う。titleの表記差だけを理由に同じWeb文書を重複作成
+しない。normalizationはscheme/hostのcase、default port、fragment、非rootの
+末尾slashに限定し、http/httpsおよびquery stringは区別する。
+
+同一identityの既存Sourceが1件だけで、publisher、verification_status、
+confidence、bibliography、languageがseedと一致するときだけ再利用できる。
+複数一致は`SOURCE_REUSE_AMBIGUOUS`、重要metadata差は
+`SOURCE_REUSE_CONFLICT`としてimport全体を停止する。既存Sourceを上書きせず、
+Production numeric PKをseedへ記録しない。URLを持たないSourceは既存の
+`source_type + title + bibliography`契約を維持する。
+
 ### accessed_atとverified_at
 
 - `accessed_at`: 情報源（URL・資料）へアクセスした日


### PR DESCRIPTION
## 概要

Batch 9 Production Import Gateで検出された、箱根神社の既存公式Sourceとseed Sourceが同一URLにもかかわらず、タイトル差異によって新規作成扱いになる問題を解消します。

## 原因

従来のSource自然キーは `source_type + title + URL` を基準としていたため、同一の公式ページでもタイトル表記が異なると別Sourceとして扱われていました。

## 変更内容

- URL付きSourceを `source_type + normalized URL` で識別
- scheme/hostの大小文字、default port、fragment、非root末尾スラッシュを安全に正規化
- 一意かつ意味のあるmetadataが一致する場合は `REUSE_EXISTING`
- metadata不一致は `CONFLICT`、複数一致は `AMBIGUOUS` としてimport全体を停止
- Batch 9の箱根神社Source metadataをProduction既存Sourceへ整合
- 既存Batch 1〜8との互換性、再利用、競合、曖昧性、idempotencyのテストを追加
- remediation監査記録とSource identity contractを更新

## 検証

- Django system check: PASS
- Ruff / Black: PASS
- 関連回帰テスト: 57 passed
- pre-push OpenAPI lint: PASS
- pre-push Web契約テスト: 731 passed
- local隔離DB import / idempotency: PASS
- Production-equivalent restore import / idempotency / aggregate regression: PASS
- Production validate-only: PASS
- Production dry-run:
  - Source CREATE 5
  - Source REUSE_EXISTING 1
  - Deity CREATE 13
  - History CREATE 5
- credential / connection string / private host scan: PASS
- git diff --check: PASS

## 安全性

- Production DB writes: 0
- Batch 9 Production import: NOT_EXECUTED
- Batch 10: NOT_STARTED
- 自動修復・二重import: 未実施

最終分類: `BATCH9_SOURCE_REMEDIATION_READY`
