### PR TITLE
PostHog Analyticsのread-only取得基盤を追加

### DIFF
--- a/docs/audit/posthog-readonly-analytics-access.md
+++ b/docs/audit/posthog-readonly-analytics-access.md
@@ -1,0 +1,263 @@
+> **Status: `POSTHOG_READ_ACCESS_FOUNDATION_READY`。**
+>
+> [knowledge-recommendation-analytics-baseline-readiness.md](knowledge-recommendation-analytics-baseline-readiness.md)
+> （`KNOWLEDGE_ANALYTICS_READ_ACCESS_REQUIRED`）で提示した「Analytics
+> read-only access整備」を、**credentialを一切作成・登録せずに**tooling
+> として実装した。real PostHog Personal API Keyの発行・登録は本セッション
+> では行わない（Human Boundary）。したがって実PostHogへの接続確認
+> （Production smoke test）は未実施のまま残る。PostHog mutation・
+> event削除・event backfill・Dashboard変更・Recommendation/Ranking変更・
+> Production DB writeはいずれも行っていない。
+
+---
+
+## 1. develop SHA
+
+`72a94e05e83a89c5bf5f63eacee6746b19434dbd`（2026-08-12 15:42:37 +0900）
+
+PR #2386（[knowledge-recommendation-analytics-baseline-readiness.md](knowledge-recommendation-analytics-baseline-readiness.md)）
+merge確認済み。develop同期・working tree clean。
+
+---
+
+## 2. PostHog Official Access Model（Phase 1）
+
+PostHog公式ドキュメント（[Personal API keys](https://posthog.com/docs/api/personal-api-keys)、
+[API queries](https://posthog.com/docs/api/queries)）をfresh確認した。
+
+| 項目 | 内容 |
+|---|---|
+| 認証方式 | `Authorization: Bearer ${POSTHOG_PERSONAL_API_KEY}`ヘッダー |
+| Query用scope | `query:read`（推奨: 必要最小限のscopeのみ選択） |
+| Query endpoint | `POST /api/projects/{project_id}/query/`（HogQL、HTTPメソッドはPOSTだが、クエリを実行し結果を返すのみで状態変更を伴わない、公式ドキュメントの定義上read-only） |
+| Query制限 | rate limit 120/hour、デフォルト最大100行、`LIMIT`指定で最大5万行 |
+| Region | `us.posthog.com`等、リージョンごとにhostが異なりうる（本監査ではリポジトリのProduction実host値は確認していない、credential shapeの範囲外） |
+
+既存の`NEXT_PUBLIC_POSTHOG_KEY`（[knowledge-recommendation-analytics-baseline-readiness.md](knowledge-recommendation-analytics-baseline-readiness.md)
+3章で確認済み）はwrite専用のingestion keyであり、read/query用のPersonal
+API Keyとは別物であることを再確認した。**流用しない。**
+
+---
+
+## 3. Credential Type（Phase 2）
+
+| 項目 | 決定 |
+|---|---|
+| 変数名 | `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` / `POSTHOG_HOST`（optional） |
+| NEXT_PUBLIC_ prefix | 使用しない（Frontendへ露出させない） |
+| repoへの値保存 | しない |
+| `.env.example`への記載 | しない（app実行時envとは別系統の、`scripts/migration_safety/`と同型のrepo外credential fileパターンを採用したため） |
+| CI必須化 | しない |
+
+---
+
+## 4. Permission Gate（Phase 3）
+
+| 許可 | 不要（発行時に選択しない） |
+|---|---|
+| `query:read` | event mutation |
+| （projectメタデータread、必要になった場合のみ検討） | feature flag mutation |
+| | project settings mutation |
+| | user management |
+| | billing |
+| | deletion |
+
+read-only相当のscopeが`query:read`として公式に存在するため、
+「read-only equivalentが存在しない」という制限は発生していない。
+
+---
+
+## 5. Ownership Status（Phase 4）
+
+以下はいずれも本セッションからは決定できず、Mother Ship decisionとして
+明示的に残す（[knowledge-recommendation-analytics-baseline-readiness.md](knowledge-recommendation-analytics-baseline-readiness.md)
+13章から不変）。
+
+- PostHog account owner: 不明
+- Personal API Key発行・保管者: 不明
+- token rotation方針: 不明
+- revocation owner: 不明
+- query/report実行owner: 不明
+- report cadence: 不明
+
+---
+
+## 6. Credential Bridge（Phase 5）
+
+`scripts/analytics_safety/`配下に、既存`scripts/migration_safety/`の
+安全設計（credential file はrepo外・chmod 600必須・presence/shapeのみ
+出力・値は一切表示しない）をPostHog専用に再構成して実装した。
+
+- `check_posthog_credential_presence.sh`: `POSTHOG_PERSONAL_API_KEY`/
+  `POSTHOG_PROJECT_ID`/`POSTHOG_HOST`それぞれについて`VAR_SET=0/1`と
+  shape（length_bucket・has_whitespace）のみを出力。
+- repo内パスを credential file として渡すと`BLOCKED`で拒否（
+  `migration_safety`と同じrepo境界チェック）。
+- fileパーミッションが`600`でない場合は`BLOCKED`。
+
+---
+
+## 7. Read-only Query Wrapper（Phase 6）
+
+`posthog_readonly_query.py`が唯一のHTTP発呼経路。
+
+- credentialは環境変数からのみ読む（CLI引数では受け取らない、`ps`/
+  シェル履歴への露出を防ぐ）。
+- `POST {host}/api/projects/{project_id}/query/`のみを呼ぶ（8章参照）。
+- HogQLクエリ文字列は送信前に`guard.is_readonly_hogql()`で
+  mutation keyword（`INSERT`/`UPDATE`/`DELETE`/`DROP`/`ALTER`/
+  `TRUNCATE`/`CREATE`/`GRANT`/`REVOKE`/`MERGE`）を含まないことを確認
+  （query APIそのものが公式にread-onlyであることに加えた多層防御）。
+- `--fixture <path>`モードではネットワーク接続を一切行わない。
+
+---
+
+## 8. Endpoint Allowlist（Phase 7）
+
+```python
+ALLOWED_PATH_TEMPLATE = "/api/projects/{project_id}/query/"
+ALLOWED_METHOD = "POST"
+```
+
+`guard.is_endpoint_allowed()`はこの1エンドポイント以外を常にFalseと
+判定する。呼び出し元（`posthog_readonly_query.py`）も任意のpathを
+受け付ける設計になっていない（`project_id`を`build_allowed_path()`へ
+渡してこのテンプレートへ埋め込むだけ）ため、event capture・feature
+flag・project settings・person削除等のendpointはコード上そもそも
+呼び出せない。
+
+---
+
+## 9. Failure Redaction（Phase 8）
+
+| エラー種別 | 表示メッセージ |
+|---|---|
+| credential未設定 | `PostHog read-only query failed: credential not configured.` |
+| query rejected（mutation疑い/空） | `PostHog read-only query failed: query rejected (not read-only).` |
+| endpoint rejected | `PostHog read-only query failed: endpoint not permitted.` |
+| 401/403 | `PostHog read-only query failed: authentication or authorization error.` |
+| timeout | `PostHog read-only query failed: request timed out.` |
+| DNS/接続エラー | `PostHog read-only query failed: network error.` |
+| 応答JSON不正 | `PostHog read-only query failed: malformed response.` |
+| 5xx / その他不明なstatus | `PostHog read-only query failed: upstream error.` |
+
+いずれもtoken・host・project id・Authorizationヘッダー・生のresponse
+bodyを一切含まない固定文言。transport例外は型名（`Timeout`か否か）
+のみで分類し、例外の`str()`はログにも出力に一切使わない。
+
+---
+
+## 10. PII Guard（Phase 11）
+
+`QUERY_CONTRACT`（6種類）・`UNVERIFIED_SEGMENTED_QUERY_CONTRACT`（1種類）
+の全テンプレートについて、以下のフィールドが含まれないことを
+テストで固定化した:
+
+`consultation` / `raw_text` / `email` / `moodBefore` / `moodAfter` /
+`answer` / `person.email` / `person.name`
+
+いずれのクエリもevent名・enum値・boolean値・countのみを対象とする。
+
+---
+
+## 11. Baseline Query Contract（Phase 10・12）
+
+| クエリ名 | 内容 |
+|---|---|
+| `recommendation_quality_count` | 期間内`recommendation_quality`イベント総数 |
+| `classification_distribution` | `knowledge_backing_class`ごとの件数 |
+| `property_completeness` | 3新規propertyそれぞれのpresence件数／全体件数 |
+| `unique_recommendation_sessions` | `concierge_result_impression`のユニークthreadId数 |
+| `impression_count` | `concierge_result_impression`件数 |
+| `detail_transition_count` | `shrine_detail_transition`件数 |
+| `save_count` | `shrine_decision`(action=save)件数 |
+| `route_open_count` | `route_open`件数 |
+
+**`ctr_by_classification`等のsegmented query（`UNVERIFIED_SEGMENTED_QUERY_CONTRACT`）
+は、実PostHogデータに対して一度も実行・検証していない。** HogQLの
+JOIN構文としての妥当性は設計時点のベストエフォートであり、実接続後に
+人間が確認するまで正しさを保証しない。
+
+---
+
+## 12. Rollout Window（Phase 13）
+
+デフォルト`--since`は`2026-08-12T04:12:15Z`（PR #2384のProduction
+deploy時刻、[knowledge-recommendation-analytics-observability.md](knowledge-recommendation-analytics-observability.md)
+2章から）。全履歴を対象にしない設計とした。`--until`未指定時は実行
+時点のUTC時刻。
+
+---
+
+## 13. Fixture Tests（Phase 14・9・23）
+
+| ファイル | テスト数 |
+|---|---:|
+| `tests/test_guard.py` | 29 |
+| `tests/test_posthog_readonly_query.py` | 23 |
+| `tests/test_posthog_baseline_report.py` | 10 |
+| 合計 | 62 |
+
+すべて`requests_mock`によるモックHTTPのみ、実PostHog credentialは
+一切使用していない（fake値: `phx_fake_credential_for_tests_only`）。
+カバー範囲: success/401/403/timeout/DNS失敗/malformed response/5xx/
+credential欠落/mutation attempt拒否/endpoint allowlist/secret
+非露出（例外メッセージ・CLI stderr両方）/fixtureモードのネットワーク
+呼び出しゼロ/PII guard/read-only HogQL契約。
+
+実行確認（2026-08-12、backend venv、`python3 -m pytest -p no:dotenv
+scripts/analytics_safety/tests/ -v`）: **62 passed**。
+
+---
+
+## 14. Production Credential Status（Phase 17）
+
+`POSTHOG_READ_CREDENTIAL_REQUIRED`のまま。本セッションはreal PostHog
+Personal API Keyを作成・登録していない（Human Boundary、絶対禁止
+事項）。CLIの動作確認:
+
+```
+$ python3 scripts/analytics_safety/posthog_baseline_report.py
+POSTHOG_READ_CREDENTIAL_REQUIRED
+(exit code 1)
+```
+
+---
+
+## 15. Production Smoke Query（Phase 18）
+
+**未実施。** credentialがないため実行できない。Mother Shipが
+Personal API Key（`query:read`のみ）を発行し、`README.md`の手順で
+credential fileを用意した場合にのみ、次のステップとして最小限の
+event countクエリ1回のみを実行し、mutation 0・secret非出力を確認する
+ことを想定する。
+
+---
+
+## 16. Limitations
+
+- `ctr_by_classification`等のsegmented queryはHogQL構文として未検証
+  （11章）。
+- Production credential・接続は本監査の範囲では確立していない
+  （14-15章）。
+- Ownership（5章）はすべてMother Ship決定として未確定のまま残る。
+- `POSTHOG_HOST`のデフォルト値（`https://us.posthog.com`）は本アプリの
+  実際の使用リージョンと一致するとは限らない。Production実host値は
+  確認していない。
+
+---
+
+## Final Classification
+
+**`POSTHOG_READ_ACCESS_FOUNDATION_READY`**
+
+Credential bridge・read-onlyクエリラッパー・endpoint allowlist・
+安全な失敗処理・PII guard・baseline query contract・fixtureモード・
+62件のfake-credentialテストが完成し、全てpassした。実PostHog
+credentialの発行・登録・接続確認は、Human Boundaryに従い本セッション
+では意図的に行っていない（`POSTHOG_READ_CREDENTIAL_REQUIRED`のまま）。
+
+Production DB writes = 0
+PostHog mutations = 0
+Recommendation behavior changes = 0
+Ranking changes = 0

--- a/scripts/analytics_safety/README.md
+++ b/scripts/analytics_safety/README.md
@@ -1,0 +1,127 @@
+# Analytics Safety Tooling — PostHog Read-only Access
+
+Tooling to read aggregate PostHog analytics data (Knowledge recommendation
+quality metrics) without ever being able to mutate PostHog, and without a
+credential ever appearing in `ps`, shell history, or a raised exception's
+text.
+
+**This tooling never connects to real PostHog on its own.** It has no
+built-in Personal API Key, does not create one, and does not prompt for
+one. A human (Mother Ship) provisions a credential file, once, outside
+this repository — every script here reads it explicitly, there is no
+default and nothing is wired into CI or a deploy pipeline.
+
+Background reading:
+
+1. [`docs/audit/knowledge-recommendation-analytics-baseline-readiness.md`](../../docs/audit/knowledge-recommendation-analytics-baseline-readiness.md) — why this tooling exists (no PostHog read access existed before it)
+2. [`docs/audit/posthog-readonly-analytics-access.md`](../../docs/audit/posthog-readonly-analytics-access.md) — this Foundation's design record
+3. [`docs/audit/knowledge-recommendation-analytics-contract.md`](../../docs/audit/knowledge-recommendation-analytics-contract.md) — the event/property contract these queries read
+
+## What's here
+
+| File | Purpose |
+|---|---|
+| `guard.py` | Pure-Python safety guard. Allow-list (not deny-list) check for the one HTTP endpoint this tooling may ever call; mutation-keyword rejection for HogQL query text; credential shape description (never the value); error-text redaction. No network code. |
+| `check_posthog_credential_presence.sh` | Reports whether `POSTHOG_PERSONAL_API_KEY` / `POSTHOG_PROJECT_ID` / `POSTHOG_HOST` are set in a credential file — booleans and coarse shape only, never the values. |
+| `posthog_readonly_query.py` | Sends exactly one query to PostHog: `POST {host}/api/projects/{project_id}/query/` (PostHog's HogQL query endpoint — POST by HTTP method, but semantically read-only: it executes a query and returns rows, it does not mutate state, per [PostHog's own API docs](https://posthog.com/docs/api/queries)). Every other PostHog endpoint is unreachable through this module by construction. On any failure, prints one fixed generic message and exits non-zero — never the credential, host, project id, or raw response body. |
+| `posthog_baseline_report.py` | Runs the fixed named query set in `QUERY_CONTRACT` and prints one aggregate-only JSON report. `--fixture <dir>` mode reads canned per-query JSON instead of calling PostHog — no network call, no credential needed. Without `--fixture` and without a credential configured, exits with `POSTHOG_READ_CREDENTIAL_REQUIRED` rather than fabricating a result. |
+| `fixtures/sample_baseline/` | Canned all-zero fixture files (one per query in `QUERY_CONTRACT`) for `--fixture` dry runs and tests. Not real data. |
+| `tests/test_guard.py` | Unit tests for `guard.py`: endpoint allow-list, HogQL mutation-keyword rejection, credential-shape description, error redaction. No network. |
+| `tests/test_posthog_readonly_query.py` | Tests for `posthog_readonly_query.py` using `requests_mock` (a fake, obviously-not-real credential value): success, 401/403, timeout, DNS/connection failure, malformed response, 5xx, missing credential, mutation-attempt rejection, endpoint-allow-list rejection, secret non-exposure in every error path, fixture mode. |
+| `tests/test_posthog_baseline_report.py` | Tests for `posthog_baseline_report.py`: fixture mode, credential-required gate, every contract query is called exactly once in real mode (mocked), PII guard (no query template references a free-text field), every query template passes the read-only HogQL check. |
+
+## Creating the key (a human does this, not this tooling)
+
+1. Sign in to PostHog, go to **Personal API keys** in account settings.
+2. Click **+ Create a personal API Key**.
+3. Under scopes, select **only** `query:read`. Do not grant `*` (full
+   access), event capture, feature flag, project settings, person, or
+   billing scopes — this tooling never needs them and never uses them.
+4. Note the numeric **Project ID** (Project settings) you want to query.
+5. Create a file **outside this repository**, e.g.
+   `~/.config/kami-musubi/posthog-readonly.env`, containing:
+
+   ```bash
+   export POSTHOG_PERSONAL_API_KEY="phx_..."
+   export POSTHOG_PROJECT_ID="12345"
+   export POSTHOG_HOST="https://us.posthog.com"   # or your region's host
+   ```
+
+6. `chmod 600` that file.
+7. Verify presence (never prints the value):
+
+   ```bash
+   scripts/analytics_safety/check_posthog_credential_presence.sh ~/.config/kami-musubi/posthog-readonly.env
+   ```
+
+Never paste the key value into a chat session with an AI assistant or
+anyone else. This tooling never asks for it directly — only via the
+environment, after you `source` the credential file yourself.
+
+## Running a query
+
+```bash
+set -a; source ~/.config/kami-musubi/posthog-readonly.env; set +a
+python3 scripts/analytics_safety/posthog_readonly_query.py \
+  --query "SELECT count() FROM events WHERE event = 'recommendation_quality'"
+```
+
+## Running the baseline report
+
+```bash
+set -a; source ~/.config/kami-musubi/posthog-readonly.env; set +a
+python3 scripts/analytics_safety/posthog_baseline_report.py
+```
+
+Or, without any credential, to see the report shape:
+
+```bash
+python3 scripts/analytics_safety/posthog_baseline_report.py \
+  --fixture scripts/analytics_safety/fixtures/sample_baseline
+```
+
+## The core safety properties
+
+- **Endpoint allow-list, not deny-list.** `guard.is_endpoint_allowed()`
+  only returns true for `POST /api/projects/{project_id}/query/`.
+  Nothing else — event capture, feature flags, project settings, person
+  deletion — is reachable through this tooling's code paths, because no
+  function here accepts an arbitrary path.
+- **HogQL mutation-keyword rejection as defense in depth.** Even though
+  the query endpoint is itself read-only by PostHog's design, every
+  query text is checked for `INSERT`/`UPDATE`/`DELETE`/`DROP`/`ALTER`/
+  `TRUNCATE`/`CREATE`/`GRANT`/`REVOKE`/`MERGE` before it is sent.
+- **Credential never appears in `ps`, shell history, or an exception.**
+  The key is read only from the environment, sent only in the
+  `Authorization` header, and every failure path raises one of a fixed
+  set of generic `ERROR_*` messages — never the exception's raw text,
+  the request URL, or the response body.
+- **Fixture mode makes zero network calls.** `--fixture` is the default
+  way to develop against and test this tooling; a real credential is
+  only needed for `--fixture`-less runs.
+- **Query contract is a fixed, reviewed list.** `QUERY_CONTRACT` in
+  `posthog_baseline_report.py` is the only set of queries the baseline
+  report will ever send — no caller-supplied query text reaches
+  PostHog through that command. Every template references only event
+  names, enum property values, boolean property values, and counts —
+  never free-text properties, person properties, emails, or names (see
+  PII Guard tests in `tests/test_posthog_baseline_report.py`).
+- **Output minimization.** The report contains only counts, rates
+  (where computed), enum labels, and the query period — never a
+  per-user/per-thread/per-event raw row dump.
+
+## What this Foundation does not do
+
+- It does not create, register, or rotate a PostHog Personal API Key.
+- It has never connected to real Production PostHog (no credential
+  exists in the environment this was built in — see
+  [`knowledge-recommendation-analytics-baseline-readiness.md`](../../docs/audit/knowledge-recommendation-analytics-baseline-readiness.md)).
+  `posthog_readonly_query.py` and `posthog_baseline_report.py` are
+  fully tested against mocked HTTP, not real PostHog.
+- The `ctr_by_classification` / save-rate / visit-intent "segmented by
+  Knowledge classification" queries
+  (`UNVERIFIED_SEGMENTED_QUERY_CONTRACT` in
+  `posthog_baseline_report.py`) are a best-effort HogQL design, not
+  verified against real data. Treat their exact correctness as
+  unconfirmed until run once against real PostHog and checked by a
+  human.

--- a/scripts/analytics_safety/check_posthog_credential_presence.sh
+++ b/scripts/analytics_safety/check_posthog_credential_presence.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Check whether a PostHog read-only credential is present and well-formed,
+# WITHOUT ever printing its value, host, project id, or any other
+# identifying substring.
+#
+# Usage:
+#   scripts/analytics_safety/check_posthog_credential_presence.sh <CREDENTIAL_FILE>
+#
+# CREDENTIAL_FILE: a shell-sourceable file living OUTSIDE this repository,
+#   e.g. ~/.config/kami-musubi/posthog-readonly.env, containing:
+#     export POSTHOG_PERSONAL_API_KEY="phx_..."
+#     export POSTHOG_PROJECT_ID="12345"
+#     export POSTHOG_HOST="https://us.posthog.com"   # optional, has a default
+#
+#   This tooling never creates or populates this file. A human (Mother
+#   Ship) creates a Personal API Key in PostHog with ONLY the `query:read`
+#   scope (see README.md "Creating the key") and writes it here once,
+#   locally, outside the repository, chmod 600.
+#
+# Prints only: VAR_SET=0|1 per variable, and if set, a shape dict
+# (length_bucket, has_whitespace). Never echoes the file, never uses
+# `set -x`, never greps for the value.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+if [ $# -ne 1 ]; then
+  echo "[check_posthog_credential_presence] usage: $0 <CREDENTIAL_FILE>" >&2
+  exit 2
+fi
+
+CRED_FILE="$1"
+
+case "${CRED_FILE}" in
+  "${REPO_ROOT}"/*)
+    echo "[check_posthog_credential_presence] BLOCKED: credential file must be outside the repository." >&2
+    exit 1
+    ;;
+esac
+
+if [ ! -f "${CRED_FILE}" ]; then
+  echo "VAR_SET=0"
+  echo "[check_posthog_credential_presence] no credential file at that path yet — this is expected before a Personal API Key has been provisioned. See README.md." >&2
+  exit 0
+fi
+
+PERMS="$(stat -f '%OLp' "${CRED_FILE}" 2>/dev/null || stat -c '%a' "${CRED_FILE}" 2>/dev/null)"
+if [ "${PERMS}" != "600" ]; then
+  echo "[check_posthog_credential_presence] BLOCKED: file permissions are ${PERMS}, expected 600 (owner read/write only). Run: chmod 600 ${CRED_FILE}" >&2
+  exit 1
+fi
+
+for VAR_NAME in POSTHOG_PERSONAL_API_KEY POSTHOG_PROJECT_ID POSTHOG_HOST; do
+  # Source in a throwaway subshell so nothing leaks into this script's own
+  # environment, and the value never touches argv or stdout directly —
+  # only guard.py's shape-only JSON output does.
+  SHAPE_OUTPUT="$(
+    bash -c "
+      set -a
+      # shellcheck disable=SC1090
+      source '${CRED_FILE}'
+      set +a
+      printf '%s' \"\${${VAR_NAME}:-}\"
+    " | python3 "${SCRIPT_DIR}/guard.py" describe-credential-shape
+  )"
+
+  VAR_IS_SET="$(bash -c "
+    set -a
+    # shellcheck disable=SC1090
+    source '${CRED_FILE}'
+    set +a
+    [ -n \"\${${VAR_NAME}:-}\" ] && echo 1 || echo 0
+  ")"
+
+  echo "${VAR_NAME}_SET=${VAR_IS_SET}"
+  if [ "${VAR_IS_SET}" = "1" ]; then
+    echo "${VAR_NAME}_SHAPE=${SHAPE_OUTPUT}"
+  fi
+done

--- a/scripts/analytics_safety/fixtures/sample_baseline/classification_distribution.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/classification_distribution.json
@@ -1,0 +1,4 @@
+{
+  "results": [],
+  "columns": ["classification", "count"]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/detail_transition_count.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/detail_transition_count.json
@@ -1,0 +1,4 @@
+{
+  "results": [[0]],
+  "columns": ["count"]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/impression_count.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/impression_count.json
@@ -1,0 +1,4 @@
+{
+  "results": [[0]],
+  "columns": ["count"]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/property_completeness.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/property_completeness.json
@@ -1,0 +1,9 @@
+{
+  "results": [[0, 0, 0, 0]],
+  "columns": [
+    "knowledge_backing_class_present",
+    "deity_knowledge_used_present",
+    "history_knowledge_used_present",
+    "total"
+  ]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/recommendation_quality_count.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/recommendation_quality_count.json
@@ -1,0 +1,4 @@
+{
+  "results": [[0]],
+  "columns": ["count"]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/route_open_count.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/route_open_count.json
@@ -1,0 +1,4 @@
+{
+  "results": [[0]],
+  "columns": ["count"]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/save_count.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/save_count.json
@@ -1,0 +1,4 @@
+{
+  "results": [[0]],
+  "columns": ["count"]
+}

--- a/scripts/analytics_safety/fixtures/sample_baseline/unique_recommendation_sessions.json
+++ b/scripts/analytics_safety/fixtures/sample_baseline/unique_recommendation_sessions.json
@@ -1,0 +1,4 @@
+{
+  "results": [[0]],
+  "columns": ["count"]
+}

--- a/scripts/analytics_safety/guard.py
+++ b/scripts/analytics_safety/guard.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Safety guard for PostHog read-only analytics queries.
+
+Mirrors the design of scripts/migration_safety/guard.py: this module
+contains no network code and never touches a real credential value. It
+only answers safety questions using an allow-list (not a deny-list):
+
+- is this HTTP method + path allowed to be called at all? (only the
+  single HogQL query endpoint is permitted, regardless of what a caller
+  asks for)
+- does this HogQL query text contain a write/mutation keyword? (defense
+  in depth on top of the endpoint allow-list — the query endpoint is
+  itself read-only by PostHog's own API design, per
+  https://posthog.com/docs/api/queries, but we do not rely on that
+  alone)
+- what is the structural shape of a credential value, without ever
+  returning the value itself? (VAR_SET, non-empty, length bucket only)
+- how should an error be redacted before it reaches stdout/stderr?
+
+No function here executes an HTTP request, reads a credential from disk,
+or prints a secret. Callers (posthog_readonly_query.py) are responsible
+for the actual request; this module only decides whether it is safe to
+attempt and how to describe the outcome without leaking anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+
+# The only endpoint this tooling is ever allowed to call. PostHog's HogQL
+# query endpoint is POST by HTTP method but semantically read-only (it
+# executes a query and returns rows; it does not mutate state) per
+# PostHog's own API documentation. No other PostHog endpoint — event
+# capture, insights mutation, feature flags, project settings, person
+# deletion, etc. — is reachable through this tooling, by construction:
+# the wrapper never accepts a path, only a project_id substituted into
+# this exact template.
+ALLOWED_PATH_TEMPLATE = "/api/projects/{project_id}/query/"
+ALLOWED_METHOD = "POST"
+
+# Keywords that must never appear in a HogQL query string sent through
+# this tooling, checked in addition to (not instead of) the endpoint
+# allow-list above. HogQL is a read-only SQL dialect for PostHog's own
+# query endpoint, but this list blocks anything that even superficially
+# resembles a mutation statement, as defense in depth.
+_FORBIDDEN_QUERY_KEYWORDS = (
+    "insert",
+    "update",
+    "delete",
+    "drop",
+    "alter",
+    "truncate",
+    "create",
+    "grant",
+    "revoke",
+    "merge",
+)
+
+_QUERY_KEYWORD_RE = re.compile(
+    r"\b(" + "|".join(_FORBIDDEN_QUERY_KEYWORDS) + r")\b", re.IGNORECASE
+)
+
+
+def is_endpoint_allowed(*, method: str, path: str) -> bool:
+    """True only for POST to the exact HogQL query path shape."""
+    if method.upper() != ALLOWED_METHOD:
+        return False
+    # path must match /api/projects/<something non-empty, no slash>/query/
+    return bool(re.fullmatch(r"/api/projects/[^/]+/query/", path))
+
+
+def build_allowed_path(project_id: str) -> str:
+    if not project_id or "/" in project_id:
+        raise ValueError("invalid project_id")
+    return ALLOWED_PATH_TEMPLATE.format(project_id=project_id)
+
+
+def is_readonly_hogql(query_text: str) -> bool:
+    """True if query_text contains no forbidden mutation keyword.
+
+    This is a coarse, conservative check (keyword search, not a real SQL
+    parser) by design — the goal is to fail closed on anything
+    ambiguous, not to be a complete HogQL grammar.
+    """
+    if not isinstance(query_text, str) or not query_text.strip():
+        return False
+    return _QUERY_KEYWORD_RE.search(query_text) is None
+
+
+def describe_credential_shape(value: str | None) -> dict:
+    """Structural-shape-only description of a credential value.
+
+    Never includes the value, a prefix/suffix of it, or its exact
+    length — only coarse booleans and a length bucket, matching the
+    redaction level of migration_safety/guard.py's describe_url_shape().
+    """
+    if not value:
+        return {"present": False}
+
+    length = len(value)
+    if length < 20:
+        bucket = "short"
+    elif length < 60:
+        bucket = "typical"
+    else:
+        bucket = "long"
+
+    return {
+        "present": True,
+        "length_bucket": bucket,
+        "has_whitespace": bool(re.search(r"\s", value)),
+    }
+
+
+_REDACT_PATTERNS = (
+    # "Bearer <token>" must be redacted before the more general
+    # "Authorization: <token>" pattern below, otherwise the latter only
+    # consumes the word "Bearer" and leaves the actual token untouched.
+    (re.compile(r"(?i)bearer\s+\S+"), "bearer <redacted>"),
+    # Authorization header values of any kind (non-Bearer schemes).
+    (re.compile(r"(?i)authorization:\s*\S+"), "authorization: <redacted>"),
+    # Anything that looks like a URL with a host, to avoid leaking the
+    # configured PostHog host/project endpoint in error text.
+    (re.compile(r"https?://\S+"), "<redacted-url>"),
+)
+
+
+def redact_error_text(text: str) -> str:
+    """Best-effort redaction for exception text before it is ever printed.
+
+    Callers should prefer generic, pre-written error messages (see
+    posthog_readonly_query.py's ERROR_* constants) over surfacing
+    exception text at all; this function is a defense-in-depth backstop
+    for the rare case an exception message is included.
+    """
+    if not text:
+        return text
+    redacted = text
+    for pattern, replacement in _REDACT_PATTERNS:
+        redacted = pattern.sub(replacement, redacted)
+    return redacted
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    describe = sub.add_parser(
+        "describe-credential-shape",
+        help="Read a credential value from stdin and print only its shape as JSON.",
+    )
+    describe.set_defaults(command="describe-credential-shape")
+
+    check_query = sub.add_parser(
+        "check-readonly-hogql",
+        help="Read a HogQL query from stdin; exit 0 if it looks read-only, 1 otherwise.",
+    )
+    check_query.set_defaults(command="check-readonly-hogql")
+
+    args = parser.parse_args()
+
+    if args.command == "describe-credential-shape":
+        value = sys.stdin.read().rstrip("\n")
+        print(json.dumps(describe_credential_shape(value or None), sort_keys=True))
+        return 0
+
+    if args.command == "check-readonly-hogql":
+        query_text = sys.stdin.read()
+        if is_readonly_hogql(query_text):
+            print("READONLY_OK")
+            return 0
+        print("BLOCKED: query contains a forbidden keyword or is empty", file=sys.stderr)
+        return 1
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/analytics_safety/posthog_baseline_report.py
+++ b/scripts/analytics_safety/posthog_baseline_report.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Knowledge Recommendation Analytics baseline report (read-only).
+
+Combines a fixed set of named, read-only HogQL queries (see
+QUERY_CONTRACT below) into one aggregate-only report. Every query goes
+through posthog_readonly_query.run_readonly_hogql_query(), which enforces
+the endpoint allow-list and the mutation-keyword rejection in
+guard.py — this module adds no new HTTP path.
+
+Output contract: the report contains only counts, rates, enum labels,
+and the query period. It never contains a per-user/per-thread/per-event
+row dump, and no query template in QUERY_CONTRACT selects a raw
+property that could carry consultation text, email, name, or other PII
+(see PII Guard in README.md and
+docs/audit/posthog-readonly-analytics-access.md).
+
+Two modes:
+
+  --fixture <dir>   Read canned per-query JSON files from a local
+                     directory instead of calling PostHog. No network
+                     call is made. Use this for dry runs and tests.
+  (no --fixture)    Call the real PostHog query endpoint for each named
+                     query, using POSTHOG_PERSONAL_API_KEY/
+                     POSTHOG_PROJECT_ID/POSTHOG_HOST from the
+                     environment. Requires those to be set — see
+                     check_posthog_credential_presence.sh. If they are
+                     not set, this exits non-zero with
+                     POSTHOG_READ_CREDENTIAL_REQUIRED rather than
+                     guessing or fabricating a result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from posthog_readonly_query import (  # noqa: E402
+    PostHogReadOnlyQueryError,
+    run_readonly_hogql_query,
+)
+
+# PR #2384 Production deployment timestamp (Vercel production deployment
+# dpl_AcehvHCZesf5j8xYqwqK4d7k9xwC, per
+# docs/audit/knowledge-recommendation-analytics-observability.md). The
+# default query window never reaches further back than this, so
+# pre-rollout events (which cannot carry the new properties) are not
+# counted as if they were missing-property post-rollout events.
+DEFAULT_ROLLOUT_SINCE = "2026-08-12T04:12:15Z"
+
+# Every query this tool will ever send. Each entry is read-only HogQL
+# (enforced again, redundantly, by guard.is_readonly_hogql at call time)
+# selecting only: event name, enum property values, boolean property
+# values, and counts. No query here selects free-text properties,
+# person properties, emails, or names.
+QUERY_CONTRACT: dict[str, str] = {
+    "recommendation_quality_count": (
+        "SELECT count() AS count FROM events "
+        "WHERE event = 'recommendation_quality' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+    "classification_distribution": (
+        "SELECT properties.knowledge_backing_class AS classification, count() AS count "
+        "FROM events "
+        "WHERE event = 'recommendation_quality' "
+        "AND timestamp >= {since} AND timestamp < {until} "
+        "GROUP BY classification"
+    ),
+    "property_completeness": (
+        "SELECT "
+        "countIf(isNotNull(properties.knowledge_backing_class)) AS knowledge_backing_class_present, "
+        "countIf(isNotNull(properties.deity_knowledge_used)) AS deity_knowledge_used_present, "
+        "countIf(isNotNull(properties.history_knowledge_used)) AS history_knowledge_used_present, "
+        "count() AS total "
+        "FROM events "
+        "WHERE event = 'recommendation_quality' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+    "unique_recommendation_sessions": (
+        "SELECT count(DISTINCT properties.threadId) AS count FROM events "
+        "WHERE event = 'concierge_result_impression' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+    "impression_count": (
+        "SELECT count() AS count FROM events WHERE event = 'concierge_result_impression' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+    "detail_transition_count": (
+        "SELECT count() AS count FROM events WHERE event = 'shrine_detail_transition' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+    "save_count": (
+        "SELECT count() AS count FROM events WHERE event = 'shrine_decision' "
+        "AND properties.action = 'save' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+    "route_open_count": (
+        "SELECT count() AS count FROM events WHERE event = 'route_open' "
+        "AND timestamp >= {since} AND timestamp < {until}"
+    ),
+}
+
+# These two require joining recommendation_quality's classification onto
+# impression/click events by (threadId, shrineId, recommendationRank), per
+# the join key contract in
+# docs/audit/knowledge-recommendation-analytics-contract.md §7. They are
+# recorded here as a best-effort design and have never been executed
+# against real PostHog data (no credential exists in this session, see
+# docs/audit/knowledge-recommendation-analytics-baseline-readiness.md) —
+# treat their exact HogQL correctness as UNVERIFIED until run once against
+# real data and checked by a human.
+UNVERIFIED_SEGMENTED_QUERY_CONTRACT: dict[str, str] = {
+    "ctr_by_classification": (
+        "SELECT rq.properties.knowledge_backing_class AS classification, "
+        "count(DISTINCT imp.uuid) AS impressions, "
+        "count(DISTINCT dt.uuid) AS detail_transitions "
+        "FROM events AS imp "
+        "LEFT JOIN events AS dt "
+        "ON dt.event = 'shrine_detail_transition' "
+        "AND dt.properties.threadId = imp.properties.threadId "
+        "AND dt.properties.shrineId = imp.properties.shrineId "
+        "AND dt.properties.recommendationRank = imp.properties.recommendationRank "
+        "LEFT JOIN events AS rq "
+        "ON rq.event = 'recommendation_quality' "
+        "AND rq.properties.threadId = imp.properties.threadId "
+        "AND rq.properties.shrineId = imp.properties.shrineId "
+        "AND rq.properties.recommendationRank = imp.properties.recommendationRank "
+        "WHERE imp.event = 'concierge_result_impression' "
+        "AND imp.timestamp >= {since} AND imp.timestamp < {until} "
+        "GROUP BY classification"
+    ),
+}
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _render_query(template: str, *, since: str, until: str) -> str:
+    return template.format(since=repr(since), until=repr(until))
+
+
+def _run_real(since: str, until: str) -> dict:
+    results: dict = {}
+    for name, template in QUERY_CONTRACT.items():
+        query_text = _render_query(template, since=since, until=until)
+        results[name] = run_readonly_hogql_query(query_text)
+    return results
+
+
+def _run_fixture(fixture_dir: str) -> dict:
+    results: dict = {}
+    for name in QUERY_CONTRACT:
+        path = os.path.join(fixture_dir, f"{name}.json")
+        if not os.path.exists(path):
+            results[name] = None
+            continue
+        with open(path, encoding="utf-8") as f:
+            results[name] = json.load(f)
+    return results
+
+
+def build_report(*, since: str, until: str, fixture_dir: str | None) -> dict:
+    if fixture_dir:
+        raw = _run_fixture(fixture_dir)
+    else:
+        raw = _run_real(since, until)
+
+    return {
+        "period": {"since": since, "until": until},
+        "queries": raw,
+        "note": (
+            "Aggregates only. No per-user/per-thread/per-event raw rows are "
+            "included. ctr_by_classification / save_rate_by_classification / "
+            "visit_intent_by_classification are not computed by this command "
+            "(see UNVERIFIED_SEGMENTED_QUERY_CONTRACT — unverified against "
+            "real data, run separately once access exists)."
+        ),
+    }
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--since", default=DEFAULT_ROLLOUT_SINCE, help="ISO8601 window start (default: PR #2384 rollout time)")
+    parser.add_argument("--until", default=None, help="ISO8601 window end (default: now)")
+    parser.add_argument(
+        "--fixture",
+        default=None,
+        help="Directory of per-query fixture JSON files. No network call is made in this mode.",
+    )
+    args = parser.parse_args()
+
+    until = args.until or _iso_now()
+
+    if not args.fixture:
+        key_present = bool(os.environ.get("POSTHOG_PERSONAL_API_KEY"))
+        project_present = bool(os.environ.get("POSTHOG_PROJECT_ID"))
+        if not key_present or not project_present:
+            print("POSTHOG_READ_CREDENTIAL_REQUIRED", file=sys.stderr)
+            return 1
+
+    try:
+        report = build_report(since=args.since, until=until, fixture_dir=args.fixture)
+    except PostHogReadOnlyQueryError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/analytics_safety/posthog_readonly_query.py
+++ b/scripts/analytics_safety/posthog_readonly_query.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Safe, read-only PostHog HogQL query wrapper.
+
+Sends exactly one kind of request — POST to PostHog's HogQL query
+endpoint (POST {host}/api/projects/{project_id}/query/, semantically
+read-only per https://posthog.com/docs/api/queries) — and nothing else.
+No other PostHog endpoint is reachable through this module.
+
+Credential contract (never accepted as a CLI argument, only read from
+the environment, so a token never appears in `ps` or shell history):
+
+    POSTHOG_PERSONAL_API_KEY   Personal API Key, `query:read` scope only.
+    POSTHOG_PROJECT_ID         Numeric PostHog project id.
+    POSTHOG_HOST               Optional. Defaults to https://us.posthog.com.
+
+See README.md for how a human provisions these locally, outside the
+repository. This module never creates, prompts for, or persists a
+credential — it only reads one that already exists in the environment
+when invoked.
+
+On any failure (auth, network, malformed response, disallowed query),
+this module prints one of the fixed ERROR_* messages below and exits
+non-zero. It never prints the exception text, the request URL, the
+Authorization header, or the raw response body — see
+guard.redact_error_text() for the defense-in-depth backstop if an
+unexpected exception text ever needs to surface.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from guard import (  # noqa: E402
+    build_allowed_path,
+    is_endpoint_allowed,
+    is_readonly_hogql,
+    redact_error_text,
+)
+
+DEFAULT_HOST = "https://us.posthog.com"
+REQUEST_TIMEOUT_SECONDS = 30
+
+ERROR_CREDENTIAL_MISSING = "PostHog read-only query failed: credential not configured."
+ERROR_QUERY_REJECTED = "PostHog read-only query failed: query rejected (not read-only)."
+ERROR_ENDPOINT_REJECTED = "PostHog read-only query failed: endpoint not permitted."
+ERROR_AUTH = "PostHog read-only query failed: authentication or authorization error."
+ERROR_NETWORK = "PostHog read-only query failed: network error."
+ERROR_TIMEOUT = "PostHog read-only query failed: request timed out."
+ERROR_MALFORMED_RESPONSE = "PostHog read-only query failed: malformed response."
+ERROR_UPSTREAM = "PostHog read-only query failed: upstream error."
+
+
+class PostHogReadOnlyQueryError(Exception):
+    """Raised with one of the ERROR_* constants only — never raw detail."""
+
+
+def _load_credentials_from_env() -> tuple[str, str, str]:
+    key = os.environ.get("POSTHOG_PERSONAL_API_KEY", "")
+    project_id = os.environ.get("POSTHOG_PROJECT_ID", "")
+    host = os.environ.get("POSTHOG_HOST", "") or DEFAULT_HOST
+    if not key or not project_id:
+        raise PostHogReadOnlyQueryError(ERROR_CREDENTIAL_MISSING)
+    return key, project_id, host
+
+
+def run_readonly_hogql_query(
+    query_text: str,
+    *,
+    session: Any = None,
+) -> dict:
+    """Execute one read-only HogQL query against PostHog and return the JSON result.
+
+    `session` is injectable for tests (a `requests`-compatible object);
+    production callers should leave it as None to use `requests` directly.
+    """
+    if not is_readonly_hogql(query_text):
+        raise PostHogReadOnlyQueryError(ERROR_QUERY_REJECTED)
+
+    key, project_id, host = _load_credentials_from_env()
+    try:
+        path = build_allowed_path(project_id)
+    except ValueError:
+        raise PostHogReadOnlyQueryError(ERROR_ENDPOINT_REJECTED) from None
+    if not is_endpoint_allowed(method="POST", path=path):
+        raise PostHogReadOnlyQueryError(ERROR_ENDPOINT_REJECTED)
+
+    url = f"{host.rstrip('/')}{path}"
+    headers = {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+    body = {"query": {"kind": "HogQLQuery", "query": query_text}}
+
+    http = session
+    if http is None:
+        import requests  # local import: only required at actual call time
+
+        http = requests
+
+    try:
+        response = http.post(url, headers=headers, json=body, timeout=REQUEST_TIMEOUT_SECONDS)
+    except Exception as exc:  # network error, DNS failure, connection refused, etc.
+        _classify_and_raise_transport_error(exc)
+        raise  # unreachable, _classify_and_raise_transport_error always raises
+
+    if response.status_code in (401, 403):
+        raise PostHogReadOnlyQueryError(ERROR_AUTH)
+    if response.status_code >= 500:
+        raise PostHogReadOnlyQueryError(ERROR_UPSTREAM)
+    if response.status_code != 200:
+        raise PostHogReadOnlyQueryError(ERROR_UPSTREAM)
+
+    try:
+        return response.json()
+    except (ValueError, json.JSONDecodeError):
+        raise PostHogReadOnlyQueryError(ERROR_MALFORMED_RESPONSE) from None
+
+
+def _classify_and_raise_transport_error(exc: Exception) -> None:
+    """Map a transport-layer exception to a generic ERROR_* message.
+
+    Deliberately does not inspect or forward exc's message text (it may
+    contain the request URL, hostname, or other identifying detail);
+    only the exception's class shape is used to pick timeout vs.
+    generic network error.
+    """
+    type_name = type(exc).__name__
+    if "Timeout" in type_name:
+        raise PostHogReadOnlyQueryError(ERROR_TIMEOUT) from None
+    raise PostHogReadOnlyQueryError(ERROR_NETWORK) from None
+
+
+def _load_fixture(fixture_path: str) -> dict:
+    with open(fixture_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        required=False,
+        help="HogQL query text. Ignored if --fixture is given.",
+    )
+    parser.add_argument(
+        "--fixture",
+        required=False,
+        help=(
+            "Path to a local fixture JSON file to print instead of calling "
+            "the real PostHog API. Use this for dry runs / tests without a "
+            "credential. No network request is made in this mode."
+        ),
+    )
+    args = parser.parse_args()
+
+    if args.fixture:
+        try:
+            result = _load_fixture(args.fixture)
+        except (OSError, json.JSONDecodeError) as exc:
+            print(redact_error_text(f"failed to load fixture: {type(exc).__name__}"), file=sys.stderr)
+            return 1
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+
+    if not args.query:
+        print("usage: --query '<HogQL>' or --fixture <path>", file=sys.stderr)
+        return 2
+
+    try:
+        result = run_readonly_hogql_query(args.query)
+    except PostHogReadOnlyQueryError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/scripts/analytics_safety/tests/test_guard.py
+++ b/scripts/analytics_safety/tests/test_guard.py
@@ -1,0 +1,178 @@
+"""Pure unit tests for scripts/analytics_safety/guard.py.
+
+No database, no network. Run with:
+    python3 -m pytest scripts/analytics_safety/tests/test_guard.py -v
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from guard import (  # noqa: E402
+    build_allowed_path,
+    describe_credential_shape,
+    is_endpoint_allowed,
+    is_readonly_hogql,
+    redact_error_text,
+)
+
+
+# --- is_endpoint_allowed: allow-list enforcement ----------------------------
+
+
+def test_allows_exact_query_endpoint():
+    assert is_endpoint_allowed(method="POST", path="/api/projects/12345/query/") is True
+
+
+def test_rejects_get_method():
+    assert is_endpoint_allowed(method="GET", path="/api/projects/12345/query/") is False
+
+
+def test_rejects_delete_method():
+    assert is_endpoint_allowed(method="DELETE", path="/api/projects/12345/query/") is False
+
+
+def test_rejects_event_capture_endpoint():
+    assert is_endpoint_allowed(method="POST", path="/capture/") is False
+
+
+def test_rejects_feature_flag_endpoint():
+    assert is_endpoint_allowed(method="POST", path="/api/projects/12345/feature_flags/") is False
+
+
+def test_rejects_project_settings_endpoint():
+    assert is_endpoint_allowed(method="PATCH", path="/api/projects/12345/") is False
+
+
+def test_rejects_person_deletion_endpoint():
+    assert is_endpoint_allowed(method="DELETE", path="/api/projects/12345/persons/999/") is False
+
+
+def test_rejects_path_traversal_in_project_id():
+    assert is_endpoint_allowed(method="POST", path="/api/projects/../admin/query/") is False
+
+
+# --- build_allowed_path ------------------------------------------------------
+
+
+def test_build_allowed_path_returns_query_endpoint():
+    assert build_allowed_path("12345") == "/api/projects/12345/query/"
+
+
+def test_build_allowed_path_rejects_empty_project_id():
+    try:
+        build_allowed_path("")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+def test_build_allowed_path_rejects_slash_in_project_id():
+    try:
+        build_allowed_path("123/456")
+        assert False, "expected ValueError"
+    except ValueError:
+        pass
+
+
+# --- is_readonly_hogql: mutation keyword rejection --------------------------
+
+
+def test_allows_select_query():
+    assert is_readonly_hogql("SELECT count() FROM events WHERE event = 'recommendation_quality'") is True
+
+
+def test_rejects_empty_query():
+    assert is_readonly_hogql("") is False
+
+
+def test_rejects_none_query():
+    assert is_readonly_hogql(None) is False
+
+
+def test_rejects_insert():
+    assert is_readonly_hogql("INSERT INTO events VALUES (1)") is False
+
+
+def test_rejects_update():
+    assert is_readonly_hogql("UPDATE events SET event = 'x'") is False
+
+
+def test_rejects_delete():
+    assert is_readonly_hogql("DELETE FROM events") is False
+
+
+def test_rejects_drop():
+    assert is_readonly_hogql("DROP TABLE events") is False
+
+
+def test_rejects_alter():
+    assert is_readonly_hogql("ALTER TABLE events ADD COLUMN x") is False
+
+
+def test_rejects_truncate():
+    assert is_readonly_hogql("TRUNCATE events") is False
+
+
+def test_rejects_create():
+    assert is_readonly_hogql("CREATE TABLE x (id int)") is False
+
+
+def test_rejects_keyword_case_insensitively():
+    assert is_readonly_hogql("insert into events values (1)") is False
+    assert is_readonly_hogql("Insert Into events") is False
+
+
+def test_allows_select_mentioning_word_containing_keyword_substring():
+    # "updated_at" contains "update" as a substring but not as a standalone
+    # word; word-boundary matching must not false-positive on this.
+    assert is_readonly_hogql("SELECT updated_at FROM events LIMIT 1") is True
+
+
+# --- describe_credential_shape: never leaks the value -----------------------
+
+
+def test_describe_credential_shape_absent():
+    assert describe_credential_shape(None) == {"present": False}
+    assert describe_credential_shape("") == {"present": False}
+
+
+def test_describe_credential_shape_present_does_not_include_value():
+    shape = describe_credential_shape("phx_fake_credential_value_for_testing_only")
+    assert shape["present"] is True
+    assert "phx_fake_credential_value_for_testing_only" not in json_dump_safe(shape)
+    assert "value" not in shape
+
+
+def test_describe_credential_shape_length_buckets():
+    assert describe_credential_shape("short")["length_bucket"] == "short"
+    assert describe_credential_shape("x" * 40)["length_bucket"] == "typical"
+    assert describe_credential_shape("x" * 80)["length_bucket"] == "long"
+
+
+def json_dump_safe(d):
+    import json
+
+    return json.dumps(d)
+
+
+# --- redact_error_text -------------------------------------------------------
+
+
+def test_redact_error_text_removes_bearer_token():
+    text = "request failed: Authorization: Bearer phx_fake_secret_value"
+    redacted = redact_error_text(text)
+    assert "phx_fake_secret_value" not in redacted
+
+
+def test_redact_error_text_removes_urls():
+    text = "connection refused to https://us.posthog.com/api/projects/12345/query/"
+    redacted = redact_error_text(text)
+    assert "us.posthog.com" not in redacted
+    assert "12345" not in redacted
+
+
+def test_redact_error_text_empty_input():
+    assert redact_error_text("") == ""
+    assert redact_error_text(None) is None

--- a/scripts/analytics_safety/tests/test_posthog_baseline_report.py
+++ b/scripts/analytics_safety/tests/test_posthog_baseline_report.py
@@ -1,0 +1,167 @@
+"""Tests for scripts/analytics_safety/posthog_baseline_report.py.
+
+No real PostHog credential, no real network call. Run with:
+    python3 -m pytest scripts/analytics_safety/tests/test_posthog_baseline_report.py -v
+"""
+
+import io
+import json
+import os
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+import requests_mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import posthog_baseline_report as module  # noqa: E402
+from posthog_readonly_query import DEFAULT_HOST  # noqa: E402
+
+FAKE_KEY = "phx_fake_credential_for_tests_only"
+FAKE_PROJECT_ID = "999999"
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fixtures",
+    "sample_baseline",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+    monkeypatch.delenv("POSTHOG_PROJECT_ID", raising=False)
+    monkeypatch.delenv("POSTHOG_HOST", raising=False)
+
+
+# --- fixture mode: no network, no credential required ------------------------
+
+
+def test_fixture_mode_builds_report_without_credential():
+    report = module.build_report(since="2026-08-12T00:00:00Z", until="2026-08-12T12:00:00Z", fixture_dir=FIXTURE_DIR)
+    assert report["period"] == {"since": "2026-08-12T00:00:00Z", "until": "2026-08-12T12:00:00Z"}
+    assert set(module.QUERY_CONTRACT) <= set(report["queries"])
+    assert report["queries"]["recommendation_quality_count"] == {"results": [[0]], "columns": ["count"]}
+
+
+def test_fixture_mode_cli_makes_no_network_call(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["posthog_baseline_report.py", "--fixture", FIXTURE_DIR, "--since", "2026-08-12T00:00:00Z", "--until", "2026-08-12T12:00:00Z"],
+    )
+    with requests_mock.Mocker() as m:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            exit_code = module._main()
+        assert m.call_count == 0
+    assert exit_code == 0
+    printed = json.loads(stdout.getvalue())
+    assert printed["period"]["since"] == "2026-08-12T00:00:00Z"
+
+
+def test_fixture_mode_missing_query_file_is_null_not_fabricated(tmp_path):
+    empty_dir = str(tmp_path)
+    report = module.build_report(since="2026-08-12T00:00:00Z", until="2026-08-12T12:00:00Z", fixture_dir=empty_dir)
+    for name in module.QUERY_CONTRACT:
+        assert report["queries"][name] is None
+
+
+# --- credential gate: real mode without env vars never fabricates data -------
+
+
+def test_real_mode_without_credential_exits_with_required_marker():
+    with requests_mock.Mocker() as m:
+        stderr = io.StringIO()
+        orig_argv = sys.argv
+        sys.argv = ["posthog_baseline_report.py"]
+        try:
+            with redirect_stderr(stderr):
+                exit_code = module._main()
+        finally:
+            sys.argv = orig_argv
+        assert m.call_count == 0
+    assert exit_code == 1
+    assert stderr.getvalue().strip() == "POSTHOG_READ_CREDENTIAL_REQUIRED"
+
+
+# --- real mode: mocked HTTP, every query in the contract gets called ---------
+
+
+def test_real_mode_calls_every_contract_query_once(monkeypatch):
+    monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", FAKE_KEY)
+    monkeypatch.setenv("POSTHOG_PROJECT_ID", FAKE_PROJECT_ID)
+    expected_url = f"{DEFAULT_HOST}/api/projects/{FAKE_PROJECT_ID}/query/"
+
+    with requests_mock.Mocker() as m:
+        m.post(expected_url, json={"results": [[1]]}, status_code=200)
+        report = module.build_report(since="2026-08-12T00:00:00Z", until="2026-08-12T12:00:00Z", fixture_dir=None)
+
+    assert m.call_count == len(module.QUERY_CONTRACT)
+    for name in module.QUERY_CONTRACT:
+        assert report["queries"][name] == {"results": [[1]]}
+
+
+def test_real_mode_default_since_is_rollout_timestamp(monkeypatch):
+    monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", FAKE_KEY)
+    monkeypatch.setenv("POSTHOG_PROJECT_ID", FAKE_PROJECT_ID)
+    expected_url = f"{DEFAULT_HOST}/api/projects/{FAKE_PROJECT_ID}/query/"
+
+    monkeypatch.setattr(sys, "argv", ["posthog_baseline_report.py"])
+    with requests_mock.Mocker() as m:
+        m.post(expected_url, json={"results": []}, status_code=200)
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            exit_code = module._main()
+
+    assert exit_code == 0
+    printed = json.loads(stdout.getvalue())
+    assert printed["period"]["since"] == module.DEFAULT_ROLLOUT_SINCE
+
+
+def test_real_mode_query_upstream_error_propagates_generic_message(monkeypatch):
+    monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", FAKE_KEY)
+    monkeypatch.setenv("POSTHOG_PROJECT_ID", FAKE_PROJECT_ID)
+    expected_url = f"{DEFAULT_HOST}/api/projects/{FAKE_PROJECT_ID}/query/"
+
+    with requests_mock.Mocker() as m:
+        m.post(expected_url, status_code=401)
+        with pytest.raises(module.PostHogReadOnlyQueryError):
+            module.build_report(since="2026-08-12T00:00:00Z", until="2026-08-12T12:00:00Z", fixture_dir=None)
+
+
+# --- output minimization: report never contains a raw per-row dump -----------
+
+
+def test_report_note_documents_unverified_segmented_queries_are_excluded():
+    report = module.build_report(since="2026-08-12T00:00:00Z", until="2026-08-12T12:00:00Z", fixture_dir=FIXTURE_DIR)
+    assert "note" in report
+    assert "ctr_by_classification" not in report["queries"]
+
+
+def test_query_contract_never_selects_free_text_properties():
+    """PII guard: every query template must reference only enum/boolean/
+    count fields, never free-text properties like consultation raw text,
+    email, or name."""
+    forbidden_substrings = (
+        "consultation",
+        "raw_text",
+        "email",
+        "moodBefore",
+        "moodAfter",
+        "answer",
+        "person.email",
+        "person.name",
+    )
+    for name, template in {**module.QUERY_CONTRACT, **module.UNVERIFIED_SEGMENTED_QUERY_CONTRACT}.items():
+        lowered = template.lower()
+        for forbidden in forbidden_substrings:
+            assert forbidden.lower() not in lowered, f"{name} references forbidden field {forbidden}"
+
+
+def test_all_query_contract_templates_are_readonly_hogql():
+    from guard import is_readonly_hogql
+
+    for name, template in {**module.QUERY_CONTRACT, **module.UNVERIFIED_SEGMENTED_QUERY_CONTRACT}.items():
+        rendered = module._render_query(template, since="'2026-01-01T00:00:00Z'", until="'2026-01-02T00:00:00Z'")
+        assert is_readonly_hogql(rendered), f"{name} failed the read-only HogQL check"

--- a/scripts/analytics_safety/tests/test_posthog_readonly_query.py
+++ b/scripts/analytics_safety/tests/test_posthog_readonly_query.py
@@ -1,0 +1,271 @@
+"""Tests for scripts/analytics_safety/posthog_readonly_query.py.
+
+No real PostHog credential, no real network call — every HTTP
+interaction is mocked with `requests_mock`. Run with:
+    python3 -m pytest scripts/analytics_safety/tests/test_posthog_readonly_query.py -v
+"""
+
+import io
+import json
+import os
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+
+import pytest
+import requests
+import requests_mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from posthog_readonly_query import (  # noqa: E402
+    DEFAULT_HOST,
+    ERROR_AUTH,
+    ERROR_CREDENTIAL_MISSING,
+    ERROR_ENDPOINT_REJECTED,
+    ERROR_MALFORMED_RESPONSE,
+    ERROR_NETWORK,
+    ERROR_QUERY_REJECTED,
+    ERROR_TIMEOUT,
+    ERROR_UPSTREAM,
+    PostHogReadOnlyQueryError,
+    run_readonly_hogql_query,
+)
+
+FAKE_KEY = "phx_fake_credential_for_tests_only"
+FAKE_PROJECT_ID = "999999"
+FAKE_QUERY = "SELECT count() FROM events WHERE event = 'recommendation_quality'"
+
+
+@pytest.fixture(autouse=True)
+def _set_fake_env(monkeypatch):
+    # A fake, obviously-not-real credential — never a real PostHog value.
+    monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", FAKE_KEY)
+    monkeypatch.setenv("POSTHOG_PROJECT_ID", FAKE_PROJECT_ID)
+    monkeypatch.delenv("POSTHOG_HOST", raising=False)
+
+
+def _expected_url() -> str:
+    return f"{DEFAULT_HOST}/api/projects/{FAKE_PROJECT_ID}/query/"
+
+
+# --- success -----------------------------------------------------------------
+
+
+def test_success_returns_json_result():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), json={"results": [[42]]}, status_code=200)
+        result = run_readonly_hogql_query(FAKE_QUERY)
+    assert result == {"results": [[42]]}
+
+
+def test_success_sends_bearer_auth_header():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), json={"results": []}, status_code=200)
+        run_readonly_hogql_query(FAKE_QUERY)
+    sent_auth = m.last_request.headers.get("Authorization")
+    assert sent_auth == f"Bearer {FAKE_KEY}"
+
+
+def test_success_sends_hogql_query_body():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), json={"results": []}, status_code=200)
+        run_readonly_hogql_query(FAKE_QUERY)
+    sent_body = m.last_request.json()
+    assert sent_body == {"query": {"kind": "HogQLQuery", "query": FAKE_QUERY}}
+
+
+# --- auth failures -------------------------------------------------------------
+
+
+def test_401_raises_generic_auth_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), status_code=401, json={"detail": "invalid token"})
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_AUTH
+    assert "invalid token" not in str(exc_info.value)
+
+
+def test_403_raises_generic_auth_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), status_code=403, json={"detail": "insufficient scope"})
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_AUTH
+    assert "insufficient scope" not in str(exc_info.value)
+
+
+# --- transport failures ---------------------------------------------------------
+
+
+def test_timeout_raises_generic_timeout_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), exc=requests.exceptions.Timeout("connect timeout after 30s"))
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_TIMEOUT
+
+
+def test_dns_failure_raises_generic_network_error():
+    with requests_mock.Mocker() as m:
+        m.post(
+            _expected_url(),
+            exc=requests.exceptions.ConnectionError(
+                "Failed to resolve 'us.posthog.com' ([Errno 8] nodename nor servname provided)"
+            ),
+        )
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_NETWORK
+    assert "us.posthog.com" not in str(exc_info.value)
+
+
+def test_generic_connection_error_raises_generic_network_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), exc=requests.exceptions.ConnectionError("connection refused"))
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_NETWORK
+
+
+# --- malformed / upstream responses ---------------------------------------------
+
+
+def test_malformed_json_response_raises_generic_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), text="not json {{{", status_code=200)
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_MALFORMED_RESPONSE
+
+
+def test_500_raises_generic_upstream_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), status_code=500, text="internal server error, traceback...")
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_UPSTREAM
+
+
+def test_unexpected_status_code_raises_generic_upstream_error():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), status_code=302)
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert str(exc_info.value) == ERROR_UPSTREAM
+
+
+# --- credential / query / endpoint gates (no HTTP call reached) -----------------
+
+
+def test_missing_credential_raises_before_any_request(monkeypatch):
+    monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+    with requests_mock.Mocker() as m:
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+        assert m.call_count == 0
+    assert str(exc_info.value) == ERROR_CREDENTIAL_MISSING
+
+
+def test_missing_project_id_raises_before_any_request(monkeypatch):
+    monkeypatch.delenv("POSTHOG_PROJECT_ID", raising=False)
+    with requests_mock.Mocker() as m:
+        with pytest.raises(PostHogReadOnlyQueryError):
+            run_readonly_hogql_query(FAKE_QUERY)
+        assert m.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "mutation_query",
+    [
+        "INSERT INTO events VALUES (1)",
+        "UPDATE events SET event = 'x'",
+        "DELETE FROM events",
+        "DROP TABLE events",
+        "",
+    ],
+)
+def test_mutation_attempt_rejected_before_any_request(mutation_query):
+    with requests_mock.Mocker() as m:
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(mutation_query)
+        assert m.call_count == 0
+    assert str(exc_info.value) == ERROR_QUERY_REJECTED
+
+
+# --- secret non-exposure across the whole flow -----------------------------------
+
+
+def test_no_secret_leaks_into_any_raised_error_message():
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), status_code=401, json={"detail": FAKE_KEY})
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+    assert FAKE_KEY not in str(exc_info.value)
+
+
+def test_no_secret_leaks_via_cli_stderr_on_failure(monkeypatch):
+    import posthog_readonly_query as module
+
+    monkeypatch.setattr(sys, "argv", ["posthog_readonly_query.py", "--query", FAKE_QUERY])
+    with requests_mock.Mocker() as m:
+        m.post(_expected_url(), status_code=401, json={"detail": "nope"})
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = module._main()
+    assert exit_code == 1
+    assert FAKE_KEY not in stderr.getvalue()
+    assert stderr.getvalue().strip() == ERROR_AUTH
+
+
+# --- endpoint allow-list enforcement (defense in depth) --------------------------
+
+
+def test_run_query_never_calls_any_endpoint_other_than_query(monkeypatch):
+    """Even if project_id contained something unexpected, only the query
+    path shape is ever assembled — guard.build_allowed_path() raises
+    before a request could be built with anything else."""
+    monkeypatch.setenv("POSTHOG_PROJECT_ID", "123/evil")
+    with requests_mock.Mocker() as m:
+        with pytest.raises(PostHogReadOnlyQueryError) as exc_info:
+            run_readonly_hogql_query(FAKE_QUERY)
+        assert m.call_count == 0
+    assert str(exc_info.value) == ERROR_ENDPOINT_REJECTED
+
+
+# --- fixture mode: no network call at all ----------------------------------------
+
+
+def test_fixture_mode_prints_fixture_without_network_call(tmp_path, monkeypatch):
+    import posthog_readonly_query as module
+
+    fixture = tmp_path / "sample.json"
+    fixture.write_text(json.dumps({"results": [["FULLY_KNOWLEDGE_BACKED", 5]]}))
+
+    monkeypatch.setattr(sys, "argv", ["posthog_readonly_query.py", "--fixture", str(fixture)])
+    with requests_mock.Mocker() as m:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            exit_code = module._main()
+        assert m.call_count == 0
+    assert exit_code == 0
+    printed = json.loads(stdout.getvalue())
+    assert printed == {"results": [["FULLY_KNOWLEDGE_BACKED", 5]]}
+
+
+def test_fixture_mode_missing_file_fails_generically(tmp_path):
+    import posthog_readonly_query as module
+
+    missing_path = str(tmp_path / "does_not_exist.json")
+    import sys as _sys
+
+    orig_argv = _sys.argv
+    _sys.argv = ["posthog_readonly_query.py", "--fixture", missing_path]
+    try:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = module._main()
+    finally:
+        _sys.argv = orig_argv
+    assert exit_code == 1
+    assert missing_path not in stderr.getvalue()


### PR DESCRIPTION
## Summary

[Baseline Readiness監査](https://github.com/etsu33/jinja_app/pull/2386)（`KNOWLEDGE_ANALYTICS_READ_ACCESS_REQUIRED`）で提示した「Analytics read-only access整備」を実装する。**real PostHog Personal API Keyの作成・登録・接続確認はHuman Boundaryに従い本セッションでは行わない**（token値をチャットへ貼らせない、自動でcredentialを作成しない）。

## 実装内容

`scripts/analytics_safety/`（既存`scripts/migration_safety/`の安全設計を再構成）:

- **Credential bridge**: `check_posthog_credential_presence.sh` — repo外のcredential fileから`POSTHOG_PERSONAL_API_KEY`/`POSTHOG_PROJECT_ID`/`POSTHOG_HOST`のpresence/shapeのみ出力（値は一切表示しない）
- **Endpoint allowlist**: `POST /api/projects/{project_id}/query/`（PostHogのHogQL query endpoint、HTTPメソッドはPOSTだが公式に read-only）**のみ**を呼び出せる設計。他のPostHog endpoint（event capture・feature flag・project settings・person削除等）はコード上そもそも呼び出せない
- **Safe failure handling**: 401/403/timeout/DNS失敗/5xx/malformed responseいずれも固定の汎用メッセージのみを出力、token/host/project_id/生response bodyは一切表示しない
- **Baseline query contract**: 8種類のクエリ（recommendation_quality件数・classification分布・property completeness・impression/detail transition/save/route_open件数等）、event名・enum・boolean・countのみを対象としPII（相談本文・email等）は一切含まない
- **Fixtureモード**: `--fixture <dir>`でネットワーク呼び出しゼロのdry run/テストが可能

`docs/audit/posthog-readonly-analytics-access.md`: 設計記録。PostHog公式のPersonal API Key仕様（`query:read` scope）をfreshに調査した内容を含む。

## 絶対に行っていないこと

- real PostHog Personal API Keyの作成・登録
- 実PostHogへの接続（credentialが存在しないため、`POSTHOG_READ_CREDENTIAL_REQUIRED`で明示的に停止することを確認済み）
- PostHog mutation・event削除・event backfill・Dashboard変更
- Recommendation/Ranking変更
- Production DB write

## Test plan

- [x] 新規62テスト全pass（`requests_mock`によるfake credential、実PostHog接続なし） — `test_guard.py`(29)/`test_posthog_readonly_query.py`(23)/`test_posthog_baseline_report.py`(10)
- [x] `gitleaks detect --source scripts/analytics_safety --no-git` — no leaks found
- [x] 資格情報・APIトークン・PIIスキャン（該当なし、fixtureは全てゼロ値のプレースホルダー）
- [x] mutation HTTP verb（DELETE/PUT/PATCH）がコード内に存在しないことを確認
- [x] Backend全体1147テスト（既存、無変更ファイルにつき回帰なし）、Frontend全体759テスト（117 files）全pass
- [x] CLIの credential-required gate動作確認（credentialなしで`POSTHOG_READ_CREDENTIAL_REQUIRED`、exit 1）
- [x] CLIのfixtureモード動作確認（ネットワーク呼び出しゼロでレポート生成成功）
- [x] `git diff --check`、マイグレーションなし
- [ ] CI green確認（PR作成後）
- [x] mergeはしない（draft PRのまま維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)