### PR TITLE
Integrated Recommendation Intent Execution Contract

### DIFF
--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx
@@ -1,0 +1,100 @@
+// Regression test: does the closed-card preset toggle ("静か"/"駅近")
+// actually dispatch filter_set_visit_preferences alongside filter_set_extra?
+// (ConciergeSectionsRenderer.tsx togglePreset(), added in PR #2405.)
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const authMock = vi.hoisted(() => ({
+  useAuth: vi.fn(() => ({ isLoggedIn: false, loading: false })),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: authMock.useAuth,
+}));
+
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: vi.fn() }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: vi.fn() }));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+  visitPreferences: [],
+};
+
+const heroRec = {
+  shrine_id: 1,
+  display_name: "第一候補神社",
+  reason: "第一候補の理由文です。",
+  address: "東京都千代田区1-1-1",
+  trust_metadata: {
+    rank_class: "由緒あり",
+    cultural_status: ["重要文化財"],
+    lineage: "式内社",
+    origin_summary: "古くから信仰を集める神社です。",
+  },
+};
+
+describe("closed-card preset toggle -> filter_set_visit_preferences", () => {
+  it("clicking 静か dispatches filter_set_visit_preferences with ['quiet']", () => {
+    const onAction = vi.fn();
+    const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
+    const payload = buildPayloadFromUnified(u, baseFilterState);
+    render(
+      <ConciergeSectionsRenderer payload={payload!} threadId={1} onAction={onAction} isEntryRoute={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "静か" }));
+
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "filter_set_extra" }),
+    );
+    expect(onAction).toHaveBeenCalledWith({
+      type: "filter_set_visit_preferences",
+      visitPreferences: ["quiet"],
+    });
+  });
+
+  it("clicking 駅近 dispatches filter_set_visit_preferences with ['nearby']", () => {
+    const onAction = vi.fn();
+    const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
+    const payload = buildPayloadFromUnified(u, baseFilterState);
+    render(
+      <ConciergeSectionsRenderer payload={payload!} threadId={1} onAction={onAction} isEntryRoute={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "駅近" }));
+
+    expect(onAction).toHaveBeenCalledWith({
+      type: "filter_set_visit_preferences",
+      visitPreferences: ["nearby"],
+    });
+  });
+
+  it("clicking ひとり (no canonical mapping) does NOT dispatch filter_set_visit_preferences", () => {
+    const onAction = vi.fn();
+    const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
+    const payload = buildPayloadFromUnified(u, baseFilterState);
+    render(
+      <ConciergeSectionsRenderer payload={payload!} threadId={1} onAction={onAction} isEntryRoute={false} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "ひとり" }));
+
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "filter_set_extra" }),
+    );
+    expect(onAction).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "filter_set_visit_preferences" }),
+    );
+  });
+});

--- a/backend/temples/tests/test_concierge_integrated_recommendation_contract.py
+++ b/backend/temples/tests/test_concierge_integrated_recommendation_contract.py
@@ -1,0 +1,408 @@
+# backend/temples/tests/test_concierge_integrated_recommendation_contract.py
+"""Integrated Recommendation Intent Execution Contract.
+
+Covers docs/product/concierge-input-architecture.md Addendum: Integrated
+Recommendation Flow. Ties together L1 Consultation, L2 Visit Preference,
+L3-A Personal Profile, L3-B Explicit Constraint, and L3-C Recommendation
+Context (PR #2397/#2398/#2399/#2405/#2406) into one tested Contract:
+
+    Raw Consultation -> Interpretation -> Candidate Constraint -> Ranking
+    -> Recommendation Reason
+
+Core Principle under test: Consultation Meaning is the primary
+recommendation axis. Lower-level Signals (L2/L3) adjust ranking but never
+replace L1 meaning (need_tags / consultation_axis).
+
+This PR does not change any ranking weight, candidate filtering semantics,
+or Recommendation Reason text-generation logic -- it is a test + audit PR
+building on existing, unchanged behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+CAREER_QUERY = "転職を考えていて、仕事の転機に向き合いたいです"
+REQUESTED_GORIYAKU_ID = 501
+
+
+def _shrine_match(**overrides):
+    base = {
+        "name": "Match",
+        "distance_m": 500.0,
+        "lat": 35.001,
+        "lng": 139.001,
+        "popular_score": 5.0,
+        "astro_tags": ["career"],
+        "astro_elements": ["火"],
+        "goriyaku_tag_ids": [REQUESTED_GORIYAKU_ID],
+        "visit_style_tags": ["quiet"],
+        "goriyaku": "",
+        "description": "",
+        "history_theme": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _shrine_other(**overrides):
+    base = {
+        "name": "Other",
+        "distance_m": 500.0,
+        "lat": 35.002,
+        "lng": 139.002,
+        "popular_score": 5.0,
+        "astro_tags": [],
+        "astro_elements": [],
+        "goriyaku_tag_ids": [],
+        "visit_style_tags": [],
+        "goriyaku": "",
+        "description": "",
+        "history_theme": "",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def deterministic(monkeypatch, settings):
+    """Deterministic path: LLM off, real need_tags mocked to a single
+    stable tag ('career'), real (unmocked) consultation_axis/astro/goriyaku/
+    visit_style resolution -- same fixture pattern as
+    test_concierge_need_contract.py / test_concierge_visit_preference_contract.py."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    import temples.domain.need_tags as need
+
+    class FakeNeedExtract:
+        def __init__(self):
+            self.tags = ["career"]
+            self.hits = {"career": ["転職"]}
+
+    monkeypatch.setattr(need, "extract_need_tags", lambda q, max_tags=3: FakeNeedExtract(), raising=True)
+
+    import temples.domain.astrology as astro
+
+    class _Prof:
+        sign = "牡羊座"
+        element = "火"
+
+    monkeypatch.setattr(astro, "sun_sign_and_element", lambda birthdate: _Prof(), raising=True)
+    monkeypatch.setattr(
+        astro,
+        "element_priority",
+        lambda user_elem, shrine_elems: 2 if "火" in (shrine_elems or []) else 0,
+        raising=True,
+    )
+    return None
+
+
+def _run(candidates, **kwargs):
+    kwargs.setdefault("query", CAREER_QUERY)
+    kwargs.setdefault("language", "ja")
+    kwargs.setdefault("candidates", candidates)
+    return build_chat_recommendations(**kwargs)
+
+
+def _rec_by_name(recs, name):
+    for r in recs["recommendations"]:
+        if r.get("name") == name:
+            return r
+    raise AssertionError(f"{name!r} not found in recommendations: {[r.get('name') for r in recs['recommendations']]}")
+
+
+# ---------------------------------------------------------------------------
+# Task 12: Integrated Contract Tests -- combination matrix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_l1_only(deterministic):
+    recs = _run([_shrine_match(), _shrine_other()])
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    assert recs["consultation_axis"] == "career_change"
+
+
+@pytest.mark.django_db
+def test_l1_plus_l2(deterministic):
+    recs = _run([_shrine_match(), _shrine_other()], visit_preferences=["quiet"])
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    visit_style = ((top.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert visit_style.get("matched_tags") == ["quiet"]
+
+
+@pytest.mark.django_db
+def test_l1_plus_l3a_personal_profile(deterministic):
+    recs = _run([_shrine_match(), _shrine_other()], birthdate="1990-01-01")
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    assert top["breakdown"]["score_element"] == 2
+
+
+@pytest.mark.django_db
+def test_l1_plus_l3b_explicit_constraint(deterministic):
+    recs = _run(
+        [_shrine_match(), _shrine_other()],
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    signals = (top.get("score_v2") or {}).get("signals") or {}
+    assert signals.get("matched_user_selected_goriyaku_tag_ids") == [REQUESTED_GORIYAKU_ID]
+
+
+@pytest.mark.django_db
+def test_l1_plus_l3c_context(deterministic):
+    recs = _run(
+        [_shrine_match(distance_m=100.0), _shrine_other(distance_m=100000.0)],
+    )
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    context_profile = ((top.get("score_v2") or {}).get("signals") or {}).get("context_profile") or {}
+    assert context_profile.get("distance_m") == 100.0
+
+
+@pytest.mark.django_db
+def test_l1_plus_l2_plus_l3a(deterministic):
+    recs = _run(
+        [_shrine_match(), _shrine_other()],
+        visit_preferences=["quiet"],
+        birthdate="1990-01-01",
+    )
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    assert top["breakdown"]["score_element"] == 2
+    visit_style = ((top.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert visit_style.get("matched_tags") == ["quiet"]
+
+
+@pytest.mark.django_db
+def test_l1_plus_l2_plus_l3b(deterministic):
+    recs = _run(
+        [_shrine_match(), _shrine_other()],
+        visit_preferences=["quiet"],
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    signals = (top.get("score_v2") or {}).get("signals") or {}
+    assert signals.get("matched_user_selected_goriyaku_tag_ids") == [REQUESTED_GORIYAKU_ID]
+    visit_style = ((top.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert visit_style.get("matched_tags") == ["quiet"]
+
+
+@pytest.mark.django_db
+def test_l1_plus_l3b_plus_l3c(deterministic):
+    recs = _run(
+        [_shrine_match(distance_m=100.0), _shrine_other(distance_m=100000.0)],
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+    signals = (top.get("score_v2") or {}).get("signals") or {}
+    assert signals.get("matched_user_selected_goriyaku_tag_ids") == [REQUESTED_GORIYAKU_ID]
+    context_profile = signals.get("context_profile") or {}
+    assert context_profile.get("distance_m") == 100.0
+
+
+# ---------------------------------------------------------------------------
+# Task 12/13: Full Integration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_full_integration_all_levels_together(deterministic):
+    recs = _run(
+        [_shrine_match(distance_m=100.0), _shrine_other(distance_m=100000.0)],
+        visit_preferences=["quiet"],
+        birthdate="1990-01-01",
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+
+    # Candidate filter applied correctly / need score remains
+    assert top["name"] == "Match"
+    assert top["breakdown"]["score_need"] >= 1
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+
+    # consultation_axis maintained
+    assert recs["consultation_axis"] == "career_change"
+
+    # Visit preference score reflected
+    visit_style = ((top.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert visit_style.get("matched_tags") == ["quiet"]
+
+    # birthdate (element) score reflected
+    assert top["breakdown"]["score_element"] == 2
+
+    # context distance reflected
+    signals = (top.get("score_v2") or {}).get("signals") or {}
+    context_profile = signals.get("context_profile") or {}
+    assert context_profile.get("distance_m") == 100.0
+
+    # explicit constraint (goriyaku) reflected
+    assert signals.get("matched_user_selected_goriyaku_tag_ids") == [REQUESTED_GORIYAKU_ID]
+
+    # primary reason is not hijacked by a lower-priority auxiliary Signal:
+    # need_tag / user_selected_tag facts exist (Consultation + Constraint),
+    # so the primary reason must not fall back to bare "element"/"fallback".
+    assert top["_primary_reason_source"] in {"need_tag", "user_selected_tag", "text_hint", "history_theme"}
+
+    # reason_facts is consistent with the actual matched signals
+    reason_fact_types = {f["type"] for f in top["_reason_facts"]}
+    assert "need_tag" in reason_fact_types
+    assert "user_selected_tag" in reason_fact_types
+
+
+@pytest.mark.django_db
+def test_full_integration_visible_reason_text_reflects_consultation_not_lower_level_signal(deterministic):
+    """The user-visible `reason` string (build_recommendation_reason) must
+    stay driven by Consultation Meaning (need_tags/_primary_reason_label),
+    even when Visit Preference / Personal Profile / Explicit Constraint are
+    all present simultaneously."""
+    recs = _run(
+        [_shrine_match(distance_m=100.0), _shrine_other(distance_m=100000.0)],
+        visit_preferences=["quiet"],
+        birthdate="1990-01-01",
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+    # career-need reason text, not a visit-style/element-only phrase.
+    assert "仕事" in top["reason"] or "転機" in top["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Section 7: Conflict Scenarios -- L2/L3 must not override Consultation Meaning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_vs_visit_preference_does_not_flip_ranking(deterministic):
+    """相談: 仕事の転機 / Preference: 静か.
+    Expected: 相談に一致する候補（Match）が引き続き優先される。
+    'quiet' な候補というだけの理由で誤って上位が入れ替わらない。"""
+    matched = _shrine_match(distance_m=500.0)  # career + goriyaku match, no visit_style
+    matched["visit_style_tags"] = []
+    quiet_only = _shrine_other(distance_m=500.0)
+    quiet_only["visit_style_tags"] = ["quiet"]  # visit_style match only, no consultation match
+
+    recs = _run([matched, quiet_only], visit_preferences=["quiet"])
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_vs_personal_profile_does_not_flip_ranking(deterministic):
+    """相談: 仕事の転機 / birthdate: 特定element.
+    Expected: 相談一致がProfile一致より優先して上位を占める。"""
+    matched = _shrine_match(distance_m=500.0)
+    matched["astro_elements"] = []  # no element match, only consultation match
+    element_only = _shrine_other(distance_m=500.0)
+    element_only["astro_elements"] = ["火"]  # element match only, no consultation match
+
+    recs = _run([matched, element_only], birthdate="1990-01-01")
+    top = recs["recommendations"][0]
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_vs_explicit_constraint_evaluates_meaning_within_filtered_set(deterministic):
+    """相談: 転職 / goriyaku: 厄除け等.
+    Expected: goriyaku Candidate集合内で、相談との意味一致がranking軸になる
+    （Constraintは候補集合を絞るだけで、意味一致の評価自体は差し替えない）。"""
+    both_match = _shrine_match(distance_m=500.0)  # career + requested goriyaku
+    constraint_only = _shrine_other(distance_m=500.0)
+    constraint_only["goriyaku_tag_ids"] = [REQUESTED_GORIYAKU_ID]  # constraint match only, no need match
+
+    recs = _run(
+        [both_match, constraint_only],
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+    # Both candidates satisfy the constraint (both remain eligible); the one
+    # that ALSO matches Consultation Meaning ranks first.
+    assert top["name"] == "Match"
+    assert top["breakdown"]["matched_need_tags"] == ["career"]
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_vs_context_does_not_relabel_reason_as_distance_only(deterministic):
+    """相談: 心を整えたい / location: 近距離Candidate.
+    Expected: 近いだけの神社を「あなたの悩みに最も合う」と誤説明しない --
+    近い候補（Otherのみ）でも、reasonはneed一致ではなくfallback/distance
+    相当の文言になる（need一致していないものをneed一致だと言わない）。"""
+    far_match = _shrine_match(distance_m=50000.0)  # consultation match, far away
+    near_no_match = _shrine_other(distance_m=100.0)  # very close, no consultation match
+
+    recs = _run([far_match, near_no_match])
+    near = _rec_by_name(recs, "Other")
+    # The near-but-unmatched candidate must not claim a need_tag match it
+    # doesn't have.
+    assert near["breakdown"]["matched_need_tags"] == []
+    assert near["_primary_reason_source"] != "need_tag"
+
+
+# ---------------------------------------------------------------------------
+# Task 8/14: Explainability -- candidate_eligibility / meaning_fit /
+# visit_preference_fit / profile_fit / context_fit are each independently
+# inspectable (reusing existing breakdown_detail.features -- no new schema)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_breakdown_detail_separates_meaning_visit_profile_context_features(deterministic):
+    recs = _run(
+        [_shrine_match(distance_m=250.0), _shrine_other(distance_m=250.0)],
+        visit_preferences=["quiet"],
+        birthdate="1990-01-01",
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    top = recs["recommendations"][0]
+    features = ((top.get("breakdown_detail") or {}).get("features") or {})
+
+    # meaning_fit (Consultation)
+    assert features["need"]["matched_by_gid_count"] >= 1 or features["need"]["raw"] >= 1
+    # visit_preference_fit (L2)
+    assert features["visit_style"]["matched_tags"] == ["quiet"]
+    # profile_fit (L3-A)
+    assert features["element"]["raw"] == 2
+    # context_fit (L3-C)
+    assert features["distance"]["raw"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Task 15: No Behavior Drift -- weights unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_weights_unchanged_from_documented_contract(deterministic):
+    recs = _run([_shrine_match(), _shrine_other()])
+    top = recs["recommendations"][0]
+    weights = top["breakdown"]["weights"]
+    # need mode defaults (see _resolve_mode_weights) -- pinned as a
+    # regression guard, not re-tuned by this PR.
+    assert weights["element"] == pytest.approx(0.6)
+    assert weights["need"] == pytest.approx(0.3)
+    visit_style_weight = ((top.get("breakdown_detail") or {}).get("features") or {}).get("visit_style", {}).get("weight")
+    assert visit_style_weight == pytest.approx(0.35)

--- a/docs/product/concierge-input-architecture.md
+++ b/docs/product/concierge-input-architecture.md
@@ -1210,3 +1210,270 @@ Migration = 0
 - `direction_profile` naming collision解消（rename案は本Addendumに記録済み）
 - Frontend IA: L1/L2/L3の画面上段階表示
 - Learning Contract: 行動学習の正式契約
+
+---
+
+## Addendum: Integrated Recommendation Intent Execution Contract
+
+> 本Addendumは「Integrated Recommendation Intent Execution Contract」PR
+> の実装状況を記録する。Architecture Decision本文（§1〜§15）および
+> 前3つのAddendum（Implemented Contract Foundation / Level 2 Visit
+> Preference Signal Redesign / Level 3 Profile / Explicit Constraint /
+> Recommendation Context Contract）は書き換えていない。本PRは
+> **既存Signal（L1〜L3）を統合Contractとしてテスト・監査するのみ**
+> であり、ranking weight・candidate filtering semantics・
+> Recommendation Reasonのテキスト生成ロジック・Score v3 mode・DB
+> schema・Migration・Frontend IA・375px UIは、いずれも変更していない
+> （プロダクションコードの変更は0行）。
+
+### Core Principle（採用）
+
+**Consultation Meaning is the primary recommendation axis.**
+
+```text
+L1 Consultation        -> 主軸（why this shrine）
+L2 Visit Preference    -> 体験調整（what kind of visit experience fits）
+L3-A Personal Profile  -> Personalization（how to personalize for this person）
+L3-B Explicit Constraint -> Candidate制約（what must be satisfied）
+L3-C Recommendation Context -> 現実適合（what is practical for this visit）
+Learning                -> 将来の補正（今回は対象外、変更なし）
+```
+
+下位Signalが相談意味を勝手に置き換えない、という原則は、Integrated
+Contract Test（後述）で実際のコード動作として確認済み（推測ではなく
+実装から検証した）。
+
+### Integrated Recommendation Flow（実装確認済み）
+
+```text
+Raw Consultation（query）
+  ↓ resolve_need_payload / resolve_consultation_axis
+Interpretation（need_tags, consultation_axis）
+  ↓ build_chat_candidates（goriyaku_tag_idsのみhard filter適用）
+Candidate Constraint（L3-B Explicit Constraint）
+  ↓ _attach_breakdown（need/element/visit_style/distance/direction合算）
+Ranking（L1 meaning + L2 experience + L3-A personalization + L3-C context）
+  ↓ _build_reason_facts + _resolve_primary_reason + build_recommendation_reason
+Recommendation Reason（reason_facts, _primary_reason_source, reason text）
+```
+
+### Signal Responsibility（実装確認済み、既存の割当てを再確認したのみ）
+
+| Signal | Purpose | 実装箇所 |
+|---|---|---|
+| Consultation（`need_tags`/`consultation_axis`） | Why this shrine? | `resolve_need_payload`/`resolve_consultation_axis`、`_attach_breakdown`の`matched_by_tag`/`matched_by_text`/`matched_by_gid`→`score_need` |
+| Visit Preference（`visit_style_tags`） | What kind of visit experience fits? | `resolve_visit_preference_tags`（PR #2405）→`_attach_breakdown`の`score_visit_style`（w5=0.35固定） |
+| Personal Profile（`birthdate`） | How should this be personalized? | `_attach_breakdown`の`score_element`/`astro_bonus`、`_score_profile_signal` |
+| Explicit Constraint（`goriyaku_tag_ids`） | What must be satisfied? | `build_chat_candidates`のDB-level hard filter（Candidate段階、Rankingではない） |
+| Recommendation Context（`lat`/`lng`/`radius`/`visit_date`） | What is practical? | `_distance_decay`（`score_distance`）、`_resolve_direction_bonus`（`direction_bonus`） |
+
+### Candidate Selection Contract（Task 4）
+
+```text
+Candidate Selectionを変更できるのは goriyaku_tag_ids のみ
+（DB-level hard filter、build_chat_candidates内）
+  ↓
+Candidate Selection後、以下でRankingを決定:
+  Consultation Meaning（need/consultation_axis）
+  Visit Preference（visit_style）
+  Personal Profile（element/astro）
+  Recommendation Context（distance/direction）
+```
+
+`goriyaku_tag_ids`はCandidate集合を変えるが、Ranking Bonusとしての
+score加算は行わない（`_attach_breakdown`内でgoriyaku一致は
+`matched_by_gid`経由でneed scoreへ寄与することはあるが、hard filter
+そのものは加点しない）。この区別は既存実装のまま、変更していない。
+
+### Ranking Contract（Task 5、既存weight、変更なし）
+
+| 概念 | 対応する既存weight | 現在値（needモード） | 現在値（compatモード） |
+|---|---|---|---|
+| Meaning Match | `need` | 0.3 | 0.2 |
+| Personalization | `element` | 0.6 | 0.8 |
+| Practical Fit | `distance` | 0.35 | 0.15 |
+| Experience Fit | `visit_style`（固定w5） | 0.35（モード共通） | 0.35（モード共通） |
+
+いずれも`_resolve_mode_weights()`/`_attach_breakdown()`の既存値であり、
+本PRでのweight tuningは行っていない
+（`test_weights_unchanged_from_documented_contract`で固定化）。
+
+### Priority / Override Rules（Task 6、実装確認済み）
+
+- **Rule 1** — ConsultationはRecommendation Meaningの主軸。採用。
+- **Rule 2** — Visit PreferenceはConsultation Meaningを上書きしない。採用
+  （`test_conflict_consultation_vs_visit_preference_does_not_flip_ranking`
+  で確認: `visit_style`一致のみの候補は、`need_tag`一致する候補の後ろに
+  並ぶ）。
+- **Rule 3** — Personal ProfileはConsultation Meaningを上書きしない。採用
+  （`test_conflict_consultation_vs_personal_profile_does_not_flip_ranking`
+  で確認）。
+- **Rule 4** — Explicit ConstraintはCandidate集合を変更できるが、
+  Consultation Meaning自体は変更しない。採用
+  （`test_conflict_consultation_vs_explicit_constraint_evaluates_meaning_within_filtered_set`
+  で確認: 両候補がgoriyaku制約を満たしても、need一致する候補が上位）。
+- **Rule 5** — Recommendation Contextは意味ではなく現実適合へ利用する。
+  採用（`test_conflict_consultation_vs_context_does_not_relabel_reason_as_distance_only`
+  で確認: 近いだけで一致していない候補は`need_tag`をprimary reasonに
+  しない）。
+- **Rule 6** — 複数Signalが存在する場合でも、Recommendation Reasonが
+  単一補助Signalだけを主理由として誤表示しない。**部分的に採用、既知
+  Mismatchあり（次項参照）**。
+
+### Task 9/10/11: Primary Reason Audit（Current behavior / Mismatch / Proposed rule）
+
+現行実装には**2つの独立したprimary reasonシステム**が並行して存在する
+ことを確認した:
+
+1. **`reason_facts`システム**（`concierge_chat_ranking._build_reason_facts`
+   + `_resolve_primary_reason`）: `history_theme` > `culture_translation`
+   > `need_tag` > `text_hint` > `user_selected_tag` > `goriyaku_tag` >
+   `element` > `fallback` の優先順位。**`visit_style`はfact typeとして
+   一切生成されない。**
+2. **`_explanation_payload`システム**（`concierge_explanation_payload
+   .build_explanation_payload`）: 上記`reason_facts`の結果を再利用しつつ、
+   `_build_visit_style_primary_reason()`が独自に`primary_reason`を
+   **上書き**する。条件は「`reason_facts`のprimary_reasonが存在しない、
+   または`type == "fallback"`、かつvisit_style一致がある」場合のみ。
+
+**Current behavior**: 相談に一致するfactが1つもない（fallbackのみ）
+候補で、visit_style一致がある場合、`_explanation_payload.primary_reason.type`
+は`"visit_style"`になるが、同じ候補の`rec["_primary_reason_source"]`
+（`rank_explanation.primary_reason_source`と同じ値）は`"fallback"`の
+ままである。
+
+**Mismatch**: 同一レスポンス内の同一候補について、`rank_explanation
+.primary_reason_source`（`"fallback"`）と`_explanation_payload
+.primary_reason.type`（`"visit_style"`）が食い違う。両方ともpublicな
+response fieldとして返っており、どちらを「正」として参照するかが
+呼び出し側（frontend）に委ねられている。
+
+**実害の範囲（確認済み）**: 実際にユーザーへ表示される`rec["reason"]`
+文字列（`build_recommendation_reason`）は`_primary_reason_label`
+（reason_factsシステム側）のみを参照し、visit_styleを一切考慮しない。
+`_primary_reason_label`が`"element"`/`"fallback"`/`"user_selected_tag"`
+等、`_build_need_reason_text`のintent_mapに存在しないlabelの場合は
+汎用文言へ安全にfallbackする設計になっており、「静かな神社だから
+仕事に良い」のような意味の逆転をvisible textが起こすことは確認できな
+かった（`test_full_integration_visible_reason_text_reflects_consultation_not_lower_level_signal`
+で固定化）。**Mismatchは構造化fieldレベル（`_explanation_payload`
+vs `rank_explanation`）に留まり、主要な visible reason文言レベルには
+及んでいない**、というのが今回の監査結果である。
+
+**Proposed rule（案、未実装）**: `_build_visit_style_primary_reason()`の
+override先を`_explanation_payload`だけでなく`reason_facts`/
+`_resolve_primary_reason`側にも一貫させる（`PRIMARY_REASON_PRIORITY`へ
+`visit_style`を`fallback`の直前に追加する等）。ただしこれは
+`concierge_chat_ranking.py`と`concierge_explanation_payload.py`両方に
+またがる変更であり、公開response fieldの値を変えるため、**Reason
+Brush-up Follow-upへ送る**（今回のスコープでは「小さく安全な修正」
+とは判断しなかった）。
+
+### Task 10: Candidate Reason vs Rank Reason（既知の重なり、記録のみ）
+
+`user_selected_tag`（goriyaku明示指定）のreason factは、その神社が
+「候補に残った理由」（Candidate Eligibility、goriyaku hard filterを
+通過した）と「相談との一致以外に説明できる理由」（Rank Reason寄り）を
+兼ねている。`goriyaku_tag_ids`でフィルタされた候補群では、生き残った
+候補**全員**が同じ`user_selected_tag` factを持ちうるため、これだけで
+「なぜこの候補が1位か」を差別化する説明力は弱い。ただし
+`PRIMARY_REASON_PRIORITY`上`user_selected_tag`（4）は`need_tag`（2）/
+`text_hint`（3）より低優先度のため、Consultation一致がある限り
+primary reasonにはならない（Rule 4の担保、確認済み）。この重なりは
+**Current Gapとして記録するのみ**とし、Reason Brush-up Follow-upへ送る。
+
+### Task 8/14: Explainability Boundary（既存breakdown構造の再利用）
+
+新しいschemaは作らず、既存の`breakdown_detail.features`を以下へ対応
+させて確認した:
+
+| Explainability概念 | 既存field |
+|---|---|
+| candidate_eligibility | `build_chat_candidates`のgoriyaku hard filter（breakdown外、候補生成段階） |
+| meaning_fit | `breakdown_detail.features.need`（`matched_tags`/`raw`/`rank_weighted`） |
+| visit_preference_fit | `breakdown_detail.features.visit_style`（`matched_tags`/`raw`/`contribution`） |
+| profile_fit | `breakdown_detail.features.element`（`raw`/`contribution`）、`astro_bonus` |
+| context_fit | `breakdown_detail.features.distance`（`raw`/`contribution`）、`direction_bonus` |
+
+`test_breakdown_detail_separates_meaning_visit_profile_context_features`
+で、これら5つが同一Recommendationに対して独立して読み取れることを
+確認した（Why eligible? / Why ranked? / Why recommended now? への分解、
+Task 14参照。UIへの新規表示は行っていない）。
+
+### Task 12/13: Integrated Contract Tests
+
+`backend/temples/tests/test_concierge_integrated_recommendation_contract.py`
+（新規、16件）:
+
+- 組み合わせ行列: L1 only / L1+L2 / L1+L3-A / L1+L3-B / L1+L3-C /
+  L1+L2+L3-A / L1+L2+L3-B / L1+L3-B+L3-C / Full Integration（全Signal
+  同時）
+- 競合シナリオ4件（§7）: Consultation vs Visit Preference / Personal
+  Profile / Explicit Constraint / Recommendation Context
+- Explainability境界の確認1件
+- Weight不変の確認1件
+
+Full Integrationでは、Candidate filter適用・need score維持・
+consultation_axis維持・visit preference score反映・birthdate score
+反映・context distance反映・primary reasonが補助Signalのみに乗っ取ら
+れないこと・reason_factsが実際のSignalと一致することを、すべて
+1つのテストで確認している。
+
+### Task 16: Browser QA
+
+- **Case A（相談のみ）**: dev server上で「仕事の転機で迷っています」を
+  送信し、200 OK・console error無し・reasonが仕事/転機のconsultation
+  文脈を正しく反映していることを確認した。
+- **Case B（相談 + Visit Preference）**: 開いた`ConciergeFilterPanel`
+  経由の構造化Visit Preference送信は、PR #2405のBrowser QAで
+  `requested_visit_style_tags`が正しくbackendへ到達することを実機確認
+  済み（本PRでの再検証は省略）。**閉じた4-preset card**
+  （`ConciergeSectionsRenderer.tsx`の`togglePreset`、PR #2405で追加）
+  経由の同等の検証は、本PRのBrowser QA中にライブE2Eでは再現性のある
+  確認が取れなかった（自動化ブラウザ操作のタイミング起因の疑いが強い
+  ── 同一操作で意図せず2回requestが発火する事象を観測）。ライブE2Eの
+  代わりに、`ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx`
+  （新規、単体テスト）で`togglePreset`のonAction呼び出しを直接検証し、
+  「静か」→`filter_set_visit_preferences({visitPreferences:["quiet"]})`、
+  「駅近」→`["nearby"]`、「ひとり」→dispatchされない、をすべて確認した。
+  コードパス自体は正しいと判断する。
+- **Case C（Full Integration）**: 相談 + birthdate + goriyaku +
+  Visit Preferenceの同時送信は、PR #2406のBrowser QAで実機確認済み
+  （`score_element`/`matched_user_selected_goriyaku_tag_ids`/
+  `score_visit_style`が同一レスポンス内ですべて正しく反映されることを
+  確認）。本PRはranking/reasonロジックを変更していないため、再検証は
+  省略した。
+
+### No Behavior Change Verification（実行結果）
+
+```
+Backend: python -m pytest -p no:dotenv temples/ -q
+  -> 1264 passed, 9 skipped（既存1248 + 新規Integrated Contract test 16件）
+
+Web: vitest run
+  -> Test Files 119 passed, Tests 769 passed（既存766 + 新規3件、
+     closed-card visit preference dispatch回帰テスト）
+```
+
+Candidate filtering behavior change = 0
+Ranking behavior change = 0
+Recommendation Reasonのtext生成ロジック変更 = 0
+API compatibility change = 0
+Weight変更 = 0
+Migration = 0
+本PRのプロダクションコード変更 = 0行（backend/frontendとも、テスト
+ファイル2件・本ドキュメントの追加のみ）
+
+### Follow-up（本PRでは実装しない）
+
+- **Reason Brush-up**: `_explanation_payload.primary_reason`（visit_style
+  override）と`rank_explanation.primary_reason_source`（reason_facts）の
+  Mismatch解消。`PRIMARY_REASON_PRIORITY`へ`visit_style`を統合するか、
+  もしくは`_build_visit_style_primary_reason()`のoverride条件を
+  `reason_facts`側にも一貫させるかをProduct/Engineering判断とする。
+- **Weight Optimization**: 実ユーザーデータを使った重み調整（今回は
+  意図的に対象外）。
+- **Learning Feedback**: 過去行動によるPersonalization（Rule 5、既存の
+  `calculate_shrine_behavior_signal_breakdown`ループを超えた拡張）。
+- **Frontend IA**: L1→L2→L3段階UI表示。
+- **Responsive Polish**: 375/390/430px全体調整。


### PR DESCRIPTION
## Summary

PR #2397 (Signal Audit) / #2398 (Architecture Decision) / #2399 (Input Contract Foundation) / #2405 (Level 2 Visit Preference) / #2406 (Level 3 Contract) を統合し、

```
Raw Consultation -> Interpretation -> Candidate Constraint -> Ranking -> Recommendation Reason
```

というRecommendation Flowを、コード上のContractとしてテスト・監査で完成させる。**プロダクションコードの変更は0行**（test 2ファイル + ドキュメント追加のみ）。

## Core Principle

**Consultation Meaning is the primary recommendation axis.** L2 Visit Preference / L3-A Personal Profile / L3-B Explicit Constraint / L3-C Recommendation Contextが相談の意味を勝手に上書きしないことを、**既存実装から実際に検証した**（推測ではなく、コードを読み・動かして確認した）。

## 主な内容

- **Integrated Contract Test**（新規16件、`test_concierge_integrated_recommendation_contract.py`）: L1 only 〜 Full Integration までの組み合わせ行列（8パターン）+ 4件の競合シナリオ（Consultation vs Visit Preference / Personal Profile / Explicit Constraint / Recommendation Context）を `build_chat_recommendations` 経由で検証。**すべて既存実装のままpass**（コード変更なしで既にRule 1-5を満たしていることを確認）。
- **Primary Reason監査**（Task 9-11）: `reason_facts`システム（`_resolve_primary_reason`）と `_explanation_payload`システム（`_build_visit_style_primary_reason`のvisit_styleオーバーライド）という**2つの独立したprimary reasonロジックが並行している**ことを発見。両者が食い違うケース（同一候補で`rank_explanation.primary_reason_source == "fallback"` かつ `_explanation_payload.primary_reason.type == "visit_style"`）をMismatchとして記録した。ユーザーに見える`reason`テキスト自体（`build_recommendation_reason`）には実害が及んでいないことを確認した上で、修正は「小さく安全」と判断せず**Reason Brush-up Follow-upへ送った**（今回は変更していない）。
- **Explainability監査**（Task 8/14）: 新しいschemaは作らず、既存の`breakdown_detail.features`が candidate_eligibility / meaning_fit / visit_preference_fit / profile_fit / context_fit へ既に対応済みであることを確認・テスト化した。
- Browser QA中に、closed-card preset toggle（`ConciergeSectionsRenderer.togglePreset`、PR #2405で追加）のvisit_preference dispatchをlive E2Eで再現よく確認できない事象を観測。ブラウザ自動化のタイミング起因と判断し、単体テスト（新規、`ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx`）で`onAction`呼び出しを直接検証し、コードパス自体が正しいことを確定させた。

## 禁止事項（変更なし）

Level 1/2/3 semantics・ranking weight・candidate filtering・Recommendation Reasonのtext生成ロジック・Score v3 mode・DB schema・Migration・Frontend Information Architecture・375px UIは、いずれも変更していません。

## Verification

- Backend: `pytest temples/` → **1264 passed, 9 skipped**（既存1248 + 新規16件）
- Web: `vitest run` → **119 files / 769 tests passed**（既存766 + 新規3件）
- Web typecheck / build: pass
- Migration: 0件
- Live browser QA: Case A（相談のみ）を本PRのセッションで実機確認。Case B（相談+Visit Preference、open panel経路）とCase C（Full Integration）はPR #2405/#2406で実機確認済みのため再検証を省略（本PRはranking/reasonロジックを変更していないため）。

## Behavior change disclosure

- Candidate filtering behavior change: **なし**
- Ranking behavior change: **なし**
- API compatibility change: **なし**
- Persistence change: **なし**
- Migration: **0件**

## Test plan

- [x] Backend: `cd backend && python -m pytest -p no:dotenv temples/ -q`
- [x] Web: `pnpm --filter ./apps/web test:run` / `pnpm --filter ./apps/web typecheck` / `pnpm --filter ./apps/web build`
- [x] Manual: dev serverで相談のみのCase Aを実機確認、closed-card preset toggleの疑わしい挙動を単体テストで確定検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)