### PR TITLE
Concierge Input Contract Foundation

### DIFF
--- a/apps/web/src/features/concierge/types/chatRequest.ts
+++ b/apps/web/src/features/concierge/types/chatRequest.ts
@@ -1,13 +1,25 @@
 // apps/web/src/features/concierge/types/chatRequest.ts
+//
+// Level tagging below follows docs/product/concierge-input-architecture.md
+// (Architecture Decision) and docs/audit/concierge-input-level-signal-inventory.md
+// (PR #2397 audit). This is documentation only -- no field has been added,
+// removed, renamed, or had its optionality changed as part of this
+// annotation pass (Concierge Input Contract Foundation, see
+// backend/temples/services/concierge_input_contract.py for the backend
+// side of this same boundary).
 export type ConciergeChatFilters = {
-  // ===== 互換（既存backendが読む想定） =====
-  birthdate?: string; // "YYYY-MM-DD"
-  goriyaku_tag_ids?: number[]; // [1,2,3]
-  extra_condition?: string; // "駅近 ひとり"
+  // ===== Compatibility（top-level と重複送信される既存backend互換field） =====
+  birthdate?: string; // "YYYY-MM-DD" -- Level 3-A Personal Profile
+  goriyaku_tag_ids?: number[]; // [1,2,3] -- Level 3-B Explicit Constraint (NOT Profile data)
+  extra_condition?: string; // "駅近 ひとり" -- Level 2 Visit Preference (Legacy/Transitional)
 
-  // ===== 新（UI/推薦ロジック用：機械可読） =====
+  // ===== Legacy Candidate（型としては存在するが、現行backendは未消費。
+  //       docs/audit/concierge-input-level-signal-inventory.md Gap E参照） =====
   area_pref?: string[]; // ["東京都"]
   goriyaku?: string[]; // ["縁結び","厄除け"]
+
+  // ===== Compatibility（backendには送らず、hooks.ts側でextra_conditionへ
+  //       畳み込まれる。単独ではbackend契約に存在しない） =====
   crowd?: ("quiet" | "normal" | "crowded")[];
   duration_max_min?: number;
   free_text?: string; // extra_condition を最終的にここに寄せる
@@ -17,18 +29,18 @@ export type ConciergeMode = "need" | "compat";
 
 export type ConciergeChatRequestV1 = {
   version: 1;
-  query: string;
+  query: string; // Level 1 Consultation（raw input; message は互換で query に統合される）
   mode?: ConciergeMode;
   thread_id?: string;
-  filters?: ConciergeChatFilters;
-  birthdate?: string;
-  goriyaku_tag_ids?: number[];
-  extra_condition?: string;
-  visit_date?: string;
-  location?: { lat: number; lng: number };
+  filters?: ConciergeChatFilters; // Compatibility（下記top-level fieldと重複送信、Gap C）
+  birthdate?: string; // Level 3-A Personal Profile（Compatibility copy）
+  goriyaku_tag_ids?: number[]; // Level 3-B Explicit Constraint（Compatibility copy）
+  extra_condition?: string; // Level 2 Visit Preference（Compatibility copy）
+  visit_date?: string; // Level 3-C Context
+  location?: { lat: number; lng: number }; // Level 3-C Context
   profile_context?: {
-    user_profile: Record<string, unknown>;
-    derived_profile: Record<string, unknown>;
-    direction_profile?: never;
+    user_profile: Record<string, unknown>; // Level 3-A Personal Profile
+    derived_profile: Record<string, unknown>; // Level 3-A Personal Profile（Derived）
+    direction_profile?: never; // backendが必ず上書きするため、clientからは送らない
   };
 };

--- a/backend/temples/api_views_concierge.py
+++ b/backend/temples/api_views_concierge.py
@@ -2,12 +2,10 @@
 from __future__ import annotations
 import requests  # test monkeypatch compatibility
 import logging
-import re
 import uuid
 import time
 from django.db import connection, reset_queries
 
-from datetime import date
 from typing import Any, Dict, List, Optional, Tuple
 
 
@@ -35,6 +33,7 @@ from temples.services import places as Places
 from temples.services.plan_service import resolve_plan_context
 from temples.services.quota_service import check_quota, consume_quota
 from temples.services.anonymous_id import attach_anonymous_cookie, build_anonymous_cookie_value
+from temples.services.concierge_input_contract import normalize_concierge_request
 
 from temples.services.concierge_candidate_utils import (
     _dedupe_candidates,
@@ -53,32 +52,10 @@ from temples.services.billing_state import is_premium_for_user  # test monkeypat
 
 
 
-BIRTHDATE_PATTERNS = (
-    re.compile(r"^(\d{4})-(\d{2})-(\d{2})$"),
-    re.compile(r"^(\d{4})/(\d{2})/(\d{2})$"),
-    re.compile(r"^(\d{4})(\d{2})(\d{2})$"),
-)
-
-def normalize_birthdate(value: Any) -> str | None:
-    s = str(value or "").strip()
-    if not s:
-        return None
-
-    for pattern in BIRTHDATE_PATTERNS:
-        m = pattern.match(s)
-        if not m:
-            continue
-
-        yyyy, mm, dd = m.groups()
-
-        try:
-            normalized = date(int(yyyy), int(mm), int(dd))
-        except ValueError:
-            return None
-
-        return normalized.isoformat()
-
-    return None
+# normalize_birthdate / _resolve_request_inputs_basic: moved to
+# temples.services.concierge_input_contract as part of the Concierge
+# Input Contract Foundation. The view below resolves phase-1 input via
+# normalize_concierge_request(), which wraps them.
 
 
 log = logging.getLogger(__name__)
@@ -309,60 +286,6 @@ def _probe_area_locationbias_for_chat(*, area: str | None) -> None:
             len(area),
         )
 
-
-
-def _resolve_request_inputs_basic(data: Dict[str, Any]):
-    filters = data.get("filters") if isinstance(data.get("filters"), dict) else {}
-    for k in ("birthdate", "goriyaku_tag_ids", "extra_condition"):
-        if data.get(k) in (None, "", []) and filters.get(k) not in (None, "", []):
-            data[k] = filters.get(k)
-
-
-    filters = data.get("filters") or {}
-    if isinstance(filters, dict):
-        if not data.get("birthdate") and filters.get("birthdate"):
-            data["birthdate"] = filters.get("birthdate")
-
-    if not data.get("goriyaku_tag_ids") and filters.get("goriyaku_tag_ids"):
-        data["goriyaku_tag_ids"] = filters.get("goriyaku_tag_ids")
-    if not data.get("extra_condition") and filters.get("extra_condition"):
-        data["extra_condition"] = filters.get("extra_condition")
-
-    message = (data.get("message") or "").strip()
-    query = (data.get("query") or "").strip()
-    query = message or query
-
-    # backend救済: query が日付文字列なら birthdate に寄せる
-    birthdate_raw = normalize_birthdate(data.get("birthdate"))
-
-    if not birthdate_raw and isinstance(filters, dict):
-        birthdate_raw = normalize_birthdate(filters.get("birthdate"))
-        if birthdate_raw:
-            data["birthdate"] = birthdate_raw
-
-    if not birthdate_raw:
-        rescued_birthdate = normalize_birthdate(query)
-        if rescued_birthdate:
-            data["birthdate"] = rescued_birthdate
-            birthdate_raw = rescued_birthdate
-            query = ""
-
-    language = (data.get("language") or "ja").strip()
-    area = data.get("area") or data.get("where") or data.get("location_text")
-
-    birthdate = data.get("birthdate")
-    goriyaku_tag_ids = data.get("goriyaku_tag_ids")
-    extra_condition = data.get("extra_condition")
-
-    return (
-        query,
-        message,
-        language,
-        area,
-        birthdate,
-        goriyaku_tag_ids,
-        extra_condition,
-    )
 
 
 def _resolve_request_location_inputs(
@@ -599,22 +522,21 @@ class ConciergeChatView(APIView):
             )
 
             # -------------------------
-            # ① 入力解決
+            # ① 入力解決（Canonical Concierge Input、
+            #    see docs/product/concierge-input-architecture.md）
             # -------------------------
             phase = "resolve_inputs"
             t0 = time.perf_counter()
 
-            (
-                query,
-                message,
-                language,
-                area,
-                birthdate_value,
-                goriyaku_tag_ids,
-                extra_condition,
-            ) = _resolve_request_inputs_basic(data)
+            canonical_input = normalize_concierge_request(data)
+            query = canonical_input.query
+            message = canonical_input.message
+            language = canonical_input.language
+            area = canonical_input.area
+            goriyaku_tag_ids = canonical_input.goriyaku_tag_ids
+            extra_condition = canonical_input.extra_condition
 
-            birthdate = (birthdate_value or "").strip() or None
+            birthdate = (canonical_input.birthdate or "").strip() or None
 
             log.info(
                 "[concierge/perf] step=resolve_inputs rid=%s elapsed=%.3f",

--- a/backend/temples/services/concierge_input_contract.py
+++ b/backend/temples/services/concierge_input_contract.py
@@ -1,0 +1,269 @@
+# backend/temples/services/concierge_input_contract.py
+"""Concierge Chat request -> canonical input contract (Foundation).
+
+Per docs/product/concierge-input-architecture.md (Architecture Decision)
+and docs/audit/concierge-input-level-signal-inventory.md (PR #2397 audit),
+this module makes the
+
+    Raw User Input -> Canonical Request -> Compatibility Normalization
+    -> Derived Signal -> Recommendation
+
+boundary explicit in code, without changing any Recommendation behavior.
+`normalize_birthdate()` and `_resolve_request_inputs_basic()` are moved
+here verbatim from `api_views_concierge.py` (no logic change) so that the
+phase-1 (request-parse-time) resolution has one canonical home.
+
+Level tagging (Architecture Decision Signal Attribute Model, §6/§8):
+
+    query            -> Level 1 Consultation (raw input; `message` is a
+                         legacy alias folded into `query` at resolution
+                         time, not a separate signal)
+    birthdate        -> Level 3-A Personal Profile
+    goriyaku_tag_ids -> Level 3-B Explicit Constraint. NOT Personal Profile
+                         data -- PR #2397 confirmed this is a DB-level hard
+                         candidate filter, not user identity data.
+    extra_condition  -> Level 2 Visit Preference (Legacy/Transitional
+                         compatibility field; the Level 2 Signal Contract
+                         redesign itself is out of scope for this
+                         Foundation PR, see Follow-up PR2 in the
+                         Architecture Decision).
+    lat/lng/radius_m/visit_date -> Level 3-C Context (see
+                         ConciergeRecommendationContext below for why this
+                         is a separate type, resolved separately).
+
+Derived Signals (`need_tags`, `consultation_axis`, `interpretation_profile`,
+`intent`) are intentionally NOT part of this contract -- they are Runtime
+Derived Signals computed downstream from `query`, never raw request input
+(Architecture Decision §4, Core Principle 5). Nothing in this module
+computes or references them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Compatibility normalization (moved from api_views_concierge.py, unchanged)
+# ---------------------------------------------------------------------------
+
+BIRTHDATE_PATTERNS = (
+    re.compile(r"^(\d{4})-(\d{2})-(\d{2})$"),
+    re.compile(r"^(\d{4})/(\d{2})/(\d{2})$"),
+    re.compile(r"^(\d{4})(\d{2})(\d{2})$"),
+)
+
+
+def normalize_birthdate(value: Any) -> str | None:
+    """Compatibility normalization: accepts YYYY-MM-DD / YYYY/MM/DD / YYYYMMDD.
+
+    Invalid input is discarded (returns None), never raises -- see
+    docs/core/concierge-spec.md §0.2 for the accepted format contract.
+    """
+    s = str(value or "").strip()
+    if not s:
+        return None
+
+    for pattern in BIRTHDATE_PATTERNS:
+        m = pattern.match(s)
+        if not m:
+            continue
+
+        yyyy, mm, dd = m.groups()
+
+        try:
+            normalized = date(int(yyyy), int(mm), int(dd))
+        except ValueError:
+            return None
+
+        return normalized.isoformat()
+
+    return None
+
+
+def _resolve_request_inputs_basic(data: Dict[str, Any]):
+    """Compatibility normalization: top-level/filters merge, message/query
+    coalesce, query -> birthdate rescue.
+
+    Mutates `data` in place -- this is existing behavior, not new. Later,
+    independent `request.data.get(...)` reads elsewhere in the view (e.g.
+    `_build_chat_candidates_pipeline`'s own `data.get("goriyaku_tag_ids")`)
+    rely on this mutation having already happened on the same `data`
+    object (see docs/audit/concierge-input-level-signal-inventory.md).
+
+    Moved verbatim from api_views_concierge.py -- no logic change.
+    """
+    filters = data.get("filters") if isinstance(data.get("filters"), dict) else {}
+    for k in ("birthdate", "goriyaku_tag_ids", "extra_condition"):
+        if data.get(k) in (None, "", []) and filters.get(k) not in (None, "", []):
+            data[k] = filters.get(k)
+
+    filters = data.get("filters") or {}
+    if isinstance(filters, dict):
+        if not data.get("birthdate") and filters.get("birthdate"):
+            data["birthdate"] = filters.get("birthdate")
+
+    if not data.get("goriyaku_tag_ids") and filters.get("goriyaku_tag_ids"):
+        data["goriyaku_tag_ids"] = filters.get("goriyaku_tag_ids")
+    if not data.get("extra_condition") and filters.get("extra_condition"):
+        data["extra_condition"] = filters.get("extra_condition")
+
+    message = (data.get("message") or "").strip()
+    query = (data.get("query") or "").strip()
+    query = message or query
+
+    # backend救済: query が日付文字列なら birthdate に寄せる
+    birthdate_raw = normalize_birthdate(data.get("birthdate"))
+
+    if not birthdate_raw and isinstance(filters, dict):
+        birthdate_raw = normalize_birthdate(filters.get("birthdate"))
+        if birthdate_raw:
+            data["birthdate"] = birthdate_raw
+
+    if not birthdate_raw:
+        rescued_birthdate = normalize_birthdate(query)
+        if rescued_birthdate:
+            data["birthdate"] = rescued_birthdate
+            birthdate_raw = rescued_birthdate
+            query = ""
+
+    language = (data.get("language") or "ja").strip()
+    area = data.get("area") or data.get("where") or data.get("location_text")
+
+    birthdate = data.get("birthdate")
+    goriyaku_tag_ids = data.get("goriyaku_tag_ids")
+    extra_condition = data.get("extra_condition")
+
+    return (
+        query,
+        message,
+        language,
+        area,
+        birthdate,
+        goriyaku_tag_ids,
+        extra_condition,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical Concierge Input Contract (Level 1 / Level 2 / Level 3-A / 3-B)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConciergeCanonicalInput:
+    """Canonical, Level-tagged view of the phase-1 (request-parse-time)
+    Concierge Chat input. Built by `normalize_concierge_request()`.
+
+    Field -> Level mapping (see module docstring and
+    docs/product/concierge-input-architecture.md):
+
+        query            -> Level 1 Consultation (raw input)
+        birthdate        -> Level 3-A Personal Profile
+        goriyaku_tag_ids -> Level 3-B Explicit Constraint (NOT Profile data)
+        extra_condition  -> Level 2 Visit Preference (Legacy/Transitional)
+        language, area   -> neutral request metadata (`area` also feeds
+                            Level 3-C Context resolution downstream, see
+                            ConciergeRecommendationContext)
+        message          -> legacy alias, folded into `query`; kept on the
+                            struct only for callers that still need to
+                            distinguish which raw field was sent (e.g.
+                            `mode_label` telemetry)
+    """
+
+    query: str
+    message: str
+    language: str
+    area: Any
+    birthdate: Optional[str]
+    goriyaku_tag_ids: Any
+    extra_condition: Any
+
+
+def normalize_concierge_request(data: Dict[str, Any]) -> ConciergeCanonicalInput:
+    """Raw Request -> Canonical Concierge Input (phase 1).
+
+    Wraps the existing, unchanged `_resolve_request_inputs_basic()`
+    compatibility normalization. This is the phase-1 resolution entry
+    point Recommendation Service callers should use going forward; the
+    underlying compatibility mechanics (top-level/filters duplication,
+    query->birthdate rescue) are unchanged in this PR -- see
+    docs/audit/concierge-input-level-signal-inventory.md Gap C and
+    Follow-up PR1 in the Architecture Decision.
+    """
+    (
+        query,
+        message,
+        language,
+        area,
+        birthdate,
+        goriyaku_tag_ids,
+        extra_condition,
+    ) = _resolve_request_inputs_basic(data)
+
+    return ConciergeCanonicalInput(
+        query=query,
+        message=message,
+        language=language,
+        area=area,
+        birthdate=birthdate,
+        goriyaku_tag_ids=goriyaku_tag_ids,
+        extra_condition=extra_condition,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Level 3-C Recommendation Context
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ConciergeRecommendationContext:
+    """Canonical, Level-tagged shape of Level 3-C Context input
+    (`lat`/`lng`/`radius_m`/`visit_date`).
+
+    Deliberately NOT resolved by `normalize_concierge_request()` and
+    deliberately not yet constructed at the view's call site in this PR:
+    `lat`/`lng` resolution (`_resolve_request_location_inputs`, still in
+    `api_views_concierge.py`) can trigger an external geocode call, and
+    the existing view intentionally resolves it only *after* the quota
+    gate passes, to avoid a wasted geocode call for a request that will
+    be rejected anyway. Moving that resolution earlier -- or duplicating
+    it here -- would be a behavior change (extra external calls for
+    blocked/invalid requests), which this Foundation PR explicitly does
+    not make. See docs/product/concierge-input-architecture.md §6 (Level
+    3-C Context) and Follow-up PR4.
+
+    `build_concierge_recommendation_context()` below is provided as a
+    pure, tested packaging helper for callers (including Follow-up PRs)
+    that already have `lat`/`lng`/`radius_m`/`visit_date` resolved and
+    want the canonical, Level-tagged shape.
+    """
+
+    lat: Optional[float]
+    lng: Optional[float]
+    radius_m: int
+    visit_date: Any
+
+
+def build_concierge_recommendation_context(
+    *,
+    lat: Optional[float],
+    lng: Optional[float],
+    radius_m: int,
+    visit_date: Any,
+) -> ConciergeRecommendationContext:
+    """Package already-resolved Level 3-C values into the canonical shape.
+
+    Pure packaging only -- does not resolve, geocode, or default anything
+    itself. Callers must resolve `lat`/`lng`/`radius_m`/`visit_date`
+    exactly as the existing view does before calling this.
+    """
+    return ConciergeRecommendationContext(
+        lat=lat,
+        lng=lng,
+        radius_m=radius_m,
+        visit_date=visit_date,
+    )

--- a/backend/temples/tests/test_concierge_input_contract.py
+++ b/backend/temples/tests/test_concierge_input_contract.py
@@ -1,0 +1,321 @@
+# backend/temples/tests/test_concierge_input_contract.py
+"""Contract tests for temples.services.concierge_input_contract.
+
+This is a pure Contract refactor -- normalize_concierge_request() wraps
+the exact same compatibility logic that previously lived inline in
+api_views_concierge.py (top-level/filters merge, message/query coalesce,
+query->birthdate rescue). These tests pin that behavior down so a future
+change cannot silently alter what reaches the Recommendation Service.
+
+See docs/product/concierge-input-architecture.md (Architecture Decision)
+and docs/audit/concierge-input-level-signal-inventory.md (PR #2397 audit)
+for the Level tagging these fields correspond to.
+"""
+
+from temples.services.concierge_input_contract import (
+    ConciergeCanonicalInput,
+    build_concierge_recommendation_context,
+    normalize_birthdate,
+    normalize_concierge_request,
+)
+
+
+# -----------------------------------------------------------------------
+# query / message (Level 1 Consultation)
+# -----------------------------------------------------------------------
+
+
+def test_query_only():
+    canonical = normalize_concierge_request({"query": "縁結びの神社を知りたい"})
+    assert canonical.query == "縁結びの神社を知りたい"
+    assert canonical.message == ""
+
+
+def test_message_only():
+    canonical = normalize_concierge_request({"message": "転職で悩んでいます"})
+    assert canonical.query == "転職で悩んでいます"
+    assert canonical.message == "転職で悩んでいます"
+
+
+def test_message_and_query_both_present_message_wins():
+    canonical = normalize_concierge_request({"message": "message版", "query": "query版"})
+    assert canonical.query == "message版"
+
+
+def test_query_and_message_both_empty():
+    canonical = normalize_concierge_request({"query": "", "message": ""})
+    assert canonical.query == ""
+    assert canonical.message == ""
+
+
+def test_query_and_message_absent():
+    canonical = normalize_concierge_request({})
+    assert canonical.query == ""
+    assert canonical.message == ""
+
+
+def test_query_is_trimmed():
+    canonical = normalize_concierge_request({"query": "  余白あり  "})
+    assert canonical.query == "余白あり"
+
+
+# -----------------------------------------------------------------------
+# birthdate (Level 3-A Personal Profile)
+# -----------------------------------------------------------------------
+
+
+def test_birthdate_top_level():
+    canonical = normalize_concierge_request({"query": "q", "birthdate": "1990-01-01"})
+    assert canonical.birthdate == "1990-01-01"
+
+
+def test_birthdate_from_filters_when_top_level_absent():
+    canonical = normalize_concierge_request(
+        {"query": "q", "filters": {"birthdate": "1990-01-01"}}
+    )
+    assert canonical.birthdate == "1990-01-01"
+
+
+def test_birthdate_top_level_wins_over_filters():
+    canonical = normalize_concierge_request(
+        {
+            "query": "q",
+            "birthdate": "1990-01-01",
+            "filters": {"birthdate": "1985-05-05"},
+        }
+    )
+    assert canonical.birthdate == "1990-01-01"
+
+
+def test_birthdate_compat_rescue_from_query():
+    # No explicit birthdate anywhere, but query itself is a birthdate string.
+    canonical = normalize_concierge_request({"query": "1990-01-01"})
+    assert canonical.birthdate == "1990-01-01"
+    # Rescue empties the query (existing behavior).
+    assert canonical.query == ""
+
+
+def test_birthdate_compat_rescue_does_not_apply_when_birthdate_already_set():
+    canonical = normalize_concierge_request(
+        {"query": "1990-01-01", "birthdate": "2000-12-31"}
+    )
+    assert canonical.birthdate == "2000-12-31"
+    # Query is untouched because rescue only triggers when birthdate is absent.
+    assert canonical.query == "1990-01-01"
+
+
+def test_birthdate_empty():
+    canonical = normalize_concierge_request({"query": "q"})
+    assert canonical.birthdate is None
+
+
+def test_birthdate_invalid_format_passes_through_unvalidated():
+    """Pinning existing behavior: normalize_birthdate() is only consulted
+    internally to decide whether a *rescue* from `query` should happen; it
+    is not applied to a birthdate that was already explicitly provided.
+    An invalid top-level `birthdate` string therefore passes through
+    verbatim on the canonical struct -- format validation for an
+    already-present birthdate happens downstream (e.g. astrology
+    calculation), not in this normalization step. This is not new
+    behavior introduced by this refactor; see
+    test_concierge_astrology.py::test_chat_astrology_ignored_when_birthdate_invalid
+    for the downstream guard.
+    """
+    canonical = normalize_concierge_request({"query": "q", "birthdate": "not-a-date"})
+    assert canonical.birthdate == "not-a-date"
+
+
+def test_normalize_birthdate_accepts_all_documented_formats():
+    assert normalize_birthdate("1990-01-01") == "1990-01-01"
+    assert normalize_birthdate("1990/01/01") == "1990-01-01"
+    assert normalize_birthdate("19900101") == "1990-01-01"
+    assert normalize_birthdate("garbage") is None
+    assert normalize_birthdate(None) is None
+    assert normalize_birthdate("") is None
+
+
+# -----------------------------------------------------------------------
+# goriyaku_tag_ids (Level 3-B Explicit Constraint -- NOT Profile data)
+# -----------------------------------------------------------------------
+
+
+def test_goriyaku_tag_ids_top_level():
+    canonical = normalize_concierge_request({"query": "q", "goriyaku_tag_ids": [1, 2]})
+    assert canonical.goriyaku_tag_ids == [1, 2]
+
+
+def test_goriyaku_tag_ids_from_filters_when_top_level_absent():
+    canonical = normalize_concierge_request(
+        {"query": "q", "filters": {"goriyaku_tag_ids": [3]}}
+    )
+    assert canonical.goriyaku_tag_ids == [3]
+
+
+def test_goriyaku_tag_ids_top_level_wins_over_filters():
+    canonical = normalize_concierge_request(
+        {"query": "q", "goriyaku_tag_ids": [1], "filters": {"goriyaku_tag_ids": [2]}}
+    )
+    assert canonical.goriyaku_tag_ids == [1]
+
+
+def test_goriyaku_tag_ids_empty():
+    canonical = normalize_concierge_request({"query": "q"})
+    assert canonical.goriyaku_tag_ids is None
+
+
+def test_goriyaku_tag_ids_empty_list_falls_back_to_filters():
+    # An empty top-level list is treated as "absent" (matches existing
+    # `data.get(k) in (None, "", [])` compatibility check).
+    canonical = normalize_concierge_request(
+        {"query": "q", "goriyaku_tag_ids": [], "filters": {"goriyaku_tag_ids": [5]}}
+    )
+    assert canonical.goriyaku_tag_ids == [5]
+
+
+# -----------------------------------------------------------------------
+# extra_condition (Level 2 Visit Preference, Legacy/Transitional)
+# -----------------------------------------------------------------------
+
+
+def test_extra_condition_top_level():
+    canonical = normalize_concierge_request({"query": "q", "extra_condition": "駅近"})
+    assert canonical.extra_condition == "駅近"
+
+
+def test_extra_condition_from_filters_when_top_level_absent():
+    canonical = normalize_concierge_request(
+        {"query": "q", "filters": {"extra_condition": "静か"}}
+    )
+    assert canonical.extra_condition == "静か"
+
+
+def test_extra_condition_top_level_wins_over_filters():
+    canonical = normalize_concierge_request(
+        {"query": "q", "extra_condition": "駅近", "filters": {"extra_condition": "静か"}}
+    )
+    assert canonical.extra_condition == "駅近"
+
+
+def test_extra_condition_empty():
+    canonical = normalize_concierge_request({"query": "q"})
+    assert canonical.extra_condition is None
+
+
+def test_free_text_and_crowd_are_not_backend_contract_fields():
+    """free_text -> extra_condition and crowd -> extra_condition merging is
+    performed entirely client-side (apps/web/src/features/concierge/hooks.ts).
+    The backend contract never reads `filters.free_text` / `filters.crowd`
+    -- by the time a request reaches normalize_concierge_request(), any
+    such compatibility text has already been folded into extra_condition
+    by the frontend. This test pins that boundary: sending free_text/crowd
+    without extra_condition must NOT populate extra_condition server-side.
+    """
+    canonical = normalize_concierge_request(
+        {
+            "query": "q",
+            "filters": {"free_text": "静かな場所", "crowd": ["quiet"]},
+        }
+    )
+    assert canonical.extra_condition is None
+
+
+# -----------------------------------------------------------------------
+# language / area (neutral request metadata)
+# -----------------------------------------------------------------------
+
+
+def test_language_defaults_to_ja():
+    canonical = normalize_concierge_request({"query": "q"})
+    assert canonical.language == "ja"
+
+
+def test_language_explicit():
+    canonical = normalize_concierge_request({"query": "q", "language": "en"})
+    assert canonical.language == "en"
+
+
+def test_area_from_area_field():
+    canonical = normalize_concierge_request({"query": "q", "area": "東京都"})
+    assert canonical.area == "東京都"
+
+
+def test_area_from_where_field_when_area_absent():
+    canonical = normalize_concierge_request({"query": "q", "where": "大阪府"})
+    assert canonical.area == "大阪府"
+
+
+def test_area_from_location_text_field_when_others_absent():
+    canonical = normalize_concierge_request({"query": "q", "location_text": "京都府"})
+    assert canonical.area == "京都府"
+
+
+def test_area_priority_area_over_where_over_location_text():
+    canonical = normalize_concierge_request(
+        {"query": "q", "area": "東京都", "where": "大阪府", "location_text": "京都府"}
+    )
+    assert canonical.area == "東京都"
+
+
+# -----------------------------------------------------------------------
+# Canonical struct shape
+# -----------------------------------------------------------------------
+
+
+def test_normalize_concierge_request_returns_frozen_dataclass():
+    canonical = normalize_concierge_request({"query": "q"})
+    assert isinstance(canonical, ConciergeCanonicalInput)
+
+
+def test_canonical_input_does_not_include_derived_signals():
+    """Raw Input / Derived Signal separation (Architecture Decision §4,
+    Core Principle 5): need_tags, consultation_axis, interpretation_profile,
+    and intent must never appear on the canonical struct -- they are
+    Runtime Derived Signals computed downstream from `query`.
+    """
+    canonical = normalize_concierge_request({"query": "q"})
+    field_names = set(canonical.__dataclass_fields__.keys())
+    assert "need_tags" not in field_names
+    assert "consultation_axis" not in field_names
+    assert "interpretation_profile" not in field_names
+    assert "intent" not in field_names
+
+
+# -----------------------------------------------------------------------
+# Compatibility mutation side effect (existing behavior, pinned)
+# -----------------------------------------------------------------------
+
+
+def test_normalize_concierge_request_mutates_data_in_place_for_downstream_reads():
+    """_build_chat_candidates_pipeline (api_views_concierge.py) re-reads
+    request.data.get("goriyaku_tag_ids") independently after phase-1
+    resolution. This only works because _resolve_request_inputs_basic
+    mutates `data` in place. This test pins that side effect explicitly
+    so a future refactor does not silently break it.
+    """
+    data = {"query": "q", "filters": {"goriyaku_tag_ids": [7, 8]}}
+    normalize_concierge_request(data)
+    assert data["goriyaku_tag_ids"] == [7, 8]
+
+
+# -----------------------------------------------------------------------
+# Level 3-C Recommendation Context (packaging only)
+# -----------------------------------------------------------------------
+
+
+def test_build_concierge_recommendation_context_packages_values_verbatim():
+    context = build_concierge_recommendation_context(
+        lat=35.6, lng=139.7, radius_m=8000, visit_date="2026-09-01"
+    )
+    assert context.lat == 35.6
+    assert context.lng == 139.7
+    assert context.radius_m == 8000
+    assert context.visit_date == "2026-09-01"
+
+
+def test_build_concierge_recommendation_context_allows_none_lat_lng():
+    context = build_concierge_recommendation_context(
+        lat=None, lng=None, radius_m=8000, visit_date=None
+    )
+    assert context.lat is None
+    assert context.lng is None
+    assert context.visit_date is None

--- a/docs/product/concierge-input-architecture.md
+++ b/docs/product/concierge-input-architecture.md
@@ -625,3 +625,102 @@ Dead field削除 = 0
 preset chip削除 = 0
 Signal parser変更 = 0
 Score v3切替 = 0
+
+---
+
+## Addendum: Implemented Contract Foundation
+
+> 本Addendumは「Concierge Input Contract Foundation」PRの実装状況を
+> 記録する。Architecture Decision本文（§1〜§15）は書き換えていない。
+
+Backend側に、Raw Request → Canonical Concierge Input →
+Compatibility Normalization → Derived Signal → Recommendation の
+境界を実装した（`backend/temples/services/concierge_input_contract.py`）。
+Recommendation挙動・Candidate filtering・Ranking weight・API contractは
+一切変更していない（既存の compatibility 処理をそのまま関数単位で
+移設し、呼び出し順序も変更していない）。
+
+### Current Request Contract Inventory（実装確認済み）
+
+| Field | Frontend source | Request位置 | Backend read | Canonical化 | Status |
+|---|---|---|---|---|---|
+| `query`/`message` | `ConciergeClientFull.tsx`（textarea等） | top-level | `normalize_concierge_request()` | ✅ `ConciergeCanonicalInput.query` | Active |
+| `birthdate` | `ConciergeFilterPanel.tsx` | top-level + `filters` | 同上 | ✅ `ConciergeCanonicalInput.birthdate` | Active（Compatibility重複は維持） |
+| `goriyaku_tag_ids` | `ConciergeFilterPanel.tsx` | top-level + `filters` | 同上 | ✅ `ConciergeCanonicalInput.goriyaku_tag_ids` | Active（Compatibility重複は維持） |
+| `extra_condition` | `ConciergeFilterPanel.tsx`（preset/自由記述） | top-level + `filters` | 同上 | ✅ `ConciergeCanonicalInput.extra_condition`（Legacy/Transitional） | Active |
+| `free_text` | hooks.ts（クライアント側でextra_conditionへ畳み込み） | `filters`のみ | 未読（backend契約に存在しない） | 対象外 | Compatibility（frontend限定） |
+| `crowd` | hooks.ts（同上） | `filters`のみ | 未読 | 対象外 | Compatibility（frontend限定） |
+| `duration_max_min` | `ConciergeClientFull.tsx` | `filters`のみ | 未読（既存コードに読み出し経路なし、PR #2397で既知） | 対象外 | Legacy Candidate |
+| `location`/`lat`/`lng` | `OriginSelector` | top-level | `_resolve_request_location_inputs`（未移設、理由は下記） | ✅（未使用wrapper）`build_concierge_recommendation_context()` | Active |
+| `radius`/`radius_m` | 未送信（frontendに存在せず） | — | `_parse_radius`（未移設） | ✅（未使用wrapper） | Active（backend既定値のみ） |
+| `area`/`where`/`location_text` | 未送信（frontendに存在せず、backend内部fallback用） | top-level | `normalize_concierge_request()` | ✅ `ConciergeCanonicalInput.area` | Active |
+| `visit_date`/`planned_visit_date` | `ConciergeEntryCard.tsx` | top-level | view内で直接読み出し（未移設） | ✅（未使用wrapper） | Active |
+| `mode` | 送信ボタン種別で決定 | top-level | view内で直接読み出し（未移設、`_resolve_public_mode`はbirthdate依存のため対象外） | 未実施 | Active（Follow-up PR4対象） |
+| `flow` | 未送信（backend推定のみ） | — | view内で直接読み出し（未移設） | 未実施 | Deprecated Candidate（PR #2397で既知） |
+| `thread_id` | `ConciergeClientFull.tsx` | top-level | view内で直接読み出し（未移設） | 未実施 | Active（Follow-up PR4対象） |
+| `profile_context` | `derivedProfile.ts` | top-level | view内で直接読み出し（未移設、`direction_profile`計算と密結合） | 未実施 | Active（Follow-up PR4対象） |
+
+`need_tags`/`consultation_axis`/`interpretation_profile`/`intent`は、
+実装確認の結果、`ConciergeCanonicalInput`のいずれのfieldにも含まれて
+いないことをテストで固定化した
+（`test_canonical_input_does_not_include_derived_signals`）。
+
+### 実装したもの
+
+- `backend/temples/services/concierge_input_contract.py`（新規）:
+  `normalize_birthdate()`・`_resolve_request_inputs_basic()`を
+  `api_views_concierge.py`から**移設**（ロジック変更なし）。
+  `ConciergeCanonicalInput`（Level 1 / 3-A / 3-B / 2 の canonical dataclass）
+  と`normalize_concierge_request()`を新設。
+- `ConciergeRecommendationContext`（Level 3-C）: `lat`/`lng`/`radius_m`/
+  `visit_date`のcanonical shapeを定義したが、**view側では未配線**。
+  理由: `_resolve_request_location_inputs`は外部geocode呼び出しを
+  伴い、既存実装はquota判定通過後にのみ解決することでblocked/invalid
+  requestへの無駄なgeocode呼び出しを避けている。これをphase-1解決へ
+  前倒しすることは挙動変更（無駄な外部通信の発生）にあたるため、
+  本Foundation PRでは意図的に行わなかった（Follow-up PR4）。
+- `api_views_concierge.py`: phase-1入力解決を`normalize_concierge_request()`
+  呼び出しへ置き換え（内部的には移設前と同一関数を呼ぶだけのため、
+  挙動は完全に同一）。
+- `apps/web/src/features/concierge/types/chatRequest.ts`: 型定義に
+  Level/Canonical/Compatibility/Legacy Candidateの注釈を追加
+  （コメントのみ、型shape・optionality変更なし）。
+- Contract tests: `backend/temples/tests/test_concierge_input_contract.py`
+  （35件、query/message/birthdate/goriyaku_tag_ids/extra_condition/
+  free_text・crowd非対応/area/language/Raw-Derived分離/mutation側効果/
+  Level 3-C packaging を網羅）。
+
+### 実装しなかったもの（意図的、Follow-up対象）
+
+- Level 3-C Context（`lat`/`lng`/`radius_m`/`visit_date`）のview実配線
+  （上記理由により見送り、Follow-up PR4）。
+- `mode`/`flow`/`thread_id`/`profile_context`のcanonical化
+  （`public_mode`解決が`birthdate`に依存する等、密結合を安全に分離
+  するにはより広いFollow-up PRが必要と判断、Follow-up PR4）。
+- Level 2 Signal Contract自体の再設計（dead preset・soft_signal等）:
+  今回のPRの対象外（Follow-up PR3）。
+- `filters`/top-level二重送信の解消（Compatibility処理はそのまま維持、
+  Follow-up PR1）。
+
+### No Behavior Change Verification（実行結果）
+
+```
+Backend: python3 -m pytest -p no:dotenv temples/ -q
+  -> 1182 passed, 9 skipped（環境要因、既存と同数）
+  （うち371件がconcierge関連、うち新規contract test 35件）
+
+Web: pnpm --filter ./apps/web test:contract
+  -> Test Files 117 passed, Tests 759 passed
+
+Web build: pnpm --filter ./apps/web build -> success
+Web lint: pnpm --filter ./apps/web lint -> 0 errors（既存2 warning、無関係ファイル）
+Web typecheck: tsc --noEmit -> no errors
+Backend lint (ruff): 既存6件のみ（本PR起因の新規lint findingsは0、
+  移設前後で完全一致を確認済み）
+Migration: 0件
+```
+
+Recommendation behavior changes = 0
+Ranking changes = 0
+Candidate filtering changes = 0
+API contract changes = 0


### PR DESCRIPTION
## Summary

[PR #2397](https://github.com/etsu33/jinja_app/pull/2397)（現状監査）と[PR #2398](https://github.com/etsu33/jinja_app/pull/2398)（Architecture Decision）を正本として、Concierge Chat入力の

```
Raw User Input -> Canonical Request -> Compatibility Normalization -> Derived Signal -> Recommendation
```

の責務境界をコード上に実装した。**Level 1/2/3/Learningの構造自体をUIへ実装するものではない。Recommendation挙動は一切変更していない。**

## 実装内容

- **`backend/temples/services/concierge_input_contract.py`（新規）**: `normalize_birthdate()`/`_resolve_request_inputs_basic()`を`api_views_concierge.py`から**移設**（ロジック変更なし、既存のtop-level/filters merge・message/query coalesce・query→birthdate rescueをそのまま維持）。`ConciergeCanonicalInput`（Level 1 `query` / Level 3-A `birthdate` / Level 3-B `goriyaku_tag_ids` / Level 2 `extra_condition` の canonical dataclass）と`normalize_concierge_request()`を新設。
- **`ConciergeRecommendationContext`（Level 3-C）**: `lat`/`lng`/`radius_m`/`visit_date`のcanonical shapeを定義したが、**view側へは意図的に未配線**。理由: 位置解決は外部geocode呼び出しを伴い、既存実装はquota判定通過後にのみ解決することでblocked/invalid requestへの無駄なgeocode呼び出しを避けている。これを前倒しすることは挙動変更（無駄な外部通信）にあたるため見送った（Follow-up PR4）。
- **`api_views_concierge.py`**: phase-1入力解決を`normalize_concierge_request()`呼び出しへ置き換え。内部的には移設前と同一関数を呼ぶだけのため挙動は完全に同一。未使用となったimportを削除。
- **`apps/web/src/features/concierge/types/chatRequest.ts`**: 型定義にLevel/Canonical/Compatibility/Legacy Candidateのコメント注釈を追加（型shape・optionality変更なし、実挙動変更なし）。
- **Contract tests 35件**（`backend/temples/tests/test_concierge_input_contract.py`）: query/message/birthdate/goriyaku_tag_ids/extra_condition/free_text・crowd非対応/area/language/Raw-Derived分離/data mutation側効果/Level 3-C packagingを網羅。
- **`docs/product/concierge-input-architecture.md`へAddendum追記**: 本文（Architecture Decision）は書き換えず、実装状況・Current Request Contract Inventory・No Behavior Change Verification結果を記録。

## No Behavior Change Verification

```
Backend: python3 -m pytest -p no:dotenv temples/ -q
  -> 1182 passed, 9 skipped（環境要因、既存と同数）
  （うち371件がconcierge関連、うち新規contract test 35件）

Web: pnpm --filter ./apps/web test:contract -> Test Files 117 passed, Tests 759 passed
Web build: success
Web lint: 0 errors（既存2 warning、無関係ファイル）
Web typecheck (tsc --noEmit): no errors
Backend lint (ruff): 既存6件のみ（移設前後で完全一致、新規0件）
Migration: 0件
```

`goriyaku_tag_ids` hard filter・`consultation_axis` extraction・`birthdate` score・location distance behavior・`extra_condition` parser・Recommendation Reasonは、いずれも既存テスト（371件、無変更）で維持を確認した。

## Follow-up（今回は実装しない）

- PR1: Input Contract Foundation の filters/top-level 二重送信解消
- PR2: Level 1 Consultation Contract Cleanup
- PR3: Level 2 Visit Preference Signal Redesign
- PR4: Level 3-C Context の view実配線、`mode`/`flow`/`thread_id`/`profile_context`のcanonical化
- PR5〜: Frontend Information Architecture / Learning Contract / Analytics Feedback Loop

## Test plan

- [x] Backend: `python3 -m pytest -p no:dotenv temples/ -q` → 1182 passed, 9 skipped
- [x] Web: `pnpm --filter ./apps/web test:contract` → 117 files / 759 tests passed
- [x] Web build success
- [x] Web lint 0 errors
- [x] `tsc --noEmit` no errors
- [x] ruff findings: 移設前後で完全一致（新規0件）
- [x] gitleaks scan（変更5ファイルすべてno leaks found）
- [x] Migration 0件
- [ ] CI green確認待ち
- [ ] mergeしない（Mother Ship判断）

Recommendation behavior changes = 0
Ranking changes = 0
Candidate filtering changes = 0
API contract changes = 0
Migration = 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)