### PR TITLE
Knowledge推薦品質のAnalytics属性を追加

### DIFF
--- a/apps/web/src/features/concierge/__tests__/hooksNormalization.test.ts
+++ b/apps/web/src/features/concierge/__tests__/hooksNormalization.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeAccessLevel, normalizeConciergeResponse } from "@/features/concierge/hooks";
+
+describe("normalizeAccessLevel", () => {
+  it.each(["anonymous", "free", "premium"] as const)("%sをそのまま返す", (value) => {
+    expect(normalizeAccessLevel(value)).toBe(value);
+  });
+
+  it.each([undefined, null, "invalid", 1, {}])("不正な値(%s)はnullへ正規化する", (value) => {
+    expect(normalizeAccessLevel(value)).toBeNull();
+  });
+});
+
+describe("normalizeConciergeResponse", () => {
+  it("最小限のrawからdefault値を補完したUnifiedConciergeResponseを構築する", () => {
+    const result = normalizeConciergeResponse({}, []);
+
+    expect(result).toMatchObject({
+      ok: true,
+      stop_reason: null,
+      reply: null,
+      plan: null,
+      remaining: null,
+      limit: null,
+      limitReached: false,
+      thread: null,
+    });
+    expect(result.data).toMatchObject({ recommendations: [] });
+  });
+
+  it("limitReached=trueかつstop_reason未指定の場合はpaywallになる", () => {
+    const result = normalizeConciergeResponse({ limitReached: true }, []);
+    expect(result.stop_reason).toBe("paywall");
+    expect(result.limitReached).toBe(true);
+  });
+
+  it("stop_reason='design'を優先してそのまま採用する", () => {
+    const result = normalizeConciergeResponse({ stop_reason: "design", limitReached: true }, []);
+    expect(result.stop_reason).toBe("design");
+  });
+
+  it("data.replyまたはdata.rawからreply文字列を拾う", () => {
+    expect(normalizeConciergeResponse({ reply: "hello" }, []).reply).toBe("hello");
+    expect(normalizeConciergeResponse({ data: { reply: "from data" } }, []).reply).toBe(
+      "from data",
+    );
+    expect(normalizeConciergeResponse({ data: { raw: "from raw" } }, []).reply).toBe("from raw");
+    expect(normalizeConciergeResponse({ reply: 123 }, []).reply).toBeNull();
+  });
+
+  it("ok===falseのときのみfalseになる", () => {
+    expect(normalizeConciergeResponse({ ok: false }, []).ok).toBe(false);
+    expect(normalizeConciergeResponse({}, []).ok).toBe(true);
+  });
+
+  it("有効なplan文字列のみ採用し、不正な値はnullにする", () => {
+    expect(normalizeConciergeResponse({ plan: "premium" }, []).plan).toBe("premium");
+    expect(normalizeConciergeResponse({ plan: "invalid" }, []).plan).toBeNull();
+  });
+
+  it("remaining/limitは数値のみ採用する", () => {
+    const result = normalizeConciergeResponse({ remaining: 3, limit: "10" }, []);
+    expect(result.remaining).toBe(3);
+    expect(result.limit).toBeNull();
+  });
+
+  it("thread.idを数値化できる場合のみthreadを構築する", () => {
+    const result = normalizeConciergeResponse({ thread: { id: "42", title: "t" } }, []);
+    expect(result.thread).toMatchObject({ id: 42, title: "t" });
+  });
+
+  it("thread.idが数値化できない場合はthreadをnullにする", () => {
+    const result = normalizeConciergeResponse({ thread: { id: "abc" } }, []);
+    expect(result.thread).toBeNull();
+  });
+
+  it("dataが配列またはobject以外の場合は空objectとして扱う", () => {
+    const result = normalizeConciergeResponse({ data: [1, 2, 3] }, []);
+    expect(result.data).toMatchObject({ recommendations: [] });
+  });
+
+  it("recommendationsをdata.recommendationsへ差し込む", () => {
+    const recs = [{ name: "神社A" }] as any;
+    const result = normalizeConciergeResponse({}, recs);
+    expect(result.data?.recommendations).toEqual(recs);
+  });
+});

--- a/apps/web/src/features/concierge/__tests__/trackRecommendationQualityFromRecommendations.test.ts
+++ b/apps/web/src/features/concierge/__tests__/trackRecommendationQualityFromRecommendations.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getAnalyticsProvider } from "@/lib/analytics/providers";
+import { trackRecommendationQualityFromRecommendations } from "@/features/concierge/hooks";
+import type { ConciergeRecommendation } from "@/lib/api/concierge";
+
+vi.mock("@/lib/analytics/providers", () => ({
+  getAnalyticsProvider: vi.fn(),
+}));
+
+const mockedGetAnalyticsProvider = vi.mocked(getAnalyticsProvider);
+
+function rec(overrides: Partial<ConciergeRecommendation> = {}): ConciergeRecommendation {
+  return {
+    name: "テスト神社",
+    shrine_id: 1,
+    ...overrides,
+  };
+}
+
+describe("trackRecommendationQualityFromRecommendations: Knowledge品質property契約", () => {
+  const trackMock = vi.fn();
+
+  beforeEach(() => {
+    trackMock.mockReset();
+    mockedGetAnalyticsProvider.mockReturnValue({ track: trackMock });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("knowledge_backing_class=FULLY_KNOWLEDGE_BACKEDをそのまま転送する", () => {
+    trackRecommendationQualityFromRecommendations({
+      recommendations: [
+        rec({
+          recommendation_reason_quality: {
+            shrine_data_rate: 0.5,
+            knowledge_backing_class: "FULLY_KNOWLEDGE_BACKED",
+            deity_knowledge_used: true,
+            history_knowledge_used: false,
+          },
+        }),
+      ],
+      threadId: "thread-1",
+      accessLevel: "free",
+    });
+
+    expect(trackMock).toHaveBeenCalledWith(
+      "recommendation_quality",
+      expect.objectContaining({
+        knowledge_backing_class: "FULLY_KNOWLEDGE_BACKED",
+        deity_knowledge_used: true,
+        history_knowledge_used: false,
+      }),
+    );
+  });
+
+  it.each(["PARTIALLY_KNOWLEDGE_BACKED", "LEGACY_BACKED", "UNKNOWN"] as const)(
+    "knowledge_backing_class=%sをそのまま転送する",
+    (backingClass) => {
+      trackRecommendationQualityFromRecommendations({
+        recommendations: [
+          rec({
+            recommendation_reason_quality: { knowledge_backing_class: backingClass },
+          }),
+        ],
+        threadId: null,
+        accessLevel: null,
+      });
+
+      expect(trackMock).toHaveBeenCalledWith(
+        "recommendation_quality",
+        expect.objectContaining({ knowledge_backing_class: backingClass }),
+      );
+    },
+  );
+
+  it("deity/history使用有無の4パターンをそれぞれ正しく転送する", () => {
+    const cases: Array<[boolean, boolean]> = [
+      [true, true],
+      [true, false],
+      [false, true],
+      [false, false],
+    ];
+
+    cases.forEach(([deityUsed, historyUsed], index) => {
+      trackMock.mockClear();
+      trackRecommendationQualityFromRecommendations({
+        recommendations: [
+          rec({
+            shrine_id: index,
+            recommendation_reason_quality: {
+              deity_knowledge_used: deityUsed,
+              history_knowledge_used: historyUsed,
+            },
+          }),
+        ],
+        threadId: "thread-x",
+        accessLevel: "anonymous",
+      });
+
+      expect(trackMock).toHaveBeenCalledWith(
+        "recommendation_quality",
+        expect.objectContaining({
+          deity_knowledge_used: deityUsed,
+          history_knowledge_used: historyUsed,
+        }),
+      );
+    });
+  });
+
+  it("新規propertyが未定義の場合、送信payloadから省かれる（既存のnull-stripping契約に従う、後方互換）", () => {
+    trackRecommendationQualityFromRecommendations({
+      recommendations: [rec({ recommendation_reason_quality: { shrine_data_rate: 0.25 } })],
+      threadId: "thread-1",
+      accessLevel: "premium",
+    });
+
+    const payload = trackMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    // serializeSearchAnalyticsPayload()がnull/undefinedを送信前にstripする既存契約
+    // （searchEvents.ts）と同じ挙動になることを確認する。
+    expect(payload).not.toHaveProperty("knowledge_backing_class");
+    expect(payload).not.toHaveProperty("deity_knowledge_used");
+    expect(payload).not.toHaveProperty("history_knowledge_used");
+    expect(payload.shrine_data_rate).toBe(0.25);
+  });
+
+  it("既存の7 propertyは変更されない", () => {
+    trackRecommendationQualityFromRecommendations({
+      recommendations: [
+        rec({
+          recommendation_reason_quality: {
+            shrine_data_rate: 0.5,
+            consultation_reflection_rate: 0.25,
+            fallback_reason_rate: 0.0,
+            evidence_rate: 0.5,
+            action_grounding_rate: 0.33,
+            is_ai_inference_only: false,
+            fallback_source: "fallback",
+            knowledge_backing_class: "FULLY_KNOWLEDGE_BACKED",
+          },
+        }),
+      ],
+      threadId: "thread-1",
+      accessLevel: "free",
+    });
+
+    const payload = trackMock.mock.calls[0]?.[1];
+    expect(payload).toMatchObject({
+      shrine_data_rate: 0.5,
+      consultation_reflection_rate: 0.25,
+      fallback_reason_rate: 0.0,
+      evidence_rate: 0.5,
+      action_grounding_rate: 0.33,
+      is_ai_inference_only: false,
+      fallback_source: "fallback",
+    });
+  });
+
+  it("recommendation_reason_qualityが存在しない候補はイベントを送信しない", () => {
+    trackRecommendationQualityFromRecommendations({
+      recommendations: [rec({ recommendation_reason_quality: null })],
+      threadId: "thread-1",
+      accessLevel: null,
+    });
+
+    expect(trackMock).not.toHaveBeenCalled();
+  });
+
+  it("Fact本文・Source URL・相談本文に相当するkeyをpayloadへ含めない", () => {
+    trackRecommendationQualityFromRecommendations({
+      recommendations: [
+        rec({
+          recommendation_reason_quality: { knowledge_backing_class: "FULLY_KNOWLEDGE_BACKED" },
+        }),
+      ],
+      threadId: "thread-1",
+      accessLevel: null,
+    });
+
+    const payload = trackMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(payload).not.toHaveProperty("deity");
+    expect(payload).not.toHaveProperty("shrine_history");
+    expect(payload).not.toHaveProperty("source_url");
+    expect(payload).not.toHaveProperty("consultation");
+    expect(payload).not.toHaveProperty("query");
+  });
+});

--- a/apps/web/src/features/concierge/hooks.ts
+++ b/apps/web/src/features/concierge/hooks.ts
@@ -124,7 +124,7 @@ type SendInput = string | Omit<ConciergeChatRequestV1, "thread_id">;
 
 type ConciergeAccessLevel = "anonymous" | "free" | "premium" | null;
 
-function normalizeAccessLevel(value: unknown): ConciergeAccessLevel {
+export function normalizeAccessLevel(value: unknown): ConciergeAccessLevel {
   return value === "anonymous" || value === "free" || value === "premium" ? value : null;
 }
 
@@ -157,7 +157,7 @@ export function trackRecommendationQualityFromRecommendations(args: {
   });
 }
 
-function normalizeConciergeResponse(raw: any, recs: ConciergeRecommendation[]): UnifiedConciergeResponse {
+export function normalizeConciergeResponse(raw: any, recs: ConciergeRecommendation[]): UnifiedConciergeResponse {
   const limitReached = raw?.limitReached === true;
 
   const stop: StopReason =

--- a/apps/web/src/features/concierge/hooks.ts
+++ b/apps/web/src/features/concierge/hooks.ts
@@ -128,7 +128,7 @@ function normalizeAccessLevel(value: unknown): ConciergeAccessLevel {
   return value === "anonymous" || value === "free" || value === "premium" ? value : null;
 }
 
-function trackRecommendationQualityFromRecommendations(args: {
+export function trackRecommendationQualityFromRecommendations(args: {
   recommendations: ConciergeRecommendation[];
   threadId: string | null;
   accessLevel: ConciergeAccessLevel;
@@ -150,6 +150,9 @@ function trackRecommendationQualityFromRecommendations(args: {
       action_grounding_rate: quality.action_grounding_rate ?? null,
       is_ai_inference_only: quality.is_ai_inference_only ?? null,
       fallback_source: quality.fallback_source ?? null,
+      knowledge_backing_class: quality.knowledge_backing_class ?? null,
+      deity_knowledge_used: quality.deity_knowledge_used ?? null,
+      history_knowledge_used: quality.history_knowledge_used ?? null,
     });
   });
 }

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -127,6 +127,17 @@ export type RecommendationQualityAnalyticsPayload = {
   action_grounding_rate?: number | null;
   is_ai_inference_only?: boolean | null;
   fallback_source?: string | null;
+  // docs/audit/knowledge-recommendation-analytics-contract.md 提案の最小Contract。
+  // Backend recommendation_reason_quality（PR2382のbuild_shrine_reason_provenance()を
+  // 再利用して算出）から受け取るのみで、Web側では再計算しない。
+  knowledge_backing_class?:
+    | "FULLY_KNOWLEDGE_BACKED"
+    | "PARTIALLY_KNOWLEDGE_BACKED"
+    | "LEGACY_BACKED"
+    | "UNKNOWN"
+    | null;
+  deity_knowledge_used?: boolean | null;
+  history_knowledge_used?: boolean | null;
 };
 
 export function trackRecommendationQuality(payload: RecommendationQualityAnalyticsPayload) {

--- a/apps/web/src/lib/api/concierge/types.ts
+++ b/apps/web/src/lib/api/concierge/types.ts
@@ -77,6 +77,12 @@ export type ConciergeBreakdown = {
   matched_need_tags: string[];
 };
 
+export type KnowledgeBackingClass =
+  | "FULLY_KNOWLEDGE_BACKED"
+  | "PARTIALLY_KNOWLEDGE_BACKED"
+  | "LEGACY_BACKED"
+  | "UNKNOWN";
+
 export type RecommendationReasonQuality = {
   shrine_data_rate?: number | null;
   consultation_reflection_rate?: number | null;
@@ -85,6 +91,9 @@ export type RecommendationReasonQuality = {
   action_grounding_rate?: number | null;
   is_ai_inference_only?: boolean | null;
   fallback_source?: string | null;
+  knowledge_backing_class?: KnowledgeBackingClass | null;
+  deity_knowledge_used?: boolean | null;
+  history_knowledge_used?: boolean | null;
 };
 
 export type ConciergeReasonFactAxis =

--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -518,7 +518,19 @@ def _attach_recommendation_reason_quality(
     This keeps the lightweight quality payload and the display-only
     recommendation_reason_v4_detail on normal recommendations so API response and
     thread storage do not depend on debug preview visibility.
+
+    PR2382/PR2383契約: quality dictへKnowledge由来分類（knowledge_backing_class/
+    deity_knowledge_used/history_knowledge_used）をoptional propertyとして追加する。
+    分類ロジック自体はrecommendation_quality_measurement.build_shrine_reason_provenance()
+    （既存、PR2382）をそのまま再利用し、ここでは重複実装しない。
+    temples.services.recommendation_quality_measurementはこのモジュールの
+    _build_score_v3_candidate_profileをimportするため、モジュールトップレベルで
+    importすると循環importになる。関数内importで遅延解決する。
     """
+    from temples.services.recommendation_quality_measurement import (
+        build_shrine_reason_provenance,
+    )
+
     quality_by_key: dict[Any, dict[str, Any]] = {}
     detail_by_key: dict[Any, dict[str, Any]] = {}
 
@@ -536,7 +548,11 @@ def _attach_recommendation_reason_quality(
             recommendation_input_profile=recommendation_input_profile,
         )
         rec["recommendation_reason_v4"] = str(preview.get("reason_text") or "")
-        quality = preview.get("quality") or {}
+        quality = dict(preview.get("quality") or {})
+        provenance = build_shrine_reason_provenance(rec)
+        quality["knowledge_backing_class"] = provenance.classification
+        quality["deity_knowledge_used"] = provenance.deity_status == "KNOWLEDGE_USED"
+        quality["history_knowledge_used"] = provenance.history_status == "KNOWLEDGE_USED"
         rec["recommendation_reason_quality"] = quality
 
         # Display-only subset of the same preview: reason_text/fact/interpretation/action.

--- a/backend/temples/tests/services/test_recommendation_reason_quality_knowledge_properties.py
+++ b/backend/temples/tests/services/test_recommendation_reason_quality_knowledge_properties.py
@@ -1,0 +1,188 @@
+from temples.services.concierge_chat import _attach_recommendation_reason_quality
+
+
+def _rec(**overrides):
+    base = {
+        "id": 1,
+        "shrine_id": 1,
+        "name": "テスト神社",
+        "sajin": None,
+        "description": None,
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+        "meaning_payload": {},
+    }
+    base.update(overrides)
+    return base
+
+
+def _attach(recs, interpretation_profile=None):
+    payload = {"recommendations": recs}
+    _attach_recommendation_reason_quality(
+        recs=payload, interpretation_profile=interpretation_profile or {}
+    )
+    return payload["recommendations"]
+
+
+def test_fully_knowledge_backed_deity_only():
+    recs = _attach(
+        [
+            _rec(
+                knowledge_deities=[
+                    {"display_name": "経津主大神", "sort_order": 0, "confidence": "high"}
+                ],
+            )
+        ]
+    )
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "FULLY_KNOWLEDGE_BACKED"
+    assert quality["deity_knowledge_used"] is True
+    assert quality["history_knowledge_used"] is False
+
+
+def test_fully_knowledge_backed_history_only():
+    recs = _attach(
+        [
+            _rec(
+                knowledge_histories=[
+                    {
+                        "history_type": "founding",
+                        "title": "創建",
+                        "content": "由緒本文",
+                        "period_text": "",
+                        "sort_order": 0,
+                        "confidence": "high",
+                    }
+                ],
+            )
+        ]
+    )
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "FULLY_KNOWLEDGE_BACKED"
+    assert quality["deity_knowledge_used"] is False
+    assert quality["history_knowledge_used"] is True
+
+
+def test_partially_knowledge_backed():
+    recs = _attach(
+        [
+            _rec(
+                description="由緒本文レガシー",
+                knowledge_deities=[
+                    {"display_name": "祭神A", "sort_order": 0, "confidence": "high"}
+                ],
+            )
+        ]
+    )
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "PARTIALLY_KNOWLEDGE_BACKED"
+    assert quality["deity_knowledge_used"] is True
+    assert quality["history_knowledge_used"] is False
+
+
+def test_legacy_backed():
+    recs = _attach([_rec(sajin="天照大神", description="由緒本文レガシー")])
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "LEGACY_BACKED"
+    assert quality["deity_knowledge_used"] is False
+    assert quality["history_knowledge_used"] is False
+
+
+def test_unknown_when_no_facts():
+    recs = _attach([_rec()])
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "UNKNOWN"
+    assert quality["deity_knowledge_used"] is False
+    assert quality["history_knowledge_used"] is False
+
+
+def test_both_deity_and_history_knowledge_used():
+    recs = _attach(
+        [
+            _rec(
+                knowledge_deities=[
+                    {"display_name": "祭神B", "sort_order": 0, "confidence": "high"}
+                ],
+                knowledge_histories=[
+                    {
+                        "history_type": "founding",
+                        "title": "創建",
+                        "content": "由緒本文",
+                        "period_text": "",
+                        "sort_order": 0,
+                        "confidence": "high",
+                    }
+                ],
+            )
+        ]
+    )
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "FULLY_KNOWLEDGE_BACKED"
+    assert quality["deity_knowledge_used"] is True
+    assert quality["history_knowledge_used"] is True
+
+
+def test_history_theme_alone_does_not_flip_knowledge_backing_class():
+    """history_theme（Legacy分類タグ）のみが存在する場合、Knowledge由来と
+    誤分類しないことを固定化する（knowledge-recommendation-analytics-contract.md
+    Quality Property Gap対応の回帰ガード）。"""
+    recs = _attach([_rec(history_theme="学び")])
+    quality = recs[0]["recommendation_reason_quality"]
+    assert quality["knowledge_backing_class"] == "UNKNOWN"
+    assert quality["history_knowledge_used"] is False
+
+
+def test_existing_quality_keys_are_preserved():
+    recs = _attach(
+        [
+            _rec(
+                goriyaku="縁結び",
+                knowledge_deities=[
+                    {"display_name": "祭神C", "sort_order": 0, "confidence": "high"}
+                ],
+            )
+        ]
+    )
+    quality = recs[0]["recommendation_reason_quality"]
+    for key in (
+        "shrine_data_rate",
+        "consultation_reflection_rate",
+        "fallback_reason_rate",
+        "evidence_rate",
+        "action_grounding_rate",
+        "is_ai_inference_only",
+        "fallback_source",
+    ):
+        assert key in quality
+
+
+def test_quality_payload_does_not_leak_source_url_or_raw_fact_text():
+    recs = _attach(
+        [
+            _rec(
+                knowledge_deities=[
+                    {"display_name": "祭神D", "sort_order": 0, "confidence": "high"}
+                ],
+            )
+        ]
+    )
+    quality = recs[0]["recommendation_reason_quality"]
+    assert "source_url" not in quality
+    assert "deity" not in quality
+    assert "shrine_history" not in quality
+
+
+def test_recommendations_v2_receives_same_knowledge_properties():
+    payload = {
+        "recommendations": [
+            _rec(
+                knowledge_deities=[
+                    {"display_name": "祭神E", "sort_order": 0, "confidence": "high"}
+                ],
+            )
+        ],
+        "recommendations_v2": [{"shrine_id": 1, "id": 1, "name": "テスト神社"}],
+    }
+    _attach_recommendation_reason_quality(recs=payload, interpretation_profile={})
+    v2_quality = payload["recommendations_v2"][0]["recommendation_reason_quality"]
+    assert v2_quality["knowledge_backing_class"] == "FULLY_KNOWLEDGE_BACKED"

--- a/docs/audit/knowledge-recommendation-analytics-properties-implementation.md
+++ b/docs/audit/knowledge-recommendation-analytics-properties-implementation.md
@@ -1,0 +1,195 @@
+> **Status: `KNOWLEDGE_RECOMMENDATION_ANALYTICS_PROPERTIES_READY_WITH_LIMITATIONS`。**
+>
+> [knowledge-recommendation-analytics-contract.md](knowledge-recommendation-analytics-contract.md)
+> の最小価値PR（22章）を実装した。既存の`recommendation_quality`イベントへ
+> 3 property（`knowledge_backing_class`/`deity_knowledge_used`/
+> `history_knowledge_used`）を追加し、PR #2382の
+> `build_shrine_reason_provenance()`をそのまま再利用した。新規イベント・
+> 新規分類ロジックの実装はゼロ。Ranking/Score/Recommendation本文/UIは
+> 一切変更していない。Production writeゼロ。
+
+---
+
+## 1. develop SHA
+
+`d4d461daa72bda6aadcfab61f9de4fed822bd707`（2026-08-12 12:42:04 +0900）
+
+PR #2383（[knowledge-recommendation-analytics-contract.md](knowledge-recommendation-analytics-contract.md)）
+merge確認済み。develop同期・working tree clean。
+
+---
+
+## 2. Modified Files
+
+| ファイル | 変更内容 |
+|---|---|
+| `backend/temples/services/concierge_chat.py` | `_attach_recommendation_reason_quality()`で`build_shrine_reason_provenance()`（PR #2382既存関数）を呼び出し、`recommendation_reason_quality` dictへ3 propertyを追加 |
+| `apps/web/src/lib/api/concierge/types.ts` | `RecommendationReasonQuality`型へ3 optional propertyを追加、`KnowledgeBackingClass`型を新規定義 |
+| `apps/web/src/lib/analytics/searchEvents.ts` | `RecommendationQualityAnalyticsPayload`型へ同3 propertyを追加 |
+| `apps/web/src/features/concierge/hooks.ts` | `trackRecommendationQualityFromRecommendations()`で3 propertyを`?? null`フォールバック付きで転送。同関数をexport化（テスト目的のみ、ロジック変更なし） |
+| `backend/temples/tests/services/test_recommendation_reason_quality_knowledge_properties.py`（新規） | 10テスト |
+| `apps/web/src/features/concierge/__tests__/trackRecommendationQualityFromRecommendations.test.ts`（新規） | 9テスト |
+
+新規イベントの追加・既存イベント名の変更・UI変更・DB migrationはいずれも
+含まれない。
+
+---
+
+## 3. `recommendation_quality`既存Property（変更なし）
+
+```
+source, threadId, shrineId, recommendationRank, accessLevel,
+shrine_data_rate, consultation_reflection_rate, fallback_reason_rate,
+evidence_rate, action_grounding_rate, is_ai_inference_only, fallback_source
+```
+
+---
+
+## 4. 追加Property
+
+```
+knowledge_backing_class: "FULLY_KNOWLEDGE_BACKED" | "PARTIALLY_KNOWLEDGE_BACKED"
+                          | "LEGACY_BACKED" | "UNKNOWN"
+deity_knowledge_used: boolean
+history_knowledge_used: boolean
+```
+
+---
+
+## 5. Provenance Reuse（Phase 4）
+
+`_attach_recommendation_reason_quality()`は既に`_build_score_v3_candidate_profile(rec)`
+を呼んでいた箇所と同じ`rec`（Recommendation候補dict）をそのまま
+`recommendation_quality_measurement.build_shrine_reason_provenance()`
+（PR #2382で実装済み）へ渡すだけで、新しい判定ロジックは一切実装していない。
+
+```python
+from temples.services.recommendation_quality_measurement import (
+    build_shrine_reason_provenance,
+)
+...
+provenance = build_shrine_reason_provenance(rec)
+quality["knowledge_backing_class"] = provenance.classification
+quality["deity_knowledge_used"] = provenance.deity_status == "KNOWLEDGE_USED"
+quality["history_knowledge_used"] = provenance.history_status == "KNOWLEDGE_USED"
+```
+
+**循環import対応**: `recommendation_quality_measurement.py`は
+`concierge_chat._build_score_v3_candidate_profile`をモジュールトップレベルで
+importするため、`concierge_chat.py`側で同モジュールをトップレベルimportすると
+循環importになる。関数内（`_attach_recommendation_reason_quality()`の内部）で
+importすることで解決した（Pythonの標準的な遅延import解決パターン、
+両モジュールの既存構造・責務分離は変更していない）。
+
+---
+
+## 6-9. 分類ごとの挙動
+
+| classification | deity_knowledge_used | history_knowledge_used | 確認テスト |
+|---|---|---|---|
+| `FULLY_KNOWLEDGE_BACKED` | true または false（片方でも可） | 同左 | `test_fully_knowledge_backed_deity_only`, `test_fully_knowledge_backed_history_only`, `test_both_deity_and_history_knowledge_used` |
+| `PARTIALLY_KNOWLEDGE_BACKED` | Knowledge/Legacyが混在 | 同左 | `test_partially_knowledge_backed` |
+| `LEGACY_BACKED` | false | false | `test_legacy_backed` |
+| `UNKNOWN` | false | false | `test_unknown_when_no_facts` |
+
+`history_theme`（Legacy分類タグ）単独存在時に誤ってKnowledge/Legacy判定
+されないことも回帰ガードとして固定化した
+（`test_history_theme_alone_does_not_flip_knowledge_backing_class`）。
+
+---
+
+## 10. Privacy結果（Phase 11/13）
+
+新規3 propertyはいずれも列挙値・booleanのみで構成され、Fact本文
+（deity表示名・shrine_history本文）・Source URL・publisher名・相談本文は
+一切含まれない。
+
+- Backend: `test_quality_payload_does_not_leak_source_url_or_raw_fact_text`
+- Frontend: `Fact本文・Source URL・相談本文に相当するkeyをpayloadへ含めない`
+
+いずれもテストで確認済み。
+
+---
+
+## 11. Backward Compatibility
+
+- 既存7 propertyの値・型は変更していない
+  （`test_existing_quality_keys_are_preserved`、
+  `既存の7 propertyは変更されない`）。
+- 新規3 propertyが未定義の場合、Frontend側は`?? null`でフォールバックし、
+  既存の`serializeSearchAnalyticsPayload()`のnull-stripping契約
+  （`searchEvents.ts`）によりpayloadから自動的に除外される
+  （新規propertyが存在しない古いBackendレスポンスでもFrontendは壊れない）。
+- `recommendation_quality`イベント名・発火タイミング・発火回数は変更して
+  いない。
+
+---
+
+## 12. Recommendation Behavior Regression
+
+`_attach_recommendation_reason_quality()`はRanking確定後、reason_text/
+qualityメタデータを候補dictへ付与するだけの処理であり、候補リスト・
+順位・スコアには一切触れない。変更ファイルに`concierge_chat_ranking.py`・
+`recommendation_algorithm_v3.py`・`recommendation_score_v2.py`は含まれない
+（2章のModified Files参照）。
+
+---
+
+## 13. Ranking / Score Regression
+
+- `SCORE_V3_MODE`・`_score_total`計算式・`resolve_score_sort_key`は無変更。
+- Score v3関連テスト（`test_score_v3_history_signal.py`等5ファイル）を含む
+  Backend全テストスイート実行で確認: **1147 passed, 9 skipped**
+  （GDAL/PostGIS環境依存、既存から不変）、失敗0件。
+
+---
+
+## 14. Analytics Regression
+
+- `recommendation_quality`以外のイベント（`concierge_result_impression`/
+  `shrine_detail_transition`/`shrine_decision`/`route_open`/`visit_done`等）
+  は本PRで一切変更していない。
+- `recommendation_quality`イベント自体も、発火回数・発火タイミング・
+  event名は不変。追加されるのはpayloadの3 propertyのみ。
+
+---
+
+## 15. Tests
+
+| 対象 | テスト数 | 結果 |
+|---|---:|---|
+| `test_recommendation_reason_quality_knowledge_properties.py`（新規） | 10 | 全pass |
+| `apps/web/.../trackRecommendationQualityFromRecommendations.test.ts`（新規） | 9 | 全pass |
+| Backend全体（`temples/`） | 1147（新規10含む） | 全pass（9 skip、既存から不変） |
+| Frontend全体（`apps/web`） | 740（新規9含む） | 全pass（116 test files） |
+| TypeScript型検査（`tsc --noEmit`） | — | エラー0件 |
+
+---
+
+## 16. Remaining Gaps（Phase 15、意図的に未対応のまま残す）
+
+- `visit_done`のrank/resultSetId欠落
+  （[knowledge-recommendation-analytics-contract.md](knowledge-recommendation-analytics-contract.md)
+  5章、`ATTRIBUTION_GAP`）
+- Retry/相談再入力イベントの新規追加（同12章、`FUNNEL_EVENT_GAP`）
+- PostHog Dashboard実装（同21章、`DASHBOARD_GAP`）
+- Sample-sizeの具体的根拠（同19章、`SAMPLE_SIZE_NOT_YET_DEFINED`）
+- Shadow Ranking Comparison（[knowledge-recommendation-quality-audit.md](knowledge-recommendation-quality-audit.md)
+  PR候補B）
+- Recommendation Quality改善そのもの（本PRは計測基盤のみ、推薦文言・
+  ロジックの改善は含まない）
+
+---
+
+## 17. Final Classification
+
+**`KNOWLEDGE_RECOMMENDATION_ANALYTICS_PROPERTIES_READY_WITH_LIMITATIONS`**
+
+Backend/Frontendとも実装完了、新規19テスト全pass、既存1147+740テストの
+回帰なし、TypeScript型検査エラー0件、Ranking/Score/Recommendation本文/
+UIいずれも無変更を確認した。16章の残存Gapは本PRのスコープ外として
+明示的に残す。
+
+Production writes = 0
+Recommendation behavior changes = 0
+Ranking changes = 0

--- a/docs/audit/knowledge-recommendation-analytics-properties-implementation.md
+++ b/docs/audit/knowledge-recommendation-analytics-properties-implementation.md
@@ -26,12 +26,30 @@ merge確認済み。develop同期・working tree clean。
 | `backend/temples/services/concierge_chat.py` | `_attach_recommendation_reason_quality()`で`build_shrine_reason_provenance()`（PR #2382既存関数）を呼び出し、`recommendation_reason_quality` dictへ3 propertyを追加 |
 | `apps/web/src/lib/api/concierge/types.ts` | `RecommendationReasonQuality`型へ3 optional propertyを追加、`KnowledgeBackingClass`型を新規定義 |
 | `apps/web/src/lib/analytics/searchEvents.ts` | `RecommendationQualityAnalyticsPayload`型へ同3 propertyを追加 |
-| `apps/web/src/features/concierge/hooks.ts` | `trackRecommendationQualityFromRecommendations()`で3 propertyを`?? null`フォールバック付きで転送。同関数をexport化（テスト目的のみ、ロジック変更なし） |
+| `apps/web/src/features/concierge/hooks.ts` | `trackRecommendationQualityFromRecommendations()`で3 propertyを`?? null`フォールバック付きで転送。同関数と`normalizeAccessLevel()`/`normalizeConciergeResponse()`をexport化（いずれもテスト目的のみ、ロジック変更なし） |
 | `backend/temples/tests/services/test_recommendation_reason_quality_knowledge_properties.py`（新規） | 10テスト |
 | `apps/web/src/features/concierge/__tests__/trackRecommendationQualityFromRecommendations.test.ts`（新規） | 9テスト |
+| `apps/web/src/features/concierge/__tests__/hooksNormalization.test.ts`（新規） | 19テスト（3章参照） |
 
 新規イベントの追加・既存イベント名の変更・UI変更・DB migrationはいずれも
 含まれない。
+
+### Coverage閾値対応（追加作業）
+
+`trackRecommendationQualityFromRecommendations()`をテストするために
+`hooks.ts`をimportしたところ、この副作用として`hooks.ts`全体
+（従来どの既存テストからもimportされておらず、v8 coverage計測の対象に
+一度も入っていなかった138 statement）が初めてcoverage計測対象へ入り、
+Web全体のstatements coverageがdevelop時点の80.53%から77.87%へ低下し、
+CI（`web-full` job、`--coverage`）のglobal threshold（78%）を割った。
+
+対応として、`hooks.ts`内の既存の純粋関数`normalizeAccessLevel()`と
+`normalizeConciergeResponse()`（いずれもReact hookの外側にある、副作用の
+ないデータ整形関数）をexportし、`hooksNormalization.test.ts`
+（19テスト）で直接カバーした。閾値を緩めたり除外リストへ追加したりする
+形での回避は行っていない。対応後の実測: **Statements 78.18%
+（4024/5147）、Branches 69.48%、Functions 82.52%、Lines 81.06%**、
+いずれも閾値（78%/68%/80%/80%）を満たす。
 
 ---
 
@@ -160,9 +178,11 @@ qualityメタデータを候補dictへ付与するだけの処理であり、候
 |---|---:|---|
 | `test_recommendation_reason_quality_knowledge_properties.py`（新規） | 10 | 全pass |
 | `apps/web/.../trackRecommendationQualityFromRecommendations.test.ts`（新規） | 9 | 全pass |
+| `apps/web/.../hooksNormalization.test.ts`（新規、Coverage対応） | 19 | 全pass |
 | Backend全体（`temples/`） | 1147（新規10含む） | 全pass（9 skip、既存から不変） |
-| Frontend全体（`apps/web`） | 740（新規9含む） | 全pass（116 test files） |
+| Frontend全体（`apps/web`） | 759（新規28含む） | 全pass（117 test files） |
 | TypeScript型検査（`tsc --noEmit`） | — | エラー0件 |
+| Web coverage閾値 | Statements/Branches/Functions/Lines | 全て閾値クリア（78.18%/69.48%/82.52%/81.06%） |
 
 ---
 
@@ -185,10 +205,11 @@ qualityメタデータを候補dictへ付与するだけの処理であり、候
 
 **`KNOWLEDGE_RECOMMENDATION_ANALYTICS_PROPERTIES_READY_WITH_LIMITATIONS`**
 
-Backend/Frontendとも実装完了、新規19テスト全pass、既存1147+740テストの
-回帰なし、TypeScript型検査エラー0件、Ranking/Score/Recommendation本文/
-UIいずれも無変更を確認した。16章の残存Gapは本PRのスコープ外として
-明示的に残す。
+Backend/Frontendとも実装完了、新規38テスト（Backend10 + Frontend28）全
+pass、既存テスト（Backend1147 + Frontend既存731）の回帰なし、Web
+coverage閾値も全て満たす、TypeScript型検査エラー0件、Ranking/Score/
+Recommendation本文/UIいずれも無変更を確認した。16章の残存Gapは本PRの
+スコープ外として明示的に残す。
 
 Production writes = 0
 Recommendation behavior changes = 0


### PR DESCRIPTION
## Summary

[Analytics Contract監査](https://github.com/etsu33/jinja_app/pull/2383)（#2383）で提示した最小価値PR案を実装する。既存の`recommendation_quality`イベントへ、[Baseline計測](https://github.com/etsu33/jinja_app/pull/2382)（#2382）の`build_shrine_reason_provenance()`をそのまま再利用して3 propertyを追加した。

- `knowledge_backing_class`: `FULLY_KNOWLEDGE_BACKED` / `PARTIALLY_KNOWLEDGE_BACKED` / `LEGACY_BACKED` / `UNKNOWN`
- `deity_knowledge_used`: boolean
- `history_knowledge_used`: boolean

**新規イベント・新規分類ロジックはゼロ**（既存関数を呼ぶだけ）。既存7 propertyは無変更。**Ranking / Score / Recommendation本文 / UIはいずれも変更しない**。Production writeゼロ。

## 実装詳細

- Backend: `concierge_chat.py`の`_attach_recommendation_reason_quality()`内で`build_shrine_reason_provenance(rec)`を呼び出すのみ。循環import回避のため関数内importを使用（`recommendation_quality_measurement.py`が`concierge_chat._build_score_v3_candidate_profile`を参照するため）。
- Frontend: `hooks.ts`の`trackRecommendationQualityFromRecommendations()`へ3 property追加（既存の`?? null`フォールバックパターンを踏襲）。テスト目的でexport化（ロジック変更なし）。
- 型: `RecommendationReasonQuality`（`types.ts`）・`RecommendationQualityAnalyticsPayload`（`searchEvents.ts`）へoptional propertyを追加。

## Test plan

- [x] 新規Backend test 10件全pass（`test_recommendation_reason_quality_knowledge_properties.py`）
- [x] 新規Frontend test 9件全pass（`trackRecommendationQualityFromRecommendations.test.ts`）
- [x] Backend全体1147テスト（新規10含む）全pass、9 skip（GDAL/PostGIS環境依存、既存から不変）
- [x] Frontend全体740テスト（新規9含む）、116 test files 全pass
- [x] `tsc --noEmit`エラー0件
- [x] history_theme（Legacy分類タグ）とKnowledge ShrineHistoryの誤分類なしを回帰テストで確認
- [x] Fact本文・Source URL・相談本文がpayloadに含まれないことを確認（Privacy）
- [x] `git diff --check`、マイグレーションなし
- [x] 資格情報・接続文字列・PIIスキャン（該当なし）
- [x] pre-push hook（OpenAPI lint / Web契約テスト 116 files / 740 tests）全通過
- [ ] CI green確認（PR作成後）
- [x] mergeはしない（draft PRのまま維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)