### PR TITLE
Knowledge推薦理由の品質Baseline計測を追加

### DIFF
--- a/backend/temples/management/commands/measure_knowledge_recommendation_quality.py
+++ b/backend/temples/management/commands/measure_knowledge_recommendation_quality.py
@@ -1,0 +1,91 @@
+"""Knowledge推薦理由 品質Baseline計測のread-only CLI。
+
+DBへの書き込みは一切行わない。Recommendation Runtime（chat POST等）は呼び出さず、
+Django ORMのSELECTのみでBaselineを算出する。Production write禁止・
+thread/message write禁止・Analytics送信禁止（temples.services.
+recommendation_quality_measurementのdocstring参照）。
+"""
+
+from __future__ import annotations
+
+import json
+
+from django.core.management.base import BaseCommand
+
+from temples.services.recommendation_quality_measurement import (
+    build_recommendation_quality_measurement_report,
+)
+
+
+def render_text_report(report: dict) -> str:
+    lines: list[str] = []
+    lines.append("Knowledge Recommendation Quality Baseline")
+    lines.append("=" * 42)
+    lines.append(f"Sample Count: {report['sample_count']}")
+    lines.append("")
+    lines.append(
+        f"Fully Knowledge-backed: {report['fully_knowledge_backed']} "
+        f"({report['fully_knowledge_backed_rate']:.2%})"
+    )
+    lines.append(
+        f"Partially Knowledge-backed: {report['partially_knowledge_backed']} "
+        f"({report['partially_knowledge_backed_rate']:.2%})"
+    )
+    lines.append(
+        f"Legacy-backed: {report['legacy_backed']} ({report['legacy_backed_rate']:.2%})"
+    )
+    lines.append(f"Unknown: {report['unknown']} ({report['unknown_rate']:.2%})")
+    lines.append("")
+    lines.append(f"Knowledge-backed rate (Fully+Partially): {report['knowledge_backed_rate']:.2%}")
+    lines.append(f"Deity Knowledge usage rate: {report['deity_knowledge_usage_rate']:.2%}")
+    lines.append(f"History Knowledge usage rate: {report['history_knowledge_usage_rate']:.2%}")
+    lines.append(f"Deity Legacy fallback rate: {report['deity_legacy_fallback_rate']:.2%}")
+    lines.append(f"History Legacy fallback rate: {report['history_legacy_fallback_rate']:.2%}")
+    lines.append("")
+    sc = report["source_confirmed_fact"]
+    lines.append(
+        f"Source-confirmed Fact rate: {sc['source_confirmed_count']}/"
+        f"{sc['fact_ready_total']} ({sc['source_confirmed_fact_rate']:.2%})"
+    )
+    lines.append(f"Verification Status Distribution: {sc['verification_status_distribution']}")
+    return "\n".join(lines)
+
+
+class Command(BaseCommand):
+    help = (
+        "Knowledge推薦理由の品質Baselineをread-only計測して表示する。"
+        "DB書き込み・Recommendation Runtime呼び出しは一切行わない。"
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--format",
+            choices=["text", "json"],
+            default="text",
+            help="出力形式。text（既定、人間可読）またはjson。",
+        )
+        parser.add_argument(
+            "--shrine-ids",
+            type=str,
+            default=None,
+            help="カンマ区切りのshrine id一覧。未指定時はQA fixtureを除外した全Shrineが対象。",
+        )
+        parser.add_argument(
+            "--no-detail",
+            action="store_true",
+            help="classification_by_shrine（神社別内訳）をjson出力から省略する。",
+        )
+
+    def handle(self, *args, **options):
+        shrine_ids = None
+        if options["shrine_ids"]:
+            shrine_ids = [int(x) for x in options["shrine_ids"].split(",") if x.strip()]
+
+        report = build_recommendation_quality_measurement_report(shrine_ids=shrine_ids)
+
+        if options["format"] == "json":
+            if options["no_detail"]:
+                report = {k: v for k, v in report.items() if k != "classification_by_shrine"}
+            self.stdout.write(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+        else:
+            self.stdout.write(render_text_report(report))

--- a/backend/temples/services/recommendation_quality_measurement.py
+++ b/backend/temples/services/recommendation_quality_measurement.py
@@ -1,0 +1,272 @@
+"""Knowledge推薦理由 品質Baseline計測（read-only）。
+
+docs/audit/knowledge-recommendation-quality-audit.mdで定義した
+FULLY_KNOWLEDGE_BACKED / PARTIALLY_KNOWLEDGE_BACKED / LEGACY_BACKED / UNKNOWN
+の4分類を、実際のRecommendation Reason生成ロジックと完全に同一の判定で
+再現可能な計測へ落とし込む。
+
+このモジュールは以下を再実装しない（既存contractをそのまま利用する）。
+
+- Knowledge Fact取得・Fact-ready判定
+  （temples.services.shrine_knowledge_selector / evidence_gateへ委譲）
+- Knowledge優先・Legacy fallbackの合成ロジック
+  （temples.services.concierge_chat._build_score_v3_candidate_profileへ委譲）
+- confidenceに基づく表現強度判定・suppression
+  （temples.services.recommendation_reason_v4._build_factへ委譲）
+- QA fixture Shrineの除外条件
+  （temples.services.shrine_qa_fixture_exclusion.exclude_qa_fixture_shrinesへ委譲）
+
+DBへの書き込みは一切行わない。Recommendation Candidate / Ranking / Score /
+Reason生成・Action Suggestionのいずれも変更しない（read-only observer）。
+
+## history_theme名称衝突ガード
+
+docs/audit/knowledge-recommendation-quality-audit.md 4.2で確認した通り、
+`Shrine.history_theme`（Legacy分類タグ）とKnowledge（`ShrineHistory`モデル、
+`shrine_history`フィールド）は名前が似ているだけの別物である。本モジュールの
+分類は`deity`/`shrine_history`フィールドのみを対象とし、`history_theme`は
+一切参照しない（`_build_score_v3_candidate_profile`・`_build_fact`いずれも
+`history_theme`を`fact["history_theme"]`として保持するが、分類判定には
+使わない）。
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory
+from temples.services import evidence_gate
+from temples.services.concierge_chat import _build_score_v3_candidate_profile
+from temples.services.recommendation_reason_v4 import _build_fact
+from temples.services.shrine_knowledge_selector import (
+    fetch_fact_ready_knowledge_deities,
+    fetch_fact_ready_knowledge_histories,
+)
+from temples.services.shrine_qa_fixture_exclusion import exclude_qa_fixture_shrines
+
+FieldStatus = Literal["KNOWLEDGE_USED", "LEGACY_USED", "EMPTY"]
+Classification = Literal[
+    "FULLY_KNOWLEDGE_BACKED",
+    "PARTIALLY_KNOWLEDGE_BACKED",
+    "LEGACY_BACKED",
+    "UNKNOWN",
+]
+
+
+@dataclass(frozen=True)
+class ShrineReasonProvenance:
+    """1神社分の、Recommendation Reasonが実際に使用したFactの由来。"""
+
+    shrine_id: int
+    name: str
+    deity_status: FieldStatus
+    history_status: FieldStatus
+    classification: Classification
+
+
+def _field_status(*, confidence_is_knowledge: bool, fact_value: Any) -> FieldStatus:
+    """fieldの最終可視状態から由来を判定する。
+
+    confidence_is_knowledge=True でも fact_value が None（低confidenceで
+    suppressされた、またはそもそも値がない）場合はEMPTYとする。
+    「Knowledgeが存在したが表示されなかった」ことと「Legacyが使われた」ことを
+    混同しないための区別（suppressed Knowledge Factは"Legacy扱い"にしない）。
+    """
+    if fact_value is None:
+        return "EMPTY"
+    return "KNOWLEDGE_USED" if confidence_is_knowledge else "LEGACY_USED"
+
+
+def classify_provenance(
+    deity_status: FieldStatus, history_status: FieldStatus
+) -> Classification:
+    """deity/history 2フィールドの由来からshrine単位の分類を決定する。
+
+    FULLY_KNOWLEDGE_BACKED: 少なくとも一方がKNOWLEDGE_USEDで、LEGACY_USEDがない
+    PARTIALLY_KNOWLEDGE_BACKED: KNOWLEDGE_USEDとLEGACY_USEDが両方ある
+    LEGACY_BACKED: LEGACY_USEDのみ（KNOWLEDGE_USEDがない）
+    UNKNOWN: 両方EMPTY（由来を判定する材料がない）
+    """
+    statuses = (deity_status, history_status)
+    knowledge_used = "KNOWLEDGE_USED" in statuses
+    legacy_used = "LEGACY_USED" in statuses
+
+    if knowledge_used and legacy_used:
+        return "PARTIALLY_KNOWLEDGE_BACKED"
+    if knowledge_used:
+        return "FULLY_KNOWLEDGE_BACKED"
+    if legacy_used:
+        return "LEGACY_BACKED"
+    return "UNKNOWN"
+
+
+def build_shrine_reason_provenance(candidate: dict[str, Any]) -> ShrineReasonProvenance:
+    """1候補dict（build_chat_candidates()と同一shape）からprovenanceを構築する。
+
+    実際のReason生成と同一の関数（_build_score_v3_candidate_profile /
+    _build_fact）をそのまま呼び出す。計測のためだけに合成・suppressionロジックを
+    再実装しない（実装の重複によるdriftを避けるため、意図的に"private"関数を
+    直接importしている）。
+    """
+    candidate_profile = _build_score_v3_candidate_profile(candidate)
+    fact, _reason_strength = _build_fact(candidate_profile, meaning_translation={})
+
+    deity_status = _field_status(
+        confidence_is_knowledge=candidate_profile.get("deity_confidence") is not None,
+        fact_value=fact.get("deity"),
+    )
+    history_status = _field_status(
+        confidence_is_knowledge=candidate_profile.get("shrine_history_confidence") is not None,
+        fact_value=fact.get("shrine_history"),
+    )
+
+    shrine_id = candidate.get("shrine_id") or candidate.get("id")
+    return ShrineReasonProvenance(
+        shrine_id=int(shrine_id) if shrine_id is not None else 0,
+        name=str(candidate.get("name") or ""),
+        deity_status=deity_status,
+        history_status=history_status,
+        classification=classify_provenance(deity_status, history_status),
+    )
+
+
+def aggregate_measurements(records: list[ShrineReasonProvenance]) -> dict[str, Any]:
+    """provenance一覧からBaseline指標を集計する。
+
+    UNKNOWNの扱い: 全rateの分母は"分類可能な"件数ではなく、常にsample_count
+    （測定対象の全件）とする。UNKNOWNを分母から除外すると
+    knowledge_backed_rateが実態より高く見える（一部の神社にデータが
+    存在しないという事実を無視した楽観的な数値になる）ため、保守的に
+    sample_countを分母として固定する。
+    """
+    total = len(records)
+    counts = Counter(r.classification for r in records)
+
+    def rate(n: int) -> float:
+        return round(n / total, 4) if total else 0.0
+
+    fully = counts.get("FULLY_KNOWLEDGE_BACKED", 0)
+    partially = counts.get("PARTIALLY_KNOWLEDGE_BACKED", 0)
+    legacy = counts.get("LEGACY_BACKED", 0)
+    unknown = counts.get("UNKNOWN", 0)
+
+    deity_knowledge_used = sum(1 for r in records if r.deity_status == "KNOWLEDGE_USED")
+    history_knowledge_used = sum(1 for r in records if r.history_status == "KNOWLEDGE_USED")
+    deity_legacy_used = sum(1 for r in records if r.deity_status == "LEGACY_USED")
+    history_legacy_used = sum(1 for r in records if r.history_status == "LEGACY_USED")
+
+    return {
+        "sample_count": total,
+        "fully_knowledge_backed": fully,
+        "partially_knowledge_backed": partially,
+        "legacy_backed": legacy,
+        "unknown": unknown,
+        "fully_knowledge_backed_rate": rate(fully),
+        "partially_knowledge_backed_rate": rate(partially),
+        "legacy_backed_rate": rate(legacy),
+        "unknown_rate": rate(unknown),
+        # numerator: FULLY + PARTIALLY. denominator: sample_count（UNKNOWN含む）。
+        "knowledge_backed_rate": rate(fully + partially),
+        "deity_knowledge_usage_rate": rate(deity_knowledge_used),
+        "history_knowledge_usage_rate": rate(history_knowledge_used),
+        "deity_legacy_fallback_rate": rate(deity_legacy_used),
+        "history_legacy_fallback_rate": rate(history_legacy_used),
+    }
+
+
+def _audit_target_shrine_ids() -> list[int]:
+    return list(exclude_qa_fixture_shrines(Shrine.objects.all()).values_list("id", flat=True))
+
+
+def _build_candidates_for_measurement(shrine_ids: list[int]) -> list[dict[str, Any]]:
+    """build_chat_candidates()と同一shapeの最小candidate dictを構築する。
+
+    Ranking/距離/goriyaku一致等の計測に不要な処理は行わない
+    （read-only observerとしての責務を最小限に保つ）。
+    """
+    shrines = list(Shrine.objects.filter(id__in=shrine_ids).only(
+        "id", "name_jp", "name_romaji", "sajin", "description"
+    ))
+    knowledge_deities_by_shrine = fetch_fact_ready_knowledge_deities(shrine_ids)
+    knowledge_histories_by_shrine = fetch_fact_ready_knowledge_histories(shrine_ids)
+
+    candidates: list[dict[str, Any]] = []
+    for s in shrines:
+        candidates.append(
+            {
+                "id": s.id,
+                "shrine_id": s.id,
+                "name": s.name_jp or s.name_romaji,
+                "sajin": s.sajin,
+                "description": s.description,
+                "knowledge_deities": knowledge_deities_by_shrine.get(s.id, []),
+                "knowledge_histories": knowledge_histories_by_shrine.get(s.id, []),
+            }
+        )
+    return candidates
+
+
+def _source_confirmed_fact_rate(shrine_ids: list[int]) -> dict[str, Any]:
+    """Fact-ready（source_confirmed/reviewed）Deity+History中、source_confirmedの割合。
+
+    shrine単位のprovenance分類とは別軸の、Fact単位の集計であることに注意
+    （分母は「そのshrineのreasonで実際に採用されたFact数」ではなく、
+    「対象shrine群に存在するFact-ready Deity+History総数」）。
+    """
+    status_counter: Counter[str] = Counter()
+    for model in (ShrineDeity, ShrineHistory):
+        status_counter.update(
+            model.objects.filter(
+                shrine_id__in=shrine_ids,
+                verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES,
+            ).values_list("verification_status", flat=True)
+        )
+
+    total_fact_ready = sum(status_counter.values())
+    source_confirmed = status_counter.get("source_confirmed", 0)
+    rate = round(source_confirmed / total_fact_ready, 4) if total_fact_ready else 0.0
+    return {
+        "fact_ready_total": total_fact_ready,
+        "source_confirmed_count": source_confirmed,
+        "source_confirmed_fact_rate": rate,
+        "verification_status_distribution": dict(sorted(status_counter.items())),
+    }
+
+
+def build_recommendation_quality_measurement_report(
+    shrine_ids: list[int] | None = None,
+) -> dict[str, Any]:
+    """Baseline計測レポートをdictで返す（read-only、DB書き込みなし）。
+
+    shrine_idsを指定しない場合はQA fixtureを除外した全Shrineを対象にする
+    （knowledge_coverage_reportと同一の対象定義を共有する）。
+    """
+    target_ids = shrine_ids if shrine_ids is not None else _audit_target_shrine_ids()
+
+    candidates = _build_candidates_for_measurement(target_ids)
+    records = [build_shrine_reason_provenance(c) for c in candidates]
+
+    report = aggregate_measurements(records)
+    report["source_confirmed_fact"] = _source_confirmed_fact_rate(target_ids)
+    report["classification_by_shrine"] = [
+        {
+            "shrine_id": r.shrine_id,
+            "name": r.name,
+            "deity_status": r.deity_status,
+            "history_status": r.history_status,
+            "classification": r.classification,
+        }
+        for r in records
+    ]
+    return report
+
+
+__all__ = [
+    "ShrineReasonProvenance",
+    "classify_provenance",
+    "build_shrine_reason_provenance",
+    "aggregate_measurements",
+    "build_recommendation_quality_measurement_report",
+]

--- a/backend/temples/tests/services/test_recommendation_quality_measurement.py
+++ b/backend/temples/tests/services/test_recommendation_quality_measurement.py
@@ -1,0 +1,338 @@
+import pytest
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services.recommendation_quality_measurement import (
+    aggregate_measurements,
+    build_recommendation_quality_measurement_report,
+    build_shrine_reason_provenance,
+    classify_provenance,
+)
+
+
+def _candidate(**overrides):
+    base = {
+        "id": 1,
+        "shrine_id": 1,
+        "name": "テスト神社",
+        "sajin": None,
+        "description": None,
+        "history_theme": "",
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+    base.update(overrides)
+    return base
+
+
+# --- classify_provenance: 4分類の純粋関数テスト -----------------------------
+
+
+def test_classify_provenance_fully_knowledge_backed_deity_only():
+    assert classify_provenance("KNOWLEDGE_USED", "EMPTY") == "FULLY_KNOWLEDGE_BACKED"
+
+
+def test_classify_provenance_fully_knowledge_backed_history_only():
+    assert classify_provenance("EMPTY", "KNOWLEDGE_USED") == "FULLY_KNOWLEDGE_BACKED"
+
+
+def test_classify_provenance_fully_knowledge_backed_both():
+    assert classify_provenance("KNOWLEDGE_USED", "KNOWLEDGE_USED") == "FULLY_KNOWLEDGE_BACKED"
+
+
+def test_classify_provenance_partially_knowledge_backed():
+    assert classify_provenance("KNOWLEDGE_USED", "LEGACY_USED") == "PARTIALLY_KNOWLEDGE_BACKED"
+    assert classify_provenance("LEGACY_USED", "KNOWLEDGE_USED") == "PARTIALLY_KNOWLEDGE_BACKED"
+
+
+def test_classify_provenance_legacy_backed():
+    assert classify_provenance("LEGACY_USED", "EMPTY") == "LEGACY_BACKED"
+    assert classify_provenance("EMPTY", "LEGACY_USED") == "LEGACY_BACKED"
+    assert classify_provenance("LEGACY_USED", "LEGACY_USED") == "LEGACY_BACKED"
+
+
+def test_classify_provenance_unknown_when_both_empty():
+    assert classify_provenance("EMPTY", "EMPTY") == "UNKNOWN"
+
+
+# --- build_shrine_reason_provenance: 実際のcandidate dictからの分類 ----------
+
+
+def test_provenance_empty_facts_is_unknown():
+    p = build_shrine_reason_provenance(_candidate())
+    assert p.deity_status == "EMPTY"
+    assert p.history_status == "EMPTY"
+    assert p.classification == "UNKNOWN"
+
+
+def test_provenance_legacy_only_is_legacy_backed():
+    c = _candidate(sajin="天照大神", description="由緒本文レガシー")
+    p = build_shrine_reason_provenance(c)
+    assert p.deity_status == "LEGACY_USED"
+    assert p.history_status == "LEGACY_USED"
+    assert p.classification == "LEGACY_BACKED"
+
+
+def test_provenance_deity_only_knowledge_high_confidence_is_fully_backed():
+    c = _candidate(
+        knowledge_deities=[{"display_name": "経津主大神", "sort_order": 0, "confidence": "high"}],
+    )
+    p = build_shrine_reason_provenance(c)
+    assert p.deity_status == "KNOWLEDGE_USED"
+    assert p.history_status == "EMPTY"
+    assert p.classification == "FULLY_KNOWLEDGE_BACKED"
+
+
+def test_provenance_history_only_knowledge_high_confidence_is_fully_backed():
+    c = _candidate(
+        knowledge_histories=[
+            {
+                "history_type": "founding",
+                "title": "創建",
+                "content": "由緒本文",
+                "period_text": "",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    )
+    p = build_shrine_reason_provenance(c)
+    assert p.deity_status == "EMPTY"
+    assert p.history_status == "KNOWLEDGE_USED"
+    assert p.classification == "FULLY_KNOWLEDGE_BACKED"
+
+
+def test_provenance_mixed_knowledge_deity_and_legacy_history_is_partial():
+    c = _candidate(
+        description="由緒本文レガシー",
+        knowledge_deities=[{"display_name": "祭神A", "sort_order": 0, "confidence": "high"}],
+    )
+    p = build_shrine_reason_provenance(c)
+    assert p.deity_status == "KNOWLEDGE_USED"
+    assert p.history_status == "LEGACY_USED"
+    assert p.classification == "PARTIALLY_KNOWLEDGE_BACKED"
+
+
+def test_provenance_low_confidence_knowledge_deity_is_suppressed_not_legacy():
+    """confidence=lowはreason生成でsuppressされ、fact["deity"]=Noneになる。
+    これは"Legacyが使われた"ことにはならない（Knowledgeが存在したが表示されなかった、
+    というEMPTY扱いになる）。suppressed Knowledgeを誤ってLEGACY_USEDへ分類しない
+    ことを固定化する。"""
+    c = _candidate(
+        knowledge_deities=[{"display_name": "祭神B", "sort_order": 0, "confidence": "low"}],
+    )
+    p = build_shrine_reason_provenance(c)
+    assert p.deity_status == "EMPTY"
+    assert p.classification == "UNKNOWN"
+
+
+def test_provenance_mixed_sentinel_confidence_is_suppressed():
+    c = _candidate(
+        knowledge_deities=[
+            {"display_name": "祭神C", "sort_order": 0, "confidence": "high"},
+            {"display_name": "祭神D", "sort_order": 1, "confidence": "low"},
+        ],
+    )
+    p = build_shrine_reason_provenance(c)
+    assert p.deity_status == "EMPTY"
+
+
+# --- history_theme 名称衝突ガード（重要回帰ポイント） -----------------------
+
+
+def test_history_theme_alone_does_not_count_as_history_provenance():
+    """Legacy history_theme（分類タグ）のみが存在し、Knowledge ShrineHistoryも
+    Legacy descriptionも存在しない場合、history_statusはEMPTYのままであること
+    （history_themeがshrine_history由来と誤認されないこと）を固定化する。"""
+    c = _candidate(history_theme="学び")
+    p = build_shrine_reason_provenance(c)
+    assert p.history_status == "EMPTY"
+    assert p.classification == "UNKNOWN"
+
+
+def test_knowledge_shrine_history_is_distinguished_from_history_theme():
+    """history_themeとKnowledge ShrineHistoryが両方存在する場合でも、
+    分類はKnowledge ShrineHistory側の由来だけで正しく決まることを固定化する。"""
+    c = _candidate(
+        history_theme="学び",
+        knowledge_histories=[
+            {
+                "history_type": "founding",
+                "title": "創建",
+                "content": "由緒本文",
+                "period_text": "",
+                "sort_order": 0,
+                "confidence": "high",
+            }
+        ],
+    )
+    p = build_shrine_reason_provenance(c)
+    assert p.history_status == "KNOWLEDGE_USED"
+    assert p.classification == "FULLY_KNOWLEDGE_BACKED"
+
+
+def test_history_theme_with_legacy_description_is_legacy_backed_not_confused():
+    c = _candidate(history_theme="縁", description="由緒本文レガシー")
+    p = build_shrine_reason_provenance(c)
+    assert p.history_status == "LEGACY_USED"
+    assert p.classification == "LEGACY_BACKED"
+
+
+# --- aggregate_measurements: 決定論的集計 -----------------------------------
+
+
+def test_aggregate_measurements_counts_and_rates():
+    records = [
+        build_shrine_reason_provenance(_candidate(id=1, shrine_id=1, sajin="A", description="a")),
+        build_shrine_reason_provenance(
+            _candidate(
+                id=2,
+                shrine_id=2,
+                knowledge_deities=[{"display_name": "B", "sort_order": 0, "confidence": "high"}],
+            )
+        ),
+        build_shrine_reason_provenance(
+            _candidate(
+                id=3,
+                shrine_id=3,
+                sajin="C",
+                knowledge_histories=[
+                    {
+                        "history_type": "founding",
+                        "title": "t",
+                        "content": "c",
+                        "period_text": "",
+                        "sort_order": 0,
+                        "confidence": "high",
+                    }
+                ],
+            )
+        ),
+        build_shrine_reason_provenance(_candidate(id=4, shrine_id=4)),
+    ]
+    report = aggregate_measurements(records)
+
+    assert report["sample_count"] == 4
+    assert report["legacy_backed"] == 1
+    assert report["fully_knowledge_backed"] == 1
+    assert report["partially_knowledge_backed"] == 1
+    assert report["unknown"] == 1
+    # UNKNOWNは分母から除外しない（sample_count全体を分母に固定する設計）
+    assert report["knowledge_backed_rate"] == round(2 / 4, 4)
+    assert report["legacy_backed_rate"] == round(1 / 4, 4)
+    assert report["unknown_rate"] == round(1 / 4, 4)
+
+
+def test_aggregate_measurements_is_deterministic():
+    records = [
+        build_shrine_reason_provenance(_candidate(id=1, shrine_id=1, sajin="A")),
+        build_shrine_reason_provenance(_candidate(id=2, shrine_id=2)),
+    ]
+    first = aggregate_measurements(records)
+    second = aggregate_measurements(records)
+    assert first == second
+
+
+def test_aggregate_measurements_empty_sample_does_not_divide_by_zero():
+    report = aggregate_measurements([])
+    assert report["sample_count"] == 0
+    assert report["knowledge_backed_rate"] == 0.0
+    assert report["unknown_rate"] == 0.0
+
+
+# --- build_recommendation_quality_measurement_report: DB統合・read-only ----
+
+
+@pytest.mark.django_db
+def test_report_builder_is_read_only_and_classifies_db_backed_shrines():
+    complete = Shrine.objects.create(
+        name_jp="完全神社", kind="shrine", address="東京都完全区1-1-1"
+    )
+    partial_deity_only = Shrine.objects.create(
+        name_jp="部分神社（祭神のみ）", kind="shrine", address="東京都部分区1-1-1"
+    )
+    legacy_only = Shrine.objects.create(
+        name_jp="レガシーのみ神社",
+        kind="shrine",
+        address="東京都レガシー区1-1-1",
+        sajin="伝統祭神",
+        description="伝統由緒",
+    )
+    none_shrine = Shrine.objects.create(
+        name_jp="無データ神社", kind="shrine", address="東京都無データ区1-1-1"
+    )
+
+    source = ShrineKnowledgeSource.objects.create(
+        source_type="shrine_official",
+        title="公式Source",
+        url="https://example-measurement-test.jp/",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+
+    deity1 = ShrineDeity.objects.create(
+        shrine=complete,
+        display_name="祭神甲",
+        role="primary",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    deity1.sources.set([source])
+    history1 = ShrineHistory.objects.create(
+        shrine=complete,
+        history_type="founding",
+        title="創建",
+        content="由緒本文",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    history1.sources.set([source])
+
+    deity2 = ShrineDeity.objects.create(
+        shrine=partial_deity_only,
+        display_name="祭神乙",
+        role="primary",
+        verification_status="source_confirmed",
+        verified_at="2026-01-01T00:00:00Z",
+        confidence="high",
+    )
+    deity2.sources.set([source])
+
+    shrine_count_before_report = Shrine.objects.count()
+    deity_count_before_report = ShrineDeity.objects.count()
+    history_count_before_report = ShrineHistory.objects.count()
+
+    target_ids = [complete.id, partial_deity_only.id, legacy_only.id, none_shrine.id]
+    report = build_recommendation_quality_measurement_report(shrine_ids=target_ids)
+
+    assert report["sample_count"] == 4
+    by_shrine = {row["shrine_id"]: row for row in report["classification_by_shrine"]}
+    assert by_shrine[complete.id]["classification"] == "FULLY_KNOWLEDGE_BACKED"
+    assert by_shrine[partial_deity_only.id]["classification"] == "FULLY_KNOWLEDGE_BACKED"
+    assert by_shrine[legacy_only.id]["classification"] == "LEGACY_BACKED"
+    assert by_shrine[none_shrine.id]["classification"] == "UNKNOWN"
+
+    # deity1 + history1（complete） + deity2（partial_deity_only） = 3件
+    assert report["source_confirmed_fact"]["fact_ready_total"] == 3
+    assert report["source_confirmed_fact"]["source_confirmed_count"] == 3
+    assert report["source_confirmed_fact"]["source_confirmed_fact_rate"] == 1.0
+
+    # read-only: build_recommendation_quality_measurement_report() の呼び出し
+    # 前後でレコード数が完全に不変であること（SELECTのみ、writeが一切ないこと）
+    assert Shrine.objects.count() == shrine_count_before_report
+    assert ShrineDeity.objects.count() == deity_count_before_report
+    assert ShrineHistory.objects.count() == history_count_before_report
+
+
+@pytest.mark.django_db
+def test_report_builder_defaults_to_qa_fixture_excluded_all_shrines():
+    Shrine.objects.create(name_jp="通常神社", kind="shrine", address="東京都通常区1-1-1")
+    Shrine.objects.create(name_jp="テスト神社", kind="shrine", address="東京都テスト区1-1-1")
+
+    report = build_recommendation_quality_measurement_report()
+
+    names = {row["name"] for row in report["classification_by_shrine"]}
+    assert "通常神社" in names
+    assert "テスト神社" not in names

--- a/docs/audit/knowledge-recommendation-quality-baseline.md
+++ b/docs/audit/knowledge-recommendation-quality-baseline.md
@@ -1,0 +1,245 @@
+> **Status: `KNOWLEDGE_RECOMMENDATION_QUALITY_BASELINE_READY_WITH_LIMITATIONS`。**
+>
+> Knowledge推薦理由の品質を再現可能な指標として計測できるFoundation
+> （measurement service・tests・CLI report entry point）を追加した。
+> Recommendation candidate / ranking / score / reason生成 / action suggestion
+> のいずれも変更していない（read-only observer）。Production write・
+> Recommendation Runtime POSTは一切実行していない。
+
+---
+
+## 1. develop SHA
+
+`cd1bf881b8202a8bc1ade1068efe7f4dfaa2384f`（2026-08-12 12:15:43 +0900）
+
+PR #2381（[knowledge-recommendation-quality-audit.md](knowledge-recommendation-quality-audit.md)）
+merge確認済み。develop同期・working tree clean。
+
+---
+
+## 2. Measurement Definition（分類契約）
+
+[knowledge-recommendation-quality-audit.md](knowledge-recommendation-quality-audit.md)
+で定義した4分類を、実際のReason生成ロジック
+（`concierge_chat._build_score_v3_candidate_profile` /
+`recommendation_reason_v4._build_fact`）を直接再利用する形でコード化した
+（`temples/services/recommendation_quality_measurement.py`）。
+
+分類はfield（deity/shrine_history）単位の`FieldStatus`
+（`KNOWLEDGE_USED`/`LEGACY_USED`/`EMPTY`）から決定する:
+
+| deity_status | history_status | classification |
+|---|---|---|
+| KNOWLEDGE_USEDを含み、LEGACY_USEDを含まない | | `FULLY_KNOWLEDGE_BACKED` |
+| KNOWLEDGE_USEDとLEGACY_USEDを両方含む | | `PARTIALLY_KNOWLEDGE_BACKED` |
+| LEGACY_USEDを含み、KNOWLEDGE_USEDを含まない | | `LEGACY_BACKED` |
+| 両方EMPTY | | `UNKNOWN` |
+
+`FieldStatus`の判定（`_field_status()`）:
+
+- `fact[field] is None`（Reason生成内部でsuppress済み、またはそもそも値がない）→ `EMPTY`
+- `fact[field]`が非None かつ `candidate_profile[f"{field}_confidence"] is not None`（Knowledge由来） → `KNOWLEDGE_USED`
+- `fact[field]`が非None かつ `candidate_profile[f"{field}_confidence"] is None`（Legacy fallback由来） → `LEGACY_USED`
+
+**重要**: confidence=low/mixedでsuppressされたKnowledge Factは`EMPTY`扱いとし、
+`LEGACY_USED`とは区別する。「Knowledgeが存在したが表示されなかった」ことと
+「Legacyが使われた」ことを混同しない。
+
+---
+
+## 3. Dataset
+
+Production write禁止のため、以下2種類のデータセットのみを使用した。
+
+### 3.1 Unit-level fixture（`test_recommendation_quality_measurement.py`）
+
+21テストケース。complete/partial/none/deity-only/history-only/mixed-fallback/
+suppressed-low-confidence/mixed-confidence-sentinelの各パターンを個別の
+candidate dictとして構築し、分類の正確性を検証した。
+
+### 3.2 Local dev DB（`127.0.0.1/jinja_db`、Production ではない）
+
+`python manage.py measure_knowledge_recommendation_quality`をローカル開発DBに
+対して実行した（書き込みなし、SELECT のみ）。**このDBはProductionではない**
+（`DATABASES['default']['HOST'] == '127.0.0.1'`で確認済み）。
+
+sample_count=100・Fact-ready Deity+History合計415件・全件`source_confirmed`
+という結果は、Batch 16 Production Import Execution Record
+（[knowledge-batch16-production-import-execution.md](knowledge-batch16-production-import-execution.md)、
+Deity 233 + History 182 = 415）と完全に一致する。このため、このローカルDBは
+Batch 16実行時点のProductionスナップショットに由来すると推定されるが、
+**本タスクでは live Productionとの同一性を追加検証していない**
+（Shrine総数が下記4章の通りProduction側とは異なるため、完全な同一DBではない）。
+
+---
+
+## 4. Production Read-only Feasibility（Phase 15）
+
+`scripts/migration_safety/readonly_query.sh`（既存の安全なread-onlyチャネル）
+経由でProduction実データを直接確認した（2026-08-12、書き込みなし）:
+
+| 項目 | Production実測値 |
+|---|---:|
+| audit target shrine数（QA fixture除外後） | 104 |
+| Fact-ready ShrineDeity数 | 233 |
+| Fact-ready ShrineHistory数 | 182 |
+| うち`source_confirmed` | 415/415（100%） |
+
+Fact件数（415、全件`source_confirmed`）は3.2のローカルDB結果と完全一致した。
+一方、audit target shrine数はProduction=104、ローカルDB=100と一致しない
+（ローカルDBがBatch 16以降に追加された非Knowledge神社を含んでいない
+可能性が高い）。
+
+**分類判定（FULLY/PARTIALLY/LEGACY/UNKNOWN）自体をライブProductionに対して
+実行することは、本タスクでは行っていない。** 理由:
+
+- 本measurementのcore関数（`_build_score_v3_candidate_profile`/`_build_fact`）
+  はDjango ORMのモデルインスタンスではなくdictを扱うが、実データ取得には
+  Django ORM（`Shrine.objects.filter(...)`等）を使う設計である。ライブ
+  ProductionへDjango ORM接続するには`DATABASE_URL`をProduction向けに切り替える
+  必要があり、これは本セッションで確立された`readonly_query.sh`
+  （SQL文自体をread-onlyかguard.pyで検証してから接続する）とは異なる、
+  より緩やかなアクセス経路になる。
+- 代替として分類ロジックを生SQLで再実装する案は、Reason生成の実装
+  （`_build_fact`のsuppression・confidence変換）との重複・driftを生むため
+  意図的に避けた（このモジュール自体の設計方針そのものと矛盾するため）。
+
+**分類: `PRODUCTION_RECOMMENDATION_BASELINE_NOT_AVAILABLE`**（分類breakdownの
+み。Fact件数・verification_status等の集計値は上表の通りread-onlyで直接
+確認済み）。
+
+---
+
+## 5. Baseline Measurement（ローカルDB実測値、Production代表値ではない点に注意）
+
+`python manage.py measure_knowledge_recommendation_quality --format json`
+（ローカル`jinja_db`、2026-08-12）:
+
+| 指標 | 値 |
+|---|---:|
+| sample_count | 100 |
+| fully_knowledge_backed | 85（85.00%） |
+| partially_knowledge_backed | 0（0.00%） |
+| legacy_backed | 0（0.00%） |
+| unknown | 15（15.00%） |
+| knowledge_backed_rate（Fully+Partially） | 85.00% |
+| deity_knowledge_usage_rate | 85.00% |
+| history_knowledge_usage_rate | 84.00% |
+| deity_legacy_fallback_rate | 0.00% |
+| history_legacy_fallback_rate | 0.00% |
+| source_confirmed_fact_rate | 415/415（100.00%） |
+
+`partially_knowledge_backed`・`legacy_backed`がいずれも0件である点は、
+このローカルDBに`sajin`/`description`（Legacy由来fallback元）を持つ神社が
+1件も含まれていないことを示唆する。**これは「Legacy fallbackが本番で
+機能していない」ことの証拠ではなく、このローカルDBのデータ内容の特徴**
+である（4章の通りProduction側との完全同一性は確認していない）。
+
+---
+
+## 6. Quality Guard Metrics（Phase 9）
+
+generic wording率・duplicate phrase率は、既存コードに文字列類似度・
+一般性判定の仕組みが存在しないため本PRには含めない。
+`NEXT_PR_CANDIDATE`として記録する（[knowledge-recommendation-quality-audit.md](knowledge-recommendation-quality-audit.md)
+Phase 15のQuality Measurement PR候補と統合可能）。
+
+---
+
+## 7. Recommendation Behavior Regression（Phase 10-11）
+
+- 既存ファイルへの変更は一切なし（新規ファイル3件のみ追加）。
+- `temples/`配下の既存テストスイート全件を実行し、**1137 passed, 9 skipped
+  （GDAL/PostGIS環境依存のskipのみ、既存から不変）**、失敗0件を確認した。
+- Score v3関連テスト（`test_score_v3_history_signal.py`/
+  `test_score_v3_feature_flag.py`/`test_score_v3_observer.py`/
+  `test_score_v3_observation_summary.py`/`test_score_v3_dashboard_api.py`）を
+  含め全件成功。current score（`_score_total`）・shadow score（`score_v3`）・
+  rank・`SCORE_V3_MODE`のいずれも本PRで一切変更していない
+  （`concierge_chat_ranking.py`・`concierge_chat.py`・
+  `recommendation_algorithm_v3.py`への変更なし）。
+- `measure_knowledge_recommendation_quality`コマンド自体もSELECTのみで構成され
+  （`build_recommendation_quality_measurement_report`内で`.save()`/`.create()`/
+  `.delete()`等の書き込みAPIを一切呼び出さない）、read-only observerであることを
+  `test_report_builder_is_read_only_and_classifies_db_backed_shrines`で
+  レコード数不変を明示的に確認した。
+
+---
+
+## 8. Analytics Linkage 再確認（Phase 16）
+
+[knowledge-recommendation-quality-audit.md](knowledge-recommendation-quality-audit.md)
+12章の`KNOWLEDGE_RECOMMENDATION_PRODUCT_EFFECT_NOT_MEASURED`は本PRでも
+変化なし。本PRで追加した`knowledge_backed_rate`等のmeasurement出力は、
+`route_open`/`visit_done`/`reflection_saved`/`shrine_decision`等の行動指標
+イベントとは現状joinできる共通キー（shrineId等をイベント側が送っていても、
+本PR出力側にthreadId/timestampが存在しない）を持たない。
+
+**分類: `KNOWLEDGE_ANALYTICS_LINKAGE_MISSING`**（本PRでは実装しない、
+Analytics実装は絶対禁止事項のため）。
+
+---
+
+## 9. Acceptance Criteria（Phase 17）
+
+| 条件 | 結果 |
+|---|---|
+| deterministic classification | PASS（`test_aggregate_measurements_is_deterministic`） |
+| history_theme collision防止 | PASS（3テスト: history_theme単独/Knowledge併存/Legacy description併存） |
+| recommendation behavior不変 | PASS（既存ファイル変更0、全1137テストpass） |
+| ranking不変 | PASS（ranking関連コード変更0） |
+| score不変 | PASS（score関連コード変更0） |
+| measurement tests PASS | PASS（21/21） |
+| existing recommendation tests PASS | PASS（1137/1137、9 skipはGDAL/PostGIS環境依存で既存から不変） |
+| report生成PASS | PASS（`--format text`/`--format json`とも動作確認済み） |
+| Production write 0 | PASS（新規コードにwrite操作なし、Production接続自体もreadonly_query.sh経由のSELECTのみ） |
+
+---
+
+## 10. 既知の計測限界（Limitations）
+
+1. ライブProductionに対する分類breakdown（FULLY/PARTIALLY/LEGACY/UNKNOWN内訳）
+   の直接実行は行っていない（4章、`PRODUCTION_RECOMMENDATION_BASELINE_NOT_AVAILABLE`）。
+   Fact件数・verification_status distributionのみread-only直接確認済み。
+2. ローカルDBの結果（5章）はBatch 16時点のProductionスナップショットに由来する
+   可能性が高いが、Shrine総数の不一致（100 vs 104）により完全な同一性は
+   未確認。Production代表値として扱ってはならない。
+3. generic wording率・duplicate phrase率は計測未実装（6章、`NEXT_PR_CANDIDATE`）。
+4. Analytics（行動指標との相関）は引き続き計測不可（8章）。
+5. `_build_score_v3_candidate_profile`/`_build_fact`の"private"関数を意図的に
+   直接importしている。これらの関数のsignatureが将来変更された場合、本
+   モジュールも追従が必要になる（テストスイートで検知可能）。
+
+---
+
+## 11. Next PR Candidates（Phase 19、優先順位は決定しない）
+
+A. **Analytics Contract**: `knowledge_backed_rate`等の計測結果をAnalytics
+   イベント（`route_open`/`visit_done`/`reflection_saved`等）とjoin可能に
+   する共通キー設計（[knowledge-recommendation-quality-audit.md](knowledge-recommendation-quality-audit.md)
+   PR候補Bと同一）。
+
+B. **Shadow Ranking Comparison**: 既存`score_v3_shadow_observation`を候補
+   集合全体へ拡張する設計の実装（同PR候補C）。
+
+C. **Reason Quality Improvement**: 6章のQuality Guard Metrics
+   （generic wording率・duplicate phrase率）の計測実装。
+
+D. **Runtime Evidence UX**: Source/confidence/roleをWeb Detail画面へ
+   表示する対応（[post-batch16-knowledge-next-track-comparison.md](post-batch16-knowledge-next-track-comparison.md)
+   Track B）。
+
+---
+
+## 12. Final Classification
+
+**`KNOWLEDGE_RECOMMENDATION_QUALITY_BASELINE_READY_WITH_LIMITATIONS`**
+
+measurement service・tests（21件）・CLI report entry point・本baseline
+audit docを作成した。Recommendation behavior（candidate/ranking/score/
+reason/action suggestion/API response）はいずれも変更していない
+（既存1137テスト全件pass）。Production writeは0件。
+
+上記10.の限界（特にライブProductionでの分類breakdown未実行）は、次の
+実装PR着手前に解消可否を検討すべき事項として引き継ぐ。**本Baselineは
+次のPR候補（11章）のどれを選ぶべきかを結論づけない。**


### PR DESCRIPTION
## Summary

Post-Batch16比較監査（#2380）→ 推薦品質監査（#2381）に続く、Knowledge推薦理由の品質を**再現可能な指標として計測できるFoundation**を追加する。

- FULLY_KNOWLEDGE_BACKED / PARTIALLY_KNOWLEDGE_BACKED / LEGACY_BACKED / UNKNOWN の4分類を、実際のReason生成ロジック（`_build_score_v3_candidate_profile` / `_build_fact`）をそのまま再利用する形でコード化（`backend/temples/services/recommendation_quality_measurement.py`）。分類ロジックの重複実装によるdriftを避けるため、意図的に既存の内部関数を再利用している。
- `history_theme`（Legacy分類タグ）とKnowledge `ShrineHistory`の名称衝突（#2381で発見）を誤分類しないことを3テストで固定化。
- read-only CLI（`python manage.py measure_knowledge_recommendation_quality`）を追加。JSON/text両出力対応。
- **Recommendation candidate / ranking / score / reason生成 / action suggestion のいずれも変更しない**。既存ファイルへの変更は0件（新規4ファイルのみ）。
- **Production write・Recommendation Runtime POSTは一切実行しない**。Production read-only確認（`readonly_query.sh`経由）でFact-ready Deity+History=415件（全件`source_confirmed`）を直接確認したが、分類breakdown自体のライブProduction実行は、より緩やかなアクセス経路を要するため見送り、`PRODUCTION_RECOMMENDATION_BASELINE_NOT_AVAILABLE`として明示した。

## 変更内容

- 追加: `backend/temples/services/recommendation_quality_measurement.py`（測定core、read-only）
- 追加: `backend/temples/management/commands/measure_knowledge_recommendation_quality.py`（CLI）
- 追加: `backend/temples/tests/services/test_recommendation_quality_measurement.py`（21テスト）
- 追加: `docs/audit/knowledge-recommendation-quality-baseline.md`（Baseline監査ドキュメント、次PR候補4案を提示・優先順位は決定せず）

## Test plan

- [x] 新規21テスト全件pass
- [x] `temples/`配下の既存テストスイート全件pass（1137 passed, 9 skipped（GDAL/PostGIS環境依存、既存から不変）、失敗0件）
- [x] `measure_knowledge_recommendation_quality --format text` / `--format json` 動作確認
- [x] read-only性の明示的確認（レコード数がreport生成前後で不変であることをテストで検証）
- [x] `git diff --check`（空白エラーなし）、マイグレーションなし
- [x] 資格情報・接続文字列スキャン（該当なし）
- [x] pre-push hook（OpenAPI lint / Web契約テスト 115 files / 731 tests）全通過
- [ ] CI green確認（PR作成後）
- [x] mergeはしない（draft PRのまま維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)