### PR TITLE
Batch 13対象神社のKnowledge seedと投入前検証を追加

### DIFF
--- a/backend/temples/data/knowledge_seeds/batch_13_seed.json
+++ b/backend/temples/data/knowledge_seeds/batch_13_seed.json
@@ -1,0 +1,367 @@
+{
+  "schema_version": "1.0",
+  "sources": [
+    {
+      "key": "batch13-tomioka-official",
+      "source_type": "shrine_official",
+      "title": "御由緒",
+      "publisher": "富岡八幡宮",
+      "url": "http://www.tomiokahachimangu.or.jp/annai/goyuisho/goyuisho.html",
+      "bibliography": "",
+      "accessed_at": "2026-08-11",
+      "verified_at": "2026-08-11T05:20:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "公式サイトは「御祭神 応神天皇（誉田別命）外８柱」とのみ記載し、他8柱の個別名は明かしていない。本seedでは、個別名が確認できる応神天皇（誉田別命）のみをFact化し、未確認の他8柱を推測で補完していない（collective Factとしても作成していない）。寛永4年（1627）の創建と准勅祭社宣下を直接確認。"
+    },
+    {
+      "key": "batch13-iminomiya-official",
+      "source_type": "shrine_official",
+      "title": "忌宮神社",
+      "publisher": "忌宮神社",
+      "url": "https://iminomiya-jinjya.com/about/",
+      "bibliography": "",
+      "accessed_at": "2026-08-11",
+      "verified_at": "2026-08-11T05:21:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "仲哀天皇・神功皇后・応神天皇の三柱、延喜式内社・長門二宮・旧国幣社を直接確認。仲哀天皇の御神霊を豊浦宮に鎮祭したことが当社の起源と公式サイトが明記している。"
+    },
+    {
+      "key": "batch13-koura-official",
+      "source_type": "shrine_official",
+      "title": "ご祭神",
+      "publisher": "高良大社",
+      "url": "http://www.kourataisya.or.jp/kourataisya/saiji",
+      "bibliography": "",
+      "accessed_at": "2026-08-11",
+      "verified_at": "2026-08-11T05:22:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "八幡大神・高良玉垂命・住吉大神の三柱、筑後国一の宮・旧国幣大社・延喜式内明神大社を直接確認。仁徳天皇55年(367)または78年(390)の御鎮座伝承、履中天皇元年(400)の社殿建立を直接確認。"
+    },
+    {
+      "key": "batch13-kasama-official",
+      "source_type": "shrine_official",
+      "title": "笠間稲荷神社について",
+      "publisher": "笠間稲荷神社",
+      "url": "http://www.kasama.or.jp/about/index.html",
+      "bibliography": "",
+      "accessed_at": "2026-08-11",
+      "verified_at": "2026-08-11T05:23:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "宇迦之御魂神、白雉2年(651)の創建伝承、日本三大稲荷の一、御本殿が国指定重要文化財(昭和63年指定)であることを直接確認。"
+    },
+    {
+      "key": "batch13-washinomiya-official",
+      "source_type": "shrine_official",
+      "title": "鷲宮神社　神社由緒（祭神・主な御神徳）",
+      "publisher": "鷲宮神社",
+      "url": "http://www.washinomiyajinja.or.jp/history/history.html",
+      "bibliography": "",
+      "accessed_at": "2026-08-11",
+      "verified_at": "2026-08-11T05:24:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "現在の本殿祭神は天穂日命（天穂日宮の御霊徳を崇めて建てた別宮が現本殿）、相殿に武夷鳥命（景行天皇の御世に奉祀）を直接確認。由緒冒頭に登場する神崎神社・大己貴命は、天穂日命父子が別途創建した他の神社の祭神であり、鷲宮神社自体の祭神ではないためFact化していない。関東最古の大社・准勅祭社を直接確認。"
+    }
+  ],
+  "shrines": [
+    {
+      "shrine_ref": {
+        "name_jp": "富岡八幡宮",
+        "address": "東京都江東区富岡1-20-3"
+      },
+      "deities": [
+        {
+          "display_name": "応神天皇",
+          "canonical_name": "応神天皇（誉田別命）",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:20:00+00:00",
+          "note": "公式サイトは「御祭神 応神天皇（誉田別命）外８柱」と記載。他8柱は個別名が公式サイトに記載されておらず、本seedではFact化していない（推測補完・collective Fact化のいずれも行っていない）。",
+          "source_keys": ["batch13-tomioka-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "founding",
+          "title": "寛永4年(1627)の創建",
+          "content": "富岡八幡宮は寛永4年（1627年）、当時永代島と呼ばれていた現在地に御神託により創建された。周辺の砂州一帯を埋め立て、社地と氏子の居住地を開き、総じて六万五百八坪の社有地を得たとされる。世に「深川の八幡様」と親しまれ、「江戸最大の八幡様」と称される。",
+          "period_text": "寛永4年（1627）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:20:00+00:00",
+          "note": "",
+          "source_keys": ["batch13-tomioka-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "明治維新の准勅祭社宣下と徳川将軍家の崇敬",
+          "content": "江戸時代には、源氏の氏神である八幡大神を殊の外尊崇した徳川将軍家の手厚い保護を受けた。明治維新に際しては朝廷が富岡八幡宮を准勅祭社に治定し、勅使を遣わし幣帛を賜り、新しい御代の弥栄を祈念されたと公式サイトは記している。",
+          "period_text": "江戸時代〜明治維新期",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:20:00+00:00",
+          "note": "",
+          "source_keys": ["batch13-tomioka-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "忌宮神社",
+        "address": "山口県下関市長府宮の内町1-18"
+      },
+      "deities": [
+        {
+          "display_name": "仲哀天皇",
+          "canonical_name": "仲哀天皇",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:21:00+00:00",
+          "note": "仲哀天皇の御神霊を豊浦宮に鎮祭したことが当社の起源と公式サイトが明記。",
+          "source_keys": ["batch13-iminomiya-official"]
+        },
+        {
+          "display_name": "神功皇后",
+          "canonical_name": "神功皇后",
+          "role": "secondary",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:21:00+00:00",
+          "note": "仲哀天皇の御后。仲哀天皇の御神霊を豊浦宮へ鎮祭した当事者として由緒に登場する。",
+          "source_keys": ["batch13-iminomiya-official"]
+        },
+        {
+          "display_name": "応神天皇",
+          "canonical_name": "応神天皇",
+          "role": "secondary",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:21:00+00:00",
+          "note": "仲哀天皇・神功皇后とともに公式サイトが祭神として明記。",
+          "source_keys": ["batch13-iminomiya-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "仲哀天皇御神霊の鎮祭伝承",
+          "content": "第14代仲哀天皇は九州の熊襲平定のため西下し、穴門（長門）豊浦宮を興して7年間政務をとられた。天皇はさらに筑紫の香椎に進出したが1年で崩御し、神功皇后は喪を秘して重臣武内宿禰に御遺骸を奉じて豊浦宮に帰らせ、現在の長府侍町土肥山に殯斂（仮埋葬）した。皇后は懐妊中ながら新羅征討を決行し、凱旋の後、天皇の御神霊を豊浦宮に鎮祭した。これが当社の起源とされる。",
+          "period_text": "伝承（仲哀天皇御代）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:21:00+00:00",
+          "note": "公式サイト自身が由緒として記述。史実として断定していない。",
+          "source_keys": ["batch13-iminomiya-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "延喜式内社・長門二宮としての社格",
+          "content": "忌宮神社は『古事記』『日本書紀』にも記されている県内でも有数の歴史と伝統を誇る神社であり、延喜式内社に列せられている。社格は長門二宮・旧国幣社と公式サイトは記している。",
+          "period_text": "",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:21:00+00:00",
+          "note": "",
+          "source_keys": ["batch13-iminomiya-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "高良大社",
+        "address": "福岡県久留米市御井町1"
+      },
+      "deities": [
+        {
+          "display_name": "高良玉垂命",
+          "canonical_name": "高良玉垂命",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:22:00+00:00",
+          "note": "本殿中央に祀られる（公式サイトの図に基づく）。",
+          "source_keys": ["batch13-koura-official"]
+        },
+        {
+          "display_name": "八幡大神",
+          "canonical_name": "八幡大神",
+          "role": "secondary",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:22:00+00:00",
+          "note": "本殿向かって右に祀られる。",
+          "source_keys": ["batch13-koura-official"]
+        },
+        {
+          "display_name": "住吉大神",
+          "canonical_name": "住吉大神",
+          "role": "secondary",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:22:00+00:00",
+          "note": "本殿向かって左に祀られる。",
+          "source_keys": ["batch13-koura-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "仁徳天皇御代の御鎮座伝承",
+          "content": "高良大社の御鎮座は仁徳天皇55年（367）または78年（390）と伝えられ、履中天皇元年（400）に御社殿を建ててお祀りしたとされる。",
+          "period_text": "仁徳天皇55年(367)または78年(390)、履中天皇元年(400)（伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:22:00+00:00",
+          "note": "公式サイト自身が伝承として記述。史実として断定していない。",
+          "source_keys": ["batch13-koura-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "蒙古襲来時の勅使参向と綸旨",
+          "content": "文永・弘安の蒙古襲来（1274年・1281年）には勅使が参向し、蒙古調伏がなったことにより「天下の天下たるは、高良の高良たるが故なり」との綸旨を賜わったと伝えられ、「武運長久の神」として崇敬されてきたと公式サイトは記している。",
+          "period_text": "文永11年（1274）・弘安4年（1281）",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:22:00+00:00",
+          "note": "",
+          "source_keys": ["batch13-koura-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "笠間稲荷神社",
+        "address": "茨城県笠間市笠間1"
+      },
+      "deities": [
+        {
+          "display_name": "宇迦之御魂神",
+          "canonical_name": "宇迦之御魂神",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:23:00+00:00",
+          "note": "公式サイトが「御祭神」として明記する唯一の祭神。",
+          "source_keys": ["batch13-kasama-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "白雉2年(651)の創建伝承",
+          "content": "笠間稲荷神社の御創建は、社伝によれば第36代孝徳天皇の御代、白雉2年（651）と伝えられている。笠間稲荷神社は日本三大稲荷のひとつとして広く親しまれている。",
+          "period_text": "白雉2年（651）（伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:23:00+00:00",
+          "note": "公式サイト自身が伝承として記述。史実として断定していない。",
+          "source_keys": ["batch13-kasama-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "御本殿の国重要文化財指定",
+          "content": "御本殿は江戸時代末期の安政・万延年間（1854～1860）の再建で、銅瓦葺総欅の権現造。昭和63年に国の重要文化財に指定された。",
+          "period_text": "安政・万延年間（1854〜1860）再建、昭和63年指定",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:23:00+00:00",
+          "note": "",
+          "source_keys": ["batch13-kasama-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "鷲宮神社",
+        "address": "埼玉県久喜市鷲宮1-6-1"
+      },
+      "deities": [
+        {
+          "display_name": "天穂日命",
+          "canonical_name": "天穂日命",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:24:00+00:00",
+          "note": "天穂日命の御霊徳を崇めて建てられた別宮が現在の本殿であると公式サイトが明記。",
+          "source_keys": ["batch13-washinomiya-official"]
+        },
+        {
+          "display_name": "武夷鳥命",
+          "canonical_name": "武夷鳥命",
+          "role": "secondary",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:24:00+00:00",
+          "note": "景行天皇の御世に相殿へ奉祀されたと公式サイトが明記。",
+          "source_keys": ["batch13-washinomiya-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "出雲族草創の伝承と関東最古の大社",
+          "content": "鷲宮神社は出雲族の草創に係る関東最古といわれる大社である。神代の昔、天穂日宮とその御子武夷鳥宮とが部族を率いて神崎神社（大己貴命）を建てて奉祀したのに始まり、次いで天穂日宮の御霊徳を崇め別宮を建てて奉祀した。この別宮が現在の本殿であると伝えられている。",
+          "period_text": "神代の昔（伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:24:00+00:00",
+          "note": "神崎神社・大己貴命は鷲宮神社創建以前の別の神社に関する記述であり、鷲宮神社自体の祭神ではない。公式サイト自身が伝承として記述し、史実として断定していない。",
+          "source_keys": ["batch13-washinomiya-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "明治天皇御世の准勅祭社宣下",
+          "content": "明治天皇の御世には、神祗官達により准勅祭社に定められ、勅使参向のもと幣帛の奉納がなされた。明治天皇行幸の際には当神社に御少憩され、祭祀料を賜ったと公式サイトは記している。中世以降も藤原秀郷・源頼朝・徳川家康等、歴史上有名な武将の崇敬を受け、江戸時代には四百石の神領を与えられた。",
+          "period_text": "中世〜明治天皇御代",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-11T05:24:00+00:00",
+          "note": "",
+          "source_keys": ["batch13-washinomiya-official"]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/temples/tests/test_batch13_knowledge_seed.py
+++ b/backend/temples/tests/test_batch13_knowledge_seed.py
@@ -1,0 +1,204 @@
+import io
+import json
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services.knowledge_seed import parse_seed
+
+SEED_PATH = Path(__file__).resolve().parents[1] / "data" / "knowledge_seeds" / "batch_13_seed.json"
+
+TARGETS = [
+    ("富岡八幡宮", "東京都江東区富岡1-20-3"),
+    ("忌宮神社", "山口県下関市長府宮の内町1-18"),
+    ("高良大社", "福岡県久留米市御井町1"),
+    ("笠間稲荷神社", "茨城県笠間市笠間1"),
+    ("鷲宮神社", "埼玉県久喜市鷲宮1-6-1"),
+]
+
+# Deity names that must never appear: unresolvable/unnamed placeholders or
+# deities belonging to a different, merely-referenced shrine.
+EXCLUDED_NAMES = ["他8柱", "外8柱", "大己貴命"]
+
+
+def test_batch13_seed_schema_counts_and_relations():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    assert seed.errors == []
+    assert len(seed.sources) == 5
+    assert len(seed.shrines) == 5
+    assert sum(len(shrine.deities) for shrine in seed.shrines) == 10
+    assert sum(len(shrine.histories) for shrine in seed.shrines) == 10
+    assert sum(len(deity.source_keys) for shrine in seed.shrines for deity in shrine.deities) == 10
+    assert (
+        sum(len(history.source_keys) for shrine in seed.shrines for history in shrine.histories)
+        == 10
+    )
+
+    identities = [(shrine.name_jp, shrine.address) for shrine in seed.shrines]
+    assert identities == TARGETS
+    assert len(identities) == len(set(identities))
+    assert all(deity.source_keys for shrine in seed.shrines for deity in shrine.deities)
+    assert all(history.source_keys for shrine in seed.shrines for history in shrine.histories)
+
+
+def test_batch13_seed_tomioka_hachimangu_has_only_named_deity():
+    """富岡八幡宮の公式サイトは「応神天皇（誉田別命）外８柱」とのみ記載し、
+    他8柱の個別名を明かしていない。未確認の8柱を推測登録せず、
+    collective Factとしても作成していないことを固定化する。"""
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    tomioka = next(shrine for shrine in seed.shrines if shrine.name_jp == "富岡八幡宮")
+    deity_names = [d.display_name for d in tomioka.deities]
+    assert deity_names == ["応神天皇"]
+    for excluded in EXCLUDED_NAMES:
+        assert excluded not in deity_names
+
+
+def test_batch13_seed_washinomiya_excludes_referenced_shrine_deity():
+    """鷲宮神社の由緒冒頭に登場する「神崎神社（大己貴命）」は、鷲宮神社
+    創建以前に天穂日命父子が別途建てた他の神社の祭神であり、鷲宮神社
+    自体の祭神ではない。誤って鷲宮神社の祭神としてFact化していないことを
+    固定化する。"""
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    washinomiya = next(shrine for shrine in seed.shrines if shrine.name_jp == "鷲宮神社")
+    deity_names = [d.display_name for d in washinomiya.deities]
+    assert deity_names == ["天穂日命", "武夷鳥命"]
+    assert "大己貴命" not in deity_names
+
+
+def test_batch13_seed_no_within_shrine_duplicates():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    for shrine in seed.shrines:
+        names = [d.display_name for d in shrine.deities]
+        assert len(names) == len(set(names)), shrine.name_jp
+
+        history_keys = [(h.history_type, h.title) for h in shrine.histories]
+        assert len(history_keys) == len(set(history_keys)), shrine.name_jp
+
+
+def test_batch13_seed_all_facts_are_source_confirmed_high_confidence():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    for shrine in seed.shrines:
+        for deity in shrine.deities:
+            assert deity.verification_status == "source_confirmed", (shrine.name_jp, deity.display_name)
+            assert deity.confidence == "high", (shrine.name_jp, deity.display_name)
+            assert deity.verified_at is not None, (shrine.name_jp, deity.display_name)
+        for history in shrine.histories:
+            assert history.verification_status == "source_confirmed", (shrine.name_jp, history.title)
+            assert history.confidence == "high", (shrine.name_jp, history.title)
+            assert history.verified_at is not None, (shrine.name_jp, history.title)
+
+
+def test_batch13_seed_role_assignment_matches_official_hierarchy():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+    by_name = {shrine.name_jp: shrine for shrine in seed.shrines}
+
+    koura_roles = {d.display_name: d.role for d in by_name["高良大社"].deities}
+    assert koura_roles["高良玉垂命"] == "primary"
+    assert koura_roles["八幡大神"] == "secondary"
+    assert koura_roles["住吉大神"] == "secondary"
+
+    iminomiya_roles = {d.display_name: d.role for d in by_name["忌宮神社"].deities}
+    assert iminomiya_roles["仲哀天皇"] == "primary"
+    assert iminomiya_roles["神功皇后"] == "secondary"
+    assert iminomiya_roles["応神天皇"] == "secondary"
+
+
+def test_batch13_seed_source_semantic_identity_no_conflict_with_prior_batches():
+    """Batch13の5 SourceはBatch11/12のSourceと異なるURLであるべき
+    (source_type + normalized URLの衝突がないことをseed同士で確認)。"""
+    seed_dir = SEED_PATH.parent
+    batch11 = json.loads((seed_dir / "batch_11_seed.json").read_text(encoding="utf-8"))
+    batch12 = json.loads((seed_dir / "batch_12_seed.json").read_text(encoding="utf-8"))
+    batch13 = json.loads(SEED_PATH.read_text(encoding="utf-8"))
+
+    prior_urls = {s["url"] for s in batch11["sources"]} | {s["url"] for s in batch12["sources"]}
+    batch13_urls = {s["url"] for s in batch13["sources"]}
+    assert prior_urls.isdisjoint(batch13_urls)
+
+
+@pytest.mark.django_db
+def test_batch13_seed_import_is_idempotent_and_preserves_unrelated_knowledge():
+    for name_jp, address in TARGETS:
+        Shrine.objects.create(name_jp=name_jp, kind="shrine", address=address)
+
+    unrelated = Shrine.objects.create(
+        name_jp="既存Knowledge神社（Batch13無関係）", kind="shrine", address="東京都既存区5-5-5"
+    )
+    existing_source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="既存公式Source（Batch13無関係）",
+        url="https://existing-batch13.example.jp/",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    existing_deity = ShrineDeity.objects.create(
+        shrine=unrelated,
+        display_name="既存祭神（Batch13無関係）",
+        role="primary",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    existing_deity.sources.set([existing_source])
+    existing_history = ShrineHistory.objects.create(
+        shrine=unrelated,
+        history_type="historical_event",
+        title="既存沿革（Batch13無関係）",
+        content="既存の沿革本文。",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    existing_history.sources.set([existing_source])
+
+    call_command("import_shrine_knowledge", str(SEED_PATH), stdout=io.StringIO())
+
+    targets = Shrine.objects.filter(name_jp__in=[name for name, _ in TARGETS])
+    assert ShrineKnowledgeSource.objects.count() == 6
+    assert ShrineDeity.objects.filter(shrine__in=targets).count() == 10
+    assert ShrineHistory.objects.filter(shrine__in=targets).count() == 10
+    for excluded in EXCLUDED_NAMES:
+        assert not ShrineDeity.objects.filter(shrine__in=targets, display_name=excluded).exists()
+    assert all(deity.sources.exists() for deity in ShrineDeity.objects.filter(shrine__in=targets))
+    assert all(
+        history.sources.exists() for history in ShrineHistory.objects.filter(shrine__in=targets)
+    )
+
+    dry_run = io.StringIO()
+    call_command("import_shrine_knowledge", str(SEED_PATH), "--dry-run", stdout=dry_run)
+    output = dry_run.getvalue()
+    assert "'source_REUSE_EXISTING': 5" in output
+    assert "'deity_SKIP_EXISTS': 10" in output
+    assert "'history_SKIP_EXISTS': 10" in output
+    assert "CREATE" not in output
+
+    existing_deity.refresh_from_db()
+    existing_history.refresh_from_db()
+    assert existing_deity.display_name == "既存祭神（Batch13無関係）"
+    assert existing_history.content == "既存の沿革本文。"
+    assert list(existing_deity.sources.all()) == [existing_source]
+    assert list(existing_history.sources.all()) == [existing_source]
+
+
+@pytest.mark.django_db
+def test_batch13_seed_validate_only_fails_when_target_shrine_missing():
+    # Only create 4 of the 5 targets — 鷲宮神社 is intentionally missing.
+    for name_jp, address in TARGETS[:-1]:
+        Shrine.objects.create(name_jp=name_jp, kind="shrine", address=address)
+
+    with pytest.raises(Exception):
+        call_command(
+            "import_shrine_knowledge",
+            str(SEED_PATH),
+            "--validate-only",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )

--- a/docs/audit/knowledge-batch13-seed-preflight.md
+++ b/docs/audit/knowledge-batch13-seed-preflight.md
@@ -1,0 +1,438 @@
+> **Status: `BATCH13_PRODUCTION_IMPORT_READY_WITH_LIMITATIONS`。**
+>
+> 本ドキュメントは`docs/audit/knowledge-batch13-target-selection.md`
+> （`BATCH13_TARGET_SELECTION_READY`）で選定されたRecommended 5社
+> について、Knowledge seedを構築し、Production投入直前の技術Gateまで
+> 検証した記録である。
+>
+> **本ドキュメント作成のセッションでは、Production Knowledge writeは
+> 実行していない。** 実行したのは、Production read-only接続
+> （`readonly_query.sh`）、公式サイトのfresh確認（Browser pane）、
+> ローカルDBへの実際のseed投入・検証、fresh Production dumpから復元した
+> isolated DBへの実際のseed投入・検証、そしてProduction DBに対する
+> `--validate-only`・`--dry-run`（いずれもDB書き込みを一切行わない
+> モード）のみである。Production DB writeは0件。
+>
+> `READY_WITH_LIMITATIONS`とした理由は、富岡八幡宮の公式サイトが
+> 「御祭神 応神天皇（誉田別命）外８柱」とのみ記載し、他8柱の個別名を
+> 明かしていないためである（詳細はSection 5参照）。未確認の8柱は
+> 推測登録せず、Evidence Gateを遵守した限定的なFact化を行っている。
+
+develop SHA（作業開始時点）: `42b21690a50b6f8808727344edcacbf6b90ed163`
+（PR #2368反映済み、`origin/develop`と同期済み、working tree clean）。
+
+---
+
+## 1. Base state and contracts
+
+`docs/audit/knowledge-batch13-target-selection.md`を再読し、
+Recommended 5社を対象として確定した。
+
+freshに再読した既存contract:
+
+- `docs/knowledge/shrine-knowledge-contract.md`
+- `backend/temples/data/knowledge_seeds/batch_12_seed.json`（seed構造のテンプレート）
+- `backend/temples/services/knowledge_seed.py`
+- `backend/temples/management/commands/import_shrine_knowledge.py`
+
+いずれも構造変更なしで再利用可能であることを確認した。
+
+**注記**: 本タスク着手時、`docs/audit/knowledge-batch13-target-selection.md`
+を追加するPR #2368がまだmergeされていないことが判明した。Mother Shipの
+明示承認を得た上でPR #2368をmerge（squash、`42b21690`）してから本
+Seed Preparationに着手した。
+
+---
+
+## 2. Target Identity Recheck（fresh実測）
+
+Production read-only接続で、5社をfreshに再確認した。
+
+| shrine | Production id | `place_ref_id IS NULL` | 同名重複行 | deity_count | history_count |
+|---|---:|---|---:|---:|---:|
+| 富岡八幡宮 | 49（canonical）／104（非canonical重複） | true／false | 2 | 0 | 0 |
+| 忌宮神社 | 95 | true | 1 | 0 | 0 |
+| 高良大社 | 96 | true | 1 | 0 | 0 |
+| 笠間稲荷神社 | 82 | true | 1 | 0 | 0 |
+| 鷲宮神社 | 75 | true | 1 | 0 | 0 |
+
+富岡八幡宮は既知の非canonical重複行（id=104）が存在するが、
+`resolve_shrine`の`place_ref_id IS NULL`優先ロジックによりid=49が
+一意に解決される（`OK_CANONICAL_PREFERRED`）。**全5社が`IDENTITY_SAFE`。**
+numeric PKはseedへ記録しない。
+
+---
+
+## 3. Official Sources（Target Selection時の結果を再利用せずfresh確認）
+
+5社すべての公式サイトをBrowser paneで**再度**直接確認した。取得内容は
+Target Selectionセッション時と完全に一致し、drift 0件だった。
+
+| shrine | Source URL | 確認内容 |
+|---|---|---|
+| 富岡八幡宮 | http://www.tomiokahachimangu.or.jp/annai/goyuisho/goyuisho.html | 「御祭神 応神天皇（誉田別命）外８柱」、寛永4年(1627)創建、准勅祭社 |
+| 忌宮神社 | https://iminomiya-jinjya.com/about/ | 仲哀天皇・神功皇后・応神天皇、延喜式内社・長門二宮・旧国幣社 |
+| 高良大社 | http://www.kourataisya.or.jp/kourataisya/saiji | 八幡大神・高良玉垂命・住吉大神、仁徳天皇55年(367)/78年(390)伝、旧国幣大社 |
+| 笠間稲荷神社 | http://www.kasama.or.jp/about/index.html | 宇迦之御魂神、白雉2年(651)創建伝承、国指定重要文化財本殿 |
+| 鷲宮神社 | http://www.washinomiyajinja.or.jp/history/history.html | 天穂日命（本殿）・武夷鳥命（相殿）、関東最古の大社 |
+
+---
+
+## 4. Source Semantic Conflict
+
+5件のSource候補ドメインを、Production既存86件のSourceとfreshに突合した。
+
+- exact-domain照合: 5件全てProduction既存Sourceに一致なし
+- `normalize_source_url()`実装をそのまま使用した精密照合（既存85件の
+  URL保有Sourceと突合）: 5件全て一致なし
+
+**5候補Sourceすべてが`NO_CONFLICT`。**
+
+---
+
+## 5. Deity Research（各社固有の判断）
+
+### 富岡八幡宮（completeness limitation）
+
+公式サイトは「御祭神 応神天皇（誉田別命）外８柱」とのみ記載し、他8柱の
+個別名を明かしていない。以下のルールを厳守した。
+
+- 応神天皇（誉田別命）のみFact化（`role: primary`）
+- 未確認の他8柱を外部一般知識・推測で補完しない
+- 「他8柱」「外8柱」をcollective deity Factとして作成しない
+- Source `note`に、公式サイトの記載範囲の制約を明示
+
+この結果、富岡八幡宮のDeity Factは1件のみとなる。History（創建
+寛永4年・准勅祭社宣下）は公式記載どおりHIGH Evidenceで2件Fact化した。
+
+### 忌宮神社
+
+公式サイトから仲哀天皇（`role: primary`、当社の起源となった祭神）・
+神功皇后（`role: secondary`）・応神天皇（`role: secondary`）をfresh
+確認し、3柱ともFact化した。
+
+### 高良大社
+
+公式サイトから八幡大神（`role: secondary`、本殿向かって右）・
+高良玉垂命（`role: primary`、本殿中央）・住吉大神（`role: secondary`、
+本殿向かって左）をfresh確認し、3柱ともFact化した。
+
+### 笠間稲荷神社
+
+公式サイトから宇迦之御魂神（`role: primary`、唯一の御祭神）をfresh
+確認し、Fact化した。
+
+### 鷲宮神社
+
+公式サイトから天穂日命（`role: primary`、現本殿の祭神）・武夷鳥命
+（`role: secondary`、景行天皇御世に相殿へ奉祀）をfresh確認した。由緒
+冒頭に登場する「神崎神社（大己貴命）」は、天穂日命父子が鷲宮神社創建
+以前に別途建立した**別の神社**の祭神であり、鷲宮神社自体の祭神ではない
+ため、Fact化対象から明確に除外した。
+
+**禁止事項の遵守確認**: 富岡八幡宮の未確認8柱の推測登録＝0件、collective
+deity placeholder＝0件、war memorial/collective spirit混入＝0件
+（高良大社の「武内宿禰像」は博多人形の作品名であり祭神ではないため
+Fact化していない）、神仏習合対象の恣意的kami化＝該当なし、摂社/末社
+Fact混入＝0件。
+
+---
+
+## 6. History Research
+
+各社の由緒を、既存`history_type` enumへ適合する範囲でFact化した。神話的
+創建伝承（`tradition`）と、年代が特定できる歴史的出来事（`historical_event`）
+を明確に分離し、伝承文には「〜と伝えられている」等の非断定表現を用いた
+（fresh確認: 全4件のtradition Factで確認済み）。
+
+| shrine | History Fact | 分類 |
+|---|---|---|
+| 富岡八幡宮 | 寛永4年(1627)の創建 | founding |
+| 富岡八幡宮 | 明治維新の准勅祭社宣下と徳川将軍家の崇敬 | historical_event |
+| 忌宮神社 | 仲哀天皇御神霊の鎮祭伝承 | tradition |
+| 忌宮神社 | 延喜式内社・長門二宮としての社格 | historical_event |
+| 高良大社 | 仁徳天皇御代の御鎮座伝承 | tradition |
+| 高良大社 | 蒙古襲来時の勅使参向と綸旨 | historical_event |
+| 笠間稲荷神社 | 白雉2年(651)の創建伝承 | tradition |
+| 笠間稲荷神社 | 御本殿の国重要文化財指定 | historical_event |
+| 鷲宮神社 | 出雲族草創の伝承と関東最古の大社 | tradition |
+| 鷲宮神社 | 明治天皇御世の准勅祭社宣下 | historical_event |
+
+高良大社の歴代神階等の詳細な朝廷記録は、公式サイトに記載された蒙古襲来
+時の綸旨の範囲に限定し、根拠以上の年代断定を行っていない。長文の原文
+転載は行わず、要約に留めた。
+
+---
+
+## 7. Evidence Gate
+
+全10 Deity・10 History Factについて確認した。
+
+| 指標 | 値 |
+|---|---:|
+| source-less Deity | 0 |
+| source-less History | 0 |
+| `verification_status`が`source_confirmed`以外 | 0 |
+| `confidence`が`high`以外 | 0 |
+| `verified_at`未設定 | 0 |
+| invalid enum | 0 |
+| identity unsafe | 0 |
+| semantic conflict unsafe | 0 |
+
+全件がEvidence Gate要件を満たす。
+
+---
+
+## 8. Canonical seed integrity
+
+`backend/temples/data/knowledge_seeds/batch_13_seed.json`
+（`schema_version: "1.0"`）。
+
+`parse_seed()`（実装をそのまま使用したstructural検証）:
+
+| 指標 | 値 |
+|---|---:|
+| errors | 0 |
+| Source count | 5 |
+| Shrine count | 5 |
+| Deity count | 10 |
+| History count | 10 |
+| Deity–Source relation | 10 |
+| History–Source relation | 10 |
+| source-less Deity | 0 |
+| source-less History | 0 |
+| within-shrine重複 | 0 |
+| invalid enum | 0 |
+| unresolved source_key参照 | 0 |
+| 数値Production PKのhardcode | 0 |
+
+SHA-256（`batch_13_seed.json`）:
+`512225777c5509a8c75d142a276473495717e6a947d3d60699e02b156b20b9b2`
+
+---
+
+## 9. Regression tests
+
+新規: `backend/temples/tests/test_batch13_knowledge_seed.py`（9件）。
+Batch12の`test_batch12_knowledge_seed.py`と同型の構成に加え、本Batch
+固有の以下を追加した。
+
+- `test_batch13_seed_tomioka_hachimangu_has_only_named_deity`: 富岡
+  八幡宮のDeityが応神天皇1柱のみであり、「他8柱」「外8柱」が
+  Fact化されていないことを固定化
+- `test_batch13_seed_washinomiya_excludes_referenced_shrine_deity`:
+  鷲宮神社の由緒に登場する「大己貴命」（神崎神社の祭神、別の神社）が
+  鷲宮神社のFactとして混入していないことを固定化
+- `test_batch13_seed_role_assignment_matches_official_hierarchy`:
+  高良大社・忌宮神社のrole割当てが公式サイトの序列・空間配置と一致
+  することを固定化
+- `test_batch13_seed_source_semantic_identity_no_conflict_with_prior_batches`:
+  Batch11/12・Batch13のSource URLが互いに衝突しないことを固定化
+
+既存の汎用テスト（24件）・Batch9/10/11/12テスト（28件）を含め、合計
+56件すべてPASS（回帰なし）。
+
+---
+
+## 10. Local validation
+
+ローカル`jinja_db`（対象5社は既存Production idと一致する形で存在、
+import前はいずれもdeity=0/history=0を確認済み）に対して実際に実行:
+
+| step | 結果 |
+|---|---|
+| `--validate-only` | `validate-only: OK, no errors` |
+| `--dry-run`（1回目） | `{'source_CREATE': 5, 'deity_CREATE': 10, 'history_CREATE': 10}` |
+| 適用（import） | `sources created=5, deities created=10, histories created=10` |
+| 件数検証 | 対象5社の内訳は1/2・3/2・1/2・3/2・2/2件（seedと完全一致）、source-less 0件 |
+| `--dry-run`（2回目、冪等性） | `{'source_REUSE_EXISTING': 5, 'deity_SKIP_EXISTS': 10, 'history_SKIP_EXISTS': 10}`、CREATE 0件 |
+
+---
+
+## 11. Production read-only baseline
+
+Production DBをfreshに確認した（過去値を固定せず、本セッションの実測を
+正本とする）。
+
+| 指標 | 実測値 |
+|---|---:|
+| Knowledge Shrine | 66 |
+| Source | 86 |
+| Deity | 187 |
+| History | 123 |
+| Deity–Source relation | 200 |
+| History–Source relation | 128 |
+| complete | 64 |
+| partial | 2 |
+| none | 39 |
+| 総Shrine数 | 105 |
+
+Application aggregates: auth_user 1・userprofile 1・shrine 105・favorite 0・
+visit 2・goriyakutag 39・shrine_goriyaku_relation 283。
+
+対象5社は全件Knowledge none、drift 0件。
+
+---
+
+## 12. Fresh Production Backup
+
+PostgreSQL 17バージョン一致クライアント（`postgresql@17.10`）で新規取得
+（過去のBackupを再利用していない）。
+
+| ファイル | サイズ |
+|---|---:|
+| roles.sql | 5,426 bytes |
+| schema.sql | 93,021 bytes |
+| data.sql | 4,302,635 bytes |
+
+repo外（`~/kami-musubi-backups/`）に保存。接続情報・hostname・credentialは
+一切ログに出力していない。
+
+---
+
+## 13. Fresh Production-equivalent test
+
+上記backupを`kami_musubi_migration_safety_b13<timestamp>`（disposable
+local DB）へ復元した。復元は`exit 0`で完了。
+
+復元直後のisolated DB確認: Production同時刻の値（Source86・Deity187・
+History123・relation200/128・Knowledge Shrine66・総Shrine105）と完全一致。
+対象5社（富岡八幡宮の非canonical重複行id=104を含む）は全件Knowledge none。
+
+isolated DBに対して、ローカルと同一の5ステップ＋追加確認を実施:
+
+| step | 結果 |
+|---|---|
+| `--validate-only` | OK, no errors |
+| `--dry-run`（1回目） | `{'source_CREATE': 5, 'deity_CREATE': 10, 'history_CREATE': 10}` |
+| 適用 | `sources created=5, deities created=10, histories created=10` |
+| 件数検証 | Source 86→91・Deity 187→197・History 123→133・Deity–Source rel 200→210・History–Source rel 128→138・Knowledge Shrine 66→71（いずれもseed件数と完全一致） |
+| 対象5社のdeity/history内訳 | 富岡八幡宮1/2・忌宮神社3/2・笠間稲荷神社1/2・高良大社3/2・鷲宮神社2/2（seedと完全一致、混入なし） |
+| Coverage | complete 64→69・partial 2（不変）・none 39→34 |
+| source-less（DB全体） | Deity 0・History 0 |
+| 除外名混入チェック（対象5社スコープ） | 「他8柱」「外8柱」「大己貴命」いずれも対象5社では0件（DB全体では既存Batchの正当な祭神として7件存在するが、いずれも神田神社・武蔵御嶽神社・氷川神社（大宮）・大洗磯前神社・川越氷川神社・赤坂氷川神社・二荒山神社の既存祭神であり無関係） |
+| 富岡八幡宮の非canonical重複行（id=104）へのKnowledge混入 | 0件（canonical行id=49のみにFact付与されたことを確認） |
+| 無関係データ回帰チェック | 二荒山神社3/1・小網神社2/1・根津神社5/2（いずれも既存値のまま不変） |
+| Application aggregate | auth_user1・userprofile1・shrine105・favorite0・visit2・goriyakutag39・shrine_goriyaku_rel283（完全不変） |
+| `--dry-run`（2回目、冪等性） | `{'source_REUSE_EXISTING': 5, 'deity_SKIP_EXISTS': 10, 'history_SKIP_EXISTS': 10}`、CREATE 0件 |
+
+isolated DBは検証完了後に`dropdb`で削除済み。
+
+---
+
+## 14. Coverage projection
+
+isolated DB（Production-equivalent）の実測値から算出（推測値は使用して
+いない）。5社すべてが投入前`none`のため、5社ともDeity/History両方を
+獲得しcompleteへ移行する（先に決め打ちせず、実測で確認）。
+
+| 区分 | Batch13投入前（実測） | Batch13投入後（実測） |
+|---|---:|---:|
+| complete | 64 | 69 |
+| partial | 2 | 2（不変） |
+| none | 39 | 34 |
+| Knowledge Shrine合計 | 66 | 71 |
+| 全Shrine数 | 105 | 105（不変） |
+
+---
+
+## 15. Production read-only preflight
+
+Production DBに対して以下を実行した（いずれもコマンド自身の設計上、
+DB書き込みを一切行わないモード）。
+
+**`--validate-only`**: `validate-only: OK, no errors`
+
+**`--dry-run`**:
+```
+plan summary: {'source_CREATE': 5, 'deity_CREATE': 10, 'history_CREATE': 10}
+dry-run: OK, no DB writes performed
+```
+
+全項目、isolated DBの1回目`--dry-run`結果と完全一致。`SKIP_EXISTS`・
+`REUSE_EXISTING`・`SOURCE_REUSE_CONFLICT`・`SOURCE_REUSE_AMBIGUOUS`・
+`IMPORT_IDENTITY_AMBIGUOUS`・`NOT_FOUND`はいずれも0件。富岡八幡宮は
+canonical行（id=49相当）1件のみへCREATEされ、非canonical重複行は
+影響を受けない。
+
+実行後、`readonly_query.sh`で再度Production状態を確認し、対象5社の
+deity/history、および集計値（Source86・Deity187・History123・
+relation200/128・Knowledge Shrine66）が実行前と完全に不変であることを
+確認した。
+
+---
+
+## 16. Runtime expected payload
+
+seedから算出（Production import実行後に期待される値、実行はしていない）。
+
+| shrine | Deity | History | Unique Source |
+|---|---:|---:|---:|
+| 富岡八幡宮 | 1 | 2 | 1 |
+| 忌宮神社 | 3 | 2 | 1 |
+| 高良大社 | 3 | 2 | 1 |
+| 笠間稲荷神社 | 1 | 2 | 1 |
+| 鷲宮神社 | 2 | 2 | 1 |
+| **合計** | **10** | **10** | **5** |
+
+Fact–Source relation count: 20（Deity 10 + History 10）。
+
+富岡八幡宮のDeity=1は、公式サイトの記載範囲の限界を反映した値であり、
+Seed PreparationおよびProduction-equivalent双方で一貫している。
+
+---
+
+## 17. Risk Audit
+
+- **富岡八幡宮 deity completeness limitation**: 公式サイトが「外8柱」の
+  個別名を明かしていないため、Deity Factは応神天皇1柱のみ。未確認の
+  8柱を推測登録していない（テストで固定化済み）。
+- **Source page instability**: 他Batchと同様の一般的リスク。
+- **`SKIP_EXISTS`のsemantic-diff limitation**: 既知の設計上の制約であり、
+  本Batchに固有の問題ではない。
+- **historical tradition / history distinction**: 全4件のtradition Fact
+  で非断定表現を確認済み（fresh検証）。
+- **identity/address exactness**: 5社全件、Production記載住所と完全一致
+  することをfreshに確認済み。富岡八幡宮の非canonical重複行への誤混入も
+  0件を確認。
+- **regional distribution**: 東京・山口・福岡・茨城・埼玉の5都県に分散
+  （Target Selection時のtie-breaker選定結果どおり）。
+- **新規のcontent-model問題**: 発生していない。鷲宮神社の由緒に登場する
+  「神崎神社（大己貴命）」を誤って自社祭神としてFact化するリスクを
+  特定し、正しく除外した（テストで固定化済み）。
+
+---
+
+## 18. Final Classification
+
+- 5社全件が`IDENTITY_SAFE`・`NO_CONFLICT`・Evidence Gate要件を満たす
+- ローカル・Production-equivalent（fresh dump復元）の両方で
+  `--validate-only`→`--dry-run`→適用→件数検証→再`--dry-run`の
+  フルサイクルが期待どおりの結果
+- Production DBに対する`--validate-only`・`--dry-run`がProduction-equivalent
+  の結果と完全一致し、unexpected SKIP/UPDATE/conflictが0件
+- Production状態がこれらの読み取り専用操作の前後で完全に不変であることを
+  実測で確認
+- 候補の差替えは発生していない
+- **軽微な制限あり**: 富岡八幡宮のDeity Evidenceが1柱のみ（公式サイトの
+  記載範囲の限界、Evidence Gateは遵守）
+
+**`BATCH13_PRODUCTION_IMPORT_READY_WITH_LIMITATIONS`**
+
+残存する非blocking事項（Productionへの実書き込み判断とは独立）:
+
+- 富岡八幡宮の未確認8柱は、将来的に公式サイトの更新や追加Source
+  （例: 現地案内板・刊行物）が見つかった場合に追加Fact化を検討できる
+- partial 2社（阿佐ヶ谷神明宮・香取神宮）のHistory repairは別タスクの
+  まま
+- `ASSOCIATED_WORSHIP_TARGET_MODEL_REVIEW`（Batch11由来）は未着手のまま
+- 靖國神社・千葉神社・愛宕神社のcontent-model判断は引き続き保留
+- `LOCAL_TEST_ENVIRONMENT_DRIFT_NON_BLOCKING`（pytest-dotenvのlocal-only
+  のdrift）は継続、本ドキュメントでもpackage変更は行っていない
+- Production importそのもの（Fact実書き込み・Runtime QA）は本ドキュメント
+  では未実施。Mother Shipの明示的な承認後、別セッション（Human
+  Execution Boundary Gate相当）で実施する必要がある
+
+Production DB writes = 0
+Batch 13 Production import = NOT_EXECUTED
+Batch 14 = NOT_STARTED


### PR DESCRIPTION
## Summary
- Recommended 5社（富岡八幡宮・忌宮神社・高良大社・笠間稲荷神社・鷲宮神社）の公式Sourceをfresh再確認（Target Selection時のfetchを再利用せず独立取得、drift 0）
- Knowledge Contract/Evidence Gateに従いcanonical seed（`batch_13_seed.json`、Source5・Shrine5・Deity10・History10）を構築
- 富岡八幡宮は公式サイトが「応神天皇（誉田別命）外8柱」とのみ記載し個別名を明かさないため、未確認の8柱を推測登録せず応神天皇1柱のみFact化（collective Fact化もしていない）
- 鷲宮神社の由緒に登場する「大己貴命」（神崎神社という別の神社の祭神）を誤って自社祭神としてFact化しないよう明確に除外
- Source semantic conflict: 5件全て`NO_CONFLICT`（Production既存86件と重複なし）
- 新規テスト9件を含む合計56件のKnowledge seed regression testが全てPASS
- ローカル・Production-equivalent（fresh dump復元）・Production read-only（`--validate-only`/`--dry-run`）のフルサイクルを実施し、全て期待どおりの結果
- 最終分類: `BATCH13_PRODUCTION_IMPORT_READY_WITH_LIMITATIONS`（富岡八幡宮のDeity Evidenceが1柱のみという公式サイト側の制約による軽微な制限）

**Production writeは行っていない。Batch 14も未着手。**

## Test plan
- [x] `docs/audit/knowledge-batch13-seed-preflight.md`の全18セクションを記録
- [x] `backend/temples/tests/test_batch13_knowledge_seed.py`（9件、富岡八幡宮の未確認8柱非Fact化・鷲宮神社の他社祭神除外・role割当の固定化テスト含む）
- [x] 既存Knowledge seed suite（56件）全てPASS
- [x] ローカルDB: validate-only → dry-run → import → 件数検証 → 2回目dry-run（冪等性）全てPASS
- [x] Production-equivalent（fresh backup復元isolated DB）: 12ステップ全てPASS、delta完全一致、無関係aggregate不変
- [x] Production read-only: `--validate-only`/`--dry-run`が期待どおりで、実行前後でProduction状態が完全に不変であることを確認
- [x] secret scan（credential/URL/hostname非混入）を実施
- [x] pre-push hooks（Web契約テスト731件）PASS
- [ ] CI完了待ち（merge判断はMother Ship）

🤖 Generated with [Claude Code](https://claude.com/claude-code)