### PR TITLE
Level 3 Profile / Explicit Constraint / Recommendation Context Contract

### DIFF
--- a/apps/web/src/features/concierge/types/chatRequest.ts
+++ b/apps/web/src/features/concierge/types/chatRequest.ts
@@ -1,12 +1,22 @@
 // apps/web/src/features/concierge/types/chatRequest.ts
 //
 // Level tagging below follows docs/product/concierge-input-architecture.md
-// (Architecture Decision) and docs/audit/concierge-input-level-signal-inventory.md
-// (PR #2397 audit). This is documentation only -- no field has been added,
-// removed, renamed, or had its optionality changed as part of this
-// annotation pass (Concierge Input Contract Foundation, see
+// (Architecture Decision + Addendum: Level 3 Profile / Explicit Constraint /
+// Recommendation Context Contract) and
+// docs/audit/concierge-input-level-signal-inventory.md (PR #2397 audit).
+// This is documentation only -- no field has been added, removed, renamed,
+// or had its optionality changed as part of any annotation pass (Concierge
+// Input Contract Foundation / Level 3 Contract, see
 // backend/temples/services/concierge_input_contract.py for the backend
-// side of this same boundary).
+// side of this same boundary). Screen layout is unaffected by this
+// annotation -- these are type-level/comment boundaries only.
+//
+// Level 3 splits into three distinct responsibilities (do not conflate
+// them even though they may share UI screen space):
+//   3-A Personal Profile      -- user-identity data (birthdate)
+//   3-B Explicit Constraint   -- this-request hard constraints (goriyaku_tag_ids)
+//   3-C Recommendation Context -- ambient situational data, not user
+//                                 identity (location/visit_date)
 export type ConciergeChatFilters = {
   // ===== Compatibility（top-level と重複送信される既存backend互換field） =====
   birthdate?: string; // "YYYY-MM-DD" -- Level 3-A Personal Profile
@@ -41,11 +51,29 @@ export type ConciergeChatRequestV1 = {
   // Preference Signal Redesign. Canonical vocabulary: quiet/nature/reset/
   // less_crowded/nearby/classic. No top-level/filters duplication (new field,
   // does not inherit Gap C).
-  visit_date?: string; // Level 3-C Context
-  location?: { lat: number; lng: number }; // Level 3-C Context
+
+  // ===== Level 3-C Recommendation Context（ユーザー属性ではなく「今回の推薦を
+  //       計算する状況」。Personal ProfileでもExplicit Constraintでもない） =====
+  visit_date?: string; // Canonical alias -- backend側は visit_date || planned_visit_date
+  // で解決する（visit_dateが優先）。API field自体はCompatibility目的で維持、
+  // planned_visit_date という別名フィールドは本typeには存在しない（frontendは
+  // 送信しない、backend側のみが受理するlegacy alias）。
+  location?: { lat: number; lng: number }; // radius/radius_mは現状frontendから送信しない
+  // （backend既定値のみ、Concierge Chatパイプライン内ではCandidate hard filterには
+  // ならない -- soft bias/観測用のみ。/nearest endpointとは責務が異なる）。
+
   profile_context?: {
+    // Level 3-A Personal Profile。ただし注意: user_profile.birthdate/birthday は
+    // 上記 `birthdate`（Canonical scoring birthdate）とは独立した別の優先順位
+    // chainで、direction計算（planned_visit_lucky_directions等）のみに使われる
+    // -- backend/temples/services/concierge_input_contract.py の
+    // resolve_profile_context_birthdate() docstring参照。
     user_profile: Record<string, unknown>; // Level 3-A Personal Profile
     derived_profile: Record<string, unknown>; // Level 3-A Personal Profile（Derived）
     direction_profile?: never; // backendが必ず上書きするため、clientからは送らない
+    // 注意: この direction_profile（kyusei方位計算結果）と、
+    // consultation_interpreter.build_direction_profile()（相談状態のnarrative、
+    // 別概念）は同名だが無関係 -- 既知のnaming collision、本typeの対象外
+    // （backend専用の内部衝突、frontendはどちらも直接参照しない）。
   };
 };

--- a/backend/temples/api_views_concierge.py
+++ b/backend/temples/api_views_concierge.py
@@ -33,7 +33,11 @@ from temples.services import places as Places
 from temples.services.plan_service import resolve_plan_context
 from temples.services.quota_service import check_quota, consume_quota
 from temples.services.anonymous_id import attach_anonymous_cookie, build_anonymous_cookie_value
-from temples.services.concierge_input_contract import normalize_concierge_request
+from temples.services.concierge_input_contract import (
+    normalize_concierge_request,
+    resolve_profile_context_birthdate,
+    build_concierge_recommendation_context,
+)
 
 from temples.services.concierge_candidate_utils import (
     _dedupe_candidates,
@@ -547,12 +551,12 @@ class ConciergeChatView(APIView):
 
             raw_profile_context_value = data.get("profile_context")
             raw_profile_context = dict(raw_profile_context_value) if isinstance(raw_profile_context_value, dict) else None
-            profile_user = raw_profile_context.get("user_profile") if raw_profile_context else None
-            profile_birthdate = (
-                profile_user.get("birthdate") or profile_user.get("birthday")
-                if isinstance(profile_user, dict)
-                else None
-            )
+            # Level 3-A Personal Profile (direction-calc precedence chain --
+            # separate from canonical_input.birthdate, see
+            # resolve_profile_context_birthdate() docstring).
+            profile_birthdate = resolve_profile_context_birthdate(raw_profile_context)
+            # Level 3-C Recommendation Context: visit_date/planned_visit_date
+            # alias resolution. `visit_date` is canonical (wins when both sent).
             visit_date = data.get("visit_date") or data.get("planned_visit_date")
             try:
                 calculated_direction = (
@@ -694,6 +698,22 @@ class ConciergeChatView(APIView):
             remaining, limit_value = _chat_quota_fields(plan=plan_context.plan, quota=quota)
 
             lat, lng = _resolve_request_location_inputs(data, area=area)
+            # radius_m: parsed once here and reused below (bias + observability
+            # log) -- previously parsed twice from the same `data`, same value
+            # either way since _parse_radius() is a pure function of `data`.
+            radius_m = _parse_radius(data)
+            # Level 3-C Recommendation Context, canonical packaging (Task 7).
+            # Built here -- after the quota gate, same as lat/lng resolution
+            # above -- so this does not change when the geocode inside
+            # _resolve_request_location_inputs() fires (see
+            # ConciergeRecommendationContext docstring: moving this earlier
+            # would add wasted geocode calls for blocked/invalid requests).
+            l3_context = build_concierge_recommendation_context(
+                lat=lat,
+                lng=lng,
+                radius_m=radius_m,
+                visit_date=visit_date,
+            )
 
             # -------------------------
             # ② candidate build
@@ -733,12 +753,11 @@ class ConciergeChatView(APIView):
 
             bias = None
             if lat is not None and lng is not None:
-                r_m = _parse_radius(data)
-                bias = {"lat": lat, "lng": lng, "radius": r_m, "radius_m": r_m}
+                bias = {"lat": lat, "lng": lng, "radius": radius_m, "radius_m": radius_m}
                 log.info(
                     "[api/chat] computed_bias has_bias=%s radius_m=%d",
                     bias is not None,
-                    r_m,
+                    radius_m,
                 )
 
             log.info(
@@ -792,6 +811,18 @@ class ConciergeChatView(APIView):
                     birthdate is not None,
                 )
                 raise
+
+            # Level 3-C Recommendation Context: attached to the internal-only
+            # debug payload (stripped from the public response body by
+            # _build_chat_response(), same boundary as candidate_pool_observation
+            # / score_v3_mode below). Observational only -- does not change
+            # candidate filtering, ranking, or the public API contract.
+            recs.setdefault("_debug", {})["l3_context"] = {
+                "lat": l3_context.lat,
+                "lng": l3_context.lng,
+                "radius_m": l3_context.radius_m,
+                "visit_date": l3_context.visit_date,
+            }
 
             direction_profile = (
                 raw_profile_context.get("direction_profile")
@@ -921,7 +952,8 @@ class ConciergeChatView(APIView):
             result_state = signals.get("result_state") or {}
             need_meta = recs.get("_need") or {}
             need_tags_for_log = need_meta.get("tags") or []
-            radius_m = _parse_radius(data)
+            # radius_m: reuses the single value parsed above (Level 3-C
+            # Recommendation Context), not re-parsed here.
 
             try:
                 _recs_debug = recs.get("_debug") or {}

--- a/backend/temples/services/concierge_input_contract.py
+++ b/backend/temples/services/concierge_input_contract.py
@@ -286,3 +286,36 @@ def build_concierge_recommendation_context(
         radius_m=radius_m,
         visit_date=visit_date,
     )
+
+
+# ---------------------------------------------------------------------------
+# Level 3-A Personal Profile: profile_context birthdate precedence
+# ---------------------------------------------------------------------------
+
+
+def resolve_profile_context_birthdate(
+    profile_context: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Level 3-A Personal Profile: `profile_context.user_profile.{birthdate,birthday}`.
+
+    Moved verbatim from api_views_concierge.py -- no logic change.
+
+    IMPORTANT: this is a SEPARATE precedence chain from
+    `ConciergeCanonicalInput.birthdate` (the one used for astrology/element
+    scoring in `_attach_breakdown`). This one is consulted ONLY for
+    direction-calc (`planned_visit_lucky_directions`/`annual_lucky_directions`),
+    where the call site uses `resolve_profile_context_birthdate(...) or
+    canonical_input.birthdate` -- i.e. profile_context wins over the
+    canonical scoring birthdate for direction-calc specifically.
+
+    This two-precedence-chain split is a documented Current Gap (see
+    docs/product/concierge-input-architecture.md Addendum: Level 3 Profile
+    / Explicit Constraint / Recommendation Context Contract), not unified
+    in this PR -- unifying them would change existing direction-calc
+    results for requests where profile_context and canonical birthdate
+    disagree, which is out of scope here.
+    """
+    profile_user = profile_context.get("user_profile") if isinstance(profile_context, dict) else None
+    if not isinstance(profile_user, dict):
+        return None
+    return profile_user.get("birthdate") or profile_user.get("birthday")

--- a/backend/temples/tests/api/test_concierge_chat_l3_context_contract.py
+++ b/backend/temples/tests/api/test_concierge_chat_l3_context_contract.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""Level 3 Recommendation Context contract tests (view / HTTP level).
+
+Covers docs/product/concierge-input-architecture.md Addendum: Level 3
+Profile / Explicit Constraint / Recommendation Context Contract.
+
+Location source priority (top-level lat/lng > location{} > area geocode)
+is already covered by
+temples/tests/api/test_concierge_chat_view_characterization.py -- not
+duplicated here.
+"""
+import json
+from types import SimpleNamespace
+
+import pytest
+
+URL = "/api/concierge/chat/"
+
+
+def _stub_recommendations(monkeypatch):
+    """Returns (captured_kwargs, returned_recs_holder). Unlike the plain
+    kwargs-only stubs elsewhere, this also exposes the actual dict object
+    returned to the view, so tests can inspect what the view mutates onto
+    it afterwards (e.g. recs["_debug"]["l3_context"])."""
+    captured = {}
+    holder = {}
+
+    def fake_build_chat_recommendations(**kwargs):
+        captured.update(kwargs)
+        recs = {
+            "recommendations": [
+                {
+                    "name": "神社A",
+                    "reason": "ok",
+                    "reason_source": "reason:test",
+                    "breakdown": {"matched_need_tags": []},
+                }
+            ]
+        }
+        holder["recs"] = recs
+        return recs
+
+    monkeypatch.setattr(
+        "temples.api_views_concierge.build_chat_recommendations",
+        fake_build_chat_recommendations,
+    )
+    return captured, holder
+
+
+@pytest.mark.django_db
+def test_l3_context_debug_payload_reflects_resolved_lat_lng_radius_visit_date(client, monkeypatch):
+    captured, holder = _stub_recommendations(monkeypatch)
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+    payload = {
+        "message": "近場で参拝したい",
+        "lat": 35.6812,
+        "lng": 139.7671,
+        "radius_m": 12000,
+        "visit_date": "2026-09-01",
+    }
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    l3_context = holder["recs"]["_debug"]["l3_context"]
+    assert l3_context == {
+        "lat": pytest.approx(35.6812),
+        "lng": pytest.approx(139.7671),
+        "radius_m": 12000,
+        "visit_date": "2026-09-01",
+    }
+
+
+@pytest.mark.django_db
+def test_l3_context_debug_payload_is_stripped_from_public_response(client, monkeypatch):
+    _stub_recommendations(monkeypatch)
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+    payload = {"message": "近場で参拝したい", "lat": 35.0, "lng": 139.0}
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    body = r.json()
+    assert "_debug" not in body.get("data", {})
+
+
+@pytest.mark.django_db
+def test_l3_context_visit_date_wins_over_planned_visit_date_alias(client, monkeypatch):
+    _, holder = _stub_recommendations(monkeypatch)
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+    payload = {
+        "message": "参拝したい",
+        "lat": 35.0,
+        "lng": 139.0,
+        "visit_date": "2026-09-01",
+        "planned_visit_date": "2026-12-25",
+    }
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    assert holder["recs"]["_debug"]["l3_context"]["visit_date"] == "2026-09-01"
+
+
+@pytest.mark.django_db
+def test_l3_context_uses_planned_visit_date_when_visit_date_absent(client, monkeypatch):
+    _, holder = _stub_recommendations(monkeypatch)
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+    payload = {
+        "message": "参拝したい",
+        "lat": 35.0,
+        "lng": 139.0,
+        "planned_visit_date": "2026-12-25",
+    }
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    assert holder["recs"]["_debug"]["l3_context"]["visit_date"] == "2026-12-25"
+
+
+@pytest.mark.django_db
+def test_radius_is_never_passed_to_candidate_building_hard_filter_parity(client, monkeypatch):
+    """radius/radius_m never becomes a Candidate hard filter in the
+    Concierge Chat pipeline (that's /nearest's responsibility, a different
+    endpoint) -- this PR does not change that."""
+    _stub_recommendations(monkeypatch)
+    captured_cands = {}
+
+    def fake_build_chat_candidates(**kwargs):
+        captured_cands.update(kwargs)
+        return []
+
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", fake_build_chat_candidates)
+
+    payload = {"message": "近場で参拝したい", "lat": 35.0, "lng": 139.0, "radius_m": 500}
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    assert "radius_m" not in captured_cands
+    assert "radius" not in captured_cands
+
+
+@pytest.mark.django_db
+def test_profile_context_birthdate_takes_priority_over_canonical_birthdate_for_direction_calc(
+    client, monkeypatch
+):
+    """Level 3-A: profile_context.user_profile.birthdate wins over the
+    canonical scoring birthdate ONLY for the direction-calc call site --
+    a documented, separate precedence chain (resolve_profile_context_birthdate
+    docstring)."""
+    _stub_recommendations(monkeypatch)
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+    captured_direction_args = {}
+
+    def fake_annual_lucky_directions(birthdate):
+        captured_direction_args["birthdate"] = birthdate
+        return None
+
+    monkeypatch.setattr(
+        "temples.api_views_concierge.annual_lucky_directions",
+        fake_annual_lucky_directions,
+    )
+
+    payload = {
+        "message": "参拝したい",
+        "lat": 35.0,
+        "lng": 139.0,
+        "birthdate": "1990-01-01",
+        "profile_context": {"user_profile": {"birthdate": "1985-06-15"}},
+    }
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    assert captured_direction_args["birthdate"] == "1985-06-15"
+
+
+@pytest.mark.django_db
+def test_canonical_birthdate_used_for_direction_calc_when_profile_context_absent(client, monkeypatch):
+    _stub_recommendations(monkeypatch)
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+    captured_direction_args = {}
+
+    def fake_annual_lucky_directions(birthdate):
+        captured_direction_args["birthdate"] = birthdate
+        return None
+
+    monkeypatch.setattr(
+        "temples.api_views_concierge.annual_lucky_directions",
+        fake_annual_lucky_directions,
+    )
+
+    payload = {
+        "message": "参拝したい",
+        "lat": 35.0,
+        "lng": 139.0,
+        "birthdate": "1990-01-01",
+    }
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+
+    assert captured_direction_args["birthdate"] == "1990-01-01"
+
+
+@pytest.mark.django_db
+def test_blocked_request_does_not_trigger_geocode(client, monkeypatch):
+    """Level 3-C Context construction (including lat/lng resolution, which
+    can geocode `area`) must keep happening AFTER the quota gate -- moving
+    it earlier would add wasted external geocode calls for requests that
+    get rejected anyway (see ConciergeRecommendationContext docstring)."""
+
+    def fake_resolve_plan_context(request):
+        return SimpleNamespace(plan="anonymous", anon_id="anon-test-id")
+
+    def fake_check_quota(plan_context, feature):
+        return SimpleNamespace(allowed=False, unlimited=False, remaining=0, limit=0)
+
+    geocode_calls = {"count": 0}
+
+    def fake_geocode(*args, **kwargs):
+        geocode_calls["count"] += 1
+        return (35.0, 139.0)
+
+    monkeypatch.setattr("temples.api_views_concierge.resolve_plan_context", fake_resolve_plan_context)
+    monkeypatch.setattr("temples.api_views_concierge.check_quota", fake_check_quota)
+    monkeypatch.setattr("temples.api_views_concierge.geocode_google_point", fake_geocode)
+
+    payload = {"message": "近場で参拝したい", "area": "東京駅"}
+    r = client.post(URL, data=json.dumps(payload), content_type="application/json")
+    assert r.status_code == 200
+    assert r.json().get("limitReached") is True
+    assert geocode_calls["count"] == 0

--- a/backend/temples/tests/test_concierge_l3_contract.py
+++ b/backend/temples/tests/test_concierge_l3_contract.py
@@ -1,0 +1,137 @@
+# backend/temples/tests/test_concierge_l3_contract.py
+"""Level 3 Profile / Explicit Constraint / Recommendation Context contract
+tests (pure / unit level, no HTTP).
+
+Covers docs/product/concierge-input-architecture.md Addendum: Level 3
+Profile / Explicit Constraint / Recommendation Context Contract.
+
+    Raw L3 Input -> Canonical L3 Contract -> Compatibility Normalization
+    -> Recommendation
+
+Sections:
+  A. Level 3-A Personal Profile -- profile_context birthdate precedence
+  B. Level 3-C Recommendation Context -- canonical packaging
+  C. radius parsing (_parse_radius, pure)
+  D. Raw Input / Derived Signal boundary (Task 3)
+"""
+
+from temples.api_views_concierge import _parse_radius
+from temples.services.concierge_input_contract import (
+    ConciergeCanonicalInput,
+    build_concierge_recommendation_context,
+    resolve_profile_context_birthdate,
+)
+
+
+# ---------------------------------------------------------------------------
+# A. Level 3-A Personal Profile: profile_context birthdate precedence
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_profile_context_birthdate_reads_birthdate_field():
+    result = resolve_profile_context_birthdate(
+        {"user_profile": {"birthdate": "1990-01-01"}}
+    )
+    assert result == "1990-01-01"
+
+
+def test_resolve_profile_context_birthdate_falls_back_to_birthday_field():
+    result = resolve_profile_context_birthdate(
+        {"user_profile": {"birthday": "1990-01-01"}}
+    )
+    assert result == "1990-01-01"
+
+
+def test_resolve_profile_context_birthdate_birthdate_wins_over_birthday():
+    result = resolve_profile_context_birthdate(
+        {"user_profile": {"birthdate": "1990-01-01", "birthday": "1980-05-05"}}
+    )
+    assert result == "1990-01-01"
+
+
+def test_resolve_profile_context_birthdate_none_when_no_user_profile():
+    assert resolve_profile_context_birthdate({}) is None
+    assert resolve_profile_context_birthdate(None) is None
+
+
+def test_resolve_profile_context_birthdate_none_when_user_profile_not_dict():
+    assert resolve_profile_context_birthdate({"user_profile": "not-a-dict"}) is None
+
+
+def test_resolve_profile_context_birthdate_none_when_neither_field_present():
+    assert resolve_profile_context_birthdate({"user_profile": {}}) is None
+
+
+# ---------------------------------------------------------------------------
+# B. Level 3-C Recommendation Context: canonical packaging
+# ---------------------------------------------------------------------------
+
+
+def test_build_concierge_recommendation_context_visit_date_alias_resolution_is_callers_job():
+    # visit_date/planned_visit_date alias resolution happens at the call
+    # site (`data.get("visit_date") or data.get("planned_visit_date")`,
+    # api_views_concierge.py) before this packaging step -- the context
+    # object itself just stores whatever canonical value it's given.
+    ctx = build_concierge_recommendation_context(
+        lat=35.0, lng=139.0, radius_m=8000, visit_date="2026-09-01"
+    )
+    assert ctx.visit_date == "2026-09-01"
+
+
+# ---------------------------------------------------------------------------
+# C. radius parsing (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_radius_defaults_to_8000_when_absent():
+    assert _parse_radius({}) == 8000
+
+
+def test_parse_radius_uses_radius_m_when_present():
+    assert _parse_radius({"radius_m": 12000}) == 12000
+
+
+def test_parse_radius_converts_radius_km_to_meters():
+    assert _parse_radius({"radius_km": 5}) == 5000
+
+
+def test_parse_radius_radius_m_wins_over_radius_km():
+    assert _parse_radius({"radius_m": 3000, "radius_km": 5}) == 3000
+
+
+def test_parse_radius_clips_to_minimum_1():
+    assert _parse_radius({"radius_m": 0}) == 1
+    assert _parse_radius({"radius_m": -100}) == 1
+
+
+def test_parse_radius_clips_to_maximum_50000():
+    assert _parse_radius({"radius_m": 999999}) == 50000
+
+
+def test_parse_radius_invalid_value_falls_back_to_default():
+    assert _parse_radius({"radius_m": "not-a-number"}) == 8000
+
+
+# ---------------------------------------------------------------------------
+# D. Raw Input / Derived Signal boundary (Task 3)
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_input_does_not_include_astro_or_direction_derived_signals():
+    canonical = ConciergeCanonicalInput(
+        query="q",
+        message="",
+        language="ja",
+        area=None,
+        birthdate="1990-01-01",
+        goriyaku_tag_ids=None,
+        extra_condition=None,
+        visit_preferences=[],
+    )
+    # astro_profile / score_element / direction_bonus are Derived Runtime
+    # Signals computed downstream from birthdate (concierge_chat_ranking
+    # ._attach_breakdown), never part of the canonical L3-A input itself.
+    assert not hasattr(canonical, "astro_profile")
+    assert not hasattr(canonical, "score_element")
+    assert not hasattr(canonical, "direction_bonus")
+    assert not hasattr(canonical, "element")

--- a/docs/product/concierge-input-architecture.md
+++ b/docs/product/concierge-input-architecture.md
@@ -961,3 +961,252 @@ Web typecheck: tsc -p tsconfig.json --noEmit -> no errors
 - 御朱印関連fieldをShrineモデルへ追加するかのProduct判断
 - `duration_max_min`の配線または削除判断（PR1 Input Contract Foundation
   時点から持ち越し）
+
+---
+
+## Addendum: Level 3 Profile / Explicit Constraint / Recommendation Context Contract
+
+> 本Addendumは「Level 3 Profile / Explicit Constraint / Recommendation
+> Context Contract」PR（Follow-up PR4、§14）の実装状況を記録する。
+> Architecture Decision本文（§1〜§15）および前2つのAddendum
+> （Implemented Contract Foundation / Level 2 Visit Preference Signal
+> Redesign）は書き換えていない。Level 1 consultation semantics・Level 2
+> visit preference semantics・`goriyaku_tag_ids` hard candidate filter
+> semantics・birthdate astrology scoring semantics・direction bonus
+> semantics・Recommendation ranking weights・Score v3 mode・Recommendation
+> Reason全面変更・Learning Signal・Frontend Information
+> Architecture・375px UI・DB schema・Migrationは、いずれも変更していない。
+> `radius`を「名前から見てhard filterだろう」と解釈した変更も行っていない
+> （現行のsoft bias/観測用途のsemanticsを維持）。
+
+### Task 1: Level 3 Current Inventory
+
+| Signal | Input source | Current scope | Current effect | Persistence | Proposed L3 type |
+|---|---|---|---|---|---|
+| `birthdate`（canonical, top-level/filters/query-rescue） | `ConciergeCanonicalInput.birthdate`（`_resolve_request_inputs_basic`経由） | Request | Astrology/element scoring（`score_element`）、`astro_bonus`。profile_context不在時のdirection-calc fallback | なし（Concierge Chat経由でDB保存されない） | **3-A Personal Profile** |
+| `profile_context.user_profile.{birthdate,birthday}` | request top-level `profile_context` | Request | **direction-calc専用**の別優先順位chain（`planned_visit_lucky_directions`/`annual_lucky_directions`呼び出し時、canonical birthdateより優先） | なし（Concierge Chat内では未保存。`UserProfile`モデルへの永続化は別経路） | **3-A Personal Profile**（canonical birthdateとは独立した別chain、Current Gapとして記録） |
+| `profile_context.derived_profile`（kyusei/gogyo/lifePath） | request top-level `profile_context` | Request | `gogyo`のみ`_score_profile_signal`で実効。`kyusei`/`lifePath`は未消費（PR #2397既知） | なし | **3-A Personal Profile（Derived）**、変更なし |
+| `goriyaku_tag_ids` | top-level/filters | Request/Session | DB-level candidate hard filter（`build_chat_candidates`） | なし（`user.profile`へ保存されない） | **3-B Explicit Constraint** |
+| `location`/`lat`/`lng` | top-level lat/lng ＞ `location{lat,lng}` ＞ area geocode fallback | Request | Context + soft Ranking Bonus（distance decay + direction bearing）、候補pool構築時のbias中心点 | なし | **3-C Recommendation Context** |
+| `radius`/`radius_m`（frontendは現状未送信） | top-level `radius_m`/`radius_km`（既定8000、1〜50000へclip） | Request | soft bias parameterのみ（`bias`辞書）。Concierge Chatパイプライン内では**candidate hard filterには一度もならない**（`/nearest` endpointのみhard filter） | なし | **3-C Recommendation Context** |
+| `area`/`where`/`location_text` | top-level（どれか1つ） | Request | `lat`/`lng`未解決時のみ、quota gate通過後にgeocodeへ利用 | なし | **3-C Recommendation Context**（解決材料。canonical valueそのものではない） |
+| `visit_date`/`planned_visit_date` | top-level、`visit_date`優先 | Request | どちらの分岐（`planned_visit_lucky_directions` vs `annual_lucky_directions`）を使うかを決定し、direction bonus/表示へ影響 | なし | **3-C Recommendation Context** |
+
+### Task 2/3: Level 3-A Personal Profile Contract
+
+`birthdate`をPersonal Profile入力として明示する（Type=Personal Profile,
+Scope=Request, Effect=Personalization, Strength=Soft）。現行実装を確認した
+結果、Concierge Chat経由でbirthdateがDBへ永続保存される経路は**存在しない**
+ため、今回migrationやprofile保存機能は追加していない。
+
+**birthdateの2つの独立した優先順位chain（Current Gap）**:
+
+```text
+Chain A（Canonical scoring birthdate、_attach_breakdownで使用）:
+  top-level birthdate
+  ↓（無ければ）
+  filters.birthdate
+  ↓（無ければ）
+  query date rescue（"1990-01-01"等の文字列をqueryから救済）
+
+Chain B（direction-calc専用、resolve_profile_context_birthdate()）:
+  profile_context.user_profile.birthdate
+  ↓（無ければ）
+  profile_context.user_profile.birthday
+  ↓（無ければ）
+  Chain Aの結果（canonical birthdate）にfallback
+```
+
+`api_views_concierge.py`の呼び出し:
+`planned_visit_lucky_directions(profile_birthdate or birthdate, visit_date)`
+— **Chain BがChain Aより優先される**のはdirection-calcの時だけであり、
+astrology/element scoring（`score_element`）は常にChain Aのみを使う。
+この2 chain構造は今回**統一しない**（統一すると既存のdirection-calc結果が
+変わるリクエストが存在しうるため、スコープ外）。`resolve_profile_context_birthdate()`
+（`backend/temples/services/concierge_input_contract.py`、新規）へ既存ロジックを
+verbatim抽出し、Contractとして明示・テスト固定した。
+
+### Task 3: birthdate Derived Signal Boundary
+
+`astro_profile`/`score_element`/`direction_bonus`等はbirthdateから都度計算
+される Derived Runtime Signal であり、`ConciergeCanonicalInput`には含まれない
+（`test_canonical_input_does_not_include_astro_or_direction_derived_signals`
+で固定化）。
+
+### Task 4/5: Level 3-B Explicit Constraint Contract
+
+`goriyaku_tag_ids`を`Personal Profile`から明確に分離済み（PR #2399時点で
+既に`ConciergeCanonicalInput`docstring上でL3-Bタグ付け済み、本PRで変更なし）。
+
+```text
+Level = L3, Type = Explicit Constraint, Scope = Request/Session,
+Effect = Candidate Filter, Strength = Strong
+```
+
+DB-level hard filter semanticsは維持（変更なし）。API field名`goriyaku_tag_ids`
+は後方互換のため維持する。内部コードでは`concierge_chat_ranking._attach_breakdown`
+の`requested_goriyaku_tag_ids`引数名が既に責務の分かる名称になっており
+（PR #2399以前から存在）、本PRで新たなrenameは行っていない — 大規模rename
+は今回のGoalではない。
+
+### Task 6/7: Level 3-C Recommendation Context Contract
+
+PR #2399で定義済みの`ConciergeRecommendationContext`
+（`backend/temples/services/concierge_input_contract.py`）を再発明せず、
+`api_views_concierge.py`のview内で実配線した:
+
+```python
+lat, lng = _resolve_request_location_inputs(data, area=area)
+radius_m = _parse_radius(data)  # 1回だけparse（後述）
+l3_context = build_concierge_recommendation_context(
+    lat=lat, lng=lng, radius_m=radius_m, visit_date=visit_date,
+)
+```
+
+**geocode timingは変更していない**: `_resolve_request_location_inputs()`
+の呼び出し位置は、既存通りquota gate通過後（`quota.allowed`チェックの後）の
+ままである。`l3_context`の構築もこの直後に行っており、request開始直後への
+前倒しは行っていない
+（`test_blocked_request_does_not_trigger_geocode`で固定化 — quota
+blocked時に`geocode_google_point`が一度も呼ばれないことを確認）。
+
+`l3_context`は`recs["_debug"]["l3_context"]`へ内部観測用として付与した
+（`candidate_pool_observation`/`score_v3_mode`と同じ既存パターン）。
+`_build_chat_response()`が`_debug`を公開レスポンスから常に除外する既存
+境界はそのまま利用しており、public API contractへの影響はない
+（`test_l3_context_debug_payload_is_stripped_from_public_response`で
+固定化）。
+
+**副次的な簡略化（1件のみ）**: `radius_m`は従来`_parse_radius(data)`が
+biasの計算用途と観測ログ用途で2回呼ばれていた（同一`data`からの純粋関数
+なので値は常に同一）。本PRで1回にまとめ、両方の用途へ同じ変数を再利用する
+よう変更した。挙動は完全に同一（`_parse_radius`はpure function）。
+
+### Task 8: Location Source Priority
+
+現行実装（`_resolve_request_location_inputs`）のpriorityを確認した:
+
+```text
+Priority 1: top-level lat/lng
+Priority 2: location{lat,lng}
+Priority 3: area text geocode fallback
+```
+
+このpriorityは既に`temples/tests/api/test_concierge_chat_view_characterization.py`
+（`test_chat_view_uses_nested_location_latlng_as_bias`、
+`test_chat_view_uses_area_geocode_when_latlng_absent`、
+`test_chat_view_prefers_direct_latlng_even_with_area`）でcontract test化
+済みであり、本PRでは重複させていない。
+
+### Task 9: radius Contract
+
+Concierge Chat内の`radius`/`radius_m`は`bias`辞書へのsoft parameterとして
+のみ使われ、**candidate hard filterへは変更していない**
+（`test_radius_is_never_passed_to_candidate_building_hard_filter_parity`で
+固定化 — `build_chat_candidates`呼び出しに`radius`/`radius_m`が一切渡され
+ないことを確認）。`/nearest` endpoint（別実装、`d_m <= radius_m`のhard
+filter）とは責務が異なったままである。`radius` semantics統一は
+Follow-upへ送る。
+
+### Task 10: visit_date Contract
+
+```text
+Raw aliases: visit_date / planned_visit_date
+  ↓（visit_date優先、data.get("visit_date") or data.get("planned_visit_date")）
+Canonical Context: visit_date
+```
+
+API field自体の削除・rename は行っていない。`birthdate + visit_date →
+planned_visit_lucky_directions`の挙動は維持
+（`test_l3_context_visit_date_wins_over_planned_visit_date_alias`、
+`test_l3_context_uses_planned_visit_date_when_visit_date_absent`で
+固定化）。
+
+### Task 11: profile_context Boundary（direction_profile naming collision）
+
+既知の概念衝突を再確認した（PR #2397 Gap D、PR #2398 §10 #9で既に記録
+済み、本PRで新規発見ではない）:
+
+| Container | 実体 | 概念 |
+|---|---|---|
+| `profile_context.direction_profile`（`api_views_concierge.py`が`planned_visit_lucky_directions`/`annual_lucky_directions`の結果を格納） | kyusei方位計算結果 | L3-C Context、実効ranking（`_score_direction_signal`） |
+| `interpretation_profile.direction_profile`（`consultation_interpreter.build_direction_profile()`の出力） | 相談状態のnarrative方位（`{"direction","themes","source_state"}`） | Internal/L1寄り、shadow |
+
+同名だが完全に無関係な2概念であることを確認した。**Current collision**として
+記録するのみとし、rename等の実施は本PRでは行わない（rename範囲が
+`consultation_interpreter.py`/`concierge_chat_ranking.py`双方に及び、
+広範囲変更になるため）。**Proposed rename（案）**: kyusei側を
+`direction_bonus_profile`、narrative側を`consultation_direction_hint`等へ
+分離することを候補として残す。**Follow-up**へ送る。
+
+### Task 12: Canonical L3 Contract（実装形式）
+
+`PersonalProfileInput`/`ExplicitConstraintInput`/`RecommendationContext`
+という3つの独立classを新設する設計は採用しなかった（過剰なclass
+hierarchyを避けるため）。代わりに:
+
+- `ConciergeCanonicalInput`（既存、PR #2399）が`birthdate`（3-A）・
+  `goriyaku_tag_ids`（3-B）を既にdocstring上でLevel-taggedな1つのfield
+  として保持している。本PRではこのdocstringをさらに強化した
+  （2つのbirthdate優先順位chainの明示、`resolve_profile_context_birthdate()`
+  への参照追加）。
+- `ConciergeRecommendationContext`（既存、PR #2399）が3-Cを表す。本PRで
+  実際にview側から構築・使用するよう配線した（Task 6/7参照）。
+
+これにより「概念として3分離されているが、過剰なclass階層はない」という
+Task 12の要求を満たす。
+
+### Task 13: Frontend Contract
+
+`apps/web/src/features/concierge/types/chatRequest.ts`のコメントを拡充し、
+Personal Profile（3-A）/ Explicit Constraint（3-B）/ Recommendation
+Context（3-C）/ Compatibilityを型コメントレベルで識別できるようにした。
+型のshape・optionality・フィールド追加削除は行っていない（コメントのみ）。
+画面構造・UI layoutは変更していない。
+
+### Task 14: Compatibility（維持）
+
+以下の互換経路は本PRでも維持している（変更なし）:
+
+- `birthdate`: top-level / `filters.birthdate` / query rescue
+- `goriyaku_tag_ids`: top-level / `filters.goriyaku_tag_ids`
+- `location`: top-level `lat`/`lng` / `location{lat,lng}` / `area` geocode
+- `visit_date`/`planned_visit_date`のalias解決
+
+### Task 18: Persistence Decision（現状確認）
+
+| Signal | Request | Session | Persistent（Concierge Chat経由） |
+|---|---|---|---|
+| `birthdate`（canonical） | ✅ | ❌（frontend stateはsession中のみ保持、`sessionState.temporaryBirthdate`） | ❌ |
+| `profile_context.user_profile.birthdate` | ✅ | — | ❌（`UserProfile`モデルへの永続化は別経路、Concierge Chat自体は保存しない） |
+| `goriyaku_tag_ids` | ✅ | ✅（frontend `selectedTagIds` state） | ❌（`user.profile`へ保存されない、PR #2397確認済み） |
+| `location`/`lat`/`lng` | ✅ | ✅（frontend `userOrigin` state） | ❌ |
+| `visit_date` | ✅ | ✅（frontend `plannedVisitDate` state） | ❌ |
+
+「ProfileだからbirthdateをDB保存する」という新規仕様は**今回追加していない**。
+永続化が必要な場合は別Contractとして今後のFollow-upで判断する。
+
+### No Behavior Change Verification（実行結果）
+
+```
+Backend: python -m pytest -p no:dotenv temples/ -q
+  -> 1248 passed, 9 skipped（既存1225 + 新規Level 3 contract test 23件）
+
+Web typecheck: tsc -p tsconfig.json --noEmit -> no errors
+```
+
+Candidate filtering behavior change = 0
+Ranking behavior change = 0
+API compatibility change = 0（`visit_preferences`と同様、新規fieldの追加は
+  なし。`_debug.l3_context`は既存の`_debug`除外境界内の内部観測追加のみ）
+Persistence change = 0
+Migration = 0
+
+### Follow-up（本PRでは実装しない）
+
+- Profile Persistence: birthdate等をUser Profileとしてどこへ・いつ保存
+  するか（Product判断）
+- Radius Semantics: Concierge Chatと`/nearest`の責務統一可否
+- `direction_profile` naming collision解消（rename案は本Addendumに記録済み）
+- Frontend IA: L1/L2/L3の画面上段階表示
+- Learning Contract: 行動学習の正式契約


### PR DESCRIPTION
## Summary

PR #2397 (Signal Audit) / #2398 (Architecture Decision) / #2399 (Input Contract Foundation) / #2405 (Level 2 Visit Preference Signal Redesign) を基礎として、Level 3入力を以下の3責務へコード上でも明確に分離する（Follow-up PR4）。

```
Raw L3 Input -> Canonical L3 Contract -> Compatibility Normalization -> Recommendation
```

- **Level 3-A Personal Profile**（`birthdate`）: 2つの独立した優先順位chainが存在することを確認・明示。canonical scoring birthdate（astrology/element scoring用）と、`profile_context.user_profile.birthdate`（**direction-calc専用**、`planned_visit_lucky_directions`/`annual_lucky_directions`呼び出し時にcanonical birthdateより優先される）を、`resolve_profile_context_birthdate()`としてverbatim抽出しContract化・テスト固定した（既存の計算結果・優先順位は一切変更していない）。
- **Level 3-B Explicit Constraint**（`goriyaku_tag_ids`）: DB-level hard candidate filter semanticsを維持、変更なし。
- **Level 3-C Recommendation Context**（`lat`/`lng`/`radius_m`/`visit_date`）: PR #2399で定義済みだった `ConciergeRecommendationContext` を実際にview側で構築・配線した（`recs["_debug"]["l3_context"]`へ内部観測用途で付与、`_build_chat_response()`の既存`_debug`除外境界内なのでpublic API contractへの影響はない）。**geocode timing（quota gate通過後）は変更していない** — quota blockedリクエストで一度もgeocodeが発火しないことをテストで固定。`radius`をcandidate hard filterへ変更していない（Concierge Chat内では従来通りsoft bias parameterのみ）。
- 副次的な簡略化1件: `radius_m`のparse処理が従来bias用・観測ログ用で2回呼ばれていたのを1回にまとめた（`_parse_radius`はpure functionのため挙動は完全に同一）。
- 既知の`direction_profile`naming collision（kyusei方位計算結果 vs 相談状態のnarrative、PR #2397/#2398で既に発見済み）を再確認し、Current/Proposed rename案/Follow-upとしてドキュメントへ記録（renameは実施せず）。
- Frontend `ConciergeChatRequestV1`型へLevel 3-A/B/C/Compatibilityの境界コメントを追加（型shape・画面構造の変更なし、comment-only）。

## 禁止事項（変更なし）

Level 1 consultation semantics・Level 2 visit preference semantics・`goriyaku_tag_ids` hard filter semantics・birthdate astrology scoring・direction bonus semantics・Recommendation ranking weights・Score v3 mode・Recommendation Reason・Learning Signal・Frontend Information Architecture・375px UI・DB schema・Migration・Premium/Billing はいずれも変更していません。`radius`を「名前から見てhard filterだろう」と解釈した変更も行っていません。

## Verification

- Backend: `pytest temples/` → **1248 passed, 9 skipped**（既存1225 + 新規Level 3 contract test 23件）
- Web: `vitest run` → **118 files / 766 tests passed**（変更なし、comment-onlyのため）
- Web typecheck: `tsc --noEmit` → no errors
- Web build: `next build` → success
- Backend lint (ruff): 新規lint findingsは0（既存baseline 6件と完全一致、`post`のcomplexity scoreも38のまま変化なし）
- Migration: 0件
- Live browser verification: dev server上でbirthdate＋goriyaku指定＋Level 2 visit preferenceを同時に設定して送信し、`score_element`（astrology）・`matched_user_selected_goriyaku_tag_ids`（explicit constraint）・`score_visit_style`（L2 visit preference）がすべて正しくrankingへ反映されることを確認済み。

## Behavior change disclosure

- Candidate filtering behavior change: **なし**
- Ranking behavior change: **なし**
- API compatibility change: **なし**（`_debug.l3_context`は既存の`_debug`除外境界内の内部観測追加のみ、public response契約は不変）
- Persistence change: **なし**
- Migration: **0件**

## Test plan

- [x] Backend: `cd backend && python -m pytest -p no:dotenv temples/ -q`
- [x] Web: `pnpm --filter ./apps/web test:run` / `pnpm --filter ./apps/web typecheck` / `pnpm --filter ./apps/web build`
- [x] Manual: dev serverで `/concierge/full` を開き、誕生日＋ご利益＋L2参拝スタイル併用で送信し、response breakdownを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)