### PR TITLE
Level 2 Visit Preference Signal Redesign

### DIFF
--- a/apps/web/src/app/concierge/ConciergeClientFull.tsx
+++ b/apps/web/src/app/concierge/ConciergeClientFull.tsx
@@ -492,6 +492,11 @@ export default function ConciergeClientFull() {
   const [isFilterOpen, setIsFilterOpen] = useState(false);
   const [isFiltering, setIsFiltering] = useState(false);
   const [extraCondition, setExtraCondition] = useState("");
+  // Level 2 Visit Preference (Structured, canonical tags). Session-scoped
+  // like extraCondition -- not persisted as Personal Profile data. See
+  // docs/product/concierge-input-architecture.md Addendum: Level 2 Visit
+  // Preference Signal Redesign.
+  const [visitPreferences, setVisitPreferences] = useState<string[]>([]);
 
   const [goriyakuTags, setGoriyakuTags] = useState<Tag[]>([]);
   const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
@@ -1002,6 +1007,8 @@ export default function ConciergeClientFull() {
       const payloadBirthdate = input?.birthdate ?? birthdate;
       const payloadGoriyakuTagIds = input?.goriyaku_tag_ids ?? baseFilters.goriyaku_tag_ids;
       const payloadExtraCondition = input?.extra_condition ?? baseFilters.extra_condition;
+      const payloadVisitPreferences =
+        input?.visit_preferences ?? (visitPreferences.length ? visitPreferences : undefined);
       const payloadCrowd = input?.crowd ?? baseFilters.crowd;
       const payloadDurationMaxMin = input?.duration_max_min ?? baseFilters.duration_max_min;
       const payloadFreeText = input?.free_text ?? input?.extra_condition ?? baseFilters.free_text;
@@ -1030,6 +1037,7 @@ export default function ConciergeClientFull() {
         },
         goriyaku_tag_ids: payloadGoriyakuTagIds,
         extra_condition: payloadExtraCondition,
+        visit_preferences: payloadVisitPreferences,
         visit_date: plannedVisitDate || undefined,
         location: toOriginPayload(userOrigin),
         profile_context: buildProfileContext({
@@ -1040,7 +1048,7 @@ export default function ConciergeClientFull() {
         }),
       };
     },
-    [sessionState.temporaryBirthdate, needText, baseFilters, user?.profile, plannedVisitDate, userOrigin],
+    [sessionState.temporaryBirthdate, needText, baseFilters, user?.profile, plannedVisitDate, userOrigin, visitPreferences],
   );
 
   const useCurrentLocation = useCallback(() => {
@@ -1078,6 +1086,7 @@ export default function ConciergeClientFull() {
       tagsLoading,
       tagsError,
       extraCondition,
+      visitPreferences,
     }),
     [
       isFilterOpen,
@@ -1089,6 +1098,7 @@ export default function ConciergeClientFull() {
       tagsLoading,
       tagsError,
       extraCondition,
+      visitPreferences,
     ],
   );
 
@@ -1688,10 +1698,15 @@ export default function ConciergeClientFull() {
         setExtraCondition((a.extraCondition ?? "").toString());
         return;
 
+      case "filter_set_visit_preferences":
+        setVisitPreferences(Array.isArray(a.visitPreferences) ? a.visitPreferences : []);
+        return;
+
       case "filter_clear":
         snap("action:filter_clear", {});
         conciergeLog("filter_clear", { tid: activeThreadIdRef.current });
         setExtraCondition("");
+        setVisitPreferences([]);
         setSelectedTagIds([]);
         setEntryValidationError(null);
         setSessionState((prev) => ({

--- a/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
@@ -27,6 +27,13 @@ type Props = {
   extraCondition: string;
   onExtraConditionChange: (v: string) => void;
 
+  // Level 2 Visit Preference (Structured, canonical tags). Sent alongside
+  // extraCondition (Legacy/Transitional, free-text) -- see
+  // docs/product/concierge-input-architecture.md Addendum: Level 2 Visit
+  // Preference Signal Redesign.
+  visitPreferences?: readonly string[];
+  onVisitPreferencesChange?: (tags: string[]) => void;
+
   canApply?: boolean;
 };
 
@@ -69,6 +76,31 @@ const QUICK_PRESET_GROUPS: readonly {
 
 const INITIAL_VISIBLE_GORIYAKU_COUNT = 4;
 
+// UI label -> Level 2 canonical Visit Preference tag(s) (Structured Signal
+// Mapping). Sent directly, no keyword parsing -- see
+// docs/product/concierge-input-architecture.md Addendum: Level 2 Visit
+// Preference Signal Redesign and docs/product/visit-style-taxonomy.md.
+//
+// Canonical vocabulary: quiet / nature / reset / less_crowded / nearby / classic
+// (backend/temples/domain/visit_preference.py).
+//
+// "御朱印を楽しみたい" has no entry -- per visit-style-taxonomy.md it stays
+// natural-language-only (no Shrine-side capability to evaluate it, Task 13
+// Shrine Data Capability Check: Hold).
+const PRESET_VISIT_PREFERENCE_TAGS: Readonly<Record<string, readonly string[]>> = {
+  "静かな時間を過ごしたい": ["quiet"],
+  "気分を切り替えたい": ["reset"],
+  "自然を感じたい": ["nature"],
+  "歴史や文化に触れたい": ["classic"],
+  "近場がいい": ["nearby"],
+  "アクセスしやすい場所がいい": ["nearby"],
+  "有名な神社が安心": ["classic"],
+  "人混みを避けたい": ["less_crowded"],
+  "由緒を知りたい": ["classic"],
+  "神話に触れたい": ["classic"],
+  "境内をゆっくり歩きたい": ["quiet", "nature"],
+};
+
 function mergeExtra(prev: string, add: string) {
   const p = (prev || "").trim();
   const a = (add || "").trim();
@@ -76,6 +108,12 @@ function mergeExtra(prev: string, add: string) {
   if (!p) return a;
   if (p.includes(a)) return p;
   return `${p}\n${a}`;
+}
+
+function mergeVisitPreferences(prev: readonly string[], add: readonly string[]): string[] {
+  const next = new Set(prev);
+  for (const tag of add) next.add(tag);
+  return Array.from(next);
 }
 
 export default function ConciergeFilterPanel({
@@ -94,6 +132,8 @@ export default function ConciergeFilterPanel({
   tagsError,
   extraCondition,
   onExtraConditionChange,
+  visitPreferences = [],
+  onVisitPreferencesChange,
   canApply = false,
 }: Props) {
   const [showAllGoriyakuTags, setShowAllGoriyakuTags] = useState(false);
@@ -153,7 +193,13 @@ export default function ConciergeFilterPanel({
                     key={p.label}
                     type="button"
                     className="rounded-full border bg-[var(--kt-color-surface-default)] px-3 py-1 text-xs font-semibold hover:bg-slate-50"
-                    onClick={() => onExtraConditionChange(mergeExtra(extraCondition, p.value))}
+                    onClick={() => {
+                      onExtraConditionChange(mergeExtra(extraCondition, p.value));
+                      const tags = PRESET_VISIT_PREFERENCE_TAGS[p.label];
+                      if (tags?.length) {
+                        onVisitPreferencesChange?.(mergeVisitPreferences(visitPreferences, tags));
+                      }
+                    }}
                     title={p.value}
                   >
                     {p.label}

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -165,6 +165,23 @@ function parseExtraTokens(extra: string | undefined | null): string[] {
     .filter(Boolean);
 }
 
+// Closed-card preset token -> Level 2 canonical Visit Preference tag
+// (Structured Signal Mapping, see ConciergeFilterPanel.tsx for the main
+// mapping table). "ひとり"/"階段少なめ" have no Shrine-side capability
+// (Task 13 Shrine Data Capability Check: Hold) and stay natural-language-only.
+const CLOSED_PRESET_VISIT_PREFERENCE_TAGS: Readonly<Record<string, readonly string[]>> = {
+  静か: ["quiet"],
+  駅近: ["nearby"],
+};
+
+function visitPreferencesForClosedPresets(presets: readonly string[]): string[] {
+  const next = new Set<string>();
+  for (const p of presets) {
+    for (const tag of CLOSED_PRESET_VISIT_PREFERENCE_TAGS[p] ?? []) next.add(tag);
+  }
+  return Array.from(next);
+}
+
 function buildHistoryThemeDisplay(theme: string | null | undefined): { title: string; body: string } | null {
   const normalized = typeof theme === "string" ? theme.trim() : "";
   if (!normalized) return null;
@@ -588,9 +605,25 @@ export default function ConciergeSectionsRenderer({
 
               const togglePreset = (p: string) => {
                 const next = new Set(parts);
+                const turningOn = !next.has(p);
                 if (next.has(p)) next.delete(p);
                 else next.add(p);
                 onAction?.({ type: "filter_set_extra", extraCondition: Array.from(next).join(" ") });
+
+                // Structured Visit Preference is union/append-only here (like
+                // mergeExtra() in ConciergeFilterPanel.tsx) -- toggling a
+                // preset off never removes a tag, since it may also have
+                // been set via the open ConciergeFilterPanel.
+                if (turningOn) {
+                  const addedTags = visitPreferencesForClosedPresets([p]);
+                  if (addedTags.length) {
+                    const merged = new Set([...(state.visitPreferences ?? []), ...addedTags]);
+                    onAction?.({
+                      type: "filter_set_visit_preferences",
+                      visitPreferences: Array.from(merged),
+                    });
+                  }
+                }
               };
 
               const selectedPresets = presets.filter((p) => set.has(p));
@@ -688,6 +721,10 @@ export default function ConciergeSectionsRenderer({
                       extraCondition={state.extraCondition}
                       onExtraConditionChange={(v: string) =>
                         onAction?.({ type: "filter_set_extra", extraCondition: v })
+                      }
+                      visitPreferences={state.visitPreferences}
+                      onVisitPreferencesChange={(tags: string[]) =>
+                        onAction?.({ type: "filter_set_visit_preferences", visitPreferences: tags })
                       }
                     />
                   </div>

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeFilterPanel.visitPreference.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeFilterPanel.visitPreference.test.tsx
@@ -1,0 +1,163 @@
+// Level 2 Visit Preference Signal Redesign -- Structured Signal Mapping tests.
+// See docs/product/concierge-input-architecture.md Addendum: Level 2 Visit
+// Preference Signal Redesign.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ConciergeFilterPanel from "../ConciergeFilterPanel";
+
+const baseProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onApply: vi.fn(),
+  birthdate: "",
+  onBirthdateChange: vi.fn(),
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  onToggleTag: vi.fn(),
+  tagsLoading: false,
+  tagsError: null,
+};
+
+describe("ConciergeFilterPanel Visit Preference Structured Signal Mapping", () => {
+  it("clicking a Keep preset sends both the legacy extraCondition text and the canonical tag", () => {
+    const onExtraConditionChange = vi.fn();
+    const onVisitPreferencesChange = vi.fn();
+
+    render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={onExtraConditionChange}
+        visitPreferences={[]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("静かな時間を過ごしたい"));
+
+    expect(onExtraConditionChange).toHaveBeenCalledWith(
+      "静かな雰囲気で、気持ちを落ち着けて整理できる場所がいい",
+    );
+    expect(onVisitPreferencesChange).toHaveBeenCalledWith(["quiet"]);
+  });
+
+  it("clicking a Redesign preset (歴史や文化に触れたい) sends the classic canonical tag directly, no keyword parsing", () => {
+    const onVisitPreferencesChange = vi.fn();
+
+    render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={vi.fn()}
+        visitPreferences={[]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("歴史や文化に触れたい"));
+
+    expect(onVisitPreferencesChange).toHaveBeenCalledWith(["classic"]);
+  });
+
+  it("clicking アクセスしやすい場所がいい maps to nearby (per visit-style-taxonomy.md)", () => {
+    const onVisitPreferencesChange = vi.fn();
+
+    render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={vi.fn()}
+        visitPreferences={[]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("アクセスしやすい場所がいい"));
+
+    expect(onVisitPreferencesChange).toHaveBeenCalledWith(["nearby"]);
+  });
+
+  it("clicking 境内をゆっくり歩きたい sends both quiet and nature (multi-tag preset)", () => {
+    const onVisitPreferencesChange = vi.fn();
+
+    render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={vi.fn()}
+        visitPreferences={[]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("境内をゆっくり歩きたい"));
+
+    const sent = onVisitPreferencesChange.mock.calls[0][0] as string[];
+    expect(new Set(sent)).toEqual(new Set(["quiet", "nature"]));
+  });
+
+  it("clicking 御朱印を楽しみたい (Hold, no Shrine-side capability) updates extraCondition but never calls onVisitPreferencesChange", () => {
+    const onExtraConditionChange = vi.fn();
+    const onVisitPreferencesChange = vi.fn();
+
+    render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={onExtraConditionChange}
+        visitPreferences={[]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("御朱印を楽しみたい"));
+
+    expect(onExtraConditionChange).toHaveBeenCalled();
+    expect(onVisitPreferencesChange).not.toHaveBeenCalled();
+  });
+
+  it("selecting two presets that resolve to the same tag does not duplicate it", () => {
+    const onVisitPreferencesChange = vi.fn();
+
+    const { rerender } = render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={vi.fn()}
+        visitPreferences={[]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("近場がいい")); // -> nearby
+    expect(onVisitPreferencesChange).toHaveBeenLastCalledWith(["nearby"]);
+
+    rerender(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition="できるだけ近い場所を優先して"
+        onExtraConditionChange={vi.fn()}
+        visitPreferences={["nearby"]}
+        onVisitPreferencesChange={onVisitPreferencesChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("アクセスしやすい場所がいい")); // -> nearby (same tag)
+    expect(onVisitPreferencesChange).toHaveBeenLastCalledWith(["nearby"]);
+  });
+
+  it("renders without crashing when visitPreferences/onVisitPreferencesChange are omitted (backward compatible props)", () => {
+    render(
+      <ConciergeFilterPanel
+        {...baseProps}
+        extraCondition=""
+        onExtraConditionChange={vi.fn()}
+      />,
+    );
+
+    expect(() => fireEvent.click(screen.getByText("静かな時間を過ごしたい"))).not.toThrow();
+  });
+});

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.coverage.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.coverage.test.tsx
@@ -35,6 +35,7 @@ const baseFilterState: any = {
   tagsLoading: false,
   tagsError: null,
   extraCondition: "",
+  visitPreferences: [],
 };
 
 function buildTestPayload(u: any, filterState = baseFilterState) {

--- a/apps/web/src/features/concierge/sections/types.ts
+++ b/apps/web/src/features/concierge/sections/types.ts
@@ -17,7 +17,8 @@ export type ConciergeFilterState = {
   selectedTagIds: readonly number[];
   tagsLoading: boolean;
   tagsError: string | null;
-  extraCondition: string;
+  extraCondition: string; // Level 2 Visit Preference (Legacy/Transitional, free-text)
+  visitPreferences: readonly string[]; // Level 2 Visit Preference (Structured, canonical tags)
 };
 
 /* =========================
@@ -146,5 +147,6 @@ export type RendererAction =
   | { type: "filter_set_birthdate"; birthdate: string }
   | { type: "filter_toggle_tag"; tagId: number }
   | { type: "filter_set_extra"; extraCondition: string }
+  | { type: "filter_set_visit_preferences"; visitPreferences: string[] }
   | { type: "filter_clear" }
   | { type: "save_concierge_thread" };

--- a/apps/web/src/features/concierge/types/chatRequest.ts
+++ b/apps/web/src/features/concierge/types/chatRequest.ts
@@ -35,7 +35,12 @@ export type ConciergeChatRequestV1 = {
   filters?: ConciergeChatFilters; // Compatibility（下記top-level fieldと重複送信、Gap C）
   birthdate?: string; // Level 3-A Personal Profile（Compatibility copy）
   goriyaku_tag_ids?: number[]; // Level 3-B Explicit Constraint（Compatibility copy）
-  extra_condition?: string; // Level 2 Visit Preference（Compatibility copy）
+  extra_condition?: string; // Level 2 Visit Preference（Legacy/Transitional, free-text）
+  visit_preferences?: string[]; // Level 2 Visit Preference（Structured, canonical tags
+  // -- see docs/product/concierge-input-architecture.md Addendum: Level 2 Visit
+  // Preference Signal Redesign. Canonical vocabulary: quiet/nature/reset/
+  // less_crowded/nearby/classic. No top-level/filters duplication (new field,
+  // does not inherit Gap C).
   visit_date?: string; // Level 3-C Context
   location?: { lat: number; lng: number }; // Level 3-C Context
   profile_context?: {

--- a/backend/temples/api_views_concierge.py
+++ b/backend/temples/api_views_concierge.py
@@ -535,6 +535,7 @@ class ConciergeChatView(APIView):
             area = canonical_input.area
             goriyaku_tag_ids = canonical_input.goriyaku_tag_ids
             extra_condition = canonical_input.extra_condition
+            visit_preferences = canonical_input.visit_preferences
 
             birthdate = (canonical_input.birthdate or "").strip() or None
 
@@ -757,6 +758,8 @@ class ConciergeChatView(APIView):
                 applied.append("goriyaku_tag_ids")
             if (extra_condition or "").strip():
                 applied.append("extra_condition")
+            if visit_preferences:
+                applied.append("visit_preferences")
             if public_mode == "compat":
                 applied.append("mode:compat")
 
@@ -771,6 +774,7 @@ class ConciergeChatView(APIView):
                     birthdate=birthdate,
                     goriyaku_tag_ids=goriyaku_tag_ids,
                     extra_condition=extra_condition,
+                    visit_preferences=visit_preferences,
                     public_mode=public_mode,
                     flow=flow,
                     user=user if getattr(user, "is_authenticated", False) else None,

--- a/backend/temples/domain/visit_preference.py
+++ b/backend/temples/domain/visit_preference.py
@@ -1,0 +1,79 @@
+# backend/temples/domain/visit_preference.py
+"""Level 2 Visit Preference canonical tag vocabulary (Structured Signal Mapping).
+
+Per docs/product/concierge-input-architecture.md (Addendum: Level 2 Visit
+Preference Signal Redesign) and docs/product/visit-style-taxonomy.md, this
+module defines the canonical, UI-facing tag vocabulary a client may send
+directly (no keyword parsing) as `visit_preferences` on the Concierge Chat
+request.
+
+This is a *subset* of `EXTRA_TAG_META`'s `visit_style`-kind tags
+(temples/domain/extra_condition_tags.py): `business`/`study`/`urban` remain
+valid legacy visit_style tags reachable via free-text `extra_condition`, but
+are excluded here because visit-style-taxonomy.md does not treat them as
+UI-facing MVP selections. Nothing in this module removes, renames, or
+changes the scoring behavior of any existing tag.
+"""
+
+from __future__ import annotations
+
+from typing import FrozenSet, Iterable, List
+
+# Canonical Level 2 Visit Preference tags. Every tag here is also a
+# `visit_style`-kind tag in EXTRA_TAG_META, so a Structured value here and a
+# Legacy free-text-derived tag of the same name feed the exact same
+# `score_visit_style` ranking computation (concierge_chat_ranking._attach_breakdown) --
+# see resolve_visit_preference_tags() in concierge_chat_extra_condition.py for
+# the Compatibility Layer that merges the two without double-counting.
+VISIT_PREFERENCE_TAGS: FrozenSet[str] = frozenset(
+    {
+        "quiet",
+        "nature",
+        "reset",
+        "less_crowded",
+        "nearby",
+        "classic",
+    }
+)
+
+# Product decision (Level 2 Redesign, Task 7): the legacy keyword parser's
+# `max_tags=3` is an artifact of how `extract_extra_tags()` scores free-text
+# hits, not a deliberate Product limit on how many Visit Preferences a user
+# may express. Structured input selects tags directly (no parsing), so it
+# does not inherit that number. The cap below equals the full canonical
+# vocabulary size -- i.e. "no artificial limit below the full vocabulary" --
+# while still bounding request size.
+MAX_VISIT_PREFERENCES = 6
+
+
+def normalize_visit_preferences(values: Iterable[object] | None) -> List[str]:
+    """Validate + dedupe a raw Structured Visit Preference input.
+
+    Unknown tags are dropped, not raised -- consistent with the rest of the
+    Concierge Chat input contract's fail-open compatibility posture (see
+    concierge_input_contract.py). Order is preserved, duplicates removed,
+    capped at MAX_VISIT_PREFERENCES.
+    """
+    if not values:
+        return []
+
+    out: List[str] = []
+    seen: set[str] = set()
+
+    for value in values:
+        tag = str(value or "").strip()
+        if not tag or tag not in VISIT_PREFERENCE_TAGS or tag in seen:
+            continue
+        seen.add(tag)
+        out.append(tag)
+        if len(out) >= MAX_VISIT_PREFERENCES:
+            break
+
+    return out
+
+
+__all__ = [
+    "VISIT_PREFERENCE_TAGS",
+    "MAX_VISIT_PREFERENCES",
+    "normalize_visit_preferences",
+]

--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -24,6 +24,7 @@ from temples.services.score_v3_observer import (
 )
 from temples.services.concierge_chat_extra_condition import (
     resolve_extra_condition_tags,
+    resolve_visit_preference_tags,
 )
 from temples.services.concierge_chat_llm_route import (
     resolve_llm_route,
@@ -608,6 +609,7 @@ def build_chat_recommendations(
     birthdate=None,
     goriyaku_tag_ids=None,
     extra_condition=None,
+    visit_preferences: list[str] | None = None,
     public_mode="need",
     flow="A",
     need_tags: list[str] | None = None,
@@ -626,7 +628,12 @@ def build_chat_recommendations(
     Responsibility:
       - need_tags は相談テーマ由来の主推薦軸として扱う。
       - goriyaku_tag_ids はユーザー追加の補助条件として扱う。
-      - extra_condition は参拝スタイルなどの補助条件として扱う。
+      - extra_condition は参拝スタイルなどの補助条件として扱う（Legacy free-text）。
+      - visit_preferences は参拝スタイルの Structured 版として扱う
+        （Level 2 Visit Preference Signal Redesign。canonical tag のみ、
+        parser を経由しない）。extra_condition 由来の visit_style tag と
+        Compatibility Layer（resolve_visit_preference_tags）で合流し、
+        同一 tag の二重加点は発生しない。
       - birthdate / astro / direction は主軸を上書きしない補助シグナルとして扱う。
     """
     valid_candidates = [
@@ -674,15 +681,19 @@ def build_chat_recommendations(
     sort_tags = extra_tags["sort_tags"]
     hard_filter_tags = extra_tags["hard_filter_tags"]
     soft_signal_tags = extra_tags["soft_signal_tags"]
-    visit_style_tags = extra_tags["visit_style_tags"]
+    visit_style_tags = resolve_visit_preference_tags(
+        structured=visit_preferences,
+        legacy_visit_style_tags=extra_tags["visit_style_tags"],
+    )
 
     log.info(
-        "[dbg] extra_tags resolved sort=%r soft=%r visit_style=%r has_query=%s has_extra=%s",
+        "[dbg] extra_tags resolved sort=%r soft=%r visit_style=%r has_query=%s has_extra=%s has_visit_preferences=%s",
         sorted(sort_tags),
         sorted(soft_signal_tags),
         sorted(visit_style_tags),
         bool(query),
         bool(str(extra_condition or "").strip()),
+        bool(visit_preferences),
     )
 
     observe_candidate_pool(

--- a/backend/temples/services/concierge_chat_extra_condition.py
+++ b/backend/temples/services/concierge_chat_extra_condition.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Dict, Optional, Set
+from typing import Dict, Iterable, Optional, Set
 
 from temples.domain.extra_condition_tags import extract_extra_tags, split_tags_by_kind
+from temples.domain.visit_preference import VISIT_PREFERENCE_TAGS
 
 
 def resolve_extra_condition_tags(
@@ -38,6 +39,33 @@ def resolve_extra_condition_tags(
     }
 
 
+def resolve_visit_preference_tags(
+    *,
+    structured: Optional[Iterable[str]],
+    legacy_visit_style_tags: Set[str],
+) -> Set[str]:
+    """Level 2 Visit Preference Compatibility Layer (Structured + Legacy).
+
+    Merges a Structured `visit_preferences` selection (validated, canonical
+    tags -- see temples/domain/visit_preference.py) with the Legacy
+    extra_condition-derived `visit_style_tags` (free-text keyword parsing,
+    resolve_extra_condition_tags() above).
+
+    Both sides resolve into the *same* canonical tag vocabulary, so a plain
+    set union is enough to dedupe: `score_visit_style` (concierge_chat_ranking
+    ._attach_breakdown) counts distinct matched tag names, not occurrences,
+    so a tag present in both Structured and Legacy still contributes once
+    -- no double-counting regardless of which side(s) produced it.
+    """
+    structured_tags = {
+        str(tag).strip()
+        for tag in (structured or [])
+        if str(tag).strip() in VISIT_PREFERENCE_TAGS
+    }
+    return structured_tags | (legacy_visit_style_tags or set())
+
+
 __all__ = [
     "resolve_extra_condition_tags",
+    "resolve_visit_preference_tags",
 ]

--- a/backend/temples/services/concierge_input_contract.py
+++ b/backend/temples/services/concierge_input_contract.py
@@ -23,10 +23,13 @@ Level tagging (Architecture Decision Signal Attribute Model, §6/§8):
                          data -- PR #2397 confirmed this is a DB-level hard
                          candidate filter, not user identity data.
     extra_condition  -> Level 2 Visit Preference (Legacy/Transitional
-                         compatibility field; the Level 2 Signal Contract
-                         redesign itself is out of scope for this
-                         Foundation PR, see Follow-up PR2 in the
-                         Architecture Decision).
+                         compatibility field, free-text keyword parsing).
+    visit_preferences -> Level 2 Visit Preference (Structured, canonical
+                         tags -- see temples/domain/visit_preference.py and
+                         docs/product/concierge-input-architecture.md
+                         Addendum: Level 2 Visit Preference Signal Redesign).
+                         Session/Request-scoped, never persisted as Personal
+                         Profile data.
     lat/lng/radius_m/visit_date -> Level 3-C Context (see
                          ConciergeRecommendationContext below for why this
                          is a separate type, resolved separately).
@@ -43,7 +46,9 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import date
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+from temples.domain.visit_preference import normalize_visit_preferences
 
 # ---------------------------------------------------------------------------
 # Compatibility normalization (moved from api_views_concierge.py, unchanged)
@@ -164,6 +169,8 @@ class ConciergeCanonicalInput:
         birthdate        -> Level 3-A Personal Profile
         goriyaku_tag_ids -> Level 3-B Explicit Constraint (NOT Profile data)
         extra_condition  -> Level 2 Visit Preference (Legacy/Transitional)
+        visit_preferences -> Level 2 Visit Preference (Structured, canonical
+                            tags -- see temples/domain/visit_preference.py)
         language, area   -> neutral request metadata (`area` also feeds
                             Level 3-C Context resolution downstream, see
                             ConciergeRecommendationContext)
@@ -180,6 +187,7 @@ class ConciergeCanonicalInput:
     birthdate: Optional[str]
     goriyaku_tag_ids: Any
     extra_condition: Any
+    visit_preferences: List[str]
 
 
 def normalize_concierge_request(data: Dict[str, Any]) -> ConciergeCanonicalInput:
@@ -192,6 +200,14 @@ def normalize_concierge_request(data: Dict[str, Any]) -> ConciergeCanonicalInput
     query->birthdate rescue) are unchanged in this PR -- see
     docs/audit/concierge-input-level-signal-inventory.md Gap C and
     Follow-up PR1 in the Architecture Decision.
+
+    `visit_preferences` is a new field (Level 2 Visit Preference Signal
+    Redesign) with no legacy top-level/filters duplication to carry
+    forward -- it is read from top-level `visit_preferences` only, and
+    validated against the canonical tag vocabulary
+    (temples/domain/visit_preference.normalize_visit_preferences()).
+    Unlike `birthdate`/`goriyaku_tag_ids`/`extra_condition`, it does not
+    inherit Gap C (Duplicate Signals).
     """
     (
         query,
@@ -203,6 +219,8 @@ def normalize_concierge_request(data: Dict[str, Any]) -> ConciergeCanonicalInput
         extra_condition,
     ) = _resolve_request_inputs_basic(data)
 
+    visit_preferences = normalize_visit_preferences(data.get("visit_preferences"))
+
     return ConciergeCanonicalInput(
         query=query,
         message=message,
@@ -211,6 +229,7 @@ def normalize_concierge_request(data: Dict[str, Any]) -> ConciergeCanonicalInput
         birthdate=birthdate,
         goriyaku_tag_ids=goriyaku_tag_ids,
         extra_condition=extra_condition,
+        visit_preferences=visit_preferences,
     )
 
 

--- a/backend/temples/tests/test_concierge_visit_preference_contract.py
+++ b/backend/temples/tests/test_concierge_visit_preference_contract.py
@@ -1,0 +1,600 @@
+# backend/temples/tests/test_concierge_visit_preference_contract.py
+"""Level 2 Visit Preference Signal Redesign contract tests.
+
+Covers docs/product/concierge-input-architecture.md Addendum: Level 2
+Visit Preference Signal Redesign.
+
+    UI selection -> Canonical Visit Preference -> Compatibility Layer
+    -> Recommendation
+
+Sections:
+  A. Canonical tag vocabulary (temples/domain/visit_preference)
+  B. Compatibility Layer (Structured + Legacy merge, no double-counting)
+  C. Canonical Input Contract (ConciergeCanonicalInput.visit_preferences)
+  D. Ranking integration (build_chat_recommendations)
+  E. No Behavior Regression (old client path unaffected)
+
+These tests do not change Recommendation behavior for existing clients --
+`visit_preferences` is purely additive (new optional field / kwarg,
+default None / []).
+"""
+
+import pytest
+
+from temples.domain.visit_preference import (
+    MAX_VISIT_PREFERENCES,
+    VISIT_PREFERENCE_TAGS,
+    normalize_visit_preferences,
+)
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_extra_condition import (
+    resolve_visit_preference_tags,
+)
+from temples.services.concierge_input_contract import normalize_concierge_request
+
+
+# ---------------------------------------------------------------------------
+# A. Canonical tag vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_tag_set_is_the_documented_six():
+    assert VISIT_PREFERENCE_TAGS == {
+        "quiet",
+        "nature",
+        "reset",
+        "less_crowded",
+        "nearby",
+        "classic",
+    }
+
+
+@pytest.mark.parametrize("tag", sorted(VISIT_PREFERENCE_TAGS))
+def test_normalize_visit_preferences_accepts_each_canonical_tag(tag):
+    assert normalize_visit_preferences([tag]) == [tag]
+
+
+def test_normalize_visit_preferences_multiple_preferences():
+    assert normalize_visit_preferences(["quiet", "nature", "classic"]) == [
+        "quiet",
+        "nature",
+        "classic",
+    ]
+
+
+def test_normalize_visit_preferences_dedupes_duplicates_preserving_first_position():
+    assert normalize_visit_preferences(["quiet", "nature", "quiet"]) == [
+        "quiet",
+        "nature",
+    ]
+
+
+def test_normalize_visit_preferences_drops_unknown_tag():
+    assert normalize_visit_preferences(["quiet", "made_up_tag"]) == ["quiet"]
+
+
+def test_normalize_visit_preferences_drops_legacy_visit_style_tags_not_in_canonical_set():
+    # `business`/`study` are valid EXTRA_TAG_META visit_style tags but are
+    # NOT part of the Level 2 canonical structured vocabulary (Task 3/7).
+    assert normalize_visit_preferences(["business", "study", "quiet"]) == ["quiet"]
+
+
+def test_normalize_visit_preferences_empty_input():
+    assert normalize_visit_preferences(None) == []
+    assert normalize_visit_preferences([]) == []
+
+
+def test_normalize_visit_preferences_caps_at_max():
+    all_six_twice = list(VISIT_PREFERENCE_TAGS) * 2 + ["another_unknown"]
+    result = normalize_visit_preferences(all_six_twice)
+    assert len(result) <= MAX_VISIT_PREFERENCES
+    assert len(result) == len(VISIT_PREFERENCE_TAGS)
+
+
+# ---------------------------------------------------------------------------
+# B. Compatibility Layer
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_visit_preference_tags_structured_only():
+    result = resolve_visit_preference_tags(structured=["quiet"], legacy_visit_style_tags=set())
+    assert result == {"quiet"}
+
+
+def test_resolve_visit_preference_tags_legacy_only():
+    result = resolve_visit_preference_tags(structured=None, legacy_visit_style_tags={"nature"})
+    assert result == {"nature"}
+
+
+def test_resolve_visit_preference_tags_same_meaning_dedupes():
+    result = resolve_visit_preference_tags(
+        structured=["quiet"],
+        legacy_visit_style_tags={"quiet"},
+    )
+    assert result == {"quiet"}
+
+
+def test_resolve_visit_preference_tags_different_meaning_both_kept():
+    result = resolve_visit_preference_tags(
+        structured=["quiet"],
+        legacy_visit_style_tags={"less_crowded"},
+    )
+    assert result == {"quiet", "less_crowded"}
+
+
+def test_resolve_visit_preference_tags_ignores_unknown_structured_tag():
+    result = resolve_visit_preference_tags(
+        structured=["not_a_real_tag"],
+        legacy_visit_style_tags={"classic"},
+    )
+    assert result == {"classic"}
+
+
+# ---------------------------------------------------------------------------
+# C. Canonical Input Contract
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_input_visit_preferences_from_top_level():
+    canonical = normalize_concierge_request(
+        {"query": "q", "visit_preferences": ["quiet", "nature"]}
+    )
+    assert canonical.visit_preferences == ["quiet", "nature"]
+
+
+def test_canonical_input_visit_preferences_absent_defaults_to_empty_list():
+    canonical = normalize_concierge_request({"query": "q"})
+    assert canonical.visit_preferences == []
+
+
+def test_canonical_input_visit_preferences_drops_unknown_tag():
+    canonical = normalize_concierge_request(
+        {"query": "q", "visit_preferences": ["quiet", "unknown_tag"]}
+    )
+    assert canonical.visit_preferences == ["quiet"]
+
+
+def test_canonical_input_visit_preferences_dedupes():
+    canonical = normalize_concierge_request(
+        {"query": "q", "visit_preferences": ["quiet", "quiet"]}
+    )
+    assert canonical.visit_preferences == ["quiet"]
+
+
+def test_canonical_input_visit_preferences_ignores_filters_duplicate():
+    # Unlike birthdate/goriyaku_tag_ids/extra_condition, visit_preferences is
+    # a new field with no top-level/filters duplication (Gap C is not
+    # inherited here) -- filters.visit_preferences is not read.
+    canonical = normalize_concierge_request(
+        {"query": "q", "filters": {"visit_preferences": ["quiet"]}}
+    )
+    assert canonical.visit_preferences == []
+
+
+def test_canonical_input_does_not_include_derived_signals_alongside_visit_preferences():
+    canonical = normalize_concierge_request(
+        {"query": "q", "visit_preferences": ["quiet"]}
+    )
+    assert not hasattr(canonical, "need_tags")
+    assert not hasattr(canonical, "consultation_axis")
+
+
+# ---------------------------------------------------------------------------
+# D. Ranking integration
+# ---------------------------------------------------------------------------
+
+
+def _visit_style_raw(rec: dict) -> int:
+    """score_visit_style is not in the public `breakdown` dict (it never
+    contributes to the public `score_total` -- only to the internal ranking
+    score `_score_total`, see concierge_chat_ranking._attach_breakdown).
+    Tests read it from breakdown_detail.features.visit_style.raw instead."""
+    detail = ((rec.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    return int(detail.get("raw") or 0)
+
+
+def _candidates_for(tag: str):
+    return [
+        {
+            "name": "Match",
+            "distance_m": 500.0,
+            "lat": 35.001,
+            "lng": 139.001,
+            "popular_score": 5.0,
+            "visit_style_tags": [tag],
+        },
+        {
+            "name": "NoMatch",
+            "distance_m": 500.0,
+            "lat": 35.002,
+            "lng": 139.002,
+            "popular_score": 5.0,
+            "visit_style_tags": [],
+        },
+    ]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("tag", sorted(VISIT_PREFERENCE_TAGS))
+def test_structured_preference_ranks_matching_shrine_first(monkeypatch, settings, tag):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=_candidates_for(tag),
+        visit_preferences=[tag],
+    )
+
+    items = recs["recommendations"]
+    assert items[0]["name"] == "Match"
+    visit_style_detail = ((items[0].get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert tag in (visit_style_detail.get("matched_tags") or [])
+
+
+@pytest.mark.django_db
+def test_structured_multiple_preferences_all_match(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [
+        {
+            "name": "Both",
+            "distance_m": 500.0,
+            "lat": 35.001,
+            "lng": 139.001,
+            "popular_score": 5.0,
+            "visit_style_tags": ["quiet", "nature"],
+        },
+        {
+            "name": "One",
+            "distance_m": 500.0,
+            "lat": 35.002,
+            "lng": 139.002,
+            "popular_score": 5.0,
+            "visit_style_tags": ["quiet"],
+        },
+    ]
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        visit_preferences=["quiet", "nature"],
+    )
+
+    items = recs["recommendations"]
+    assert items[0]["name"] == "Both"
+    assert _visit_style_raw(items[0]) == 2
+    assert _visit_style_raw(items[1]) == 1
+
+
+@pytest.mark.django_db
+def test_structured_duplicate_preferences_no_double_count(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = _candidates_for("quiet")
+
+    recs_dup = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        visit_preferences=["quiet", "quiet"],
+    )
+    recs_single = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        visit_preferences=["quiet"],
+    )
+
+    score_dup = _visit_style_raw(recs_dup["recommendations"][0])
+    score_single = _visit_style_raw(recs_single["recommendations"][0])
+    assert score_dup == score_single == 1
+
+
+@pytest.mark.django_db
+def test_structured_unknown_preference_ignored_no_crash(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=_candidates_for("quiet"),
+        visit_preferences=["not_a_real_tag"],
+    )
+
+    items = recs["recommendations"]
+    assert all(_visit_style_raw(r) == 0 for r in items)
+
+
+@pytest.mark.django_db
+def test_compatibility_legacy_extra_condition_only_still_effective(monkeypatch, settings):
+    """Regression guard: the pre-existing free-text -> keyword -> visit_style
+    path (real, unmocked extract_extra_tags) must keep working exactly as
+    before once visit_preferences exists."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=_candidates_for("quiet"),
+        extra_condition="静かな雰囲気で、気持ちを落ち着けて過ごしたい",
+    )
+
+    items = recs["recommendations"]
+    assert items[0]["name"] == "Match"
+    assert _visit_style_raw(items[0]) == 1
+
+
+@pytest.mark.django_db
+def test_compatibility_crowd_derived_text_still_produces_less_crowded(monkeypatch, settings):
+    """crowd -> extra_condition round-trip (apps/web hooks.ts) injects
+    '空いている ひとり向け' -- confirms this still resolves to
+    less_crowded via the real (unmocked) keyword parser."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=_candidates_for("less_crowded"),
+        extra_condition="空いている ひとり向け",
+    )
+
+    items = recs["recommendations"]
+    assert items[0]["name"] == "Match"
+    assert _visit_style_raw(items[0]) == 1
+
+
+@pytest.mark.django_db
+def test_compatibility_structured_and_legacy_same_meaning_no_double_score(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=_candidates_for("quiet"),
+        extra_condition="静かな雰囲気で、気持ちを落ち着けて過ごしたい",
+        visit_preferences=["quiet"],
+    )
+
+    items = recs["recommendations"]
+    assert _visit_style_raw(items[0]) == 1
+
+
+@pytest.mark.django_db
+def test_compatibility_structured_and_legacy_different_meaning_both_applied(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [
+        {
+            "name": "Both",
+            "distance_m": 500.0,
+            "lat": 35.001,
+            "lng": 139.001,
+            "popular_score": 5.0,
+            "visit_style_tags": ["quiet", "less_crowded"],
+        },
+    ]
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        extra_condition="人混みを避けたい、混雑しにくい場所がいい",
+        visit_preferences=["quiet"],
+    )
+
+    items = recs["recommendations"]
+    assert _visit_style_raw(items[0]) == 2
+
+
+@pytest.mark.django_db
+def test_visit_style_score_parity_structured_vs_legacy_same_contribution(monkeypatch, settings):
+    """Task 10 Ranking Contract: same preference / same shrine / same score
+    contribution regardless of whether the tag arrived Structured or via
+    the Legacy free-text parser (both feed the same score_visit_style x
+    0.35 computation)."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = _candidates_for("nature")
+
+    recs_structured = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        visit_preferences=["nature"],
+    )
+    recs_legacy = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        extra_condition="自然を感じながら、ゆっくり参拝できる場所がいい",
+    )
+
+    top_structured = recs_structured["recommendations"][0]
+    top_legacy = recs_legacy["recommendations"][0]
+
+    assert top_structured["name"] == top_legacy["name"] == "Match"
+    assert (
+        _visit_style_raw(top_structured)
+        == _visit_style_raw(top_legacy)
+        == 1
+    )
+    # score_visit_style only contributes to the internal ranking score
+    # (_score_total), not the public breakdown.score_total -- see
+    # _visit_style_raw() docstring above.
+    assert top_structured["_score_total"] == top_legacy["_score_total"]
+
+
+@pytest.mark.django_db
+def test_sort_distance_unaffected_by_visit_preferences(monkeypatch, settings):
+    """Task 11 Sort Contract: `nearby` is a Preference (Ranking Bonus),
+    `sort_distance` is a separate Sort Override. Sending visit_preferences
+    (including `nearby`) must not itself trigger the distance sort
+    override -- only the legacy `sort_distance` extra_condition tag does."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    # Same candidate shape as test_concierge_sort_distance_override_sorts_by_
+    # distance (test_concierge_need_contract.py) -- under a real
+    # sort_distance override this set sorts strictly by distance:
+    # A(100m) -> B(200m) -> C(300m).
+    candidates = [
+        {"name": "B", "distance_m": 200.0, "lat": 35.002, "lng": 139.002, "popular_score": 9.0, "visit_style_tags": []},
+        {"name": "C", "distance_m": 300.0, "lat": 35.003, "lng": 139.003, "popular_score": 10.0, "visit_style_tags": []},
+        {"name": "A", "distance_m": 100.0, "lat": 35.001, "lng": 139.001, "popular_score": 1.0, "visit_style_tags": []},
+    ]
+
+    recs = build_chat_recommendations(
+        query="",
+        language="ja",
+        candidates=candidates,
+        visit_preferences=["nearby"],
+    )
+
+    items = recs["recommendations"]
+    # `nearby` is a Preference (Ranking Bonus, none of these candidates has
+    # it in visit_style_tags so it contributes 0 either way) -- it must NOT
+    # itself flip the sort into the strict-distance order that only the
+    # Legacy `sort_distance` extra_condition tag triggers.
+    assert [x["name"] for x in items] != ["A", "B", "C"]
+
+
+@pytest.mark.django_db
+def test_need_score_unaffected_by_visit_preferences(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    import temples.domain.need_tags as need
+
+    class FakeNeedExtract:
+        def __init__(self):
+            self.tags = ["rest"]
+            self.hits = {"rest": ["疲れ"]}
+
+    monkeypatch.setattr(need, "extract_need_tags", lambda q, max_tags=3: FakeNeedExtract(), raising=True)
+
+    candidates = [
+        {
+            "name": "A",
+            "distance_m": 500.0,
+            "lat": 35.001,
+            "lng": 139.001,
+            "popular_score": 5.0,
+            "astro_tags": ["rest"],
+            "visit_style_tags": [],
+        },
+    ]
+
+    recs_without = build_chat_recommendations(
+        query="疲れが取れない", language="ja", candidates=candidates,
+    )
+    recs_with = build_chat_recommendations(
+        query="疲れが取れない", language="ja", candidates=candidates, visit_preferences=["quiet"],
+    )
+
+    assert (
+        recs_without["recommendations"][0]["breakdown"]["score_need"]
+        == recs_with["recommendations"][0]["breakdown"]["score_need"]
+    )
+
+
+@pytest.mark.django_db
+def test_goriyaku_match_unaffected_by_visit_preferences(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [
+        {
+            "name": "A",
+            "distance_m": 500.0,
+            "lat": 35.001,
+            "lng": 139.001,
+            "popular_score": 5.0,
+            "goriyaku_tag_ids": [1],
+            "visit_style_tags": [],
+        },
+    ]
+
+    recs_without = build_chat_recommendations(
+        query="", language="ja", candidates=candidates, goriyaku_tag_ids=[1],
+    )
+    recs_with = build_chat_recommendations(
+        query="", language="ja", candidates=candidates, goriyaku_tag_ids=[1], visit_preferences=["classic"],
+    )
+
+    matched_without = (recs_without["recommendations"][0].get("breakdown") or {}).get("matched_need_tags")
+    matched_with = (recs_with["recommendations"][0].get("breakdown") or {}).get("matched_need_tags")
+    assert matched_without == matched_with
+
+
+@pytest.mark.django_db
+def test_birthdate_score_unaffected_by_visit_preferences(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    import temples.domain.astrology as astro
+
+    class _Prof:
+        sign = "牡牛座"
+        element = "土"
+
+    monkeypatch.setattr(astro, "sun_sign_and_element", lambda birthdate: _Prof(), raising=True)
+    monkeypatch.setattr(astro, "element_priority", lambda user_elem, shrine_elems: 2, raising=True)
+
+    candidates = [
+        {
+            "name": "A",
+            "distance_m": 500.0,
+            "lat": 35.001,
+            "lng": 139.001,
+            "popular_score": 5.0,
+            "astro_elements": ["土"],
+            "visit_style_tags": [],
+        },
+    ]
+
+    recs_without = build_chat_recommendations(
+        query="", language="ja", candidates=candidates, birthdate="1990-01-01",
+    )
+    recs_with = build_chat_recommendations(
+        query="", language="ja", candidates=candidates, birthdate="1990-01-01", visit_preferences=["nature"],
+    )
+
+    assert (
+        recs_without["recommendations"][0]["breakdown"]["score_element"]
+        == recs_with["recommendations"][0]["breakdown"]["score_element"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# E. No Behavior Regression
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_omitting_visit_preferences_kwarg_matches_explicit_empty_list(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = _candidates_for("quiet")
+
+    recs_omitted = build_chat_recommendations(query="", language="ja", candidates=candidates)
+    recs_explicit_empty = build_chat_recommendations(
+        query="", language="ja", candidates=candidates, visit_preferences=[]
+    )
+
+    assert (
+        _visit_style_raw(recs_omitted["recommendations"][0])
+        == _visit_style_raw(recs_explicit_empty["recommendations"][0])
+        == 0
+    )

--- a/docs/product/concierge-input-architecture.md
+++ b/docs/product/concierge-input-architecture.md
@@ -724,3 +724,240 @@ Recommendation behavior changes = 0
 Ranking changes = 0
 Candidate filtering changes = 0
 API contract changes = 0
+
+---
+
+## Addendum: Level 2 Visit Preference Signal Redesign
+
+> 本Addendumは「Level 2 Visit Preference Signal Redesign」PR（Follow-up
+> PR3、§14）の実装状況を記録する。Architecture Decision本文（§1〜§15）
+> および前Addendum（Implemented Contract Foundation）は書き換えていない。
+> Concierge画面の大規模UI変更・375px Information Architecture変更・
+> Level 1 query契約変更・Level 3 birthdate契約変更・`goriyaku_tag_ids`
+> hard filter semantics変更・Learning Signal変更・Score v3 mode変更・
+> Recommendation Reason全面変更・DB Model変更・Migrationは、いずれも
+> 行っていない。
+
+### 責務の再整理
+
+§5 Current（`extra_condition`責務）で記録した経路を、以下へ整理した。
+
+```text
+Current（維持、Compatibility Layerとして残す）:
+  UI preset chip / 自由記述
+    -> extraCondition（自然文）
+    -> extract_extra_tags（keyword parser）
+    -> 最大3タグ
+
+Proposed（新規、並走）:
+  UI preset chip
+    -> canonical tag（Structured, パーサを経由しない）
+    -> visit_preferences（Level 2 Visit Preference, Structured）
+```
+
+Structured と Legacy は `resolve_visit_preference_tags()`
+（`backend/temples/services/concierge_chat_extra_condition.py`）で合流する。
+両者は同一の canonical tag 語彙を使うため、単純な set union で
+dedupeされ、二重加点は発生しない（`score_visit_style` は distinct な
+tag 数のみを数える、`concierge_chat_ranking._attach_breakdown`）。
+
+### Canonical Visit Preference Model
+
+`backend/temples/domain/visit_preference.py`（新規）:
+
+```python
+VISIT_PREFERENCE_TAGS = frozenset(
+    {"quiet", "nature", "reset", "less_crowded", "nearby", "classic"}
+)
+MAX_VISIT_PREFERENCES = 6
+```
+
+- `EXTRA_TAG_META`の`visit_style`kind（8タグ）のうち、
+  `docs/product/visit-style-taxonomy.md`がUI-facing MVP選択肢として
+  定義する6タグの部分集合。`business`/`study`は既存の`visit_style`
+  タグとして残るが、canonical structured語彙には含めない（Taxonomy文書
+  がUI主要選択肢として扱っていないため）。
+- Shrine側の`Shrine.visit_style_tags`（DB field名）とは意図的に
+  field名を分離した: request側は`visit_preferences`
+  （`ConciergeCanonicalInput.visit_preferences`）、Shrine側は従来通り
+  `visit_style_tags`のまま。ユーザーの希望と神社の属性を同一名で
+  混同しない。
+- 上限（`MAX_VISIT_PREFERENCES = 6`）は、legacy `extract_extra_tags`の
+  `max_tags=3`とは無関係に定義した — legacyの3件制限はkeyword
+  parserのスコアリング実装上の副産物であり、Product上意図された
+  Level 2 Preference数の上限ではなかった。Structuredはparserを経由
+  しないため、その制限を継承しない。上限はcanonical語彙のサイズ
+  そのもの（6）とした。UI側の選択可能数そのものを変更する場合は
+  Follow-up UI PR（§14 PR6）へ送る。
+
+### Level間の責務境界（Rule 2の適用）
+
+- Structured/Legacy いずれも `need_tags`/`consultation_axis`/`query`の
+  値を上書きしない（Rule 2、§9）。`build_chat_recommendations()`の
+  `visit_preferences`引数は`visit_style_tags`のみに合流し、
+  Candidate filter（`goriyaku_tag_ids`）・need scoring
+  （`score_need`）・birthdate由来スコア（`score_element`）とは独立
+  に計算される（`test_need_score_unaffected_by_visit_preferences`、
+  `test_goriyaku_match_unaffected_by_visit_preferences`、
+  `test_birthdate_score_unaffected_by_visit_preferences`で固定化）。
+- Personal Profileとして永続化しない。`visit_preferences`は
+  top-levelのrequest fieldのみで解決し、`birthdate`/
+  `goriyaku_tag_ids`/`extra_condition`が持つtop-level⇄filters二重
+  送信（Gap C）を新規に継承しない — single source of truthとして
+  新設した。
+
+### Preference（Ranking Bonus）と Sort Directive の分離
+
+`nearby`はPreference（`score_visit_style`経由のRanking Bonus）、
+`sort_distance`は独立したSort Override（`_sort_chat_recommendations`
+の`distance_mode`分岐）として扱う。両者は概念上別のEffectであり、
+`visit_preferences`に`nearby`を含めても`sort_distance`と同じ
+distance-first sortを引き起こさない
+（`test_sort_distance_unaffected_by_visit_preferences`で固定化）。
+将来同じUI chipから両方を送出する設計はあり得るが、内部責務は
+本PRでも分離したままとする。
+
+### Level 2 Keep / Redesign / Hold / Remove（更新）
+
+§11 Keep/Redesign/Hold/Remove Matrixの Level 2 該当部分を、以下へ
+更新する（§11本文は書き換えず、本Addendumで差分として記録する）。
+
+| UI Preset | §11時点の分類 | 本PRでの扱い | Canonical tag |
+|---|---|---|---|
+| 静かな時間を過ごしたい | Keep | Structured化 | `quiet` |
+| 気分を切り替えたい | Keep（reset部分） | Structured化 | `reset` |
+| 自然を感じたい | Keep | Structured化 | `nature` |
+| 近場がいい | Keep（sort部分）/ Redesign（nearby部分） | Structured化（Preference側のみ） | `nearby` |
+| 有名な神社が安心 | Keep | Structured化 | `classic` |
+| 人混みを避けたい | Keep | Structured化 | `less_crowded` |
+| 境内をゆっくり歩きたい | Redesign | Structured化（`visit-style-taxonomy.md`が定義する`quiet`/`nature`の組み合わせを採用。Legacy parserは実際には`quiet`+`calm`しか生成しておらず、これはCurrent/Proposedの既知Gapとして記録する） | `quiet`, `nature` |
+| 歴史や文化に触れたい | Redesign | **Structured化して解消**（`visit-style-taxonomy.md`の既定マッピングをそのまま採用） | `classic` |
+| 由緒を知りたい | Redesign | **Structured化して解消** | `classic` |
+| 神話に触れたい | Redesign | **Structured化して解消** | `classic` |
+| アクセスしやすい場所がいい | Redesign | **Structured化して解消**（`visit-style-taxonomy.md`は`nearby`「アクセス情報と併用」と既定） | `nearby` |
+| 御朱印を楽しみたい | Redesign | **Hold**（Shrine Data Capability Check: `Shrine`モデルに御朱印関連fieldが存在しない。自然文のみで保持、`visit-style-taxonomy.md`の既定通り） | なし |
+| `energize`（気分を切り替えたいの一部） | Redesign | Hold（`soft_signal` kind、highlight未定義。Level 2 canonical語彙は`visit_style` kindのみを対象とし、`soft_signal`の再設計は本PR対象外） | なし |
+| `soft_signal`タグ8/9件 | Redesign Candidate | Hold（変更なし。§8 Signal Kind整理を参照） | なし |
+| `hard_filter`カテゴリ | Remove Candidate | Hold（変更なし。定義上到達不能のまま維持、削除は本PRで行わない） | なし |
+| `duration_max_min` | Hold | 変更なし | — |
+
+備考: 「近場がいい」「アクセスしやすい場所がいい」はいずれも`nearby`
+へ収束する（`visit-style-taxonomy.md`が両者を同一内部タグとして
+定義しているため）。`nearby`自体は`infer_visit_style_tags()`が
+一度も生成しないため（PR #2397 Gap A、seedデータ0件）、
+Shrine側のマッチ候補が実際には存在せず、現状の実効性はLegacy経路
+と同じくゼロに近い。これはSignalの構造的な位置づけの問題ではなく
+Shrine側データカバレッジの問題であり、Structured化によって
+悪化も改善もしない（Current通りの実効性を維持するのみ）。data
+backfillはDB Model変更を伴わない範囲であっても本PRのスコープ外
+とし、Follow-upへ送る。
+
+### Shrine Data Capability Check（Redesign対象の再評価）
+
+| 項目 | Shrine側capability | 判定 |
+|---|---|---|
+| 歴史や文化に触れたい／由緒を知りたい／神話に触れたい | `Shrine.history_theme`（CharField）は存在するが、`consultation_axis`（Level 1）の`HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`経由でのみ接続されており、Level 2 `visit_style`スコアリングへの接続はない | Level 2としては`classic`（既存capability）へ収束。`history_theme`自体をLevel 2へ新規接続することはRecommendation Reason/consultation_axisロジックへ波及するため本PR対象外（Hold、Follow-up） |
+| 御朱印を楽しみたい | `Shrine`モデルに対応fieldなし | Hold（データなし） |
+| アクセスしやすい場所がいい | 専用の交通機関/駅fieldはなく、`lat`/`lng`のみ | `nearby`（既存capability）へ収束 |
+| 境内をゆっくり歩きたい | 専用fieldなし | `quiet`+`nature`の組み合わせ（既存capability）で表現 |
+
+DB capabilityのない項目（御朱印）へcanonical tagを新規発行することは
+行っていない。
+
+### Signal Kind整理（現状維持）
+
+- `visit_style`: Level 2 canonical structured語彙の対象。維持。
+- `sort_override`（`sort_distance`）: Sort Directiveとして維持、
+  Preferenceとは別Effect。
+- `soft_signal`（9タグ、`calm`以外は実質無効）: 本PRでは再設計しない。
+  Level 2 canonical語彙は`visit_style` kindのみを対象とし、
+  `soft_signal`の扱い（Presentation-only化 / Ranking Signal昇格 /
+  Hold / 削除）はFollow-upの判断とする。
+- `hard_filter`: 変更なし、常に空集合。削除はFollow-up。
+
+### Frontend Request Contract（追加）
+
+`apps/web/src/features/concierge/types/chatRequest.ts`へ
+`visit_preferences?: string[]`を追加した（top-levelのみ、`filters`への
+重複は行っていない）。
+
+UI側の配線（Concierge画面の大規模変更は行わず、既存chipのonClick
+挙動にcanonical tag送出を追加するのみ）:
+
+- `apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx`:
+  `QUICK_PRESET_GROUPS`の各chipに`PRESET_VISIT_PREFERENCE_TAGS`
+  マッピングを追加。クリック時、既存の`onExtraConditionChange`
+  （Legacy、変更なし）に加えて`onVisitPreferencesChange`
+  （Structured、新規）を呼ぶ。
+- `apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx`:
+  閉じた4-preset card（「静か」「駅近」「ひとり」「階段少なめ」、
+  Task 1で追加確認したLevel 2 UI。本Addendumの正本監査範囲外だったが
+  実装として発見したため記録する）にも同様のmappingを追加
+  （「静か」→`quiet`、「駅近」→`nearby`）。「ひとり」「階段少なめ」は
+  Shrine側capabilityがないためHold（マッピングなし、Legacy free-text
+  のまま）。
+- `apps/web/src/app/concierge/ConciergeClientFull.tsx`: `extraCondition`
+  と並走する`visitPreferences`state・`filter_set_visit_preferences`
+  reducer caseを追加。匿名セッションスナップショット
+  （`AnonymousConciergeSnapshot`）へは含めない（Level 2は
+  Session/Request scopeであり、ページ再読み込み跨ぎの永続化は
+  設計上不要という判断、§5「Session-only」原則に従う）。
+
+### Backend Canonical Contract（追加）
+
+`ConciergeCanonicalInput`（`backend/temples/services/concierge_input_contract.py`）
+へ`visit_preferences: List[str]`を追加。`normalize_concierge_request()`が
+`temples.domain.visit_preference.normalize_visit_preferences()`で
+validate/dedupe/capする。`extra_condition`（Legacy Compatibility field）
+は変更していない — 別属性として共存する。
+
+`build_chat_recommendations()`（`backend/temples/services/concierge_chat.py`）
+に`visit_preferences`引数を追加（default `None`、既存呼び出し元は
+無変更で動作）。`resolve_visit_preference_tags()`
+（`backend/temples/services/concierge_chat_extra_condition.py`、新規）が
+Structured/Legacyの合流点。
+
+### No Behavior Regression Verification（実行結果）
+
+```
+Backend: python3 -m pytest -p no:dotenv temples/ -q
+  -> 1225 passed, 9 skipped（既存1182 + 新規Level 2 contract test 43件）
+
+Web: pnpm test:run（vitest run）
+  -> Test Files 118 passed, Tests 766 passed（既存759 + 新規7件）
+
+Web typecheck: tsc -p tsconfig.json --noEmit -> no errors
+```
+
+`visit_preferences`未送信の既存clientは、`build_chat_recommendations()`
+の`visit_preferences=None`デフォルトにより挙動不変
+（`test_omitting_visit_preferences_kwarg_matches_explicit_empty_list`
+で固定化）。
+
+### 完了条件チェック
+
+- Level 2 Canonical Visit Preference: 定義済み（`VISIT_PREFERENCE_TAGS`、6タグ）
+- UI labelとCanonical valueの分離: 済み（`PRESET_VISIT_PREFERENCE_TAGS`マッピング）
+- Structured PreferenceのFrontend→Backend到達: 済み（`visit_preferences`top-level field）
+- Legacy `extra_condition`互換維持: 済み（別属性として共存、削除なし）
+- Structured/Legacy二重加点なし: 済み（set union、`score_visit_style`はdistinct tag数のみ計上）
+- Level 1非上書き: 済み（need_tags/consultation_axis/query不変を確認済み）
+- Level 3非混在: 済み（goriyaku_tag_ids/birthdateスコア不変を確認済み）
+- visit_style scoring parity: 済み（Structured/Legacy同一貢献度を確認済み）
+- sort override責務分離: 済み（nearby選択がsort_distanceを誘発しないことを確認済み）
+- dead presetのKeep/Redesign/Hold/Remove整理: 済み（本Addendum表を参照。5件中4件をStructured化して解消、1件（御朱印）はHold）
+- DB capabilityのないSignal追加なし: 済み（御朱印にtagを発行していない）
+- Backend/Web tests pass、typecheck pass、migration 0: 済み
+
+### Follow-up（本PRでは実装しない）
+
+- Frontend IA（Level 1/2/3段階表示、375px layout、accordion、chip数のUI変更）
+- `soft_signal`（8/9タグ）の再設計方針決定
+- `hard_filter`カテゴリの削除判断
+- `nearby`のShrine側データ生成ギャップ解消（`infer_visit_style_tags()`
+  backfill、DB Model変更を伴わない場合でも本PR対象外）
+- `history_theme`をLevel 2 `visit_style`スコアリングへ接続するかの判断
+  （現状はLevel 1 consultation_axis経由のみ）
+- 御朱印関連fieldをShrineモデルへ追加するかのProduct判断
+- `duration_max_min`の配線または削除判断（PR1 Input Contract Foundation
+  時点から持ち越し）


### PR DESCRIPTION
## Summary

PR #2397 (Signal Audit) / #2398 (Architecture Decision) / #2399 (Input Contract Foundation) を正本として、Level 2「今回の参拝Preference」を構造化されたRecommendation Inputとして再設計する（Follow-up PR3）。

```
UI selection -> Canonical Visit Preference -> Compatibility Layer -> Recommendation
```

- **Canonical tag vocabulary**（`backend/temples/domain/visit_preference.py`、新規）: `quiet`/`nature`/`reset`/`less_crowded`/`nearby`/`classic` の6タグ。UI presetを日本語文章へ変換してから再解析する経路（keyword parser）を経由せず、canonical tagを直接送る。
- **Compatibility Layer**（`resolve_visit_preference_tags`）: Structured `visit_preferences` と Legacy `extra_condition` 由来の `visit_style` tagを同一canonical語彙のset unionで合流させ、二重加点を発生させない。`extra_condition` は削除せず別属性として維持。
- 無効だった5 preset chip中4件（歴史や文化に触れたい／由緒を知りたい／神話に触れたい／アクセスしやすい場所がいい）を `docs/product/visit-style-taxonomy.md` の既定マッピングに沿ってStructured化し解消。御朱印を楽しみたいはShrine側capability不在のためHold（データなし、正しく判断）。
- Level 1 (`need_tags`/`consultation_axis`)・Level 3 (`goriyaku_tag_ids`/`birthdate`) を上書きしないことをテストで固定化。
- `nearby`（Preference/Ranking Bonus）と `sort_distance`（Sort Override）の責務を分離。
- Frontend: `ConciergeFilterPanel`/`ConciergeSectionsRenderer`/`ConciergeClientFull` へ `visit_preferences` 配線を追加。**Concierge画面の大規模UI変更・375px Information Architecture変更は行っていない**（既存chipのonClick挙動にcanonical tag送出を追加するのみ）。
- `docs/product/concierge-input-architecture.md` に Addendum: Level 2 Visit Preference Signal Redesign を追加（Architecture Decision本文§1〜§15は書き換えていない）。

禁止事項（Level 1 query契約変更・Level 3 birthdate契約変更・`goriyaku_tag_ids` hard filter semantics変更・Learning Signal変更・Score v3 mode変更・Recommendation Reason全面変更・DB Model変更・Migration追加）はいずれも行っていない。

## Verification

- Backend: `pytest temples/` → **1225 passed, 9 skipped**（既存1182 + 新規Level 2 contract test 43件）
- Web: `vitest run` → **118 files / 766 tests passed**（既存759 + 新規7件）
- Web typecheck: `tsc --noEmit` → no errors
- Web build: `next build` → success
- Web lint / Backend lint (ruff): 新規lint findingsは0（既存baselineと完全一致を確認）
- Migration: 0件
- Live browser verification: dev server上で実際に「静かな時間を過ごしたい」チップをクリック→送信し、backendレスポンスで `requested_visit_style_tags: ["quiet"]` / `matched_visit_style_tags: ["quiet"]` / `score_visit_style: 1` が実際にrankingへ反映され、primary reasonが `visit_style: quiet` になることを確認済み。

## Test plan

- [x] Backend: `cd backend && python -m pytest -p no:dotenv temples/ -q`
- [x] Web: `pnpm --filter ./apps/web test:run` / `pnpm --filter ./apps/web typecheck` / `pnpm --filter ./apps/web build`
- [x] Manual: dev serverで `/concierge/full` を開き、参拝スタイルpresetチップ選択→送信→レスポンスのvisit_style match/ranking反映を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)