### PR TITLE
バックアップ処理で接続先情報をログへ出さないよう修正

### DIFF
--- a/docs/audit/migration-safety-tooling.md
+++ b/docs/audit/migration-safety-tooling.md
@@ -135,7 +135,7 @@ extension配置がローカル環境と異なる可能性がある点を「既�
 ### Phase 1 — Backup Route
 - [x] manual dump手順をRunbook化（`README.md`「Runbook: Manual Backup Route」）
 - [x] dump保存先をrepo外に固定（`guard.py`の`is_safe_dump_path`で強制）
-- [x] credential非露出チェックを入れる（`redact_url`、scriptはURLを平文でechoしない）
+- [x] credential・接続先非露出チェックを入れる（URL、username、password、hostname、port、DB名、queryを成功・失敗ログの双方で非表示）
 - [x] dump file存在/size確認手順を作る（`dump_readonly.sh`が自動で各ファイルのサイズを表示・0バイト時警告）
 
 ### Phase 2 — Restore Verification Route
@@ -171,7 +171,7 @@ extension配置がローカル環境と異なる可能性がある点を「既�
 - [x] Production hostname検出時の確認処理 → allow-list方式で実装（デザイン上の理由は上述）
 - [x] destructive commandを自動実行しない（scriptはいずれも明示的な引数なしでは何もしない。デフォルト接続先なし）
 - [x] dry-run/read-onlyをデフォルトにする（`dump_readonly.sh`はread-onlyのみ、書き込み系操作は`restore_isolated.sh`のみで、かつguard必須）
-- [x] credentialをログ出力しない（`redact_url`使用、E2Eテストでも実際にログへ`***`が出ることを確認済み）
+- [x] credential・hostnameをログ出力しない（接続先文字列を表示せず、client stderrもgeneric failureへ置換）
 - [x] dumpをGit対象外にする（`is_safe_dump_path`で強制。加えて一時dumpは`/tmp`配下、テスト終了時に削除）
 
 ### Phase 7 — Test
@@ -217,6 +217,39 @@ extension配置がローカル環境と異なる可能性がある点を「既�
 - `docs/audit/migration-safety-tooling.md`: 本ドキュメント（新規）
 - 既存コード（`backend/`アプリケーションコード）への変更: **なし**
 - Production DB・Environment・deploy設定への変更: **なし**
+
+---
+
+## 追補: Backup connection-target logging remediation
+
+Batch 9 Production Import Gateのfresh backupで、旧
+`dump_readonly.sh`がuser/passwordのみをmaskしたURLを表示し、hostname、
+port、database name、query parameterをログへ残すことが確認された。
+Production固有値を使わず、`.invalid`のdummy URLとfake clientで同じ挙動を
+再現し、`BACKUP_LOG_HOSTNAME_EXPOSURE_CONFIRMED`と分類した。
+
+修正後の契約は「接続先を表す文字列そのものを出力しない」である。
+`dump_readonly.sh`と`restore_isolated.sh`はgeneric messageのみを表示し、URLを
+libpq `PG*`環境変数へ変換してからchild processのargvから除外する。libpqの
+失敗診断は接続先要素を含み得るため、tooling境界でgeneric failureへ置換する。
+file名、file size、phase、success/failureは安全な運用metadataとして維持する。
+
+`tests/test_backup_logging.sh`はfake clientだけを使用し、成功時・失敗時ともに
+dummy username/password/hostname/port/database/queryが出力されないこと、かつ
+非0 file sizeと完了状態が残ることを固定する。Production backup、Production
+DB接続、Batch 9 importは本remediationでは実行しない。
+
+検証結果:
+
+- logging regression: PASS
+- guard unit tests: 47 PASS
+- credential bridge E2E: PASS
+- local backup/restore/migrate/rollback E2E: PASS
+- shellcheck / bash syntax / diff check: PASS
+- credential・connection string・private hostname scan: PASS（追加URLはdummy
+  `.invalid`、既存local E2E URL、generic provider exampleのみ）
+
+最終分類: `BACKUP_LOGGING_REMEDIATION_READY`
 
 ## 次にMother Shipが用意すべきもの
 

--- a/scripts/migration_safety/README.md
+++ b/scripts/migration_safety/README.md
@@ -24,14 +24,15 @@ Background reading (read in this order):
 | `guard.py` | Pure-Python safety guard. Allow-list (not deny-list) check for restore targets; repo-boundary check for dump/credential-file paths; credential redaction and structural-shape-only description for logging; read-only SQL statement allow-list; URI → `PG*` env-var export so a credential never needs to appear on a command line. No DB/network code. |
 | `check_credential_presence.sh` | Reports whether a credential file/variable is set and well-formed — booleans only, never the value, host, or length. |
 | `readonly_query.sh` | Runs a SQL file against a database using a credential file outside the repo, after checking every statement is read-only. Connects via `PG*` env vars so the credential never appears in `ps`. See "Credential Bridge" below. |
-| `dump_readonly.sh` | Read-only logical dump (`pg_dumpall --roles-only` + `pg_dump --schema-only` + `pg_dump --data-only`, `public` schema only) of a URL you pass explicitly. |
-| `restore_isolated.sh` | Restores a dump into a target URL, but only after `guard.py` confirms the target is a disposable local database. Refuses otherwise. |
+| `dump_readonly.sh` | Read-only logical dump (`pg_dumpall --roles-only` + `pg_dump --schema-only` + `pg_dump --data-only`, `public` schema only) of a URL you pass explicitly. Logs no connection-target component and keeps the URL out of child-process argv. |
+| `restore_isolated.sh` | Restores a dump into a target URL only after `guard.py` confirms the target is a disposable local database. Logs no connection-target component and keeps the URL out of `psql` argv. |
 | `sql/migration_state.sql` | SELECT-only. Per-app latest applied migration. |
 | `sql/pre_migration_snapshot.sql` | SELECT-only. Run immediately before a backup/migration attempt; records the baseline to compare against later. |
 | `sql/post_migration_verification.sql` | SELECT-only. Run after migration; every value must match the pre-migration snapshot except the two migrations you intentionally applied. |
 | `tests/test_guard.py` | Unit tests for `guard.py`, including the credential-bridge functions (`describe_url_shape`, `is_readonly_sql`, `pg_env_exports`). No DB required. |
 | `tests/test_backup_restore_e2e.sh` | End-to-end local test: builds a `users=0005`/`temples=0089` local database, dumps it, restores it into a second isolated database through the actual guarded scripts, verifies they match, applies `users 0006` + `temples 0090-0093` to the restored copy, verifies again, rolls back. Never touches Production. |
 | `tests/test_credential_bridge_e2e.sh` | End-to-end local test of the credential bridge using a fake local credential (never Production): presence check leaks nothing, a read-only query actually connects, writes/`EXPLAIN ANALYZE`/wrong-permissions/in-repo-path are all refused pre-connection. |
+| `tests/test_backup_logging.sh` | No-network regression test using fake clients. Proves successful and failed dumps never log URL, username, password, hostname, port, database name, or query parameters while retaining safe file-size/status metadata. |
 
 ## The core safety property
 
@@ -54,6 +55,19 @@ fails.
 The dump-path check works the other way: a dump's *output path* must
 resolve outside the git repository, so a Production dump can never end up
 staged for commit.
+
+## Connection-target logging contract
+
+Backup and restore tooling must never print a string that describes its
+connection target. This includes the full URL and every component: username,
+password, hostname, port, database name, and query/SSL parameters. Masking only
+userinfo is insufficient because a redacted URL still reveals the target.
+
+The scripts print generic connection-configured messages, convert URLs to
+libpq `PG*` environment variables before invoking clients, and replace client
+connection diagnostics with generic failures. Safe metadata remains visible:
+operation start, roles/schema/data phase, output file names and sizes, generic
+safety status, and success/failure. Dump files must remain outside the repo.
 
 ## Credential Bridge
 
@@ -118,6 +132,9 @@ scripts/migration_safety/tests/test_backup_restore_e2e.sh
 # Credential bridge end-to-end drill (seconds, uses a fake local
 # credential — never Production):
 scripts/migration_safety/tests/test_credential_bridge_e2e.sh
+
+# Backup logging contract (seconds, fake clients only; no DB/network):
+scripts/migration_safety/tests/test_backup_logging.sh
 ```
 
 All three are safe to run repeatedly and clean up everything they create
@@ -154,13 +171,10 @@ and wasn't requested.
    ( set -a; source ~/.config/kami-musubi/production-db.env; set +a; \
      scripts/migration_safety/dump_readonly.sh "$DATABASE_URL" ~/kami-musubi-backups/<timestamp>/ )
    ```
-   Note `dump_readonly.sh` itself still receives the resolved connection
-   string as an argument (unlike `readonly_query.sh`, it wraps `pg_dump`/
-   `pg_dumpall` directly rather than going through the `PG*` env-var
-   indirection) — this is pre-existing behavior from when the tool was
-   first built and wasn't changed here. It's a strictly read-only dump
-   either way; the credential just briefly appears in that one command's
-   argv on your own machine while it runs.
+   `dump_readonly.sh` receives the connection string as its own argument, then
+   consumes it through `guard.py pg-env-exports` and unsets it before invoking
+   `pg_dump`/`pg_dumpall`. Database-client argv and success/failure logs contain
+   no connection URL or target component.
 5. Confirm all three files (`roles.sql`, `schema.sql`, `data.sql`) exist
    and have non-zero size (the script prints sizes; it also warns on any
    zero-byte file).

--- a/scripts/migration_safety/dump_readonly.sh
+++ b/scripts/migration_safety/dump_readonly.sh
@@ -24,7 +24,12 @@
 # Safety:
 #   - OUTPUT_DIR is checked with guard.py and rejected if it resolves
 #     inside this git repository (prevents an accidental `git add`).
-#   - The URL is never echoed or logged; only its redacted form is.
+#   - No connection-target component is logged: not URL, user, password,
+#     hostname, port, database name, or query parameters.
+#   - The URL is converted to libpq PG* environment variables before the
+#     dump clients run, so child-process arguments contain no connection URL.
+#   - Client stderr is replaced with a generic failure message because libpq
+#     connection errors can include hostname, port, user, and database name.
 #   - Dump is scoped to `--schema=public` only (see docs/audit/
 #     production-manual-backup-restore-gate.md Phase 2 for why).
 set -euo pipefail
@@ -43,8 +48,7 @@ OUTPUT_DIR="$2"
 PG_DUMP_BIN="${PG_DUMP_BIN:-pg_dump}"
 PG_DUMPALL_BIN="${PG_DUMPALL_BIN:-pg_dumpall}"
 
-REDACTED_URL="$(python3 "${SCRIPT_DIR}/guard.py" redact "${SOURCE_DATABASE_URL}")"
-echo "[dump_readonly] source: ${REDACTED_URL}"
+echo "[dump_readonly] source connection configured"
 
 if ! python3 "${SCRIPT_DIR}/guard.py" check-dump-path "${OUTPUT_DIR}" "${REPO_ROOT}"; then
   echo "[dump_readonly] BLOCKED: output dir must be outside the repository. Aborting." >&2
@@ -53,17 +57,31 @@ fi
 
 mkdir -p "${OUTPUT_DIR}"
 
+# Consume the URL without printing it and keep it out of pg_dump/pg_dumpall
+# argv. Never print the generated exports: they contain the credential.
+eval "$(printf '%s' "${SOURCE_DATABASE_URL}" | python3 "${SCRIPT_DIR}/guard.py" pg-env-exports)"
+unset SOURCE_DATABASE_URL
+
 echo "[dump_readonly] dumping roles (read-only)..."
-"${PG_DUMPALL_BIN}" --dbname="${SOURCE_DATABASE_URL}" --roles-only --no-role-passwords \
-  > "${OUTPUT_DIR}/roles.sql"
+if ! "${PG_DUMPALL_BIN}" --roles-only --no-role-passwords \
+  > "${OUTPUT_DIR}/roles.sql" 2>/dev/null; then
+  echo "[dump_readonly] FAILED: roles dump command failed; connection details suppressed" >&2
+  exit 1
+fi
 
 echo "[dump_readonly] dumping schema (read-only, public schema only)..."
-"${PG_DUMP_BIN}" --dbname="${SOURCE_DATABASE_URL}" --schema-only --schema=public --no-owner --no-privileges \
-  > "${OUTPUT_DIR}/schema.sql"
+if ! "${PG_DUMP_BIN}" --schema-only --schema=public --no-owner --no-privileges \
+  > "${OUTPUT_DIR}/schema.sql" 2>/dev/null; then
+  echo "[dump_readonly] FAILED: schema dump command failed; connection details suppressed" >&2
+  exit 1
+fi
 
 echo "[dump_readonly] dumping data (read-only, public schema only)..."
-"${PG_DUMP_BIN}" --dbname="${SOURCE_DATABASE_URL}" --data-only --schema=public --no-owner --no-privileges \
-  > "${OUTPUT_DIR}/data.sql"
+if ! "${PG_DUMP_BIN}" --data-only --schema=public --no-owner --no-privileges \
+  > "${OUTPUT_DIR}/data.sql" 2>/dev/null; then
+  echo "[dump_readonly] FAILED: data dump command failed; connection details suppressed" >&2
+  exit 1
+fi
 
 for f in roles.sql schema.sql data.sql; do
   size=$(wc -c < "${OUTPUT_DIR}/${f}" | tr -d ' ')

--- a/scripts/migration_safety/restore_isolated.sh
+++ b/scripts/migration_safety/restore_isolated.sh
@@ -33,11 +33,10 @@ TARGET_DATABASE_URL="$2"
 
 PSQL_BIN="${PSQL_BIN:-psql}"
 
-REDACTED_URL="$(python3 "${SCRIPT_DIR}/guard.py" redact "${TARGET_DATABASE_URL}")"
-echo "[restore_isolated] target: ${REDACTED_URL}"
+echo "[restore_isolated] target connection configured"
 
-if ! python3 "${SCRIPT_DIR}/guard.py" check-restore-target "${TARGET_DATABASE_URL}"; then
-  echo "[restore_isolated] BLOCKED: target failed the isolation-target guard. Aborting. See stderr above for reason." >&2
+if ! python3 "${SCRIPT_DIR}/guard.py" check-restore-target "${TARGET_DATABASE_URL}" 2>/dev/null; then
+  echo "[restore_isolated] BLOCKED: target failed the isolation-target guard; connection details suppressed" >&2
   exit 1
 fi
 
@@ -48,21 +47,36 @@ for f in roles.sql schema.sql data.sql; do
   fi
 done
 
+# Keep the target URL out of psql argv and suppress libpq diagnostics, which
+# may contain hostname, port, username, or database name. The guard above has
+# already proved that this is an allow-listed disposable local target.
+eval "$(printf '%s' "${TARGET_DATABASE_URL}" | python3 "${SCRIPT_DIR}/guard.py" pg-env-exports)"
+unset TARGET_DATABASE_URL
+
 echo "[restore_isolated] applying roles.sql (best-effort; roles may already exist)..."
-"${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" --file="${DUMP_DIR}/roles.sql" --quiet || \
-  echo "[restore_isolated] roles.sql had non-fatal errors (likely pre-existing roles); continuing"
+"${PSQL_BIN}" --file="${DUMP_DIR}/roles.sql" --quiet 2>/dev/null || \
+  echo "[restore_isolated] roles.sql had non-fatal errors; connection details suppressed; continuing"
 
 echo "[restore_isolated] ensuring required extensions exist (postgis, pg_trgm — a --schema=public dump omits extension objects, since Supabase installs extensions outside public; this app's migrations only ever require these two, see backend/temples/migrations/0001_initial.py, 0027, 0036)..."
-"${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" --variable ON_ERROR_STOP=1 --quiet \
-  --command "CREATE EXTENSION IF NOT EXISTS postgis; CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+if ! "${PSQL_BIN}" --variable ON_ERROR_STOP=1 --quiet \
+  --command "CREATE EXTENSION IF NOT EXISTS postgis; CREATE EXTENSION IF NOT EXISTS pg_trgm;" 2>/dev/null; then
+  echo "[restore_isolated] FAILED: extension setup failed; connection details suppressed" >&2
+  exit 1
+fi
 
 echo "[restore_isolated] applying schema.sql (dropping the redundant 'CREATE SCHEMA public;' line — a fresh target DB already has an empty public schema from createdb, so re-issuing it would error)..."
-grep -v '^CREATE SCHEMA public;$' "${DUMP_DIR}/schema.sql" | "${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" \
-  --single-transaction --variable ON_ERROR_STOP=1 --quiet
+if ! grep -v '^CREATE SCHEMA public;$' "${DUMP_DIR}/schema.sql" | "${PSQL_BIN}" \
+  --single-transaction --variable ON_ERROR_STOP=1 --quiet 2>/dev/null; then
+  echo "[restore_isolated] FAILED: schema restore failed; connection details suppressed" >&2
+  exit 1
+fi
 
 echo "[restore_isolated] applying data.sql..."
-"${PSQL_BIN}" --dbname="${TARGET_DATABASE_URL}" --single-transaction --variable ON_ERROR_STOP=1 \
+if ! "${PSQL_BIN}" --single-transaction --variable ON_ERROR_STOP=1 \
   --command "SET session_replication_role = replica;" \
-  --file="${DUMP_DIR}/data.sql" --quiet
+  --file="${DUMP_DIR}/data.sql" --quiet 2>/dev/null; then
+  echo "[restore_isolated] FAILED: data restore failed; connection details suppressed" >&2
+  exit 1
+fi
 
 echo "[restore_isolated] done."

--- a/scripts/migration_safety/tests/test_backup_logging.sh
+++ b/scripts/migration_safety/tests/test_backup_logging.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Logging-contract regression tests for dump_readonly.sh.
+# Uses fake client binaries only: no database or network connection occurs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MIGSAFE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEST_DIR="$(mktemp -d /tmp/migration_safety_logging.XXXXXX)"
+SUCCESS_DUMP="${TEST_DIR}/success"
+FAIL_DUMP="${TEST_DIR}/failure"
+FAKE_DUMP="${TEST_DIR}/fake-pg-dump"
+FAKE_DUMPALL="${TEST_DIR}/fake-pg-dumpall"
+FAIL_DUMP_BIN="${TEST_DIR}/failing-pg-dump"
+
+DUMMY_USER="logging-regression-user"
+DUMMY_PASSWORD="logging-regression-password"
+DUMMY_HOST="logging-target.example.invalid"
+DUMMY_PORT="6543"
+DUMMY_DB="logging_regression_database"
+DUMMY_QUERY="sslmode=require"
+DUMMY_URL="postgresql://${DUMMY_USER}:${DUMMY_PASSWORD}@${DUMMY_HOST}:${DUMMY_PORT}/${DUMMY_DB}?${DUMMY_QUERY}"
+
+cleanup() {
+  rm -rf "${TEST_DIR}"
+}
+trap cleanup EXIT
+
+cat > "${FAKE_DUMP}" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' 'fake dump content'
+FAKE
+cat > "${FAKE_DUMPALL}" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' 'fake roles content'
+FAKE
+cat > "${FAIL_DUMP_BIN}" <<'FAKE'
+#!/usr/bin/env bash
+printf '%s\n' "simulated client error user=${PGUSER} password=${PGPASSWORD} host=${PGHOST} port=${PGPORT} database=${PGDATABASE}" >&2
+exit 1
+FAKE
+chmod +x "${FAKE_DUMP}" "${FAKE_DUMPALL}" "${FAIL_DUMP_BIN}"
+
+assert_no_connection_detail() {
+  local output="$1"
+  local token
+  for token in "${DUMMY_USER}" "${DUMMY_PASSWORD}" "${DUMMY_HOST}" "${DUMMY_PORT}" "${DUMMY_DB}" "${DUMMY_QUERY}" "${DUMMY_URL}"; do
+    if grep -Fq "${token}" <<<"${output}"; then
+      echo "[logging-test] FAIL: output leaked a connection-target component" >&2
+      exit 1
+    fi
+  done
+}
+
+echo "[logging-test] === successful fake dump ==="
+SUCCESS_OUTPUT="$(
+  PG_DUMP_BIN="${FAKE_DUMP}" PG_DUMPALL_BIN="${FAKE_DUMPALL}" \
+    "${MIGSAFE_DIR}/dump_readonly.sh" "${DUMMY_URL}" "${SUCCESS_DUMP}" 2>&1
+)"
+assert_no_connection_detail "${SUCCESS_OUTPUT}"
+grep -Fq '[dump_readonly] source connection configured' <<<"${SUCCESS_OUTPUT}"
+grep -Eq 'roles\.sql: [1-9][0-9]* bytes' <<<"${SUCCESS_OUTPUT}"
+grep -Eq 'schema\.sql: [1-9][0-9]* bytes' <<<"${SUCCESS_OUTPUT}"
+grep -Eq 'data\.sql: [1-9][0-9]* bytes' <<<"${SUCCESS_OUTPUT}"
+grep -Fq '[dump_readonly] done.' <<<"${SUCCESS_OUTPUT}"
+echo "[logging-test] PASS: safe metadata remains and all target components are hidden"
+
+echo "[logging-test] === failed fake dump ==="
+set +e
+FAIL_OUTPUT="$(
+  PG_DUMP_BIN="${FAIL_DUMP_BIN}" PG_DUMPALL_BIN="${FAKE_DUMPALL}" \
+    "${MIGSAFE_DIR}/dump_readonly.sh" "${DUMMY_URL}" "${FAIL_DUMP}" 2>&1
+)"
+FAIL_STATUS=$?
+set -e
+if [ "${FAIL_STATUS}" -eq 0 ]; then
+  echo "[logging-test] FAIL: failing client unexpectedly returned success" >&2
+  exit 1
+fi
+assert_no_connection_detail "${FAIL_OUTPUT}"
+grep -Fq 'connection details suppressed' <<<"${FAIL_OUTPUT}"
+echo "[logging-test] PASS: failed-client diagnostics cannot leak connection details"
+
+echo "[logging-test] ALL CHECKS PASSED. No database connection was attempted."

--- a/scripts/migration_safety/tests/test_backup_restore_e2e.sh
+++ b/scripts/migration_safety/tests/test_backup_restore_e2e.sh
@@ -26,15 +26,18 @@ STAMP="$(date +%Y%m%d%H%M%S)"
 SOURCE_DB="jinja_migration_safety_source_${STAMP}"
 RESTORE_DB="jinja_migration_safety_restore_test_${STAMP}"
 DUMP_DIR="$(mktemp -d /tmp/migration_safety_dump.XXXXXX)"
+DUMP_LOG="$(mktemp /tmp/migration_safety_dump_log.XXXXXX)"
+RESTORE_LOG="$(mktemp /tmp/migration_safety_restore_log.XXXXXX)"
 
 SOURCE_URL="postgres://$(whoami)@localhost:5432/${SOURCE_DB}"
 RESTORE_URL="postgres://$(whoami)@localhost:5432/${RESTORE_DB}"
 
 cleanup() {
-  echo "[e2e] cleanup: dropping ${SOURCE_DB}, ${RESTORE_DB}, removing ${DUMP_DIR}"
+  echo "[e2e] cleanup: dropping ${SOURCE_DB}, ${RESTORE_DB}, removing temporary files"
   dropdb --if-exists "${SOURCE_DB}" || true
   dropdb --if-exists "${RESTORE_DB}" || true
   rm -rf "${DUMP_DIR}"
+  rm -f "${DUMP_LOG}" "${RESTORE_LOG}"
 }
 trap cleanup EXIT
 
@@ -109,13 +112,27 @@ SELECT (SELECT COUNT(*) FROM auth_user) || ',' || (SELECT COUNT(*) FROM users_us
 echo "[e2e] source aggregate snapshot (auth_user,userprofile,shrine): ${SOURCE_SNAPSHOT}"
 
 echo "[e2e] === dumping source via dump_readonly.sh ==="
-"${MIGSAFE_DIR}/dump_readonly.sh" "${SOURCE_URL}" "${DUMP_DIR}"
+"${MIGSAFE_DIR}/dump_readonly.sh" "${SOURCE_URL}" "${DUMP_DIR}" 2>&1 | tee "${DUMP_LOG}"
+for token in localhost 5432 "${SOURCE_DB}"; do
+  if grep -Fq "${token}" "${DUMP_LOG}"; then
+    echo "[e2e] FAIL: dump tooling leaked a connection-target component" >&2
+    exit 1
+  fi
+done
+echo "[e2e] PASS: successful local dump logged no connection-target component"
 
 echo "[e2e] === creating isolated restore target (${RESTORE_DB}) ==="
 createdb "${RESTORE_DB}"
 
 echo "[e2e] === restoring via restore_isolated.sh (guarded) ==="
-"${MIGSAFE_DIR}/restore_isolated.sh" "${DUMP_DIR}" "${RESTORE_URL}"
+"${MIGSAFE_DIR}/restore_isolated.sh" "${DUMP_DIR}" "${RESTORE_URL}" 2>&1 | tee "${RESTORE_LOG}"
+for token in localhost 5432 "${RESTORE_DB}"; do
+  if grep -Fq "${token}" "${RESTORE_LOG}"; then
+    echo "[e2e] FAIL: restore tooling leaked a connection-target component" >&2
+    exit 1
+  fi
+done
+echo "[e2e] PASS: successful local restore logged no connection-target component"
 
 echo "[e2e] === comparing restored DB against source snapshot ==="
 RESTORE_SNAPSHOT="$(psql -d "${RESTORE_DB}" -tAc "


### PR DESCRIPTION
## 概要

Batch 9 Production Import Gateで検出された、backup toolingが接続先hostnameをログへ表示する問題を修正します。

## 原因

`dump_readonly.sh`と`restore_isolated.sh`はusername/passwordだけをmaskしたURLを表示していたため、hostname、port、database name、query parameterが残っていました。また、database clientの接続失敗stderrにも接続先情報が含まれる可能性がありました。

## 変更内容

- 接続URLやその構成要素を一切ログへ出さないcontractを明文化
- dump/restoreの接続先ログをgeneric messageへ変更
- URLをlibpqの`PG*`環境変数へ変換し、child-process argvから除外
- client stderrを接続情報を含まないgeneric failureへ置換
- 成功・失敗両方のlogging regression testを追加
- local backup/restore E2Eでhostname、port、DB名の非表示を検証
- READMEとmigration safety監査文書を更新

## 検証

- 現行漏えい再現: `BACKUP_LOG_HOSTNAME_EXPOSURE_CONFIRMED`
- 新規logging regression: PASS
- guard unit tests: 47 passed
- credential bridge E2E: PASS
- local backup/restore/migrate/rollback E2E: PASS
- shellcheck / bash syntax: PASS
- git diff --check: PASS
- credential / connection string / private hostname scan: PASS
- pre-push OpenAPI lint: PASS
- pre-push Web契約テスト: 731 passed

## 安全性

- Production backup: NOT_EXECUTED
- Production DB writes: 0
- Batch 9 import: NOT_EXECUTED
- Batch 10: NOT_STARTED

最終分類: `BACKUP_LOGGING_REMEDIATION_READY`
