### PR TITLE
Batch 16 Knowledge Seedと投入前検証を追加

### DIFF
--- a/backend/temples/data/knowledge_seeds/batch_16_seed.json
+++ b/backend/temples/data/knowledge_seeds/batch_16_seed.json
@@ -1,0 +1,476 @@
+{
+  "schema_version": "1.0",
+  "sources": [
+    {
+      "key": "batch16-hachiman-official",
+      "source_type": "shrine_official",
+      "title": "ご由緒・概要",
+      "publisher": "平塚八幡宮",
+      "url": "http://www.hachiman.org/yurai.php",
+      "bibliography": "",
+      "accessed_at": "2026-08-12",
+      "verified_at": "2026-08-12T07:00:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "御祭神は応神天皇・神功皇后・武内宿禰の三柱を直接確認。境内絵図に「弁財天社」（七福神の一・仏教/ヒンドゥー由来の弁財天を祀る社）・「末社三社」が別途記載されており、本社Factに含めていない。当サイトはHTTPSではなくHTTPで運用されており、証明書はホスト名と一致しないため、Browser paneで直接コンテンツを確認した（HTTP接続自体は到達可能）。"
+    },
+    {
+      "key": "batch16-sakuragi-official",
+      "source_type": "shrine_official",
+      "title": "櫻木神社について",
+      "publisher": "櫻木神社",
+      "url": "https://sakuragi.info/about/",
+      "bibliography": "",
+      "accessed_at": "2026-08-12",
+      "verified_at": "2026-08-12T07:05:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "御祭神は伊弉諾尊・伊弉冉尊・倉稲魂命・武甕槌命の四柱を、各柱の個別説明とともに直接確認。仁寿元年(851)の創建伝承、永祚元年(989)の宮所建立、正暦3年(992)以降の髙梨氏による祭祀継承を直接確認。"
+    },
+    {
+      "key": "batch16-sengenjinja-official",
+      "source_type": "shrine_official",
+      "title": "多摩川浅間神社のご案内（由緒、御祭神、歴史）",
+      "publisher": "多摩川浅間神社",
+      "url": "https://sengenjinja.info/about/index.html",
+      "bibliography": "",
+      "accessed_at": "2026-08-12",
+      "verified_at": "2026-08-12T07:10:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "現在の御祭神は木花咲耶姫命の一柱のみと直接確認。創祀伝承（文治年間/1185-90年、北条政子が観世音像を建立し村人が「富士浅間大菩薩」と称したという故事）自体は仏教的要素を含む伝承として記載されているが、現在の御祭神ページには木花咲耶姫命のみが記載されており、当該伝承を史実として断定せず、また観世音像それ自体をDeity Factとして登録していない。明治40年(1907)の合祀政令により旧赤城神社・熊野神社（下沼部村の他2社）を統合したことも直接確認したが、両社の祭神は現在の御祭神一覧に含まれていないためFact化していない。"
+    },
+    {
+      "key": "batch16-futaarayama-official",
+      "source_type": "shrine_official",
+      "title": "由緒・歴史",
+      "publisher": "二荒山神社（宇都宮）",
+      "url": "http://futaarayamajinja.jp/yuisyo/",
+      "bibliography": "",
+      "accessed_at": "2026-08-12",
+      "verified_at": "2026-08-12T07:15:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "当社は栃木県宇都宮市に鎮座する「宇都宮二荒山神社」（下野国一之宮）であり、栃木県日光市の「日光二荒山神社」とは別法人・別神社である。Production側のshrine_ref（name_jp=宇都宮二荒山神社、address=栃木県宇都宮市馬場通り1-1-1）と公式サイト記載の所在地が一致することを確認済み。御祭神は豊城入彦命（御祭神）・大物主命・事代主命（相殿）の三柱を直接確認。境内に十二の末社があることも明記されており、本社Factには含めていない。"
+    },
+    {
+      "key": "batch16-hakusan-10jinja",
+      "source_type": "shrine_official",
+      "title": "白山神社",
+      "publisher": "東京十社会",
+      "url": "http://10jinja.tokyo/hakusanjinja.html",
+      "bibliography": "",
+      "accessed_at": "2026-08-12",
+      "verified_at": "2026-08-12T07:20:00+00:00",
+      "verification_status": "source_confirmed",
+      "confidence": "high",
+      "language": "ja",
+      "note": "白山神社（文京区）自体の独立公式ドメインは本セッションでは確認できなかったため、東京十社（当社を含む参加10社が共同運営する公式団体、©東京十社会）の公式サイトを直接確認した。所在地（東京都文京区白山5-31-26）がProduction側のshrine_refと一致することを確認済み。御祭神は菊理姫命・伊弉諾命・伊弉冊命の三柱を直接確認。白山信仰一般の解説文はなく、当社固有の由緒（天暦二年勧請、建武四年足利尊氏祈願所、元和二年以降の遷座歴）のみが記載されている。境内社の記載はこのページにはない。"
+    }
+  ],
+  "shrines": [
+    {
+      "shrine_ref": {
+        "name_jp": "平塚八幡宮",
+        "address": "神奈川県平塚市浅間町1-6"
+      },
+      "deities": [
+        {
+          "display_name": "応神天皇",
+          "canonical_name": "応神天皇",
+          "role": "unknown",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:00:00+00:00",
+          "note": "公式サイトは応神天皇・神功皇后・武内宿禰を序列を示さず列挙している。",
+          "source_keys": ["batch16-hachiman-official"]
+        },
+        {
+          "display_name": "神功皇后",
+          "canonical_name": "神功皇后",
+          "role": "unknown",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:00:00+00:00",
+          "note": "公式サイトは応神天皇・神功皇后・武内宿禰を序列を示さず列挙している。",
+          "source_keys": ["batch16-hachiman-official"]
+        },
+        {
+          "display_name": "武内宿禰",
+          "canonical_name": "武内宿禰",
+          "role": "unknown",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:00:00+00:00",
+          "note": "公式サイトは応神天皇・神功皇后・武内宿禰を序列を示さず列挙している。",
+          "source_keys": ["batch16-hachiman-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "仁徳天皇御代68年(380)の創祀伝承",
+          "content": "平塚八幡宮は、仁徳天皇の御代68年（380年）にこの地で大きな地震があり、人々の苦しむ様を見かねた仁徳天皇が社を建てられたことが創祀とされていると公式サイトは記している。",
+          "period_text": "仁徳天皇御代68年（380年、伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:00:00+00:00",
+          "note": "公式サイト自身が「創祀とされています」と記述。史実として断定していない。",
+          "source_keys": ["batch16-hachiman-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "戦国期の兵火と徳川家康公による復興",
+          "content": "歴代の天皇や源頼朝公をはじめとする武士から崇敬を集めたが、戦国時代になると兵火に遭い、御社殿や社宝、社伝記のことごとくを焼失した。その後、江戸に入府した徳川家康公が荒廃していた御社殿を復興させたと公式サイトは記している。",
+          "period_text": "戦国時代〜江戸時代初期",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:00:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-hachiman-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "関東大震災による倒壊と現社殿の竣工",
+          "content": "大正12年（1923年）の関東大震災により社殿が倒壊し、現在の社殿は昭和3年（1928年）に竣工したと公式サイトは記している。",
+          "period_text": "大正12年（1923）〜昭和3年（1928）",
+          "event_date": null,
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:00:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-hachiman-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "櫻木神社",
+        "address": "千葉県野田市桜台210"
+      },
+      "deities": [
+        {
+          "display_name": "伊弉諾尊",
+          "canonical_name": "伊弉諾尊",
+          "role": "unknown",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "公式サイトは四柱を序列を示さず個別説明とともに列挙している。",
+          "source_keys": ["batch16-sakuragi-official"]
+        },
+        {
+          "display_name": "伊弉冉尊",
+          "canonical_name": "伊弉冉尊",
+          "role": "unknown",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "公式サイトは四柱を序列を示さず個別説明とともに列挙している。",
+          "source_keys": ["batch16-sakuragi-official"]
+        },
+        {
+          "display_name": "倉稲魂命",
+          "canonical_name": "倉稲魂命",
+          "role": "unknown",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "由緒によれば創建の由来で最初に祀られた神。公式サイトは四柱を序列を示さず個別説明とともに列挙している。",
+          "source_keys": ["batch16-sakuragi-official"]
+        },
+        {
+          "display_name": "武甕槌命",
+          "canonical_name": "武甕槌命",
+          "role": "unknown",
+          "sort_order": 3,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "由緒によれば倉稲魂命の後に祀られた神。公式サイトは四柱を序列を示さず個別説明とともに列挙している。",
+          "source_keys": ["batch16-sakuragi-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "仁寿元年(851)の創建伝承",
+          "content": "社記によれば、平安朝の仁寿元年（851年）、藤原鎌足公五代の後胤である冬嗣公三男の嗣良公がこの地に居を移した際、桜の美しい大木の下に倉稲魂命を祀り、その後武甕槌命を祀ったのが始まりであると伝えられている。",
+          "period_text": "仁寿元年（851、伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "公式サイト自身が「伝えています」「諸説あり」と記述。史実として断定していない。",
+          "source_keys": ["batch16-sakuragi-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "永祚元年(989)の宮所建立",
+          "content": "社家文書によれば、永祚元年（989年）12月の初午の日に、桜の木の元へ宮所が建立され、この時に「桜台」と号したと記されている。",
+          "period_text": "永祚元年（989）12月",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-sakuragi-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "正暦3年(992)以降の髙梨氏による祭祀継承",
+          "content": "正暦3年（992年）の宮司家文書によれば、その後、冬嗣公の子孫にあたる藤原朝臣髙梨則忠氏が祭祀を継承したと伝えられる。現在の社家はその継承から28代目、初代から31代目にあたると公式サイトは記している。",
+          "period_text": "正暦3年（992）以降",
+          "event_date": null,
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:05:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-sakuragi-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "多摩川浅間神社",
+        "address": "東京都大田区田園調布1-55-12"
+      },
+      "deities": [
+        {
+          "display_name": "木花咲耶姫命",
+          "canonical_name": "木花咲耶姫命",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:10:00+00:00",
+          "note": "公式サイトが「ご祭神」として明記する唯一の祭神。明治40年(1907)の合祀政令により統合された旧赤城神社・熊野神社の祭神は現在の御祭神一覧に含まれておらずFact化していない。",
+          "source_keys": ["batch16-sengenjinja-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "文治年間(1185-90)の創祀伝承",
+          "content": "鎌倉時代の文治年間（1185〜90年）、源頼朝の妻北条政子が、夫の武運長久を祈って亀甲山に「正観世音像」を建てたのが起こりと伝えられ、村人たちはこの像を「富士浅間大菩薩」と呼び尊崇したと公式サイトは記している。",
+          "period_text": "文治年間（1185〜90、伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:10:00+00:00",
+          "note": "公式サイト自身が「創建と伝えられます」と記述する創祀伝承であり、史実として断定していない。当該伝承に登場する観世音像自体をDeity Factとして登録していない。",
+          "source_keys": ["batch16-sengenjinja-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "承応元年(1652)の観世音立像発掘と祭礼",
+          "content": "承応元年（1652年）5月、表坂の土留め工事の際に唐銅製の正観世音の立像が発掘され、以後6月1日に神事を行うようになり、現在もご祭礼は6月に行われていると公式サイトは記している。",
+          "period_text": "承応元年（1652）5月",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:10:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-sengenjinja-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "明治40年(1907)の合祀政令による現在の形の成立",
+          "content": "かつて下沼部村には浅間・赤城・熊野の三つの神社があったが、明治40年（1907年）の「一村一社」の合祀政令を受けた村人たちの話し合いにより、浅間神社が新しい村の鎮守となったと公式サイトは記している。",
+          "period_text": "明治40年（1907）",
+          "event_date": null,
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:10:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-sengenjinja-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "宇都宮二荒山神社",
+        "address": "栃木県宇都宮市馬場通り1-1-1"
+      },
+      "deities": [
+        {
+          "display_name": "豊城入彦命",
+          "canonical_name": "豊城入彦命",
+          "role": "primary",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:15:00+00:00",
+          "note": "公式サイトが「御祭神」として明記。毛野国を開拓し宇都宮の始祖として崇敬されている。",
+          "source_keys": ["batch16-futaarayama-official"]
+        },
+        {
+          "display_name": "大物主命",
+          "canonical_name": "大物主命",
+          "role": "secondary",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:15:00+00:00",
+          "note": "公式サイトが「相殿」として明記。",
+          "source_keys": ["batch16-futaarayama-official"]
+        },
+        {
+          "display_name": "事代主命",
+          "canonical_name": "事代主命",
+          "role": "secondary",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:15:00+00:00",
+          "note": "公式サイトが「相殿」として明記。",
+          "source_keys": ["batch16-futaarayama-official"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "tradition",
+          "title": "崇神天皇御代の起源伝承と荒尾崎への奉斎",
+          "content": "二荒山神社は第十代崇神天皇の御代に遡るとされる。第16代仁徳天皇の御代に毛野国が上下二国に分けられた際、豊城入彦命の四世孫奈良別王が下毛野国の国造に任ぜられ、祖神である豊城入彦命を荒尾崎（下之宮）に祀ったのが始まりと伝えられている。",
+          "period_text": "崇神天皇御代〜仁徳天皇御代（伝承）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:15:00+00:00",
+          "note": "公式サイト自身が「伝えられています」と記述。史実として断定していない。",
+          "source_keys": ["batch16-futaarayama-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "承和5年(838)の臼ケ峰遷座",
+          "content": "承和5年（838年）、現在の地である臼ケ峰に遷座されたと公式サイトは記している。",
+          "period_text": "承和5年（838）",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:15:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-futaarayama-official"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "延喜式神名帳への記載と下野国一之宮",
+          "content": "延長5年（927年）に完成した延喜式・神名帳には「下野國河内郡一座大 二荒山神社 名神大」と記載があり、栃木県内唯一の名神大社として、また下野国一之宮として広く崇められてきたと公式サイトは記している。",
+          "period_text": "延長5年（927）",
+          "event_date": null,
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:15:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-futaarayama-official"]
+        }
+      ]
+    },
+    {
+      "shrine_ref": {
+        "name_jp": "白山神社",
+        "address": "東京都文京区白山5-31-26"
+      },
+      "deities": [
+        {
+          "display_name": "菊理姫命",
+          "canonical_name": "菊理姫命",
+          "role": "unknown",
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:20:00+00:00",
+          "note": "公式サイトは三柱を序列を示さず列挙している。",
+          "source_keys": ["batch16-hakusan-10jinja"]
+        },
+        {
+          "display_name": "伊弉諾命",
+          "canonical_name": "伊弉諾命",
+          "role": "unknown",
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:20:00+00:00",
+          "note": "公式サイトは三柱を序列を示さず列挙している。",
+          "source_keys": ["batch16-hakusan-10jinja"]
+        },
+        {
+          "display_name": "伊弉冊命",
+          "canonical_name": "伊弉冊命",
+          "role": "unknown",
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:20:00+00:00",
+          "note": "公式サイトは三柱を序列を示さず列挙している。",
+          "source_keys": ["batch16-hakusan-10jinja"]
+        }
+      ],
+      "histories": [
+        {
+          "history_type": "founding",
+          "title": "天暦2年(948)の加賀白山神社勧請",
+          "content": "天暦二年（948年）、加賀一宮白山神社を現在の本郷元町の地に奉勧請したのが始まりと公式サイトは記している。",
+          "period_text": "天暦2年（948）",
+          "event_date": null,
+          "sort_order": 0,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:20:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-hakusan-10jinja"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "建武4年(1337)の国家平安祈願所",
+          "content": "建武四年（1337年）、足利尊氏公により国家平安御祈願所に命ぜられたと公式サイトは記している。",
+          "period_text": "建武4年（1337）",
+          "event_date": null,
+          "sort_order": 1,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:20:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-hakusan-10jinja"]
+        },
+        {
+          "history_type": "historical_event",
+          "title": "江戸期の遷座と現社地への移転",
+          "content": "元和二年（1616年）、徳川秀忠公の命により巣鴨原へ遷座、慶安四年（1651年）に徳川家綱公の用地となったことから、明暦元年（1655年）に現社地へ移った。後に五代将軍徳川綱吉公とその生母桂昌院の信仰を受け、小石川の鎮守となったと公式サイトは記している。",
+          "period_text": "元和2年（1616）〜明暦元年（1655）",
+          "event_date": null,
+          "sort_order": 2,
+          "verification_status": "source_confirmed",
+          "confidence": "high",
+          "verified_at": "2026-08-12T07:20:00+00:00",
+          "note": "",
+          "source_keys": ["batch16-hakusan-10jinja"]
+        }
+      ]
+    }
+  ]
+}

--- a/backend/temples/tests/test_batch16_knowledge_seed.py
+++ b/backend/temples/tests/test_batch16_knowledge_seed.py
@@ -1,0 +1,223 @@
+import io
+import json
+from pathlib import Path
+
+import pytest
+from django.core.management import call_command
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services.knowledge_seed import parse_seed
+
+SEED_PATH = Path(__file__).resolve().parents[1] / "data" / "knowledge_seeds" / "batch_16_seed.json"
+
+TARGETS = [
+    ("平塚八幡宮", "神奈川県平塚市浅間町1-6"),
+    ("櫻木神社", "千葉県野田市桜台210"),
+    ("多摩川浅間神社", "東京都大田区田園調布1-55-12"),
+    ("宇都宮二荒山神社", "栃木県宇都宮市馬場通り1-1-1"),
+    ("白山神社", "東京都文京区白山5-31-26"),
+]
+
+
+def test_batch16_seed_schema_counts_and_relations():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    assert seed.errors == []
+    assert len(seed.sources) == 5
+    assert len(seed.shrines) == 5
+    assert sum(len(shrine.deities) for shrine in seed.shrines) == 14
+    assert sum(len(shrine.histories) for shrine in seed.shrines) == 15
+    assert sum(len(deity.source_keys) for shrine in seed.shrines for deity in shrine.deities) == 14
+    assert (
+        sum(len(history.source_keys) for shrine in seed.shrines for history in shrine.histories)
+        == 15
+    )
+
+    identities = [(shrine.name_jp, shrine.address) for shrine in seed.shrines]
+    assert identities == TARGETS
+    assert len(identities) == len(set(identities))
+    assert all(deity.source_keys for shrine in seed.shrines for deity in shrine.deities)
+    assert all(history.source_keys for shrine in seed.shrines for history in shrine.histories)
+
+
+def test_batch16_seed_hiratsuka_hachimangu_excludes_sub_shrines():
+    """平塚八幡宮の境内絵図に記載される「弁財天社」（七福神の一）・
+    「末社三社」を本社Factへ混入させていないことを固定化する。"""
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    hiratsuka = next(shrine for shrine in seed.shrines if shrine.name_jp == "平塚八幡宮")
+    deity_names = [d.display_name for d in hiratsuka.deities]
+    assert deity_names == ["応神天皇", "神功皇后", "武内宿禰"]
+
+
+def test_batch16_seed_sengenjinja_excludes_absorbed_shrine_deities():
+    """多摩川浅間神社が明治40年(1907)の合祀政令で統合した旧赤城神社・
+    熊野神社の祭神を、現在の御祭神一覧に含まれていないことに基づき
+    Fact化していないことを固定化する（木花咲耶姫命の一柱のみ）。"""
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    sengen = next(shrine for shrine in seed.shrines if shrine.name_jp == "多摩川浅間神社")
+    deity_names = [d.display_name for d in sengen.deities]
+    assert deity_names == ["木花咲耶姫命"]
+
+
+def test_batch16_seed_futaarayama_excludes_sub_shrines_and_is_utsunomiya():
+    """宇都宮二荒山神社の境内十二末社を本社Factへ混入させていないこと、
+    および日光二荒山神社と混同していないこと（address一致）を固定化する。"""
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    futaarayama = next(shrine for shrine in seed.shrines if shrine.name_jp == "宇都宮二荒山神社")
+    assert futaarayama.address == "栃木県宇都宮市馬場通り1-1-1"
+    deity_names = [d.display_name for d in futaarayama.deities]
+    assert deity_names == ["豊城入彦命", "大物主命", "事代主命"]
+
+
+def test_batch16_seed_hakusan_identity_and_source():
+    """白山神社（文京区）が正しいidentityで登録され、東京十社会の
+    公式Sourceを使用していることを固定化する。"""
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    hakusan = next(shrine for shrine in seed.shrines if shrine.name_jp == "白山神社")
+    assert hakusan.address == "東京都文京区白山5-31-26"
+    deity_names = [d.display_name for d in hakusan.deities]
+    assert deity_names == ["菊理姫命", "伊弉諾命", "伊弉冊命"]
+    for deity in hakusan.deities:
+        assert deity.source_keys == ["batch16-hakusan-10jinja"]
+
+
+def test_batch16_seed_no_within_shrine_duplicates():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    for shrine in seed.shrines:
+        names = [d.display_name for d in shrine.deities]
+        assert len(names) == len(set(names)), shrine.name_jp
+
+        history_keys = [(h.history_type, h.title) for h in shrine.histories]
+        assert len(history_keys) == len(set(history_keys)), shrine.name_jp
+
+
+def test_batch16_seed_all_facts_are_source_confirmed_high_confidence():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+
+    for shrine in seed.shrines:
+        for deity in shrine.deities:
+            assert deity.verification_status == "source_confirmed", (shrine.name_jp, deity.display_name)
+            assert deity.confidence == "high", (shrine.name_jp, deity.display_name)
+            assert deity.verified_at is not None, (shrine.name_jp, deity.display_name)
+        for history in shrine.histories:
+            assert history.verification_status == "source_confirmed", (shrine.name_jp, history.title)
+            assert history.confidence == "high", (shrine.name_jp, history.title)
+            assert history.verified_at is not None, (shrine.name_jp, history.title)
+
+
+def test_batch16_seed_role_assignment_matches_official_hierarchy():
+    seed = parse_seed(json.loads(SEED_PATH.read_text(encoding="utf-8")))
+    by_name = {shrine.name_jp: shrine for shrine in seed.shrines}
+
+    futaarayama_roles = {d.display_name: d.role for d in by_name["宇都宮二荒山神社"].deities}
+    assert futaarayama_roles["豊城入彦命"] == "primary"
+    assert futaarayama_roles["大物主命"] == "secondary"
+    assert futaarayama_roles["事代主命"] == "secondary"
+
+    sengen_roles = {d.display_name: d.role for d in by_name["多摩川浅間神社"].deities}
+    assert sengen_roles["木花咲耶姫命"] == "primary"
+
+    # 序列の記載がない神社は role=unknown で対等に列挙する
+    hiratsuka_roles = {d.role for d in by_name["平塚八幡宮"].deities}
+    assert hiratsuka_roles == {"unknown"}
+    sakuragi_roles = {d.role for d in by_name["櫻木神社"].deities}
+    assert sakuragi_roles == {"unknown"}
+    hakusan_roles = {d.role for d in by_name["白山神社"].deities}
+    assert hakusan_roles == {"unknown"}
+
+
+def test_batch16_seed_source_semantic_identity_no_conflict_with_prior_batches():
+    """Batch16の5 SourceはBatch14/15のSourceと異なるURLであるべき
+    (source_type + normalized URLの衝突がないことをseed同士で確認)。"""
+    seed_dir = SEED_PATH.parent
+    batch14 = json.loads((seed_dir / "batch_14_seed.json").read_text(encoding="utf-8"))
+    batch15 = json.loads((seed_dir / "batch_15_seed.json").read_text(encoding="utf-8"))
+    batch16 = json.loads(SEED_PATH.read_text(encoding="utf-8"))
+
+    prior_urls = {s["url"] for s in batch14["sources"]} | {s["url"] for s in batch15["sources"]}
+    batch16_urls = {s["url"] for s in batch16["sources"]}
+    assert prior_urls.isdisjoint(batch16_urls)
+
+
+@pytest.mark.django_db
+def test_batch16_seed_import_is_idempotent_and_preserves_unrelated_knowledge():
+    for name_jp, address in TARGETS:
+        Shrine.objects.create(name_jp=name_jp, kind="shrine", address=address)
+
+    unrelated = Shrine.objects.create(
+        name_jp="既存Knowledge神社（Batch16無関係）", kind="shrine", address="東京都既存区8-8-8"
+    )
+    existing_source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="既存公式Source（Batch16無関係）",
+        url="https://existing-batch16.example.jp/",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    existing_deity = ShrineDeity.objects.create(
+        shrine=unrelated,
+        display_name="既存祭神（Batch16無関係）",
+        role="primary",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    existing_deity.sources.set([existing_source])
+    existing_history = ShrineHistory.objects.create(
+        shrine=unrelated,
+        history_type="historical_event",
+        title="既存沿革（Batch16無関係）",
+        content="既存の沿革本文。",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    existing_history.sources.set([existing_source])
+
+    call_command("import_shrine_knowledge", str(SEED_PATH), stdout=io.StringIO())
+
+    targets = Shrine.objects.filter(name_jp__in=[name for name, _ in TARGETS])
+    assert ShrineKnowledgeSource.objects.count() == 6  # 5 batch16 + 1 unrelated
+    assert ShrineDeity.objects.filter(shrine__in=targets).count() == 14
+    assert ShrineHistory.objects.filter(shrine__in=targets).count() == 15
+    assert all(deity.sources.exists() for deity in ShrineDeity.objects.filter(shrine__in=targets))
+    assert all(
+        history.sources.exists() for history in ShrineHistory.objects.filter(shrine__in=targets)
+    )
+
+    dry_run = io.StringIO()
+    call_command("import_shrine_knowledge", str(SEED_PATH), "--dry-run", stdout=dry_run)
+    output = dry_run.getvalue()
+    assert "'source_REUSE_EXISTING': 5" in output
+    assert "'deity_SKIP_EXISTS': 14" in output
+    assert "'history_SKIP_EXISTS': 15" in output
+    assert "CREATE" not in output
+
+    existing_deity.refresh_from_db()
+    existing_history.refresh_from_db()
+    assert existing_deity.display_name == "既存祭神（Batch16無関係）"
+    assert existing_history.content == "既存の沿革本文。"
+    assert list(existing_deity.sources.all()) == [existing_source]
+    assert list(existing_history.sources.all()) == [existing_source]
+
+
+@pytest.mark.django_db
+def test_batch16_seed_validate_only_fails_when_target_shrine_missing():
+    # Only create 4 of the 5 targets — 白山神社 is intentionally missing.
+    for name_jp, address in TARGETS[:-1]:
+        Shrine.objects.create(name_jp=name_jp, kind="shrine", address=address)
+
+    with pytest.raises(Exception):
+        call_command(
+            "import_shrine_knowledge",
+            str(SEED_PATH),
+            "--validate-only",
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )

--- a/docs/audit/knowledge-batch16-seed-preflight.md
+++ b/docs/audit/knowledge-batch16-seed-preflight.md
@@ -1,0 +1,529 @@
+> **Status: `BATCH16_PRODUCTION_IMPORT_READY`。**
+>
+> 本ドキュメントは`docs/audit/knowledge-batch16-target-selection.md`
+> （`BATCH16_TARGET_SELECTION_READY`、ただしBatch17継続性への強い
+> 警告付き）で選定されたRecommended 5社について、Knowledge seedを
+> 構築し、Production投入直前の技術Gateまで検証した記録である。
+>
+> **本ドキュメント作成のセッションでは、Production Knowledge writeは
+> 実行していない。** 実行したのは、Production read-only接続
+> （`readonly_query.sh`）、公式サイトのfresh確認（Browser pane）、
+> ローカルDBへの実際のseed投入・検証、fresh Production dumpから復元
+> した isolated DBへの実際のseed投入・検証、そしてProduction DBに
+> 対する`--validate-only`・`--dry-run`（いずれもDB書き込みを一切行わ
+> ないモード）のみである。Production DB writeは0件。
+>
+> 全14 Deity・15 History Factが`confidence: high`で確定でき、限定的な
+> データ完全性の制約（Batch14の玉前神社のような`confidence: medium`
+> 格下げ）は生じなかったため`READY`とした。`SAFE_CANDIDATES_AFTER_BATCH16
+> = 0`（`NORMAL_BATCH_CONTINUATION_EXHAUSTED`）はSection 22で再確認
+> したとおりTarget Selection時点から変化していない。
+
+develop SHA（作業開始時点）: `032e2493d274fe74603802864ecfeb2f77a12fad`
+（PR #2377反映済み、`origin/develop`と同期済み、working tree clean）。
+
+---
+
+## 1. Base state and contracts
+
+`docs/audit/knowledge-batch16-target-selection.md`を再読し、
+Recommended 5社を対象として確定した。
+
+freshに再読した既存contract:
+
+- `docs/knowledge/shrine-knowledge-contract.md`
+- `backend/temples/data/knowledge_seeds/batch_15_seed.json`（seed構造のテンプレート）
+- `backend/temples/tests/test_batch15_knowledge_seed.py`
+- `backend/temples/services/knowledge_seed.py`
+- `backend/temples/management/commands/import_shrine_knowledge.py`
+- `docs/audit/knowledge-batch15-seed-preflight.md`
+- `docs/audit/knowledge-batch15-closure-batch16-reentry.md`
+
+いずれも構造変更なしで再利用可能であることを確認した。
+
+---
+
+## 2. Target Identity Recheck（fresh実測）
+
+Production read-only接続で、5社をfreshに再確認した。
+
+| shrine | Production id | `place_ref_id IS NULL` | 同名重複 | deity_count | history_count |
+|---|---:|---|---:|---:|---:|
+| 平塚八幡宮 | 94 | true | 1 | 0 | 0 |
+| 櫻木神社 | 80 | true | 1 | 0 | 0 |
+| 多摩川浅間神社 | 70 | true | 1 | 0 | 0 |
+| 宇都宮二荒山神社 | 84 | true | 1 | 0 | 0 |
+| 白山神社 | 65 | true | 1 | 0 | 0 |
+
+**全5社が`IDENTITY_SAFE`。** Target Selection時点の記載と完全一致
+（drift 0）。numeric PKはseedへ記録しない。宇都宮二荒山神社の
+`name_jp`が「宇都宮二荒山神社」で確定しており、栃木県日光市の
+「日光二荒山神社」（別法人・別レコード）との混同がないことを確認済み。
+
+---
+
+## 3. Official Sources（Target Selection時の結果を再利用せずfresh確認）
+
+5社すべての公式サイト（白山神社のみ東京十社会公式）をBrowser paneで
+**再度**直接確認した。取得内容はTarget Selectionセッション時と完全に
+一致し、drift 0件だった。
+
+| shrine | Source URL | 確認内容 |
+|---|---|---|
+| 平塚八幡宮 | http://www.hachiman.org/yurai.php | 応神天皇・神功皇后・武内宿禰、仁徳天皇御代68年(380)創祀伝承、戦国期兵火、徳川家康による復興、大正12年(1923)関東大震災倒壊、昭和3年(1928)現社殿竣工 |
+| 櫻木神社 | https://sakuragi.info/about/ | 伊弉諾尊・伊弉冉尊・倉稲魂命・武甕槌命、仁寿元年(851)創建伝承、永祚元年(989)宮所建立、正暦3年(992)以降の髙梨氏継承 |
+| 多摩川浅間神社 | https://sengenjinja.info/about/index.html | 木花咲耶姫命（単一）、文治年間(1185-90)創祀伝承、承応元年(1652)観世音立像発掘、明治40年(1907)合祀政令による現形成立 |
+| 宇都宮二荒山神社 | http://futaarayamajinja.jp/yuisyo/ | 豊城入彦命（御祭神）・大物主命・事代主命（相殿）、崇神天皇御代起源伝承、承和5年(838)臼ケ峰遷座、延長5年(927)延喜式名神大社記載 |
+| 白山神社 | http://10jinja.tokyo/hakusanjinja.html（東京十社会公式） | 菊理姫命・伊弉諾命・伊弉冊命、天暦2年(948)勧請、建武4年(1337)足利尊氏祈願所、元和2年(1616)〜明暦元年(1655)の遷座歴 |
+
+平塚八幡宮の公式サイトはHTTPS証明書がホスト名と一致しないため
+Browser paneで直接コンテンツを確認した（HTTP接続自体は到達可能で、
+内容の推測は行っていない）。
+
+---
+
+## 4. Source Semantic Conflict
+
+Production既存104件のSourceと`normalize_source_url()`実装をそのまま
+使用して照合した。
+
+```sql
+SELECT id, source_type, title, publisher, url FROM temples_shrineknowledgesource
+WHERE url ILIKE '%hachiman.org%' OR url ILIKE '%sakuragi.info%'
+   OR url ILIKE '%sengenjinja.info%' OR url ILIKE '%futaarayamajinja%'
+   OR url ILIKE '%10jinja.tokyo%';
+```
+
+結果: 0件。**5候補Sourceすべてが`NO_CONFLICT`。**
+
+---
+
+## 5. Deity Research（各社固有の判断）
+
+### 平塚八幡宮
+
+公式サイトから応神天皇・神功皇后・武内宿禰の三柱をfresh確認した。
+序列の記載がないため三柱とも`role: unknown`とした。境内絵図に記載の
+「弁財天社」（七福神の一）・「末社三社」は本社Factから除外した。
+
+### 櫻木神社
+
+公式サイトから伊弉諾尊・伊弉冉尊・倉稲魂命・武甕槌命の四柱を、各柱の
+個別説明とともにfresh確認した。序列の記載がないため四柱とも
+`role: unknown`とした。
+
+### 多摩川浅間神社（completeness/tradition限定）
+
+公式サイトから木花咲耶姫命の一柱をfresh確認した。創祀伝承には仏教的
+要素（「正観世音像」「富士浅間大菩薩」という呼称）が登場するが、現在の
+「御祭神」欄には木花咲耶姫命のみが記載されており、伝承をtradition
+分類で非断定的に扱い、観世音像自体をDeity Factとして登録していない。
+明治40年(1907)の合祀政令により統合された旧赤城神社・熊野神社の祭神は
+現在の御祭神一覧に含まれないためFact化していない。
+
+### 宇都宮二荒山神社（identity厳密確認）
+
+公式サイトから豊城入彦命（`role: primary`、御祭神）・大物主命・
+事代主命（`role: secondary`、相殿）の三柱をfresh確認した。当社が
+栃木県宇都宮市に鎮座する「宇都宮二荒山神社」であり、栃木県日光市の
+「日光二荒山神社」とは別法人であることを、Production側のaddressと
+公式サイト記載の所在地の一致によって確認した。境内の十二末社は
+本社Factから除外した。
+
+### 白山神社（東京十社会公式Source）
+
+白山神社（文京区）自体の独立公式ドメインは確認できなかったため、
+当社を含む参加10社が共同運営する公式団体「東京十社会」の公式サイト
+（©東京十社会）から直接fresh確認した。菊理姫命・伊弉諾命・伊弉冊命の
+三柱を、序列を示さない形で確認した。白山信仰一般の解説は含まれず、
+当社固有の由緒のみが記載されていることを確認済み。境内社の記載は
+このページにはない。
+
+**禁止事項の遵守確認**: unnamed deityの推測登録＝0件、collective
+Fact化＝0件、摂社/末社/境内社祭神の混入＝0件（平塚八幡宮の弁財天社・
+末社三社、多摩川浅間神社の旧赤城神社・熊野神社、宇都宮二荒山神社の
+十二末社をいずれも除外）、仏教尊格の無理なDeity化＝0件（多摩川浅間
+神社の観世音像を除外）、associated worship target混入＝0件。
+
+---
+
+## 6. History Research
+
+各社の由緒を、既存`history_type` enumへ適合する範囲でFact化した。
+伝承（`tradition`）と歴史的出来事（`historical_event`）を明確に分離し、
+伝承文には非断定表現を用いた（fresh確認: 全4件のtradition Factで
+確認済み: 平塚八幡宮の380年創祀伝承、櫻木神社の851年創建伝承、多摩川
+浅間神社の1185-90年創祀伝承、宇都宮二荒山神社の起源伝承）。
+
+BiographyとShrine Historyの混同はない（本Batchの候補にはBatch15の
+報徳二宮神社のような人物伝記型の候補は含まれていない）。
+
+---
+
+## 7. Shrine-specific Content-model Review
+
+| shrine | 確認事項 | 結果 |
+|---|---|---|
+| 平塚八幡宮 | 境内社（弁財天社・末社三社）を除外。HTTP-only sourceでも内容根拠を保持（Browser paneで直接確認） | `MODEL_FIT_SAFE` |
+| 櫻木神社 | 合祀・境内社の記載なし。collective表現の過剰Fact化なし | `MODEL_FIT_SAFE` |
+| 多摩川浅間神社 | 木花咲耶姫命のみFact化。富士信仰の伝承と歴史的出来事（発掘・合祀政令）を分離。富士塚等の関連信仰対象は登場せず別Fact化していない | `MODEL_FIT_SAFE`（tradition内の仏教的要素は非断定表現で処理） |
+| 宇都宮二荒山神社 | 日光二荒山神社との混同なし（address一致確認）。十二末社を除外 | `MODEL_FIT_SAFE` |
+| 白山神社 | 東京十社会公式Sourceのidentity/address一致確認済み。白山信仰一般論の混入なし。境内社の記載なし | `MODEL_FIT_SAFE` |
+
+**Recommended 5全件が`MODEL_FIT_SAFE`。**
+
+---
+
+## 8. Evidence Gate
+
+全14 Deity・15 History Factについて確認した。
+
+| 指標 | 値 |
+|---|---:|
+| source-less Deity | 0 |
+| source-less History | 0 |
+| `verification_status`が`source_confirmed`以外 | 0 |
+| `confidence`が`high`以外 | 0 |
+| `verified_at`未設定 | 0 |
+| invalid enum | 0 |
+| identity unsafe | 0 |
+| semantic conflict unsafe | 0 |
+
+全件がEvidence Gate要件を満たす。全29 Fact（Deity14+History15）が
+`confidence: high`。
+
+---
+
+## 9. Canonical seed integrity
+
+`backend/temples/data/knowledge_seeds/batch_16_seed.json`
+（`schema_version: "1.0"`）。
+
+`parse_seed()`（実装をそのまま使用したstructural検証）:
+
+| 指標 | 値 |
+|---|---:|
+| errors | 0 |
+| Source count | 5 |
+| Shrine count | 5 |
+| Deity count | 14 |
+| History count | 15 |
+| Deity–Source relation | 14 |
+| History–Source relation | 15 |
+| source-less Deity | 0 |
+| source-less History | 0 |
+| within-shrine重複 | 0 |
+| invalid enum | 0 |
+| unresolved source_key参照 | 0 |
+| 数値Production PKのhardcode | 0 |
+
+SHA-256（`batch_16_seed.json`）:
+`41ca48e3e980da5dcb9cb0b38050d4e43e8828bc5553f8dee27c42b996fee4e9`
+
+---
+
+## 10. Regression tests
+
+新規: `backend/temples/tests/test_batch16_knowledge_seed.py`（11件）。
+Batch15の`test_batch15_knowledge_seed.py`と同型の構成に加え、本Batch
+固有の以下を追加した。
+
+- `test_batch16_seed_hiratsuka_hachimangu_excludes_sub_shrines`: 平塚
+  八幡宮の弁財天社・末社三社が本社Factに混入していないことを固定化
+- `test_batch16_seed_sengenjinja_excludes_absorbed_shrine_deities`:
+  多摩川浅間神社が木花咲耶姫命の一柱のみをFact化し、合祀された旧
+  赤城神社・熊野神社の祭神を含んでいないことを固定化
+- `test_batch16_seed_futaarayama_excludes_sub_shrines_and_is_utsunomiya`:
+  宇都宮二荒山神社の十二末社が混入していないこと、addressが日光
+  二荒山神社と混同されていないことを固定化
+- `test_batch16_seed_hakusan_identity_and_source`: 白山神社の
+  identity・東京十社会公式Sourceの参照関係を固定化
+
+既存の汎用テスト（24件）・Batch9〜15テスト（55件）を含め、合計90件
+すべてPASS（回帰なし。`pytest -p no:dotenv`でlocal-onlyの
+`pytest-dotenv`プラグイン競合を回避）。
+
+---
+
+## 11. Local validation
+
+ローカル`jinja_db`（対象5社は既存Production idと一致する形で存在、
+import前はいずれもdeity=0/history=0を確認済み）に対して実際に実行:
+
+| step | 結果 |
+|---|---|
+| `--validate-only` | `validate-only: OK, no errors` |
+| `--dry-run`（1回目） | `{'source_CREATE': 5, 'deity_CREATE': 14, 'history_CREATE': 15}` |
+| 適用（import） | `sources created=5, deities created=14, histories created=15` |
+| 件数検証 | 対象5社の内訳は3/3・4/3・1/3・3/3・3/3件（seedと完全一致）、source-less 0件 |
+| `--dry-run`（2回目、冪等性） | `{'source_REUSE_EXISTING': 5, 'deity_SKIP_EXISTS': 14, 'history_SKIP_EXISTS': 15}`、CREATE 0件 |
+
+---
+
+## 12. Production read-only baseline
+
+Production DBをfreshに確認した（過去値を固定せず、本セッションの実測を
+正本とする）。
+
+| 指標 | 実測値 |
+|---|---:|
+| Knowledge Shrine | 81 |
+| Source | 104 |
+| Deity | 219 |
+| History | 167 |
+| Deity–Source relation | 232 |
+| History–Source relation | 172 |
+| complete | 79 |
+| partial | 2 |
+| none | 24 |
+| 総Shrine数 | 105 |
+
+Application aggregates: auth_user 1・userprofile 1・shrine 105・favorite 0・
+visit 2・goriyakutag 39・shrine_goriyaku_relation 283。
+
+対象5社は全件Knowledge none、drift 0件。
+
+---
+
+## 13. Fresh Production Backup
+
+PostgreSQL 17バージョン一致クライアント（`postgresql@17.10`）で新規
+取得（過去のBackupを再利用していない）。
+
+| ファイル | サイズ |
+|---|---:|
+| roles.sql | 5,426 bytes |
+| schema.sql | 93,021 bytes |
+| data.sql | 4,346,373 bytes |
+
+repo外（`~/kami-musubi-backups/batch16-seed-preparation-<timestamp>/`）
+に保存。接続情報・hostname・credentialは一切ログに出力していない。
+
+---
+
+## 14. Fresh Production-equivalent test
+
+上記backupを`kami_musubi_migration_safety_b16<timestamp>`（disposable
+local DB）へ復元した。復元は`exit 0`で完了。
+
+復元直後のisolated DB確認: Production同時刻の値（Source104・Deity219・
+History167・relation232/172・Knowledge Shrine81・総Shrine105）と完全
+一致。対象5社は全件Knowledge none。
+
+isolated DBに対して、ローカルと同一の5ステップ＋追加確認を実施:
+
+| step | 結果 |
+|---|---|
+| `--validate-only` | OK, no errors |
+| `--dry-run`（1回目） | `{'source_CREATE': 5, 'deity_CREATE': 14, 'history_CREATE': 15}` |
+| 適用 | `sources created=5, deities created=14, histories created=15` |
+| 件数検証 | Source 104→109・Deity 219→233・History 167→182・Deity–Source rel 232→246・History–Source rel 172→187・Knowledge Shrine 81→86（いずれもseed件数と完全一致） |
+| 対象5社のdeity/history内訳 | 平塚八幡宮3/3・櫻木神社4/3・多摩川浅間神社1/3・宇都宮二荒山神社3/3・白山神社3/3（seedと完全一致、混入なし） |
+| Coverage | complete 79→84・partial 2（不変）・none 24→19 |
+| source-less（DB全体） | Deity 0・History 0 |
+| 無関係データ回帰チェック | Batch14・Batch15投入分（王子神社・足利織姫神社・鶴嶺八幡宮・穴守稲荷神社・玉前神社・湯島天満宮・報徳二宮神社・箭弓稲荷神社・水戸東照宮・葛西神社）すべて既存値のまま不変 |
+| Application aggregate | auth_user1・userprofile1・shrine105・favorite0・visit2・goriyakutag39・shrine_goriyaku_rel283（完全不変） |
+| `--dry-run`（2回目、冪等性） | `{'source_REUSE_EXISTING': 5, 'deity_SKIP_EXISTS': 14, 'history_SKIP_EXISTS': 15}`、CREATE 0件 |
+
+isolated DBは検証完了後に`dropdb`で削除済み（削除後の存在確認も実施
+済み）。
+
+---
+
+## 15. Coverage Projection
+
+isolated DB（Production-equivalent）の実測値から算出（推測値は使用して
+いない）。
+
+| 区分 | Batch16投入前（実測） | Batch16投入後（projection） |
+|---|---:|---:|
+| complete | 79 | 84 |
+| partial | 2 | 2（不変） |
+| none | 24 | 19 |
+| Knowledge Shrine合計 | 81 | 86 |
+| 全Shrine数 | 105 | 105（不変） |
+
+---
+
+## 16. Production read-only preflight
+
+Production DBに対して以下を実行した（いずれもコマンド自身の設計上、
+DB書き込みを一切行わないモード）。
+
+**`--validate-only`**: `validate-only: OK, no errors`
+
+**`--dry-run`**:
+```
+plan summary: {'source_CREATE': 5, 'deity_CREATE': 14, 'history_CREATE': 15}
+dry-run: OK, no DB writes performed
+```
+
+全項目、isolated DBの1回目`--dry-run`結果と完全一致。`SKIP_EXISTS`・
+`REUSE_EXISTING`・`SOURCE_REUSE_CONFLICT`・`SOURCE_REUSE_AMBIGUOUS`・
+`IMPORT_IDENTITY_AMBIGUOUS`・`NOT_FOUND`はいずれも0件。
+
+実行後、`readonly_query.sh`で再度Production状態を確認し、対象5社の
+deity/history、および集計値（Source104・Deity219・History167・
+relation232/172・Knowledge Shrine81・総Shrine105）が実行前と完全に
+不変であることを確認した。
+
+---
+
+## 17. Runtime Expected Payload
+
+seedから算出（Production import実行後に期待される値、実行はしていない）。
+
+| shrine | Deity | History | Unique Source |
+|---|---:|---:|---:|
+| 平塚八幡宮 | 3 | 3 | 1 |
+| 櫻木神社 | 4 | 3 | 1 |
+| 多摩川浅間神社 | 1 | 3 | 1 |
+| 宇都宮二荒山神社 | 3 | 3 | 1 |
+| 白山神社 | 3 | 3 | 1 |
+| **合計** | **14** | **15** | **5** |
+
+Fact–Source relation count: 29（Deity 14 + History 15）。
+
+---
+
+## 18. Runtime Compatibility
+
+コード変更は一切行っていない。`GET https://jinja-backend.onrender.com/api/shrines/64/data/`
+を実行し、Batch15投入分（湯島天満宮、deities=2, histories=4）が変わらず
+Runtime公開されていることをfresh再確認した。本Batch16 seedはBatch14/15
+と同一の`schema_version: "1.0"`・同一field構成であり、
+`ShrineDeitySerializer`/`ShrineHistorySerializer`の`fields`と完全に
+互換である。
+
+**分類: `KNOWLEDGE_RUNTIME_COMPATIBLE`。**
+
+---
+
+## 19. Remaining-normal-batch Audit（fresh再確認、重要KPI）
+
+Target Selection時点の判定（`SAFE_CANDIDATES_AFTER_BATCH16 = 0`）を
+盲信せず、本セッションでもfreshにDBを再照会した。
+
+raw `none`（Batch16投入前の現状値、24件）から、Batch16の5社が離脱した
+後を projectionとして算出:
+
+| 区分 | 件数（Batch16後projection） |
+|---|---:|
+| raw none | 19（24-5） |
+| canonical candidate | 14（19-5の除外＝変化なし） |
+| model-risk（既存6件＋Batch16 Target Selection時点で新規判明3件） | 9 |
+| `ADDITIONAL_RESEARCH_REQUIRED` | 4 |
+| `SOURCE_INSUFFICIENT` | 1 |
+| **通常Batchで即座に安全な候補** | **0** |
+
+**`SAFE_CANDIDATES_AFTER_BATCH16 = 0`（fresh再確認、drift 0）。**
+
+**分類: `NORMAL_BATCH_CONTINUATION_EXHAUSTED`。**
+
+Target Selection以降、model-risk・研究要求候補の状態に変化はない
+（Mother Shipによる新たな設計判断が行われていないため）。
+
+---
+
+## 20. Risk Audit
+
+- **identity ambiguity**: 0件。宇都宮二荒山神社は日光二荒山神社との
+  混同がないことをaddress照合で確認済み
+- **Source instability**: 平塚八幡宮はHTTPS証明書がホスト名と一致しない
+  ためHTTP接続で確認した（一般的なリスクとして記録、内容の推測は
+  行っていない）
+- **unnamed deities**: 0件
+- **collective deity**: 0件
+- **shinbutsu-shugo**: 多摩川浅間神社の創祀伝承に仏教的要素（観世音像）
+  が含まれるが、現在の御祭神は木花咲耶姫命のみであり、伝承を
+  非断定的なtradition Factとして扱い、観世音像自体をDeity Fact化して
+  いない。榛名神社・古峯神社のような現役の仏教組織支配の歴史とは
+  性質が異なると判断した
+- **sub-shrine contamination**: 0件（平塚八幡宮・多摩川浅間神社・
+  宇都宮二荒山神社いずれも境内社/合祀吸収元を除外）
+- **`SKIP_EXISTS`のsemantic-diff limitation**: 既知の設計上の制約であり、
+  本Batchに固有の問題ではない
+
+新規にMother Ship判断が必要なcontent-model問題は生じなかった。
+`MOTHER_SHIP_REVIEW_REQUIRED`には該当しない。
+
+---
+
+## 21. Final Classification
+
+- 5社全件が`IDENTITY_SAFE`・`NO_CONFLICT`・Evidence Gate要件を満たす
+- ローカル・Production-equivalent（fresh dump復元）の両方で
+  `--validate-only`→`--dry-run`→適用→件数検証→再`--dry-run`の
+  フルサイクルが期待どおりの結果
+- Production DBに対する`--validate-only`・`--dry-run`がProduction-equivalent
+  の結果と完全一致し、unexpected SKIP/UPDATE/conflictが0件
+- Production状態がこれらの読み取り専用操作の前後で完全に不変であることを
+  実測で確認
+- 候補の差替えは発生していない
+- 全29 Fact（Deity14+History15）が`confidence: high`
+- `KNOWLEDGE_RUNTIME_COMPATIBLE`確認済み
+- Risk Auditで新規content-model判断は不要と判定
+- `SAFE_CANDIDATES_AFTER_BATCH16 = 0`（`NORMAL_BATCH_CONTINUATION_EXHAUSTED`）
+  をfresh再確認
+
+**`BATCH16_PRODUCTION_IMPORT_READY`**
+
+残存する非blocking事項（Productionへの実書き込み判断とは独立）:
+
+- partial 2社（阿佐ヶ谷神明宮・香取神宮）のHistory repairは別タスクの
+  まま
+- model-risk 9件（うち3件はBatch16 Target Selectionで新規判明）の
+  content-model判断は引き続き保留
+- `ADDITIONAL_RESEARCH_REQUIRED`4件（花園神社・武蔵一宮氷川女體神社・
+  調神社・鳥越神社）への追加調査は未着手
+- **Batch 16の実施をもって、通常のBatch継続（Option A）は事実上停止
+  する。Batch 17を開始する場合は、Mother Shipによる次工程（Option
+  A-F、`knowledge-batch16-target-selection.md` Section 21参照）の
+  明示判断が必須である**
+- Production importそのもの（Fact実書き込み・Runtime QA）は本ドキュメント
+  では未実施。Mother Shipの明示的な承認後、別セッション（Human
+  Execution Boundary Gate相当）で実施する必要がある
+
+Production DB writes = 0
+Batch 16 Production import = NOT_EXECUTED
+Batch 17 = NOT_STARTED
+
+---
+
+## 最終報告サマリ
+
+1. develop SHA: `032e2493d274fe74603802864ecfeb2f77a12fad`
+2. target5: 平塚八幡宮・櫻木神社・多摩川浅間神社・宇都宮二荒山神社・白山神社
+3. identity: 全5社`IDENTITY_SAFE`
+4. official Sources: 全5社公式/準公式Source直接確認、drift 0
+5. Source conflict: 5件全て`NO_CONFLICT`
+6. seed hash: `41ca48e3e980da5dcb9cb0b38050d4e43e8828bc5553f8dee27c42b996fee4e9`
+7. seed counts: Shrine5・Source5・Deity14・History15・relation29
+8. Deity: 14（全件confidence: high）
+9. History: 15（全件confidence: high）
+10. Evidence Gate: 全件PASS、source-less 0
+11. content-model exclusions: 弁財天社/末社三社（平塚八幡宮）・旧赤城
+    神社/熊野神社（多摩川浅間神社）・十二末社（宇都宮二荒山神社）
+12. tests: 新規11件＋既存79件＝合計90件PASS
+13. local validation: フルサイクル完了、件数一致
+14. Production baseline: Knowledge Shrine81・Source104・Deity219・
+    History167・rel232/172
+15. backup: roles 5,426B・schema 93,021B・data 4,346,373B（repo外保存）
+16. Production-equivalent: フルサイクル完了、件数一致、コンタミネーション0
+17. Coverage projection: complete79→84・partial2（不変）・none24→19
+18. Production validate-only: OK, no errors
+19. Production dry-run: `{'source_CREATE': 5, 'deity_CREATE': 14, 'history_CREATE': 15}`、Production状態不変
+20. Runtime Expected Payload: 合計Deity14・History15・Unique Source5
+21. Runtime compatibility: `KNOWLEDGE_RUNTIME_COMPATIBLE`
+22. SAFE_CANDIDATES_AFTER_BATCH16: **0**（fresh再確認、drift 0）
+23. normal-batch viability: **`NORMAL_BATCH_CONTINUATION_EXHAUSTED`**
+24. remaining risks: Section 20参照（新規Mother Ship判断は不要と判定）
+25. audit doc: 本ドキュメント
+    （`docs/audit/knowledge-batch16-seed-preflight.md`）
+26. PR: 別途作成（本ドキュメントのcommit時に作成）
+27. CI: PR作成後に確認
+28. final classification: `BATCH16_PRODUCTION_IMPORT_READY`
+
+Production DB writes = 0
+Batch16 Production import = NOT_EXECUTED
+Batch17 = NOT_STARTED


### PR DESCRIPTION
## 概要

`docs/audit/knowledge-batch16-target-selection.md`（`BATCH16_TARGET_SELECTION_READY`、PR #2377）で選定されたRecommended 5社について、Knowledge seedを作成し、Production投入直前の技術Gateまで検証した。

対象5社: 平塚八幡宮・櫻木神社・多摩川浅間神社・宇都宮二荒山神社・白山神社

詳細は [`docs/audit/knowledge-batch16-seed-preflight.md`](../blob/feature/knowledge-batch16-seed-preparation/docs/audit/knowledge-batch16-seed-preflight.md) を参照。

**最終分類: `BATCH16_PRODUCTION_IMPORT_READY`**

全29 Fact（Deity14+History15）が`confidence: high`で確定できました。

## 実施した内容（Production write 0件）

- 5社の公式サイト（白山神社のみ東京十社会公式）をBrowser paneでfresh確認
- `backend/temples/data/knowledge_seeds/batch_16_seed.json` を新規作成（Source 5・Deity 14・History 15）
- `backend/temples/tests/test_batch16_knowledge_seed.py` を新規追加（11件、含む平塚八幡宮の境内社非混入・多摩川浅間神社の合祀吸収元非混入・宇都宮二荒山神社の日光二荒山神社非混同の固定化テスト）
- ローカルDB・fresh Production dump復元のisolated DB双方でフルサイクル（`--validate-only` → `--dry-run` → import → 件数検証 → 再`--dry-run`）を実施し、いずれも期待どおりの結果
- Production DBに対しては `--validate-only` / `--dry-run`（いずれもDB書き込みなし）のみ実行し、Production状態が実行前後で完全に不変であることを確認
- `SAFE_CANDIDATES_AFTER_BATCH16 = 0`（`NORMAL_BATCH_CONTINUATION_EXHAUSTED`）をfresh再確認（Target Selection時点から変化なし）

## 特記事項

多摩川浅間神社の創祀伝承には仏教的要素（「正観世音像」「富士浅間大菩薩」）が登場するが、現在の御祭神は木花咲耶姫命のみであり、伝承をtradition分類で非断定的に扱い、観世音像自体をDeity Factとして登録していません。宇都宮二荒山神社は日光二荒山神社（別法人）との混同がないことをaddress照合で確認しました。

## 対象外（このPRでは実施しない）

- Production Knowledge write（Batch 16 Production import自体）
- Batch 17の開始

## Test plan

- [x] `pytest temples/tests/test_batch16_knowledge_seed.py -p no:dotenv` — 11件PASS
- [x] Batch9-16 + 既存汎用テスト合計90件PASS（回帰なし）
- [x] ローカルDBでのフルサイクル（validate-only → dry-run → import → 冪等性確認）
- [x] fresh Production dump復元のisolated DBでのフルサイクル
- [x] Production `--validate-only` / `--dry-run`（write 0件、実行前後で状態不変）
- [x] pre-push hook（OpenAPI lint・Web契約テスト731件）PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)