### PR TITLE
Recommendation Primary Reason Contract Unification

### DIFF
--- a/backend/temples/services/concierge_chat_ranking.py
+++ b/backend/temples/services/concierge_chat_ranking.py
@@ -486,6 +486,7 @@ NEED_LABELS_JA: Dict[str, str] = {
     "fallback": "近い候補",
     "history_theme": "歴史文脈",
     "culture_translation": "神社固有文脈",
+    "visit_style": "参拝スタイル",
 }
 
 # Recommendation Reason Responsibility:
@@ -502,6 +503,16 @@ PRIMARY_REASON_PRIORITY: Dict[str, int] = {
     "user_selected_tag": 4,
     "goriyaku_tag": 5,
     "element": 6,
+    # visit_style: Level 2 Visit Preference. Lowest priority short of
+    # fallback -- it is a "fallback primary reason candidate" (Task 8,
+    # Recommendation Primary Reason Contract Unification): it only becomes
+    # the primary reason when nothing else (not even element) matched.
+    # This mirrors the precedence the previous, now-removed
+    # concierge_explanation_payload._build_visit_style_primary_reason()
+    # override enforced (it only fired when the reason_facts primary was
+    # None/"fallback"), now expressed as a single ordinary priority tier
+    # instead of a second, independent resolver.
+    "visit_style": 7,
     "fallback": 9,
 }
 
@@ -552,6 +563,7 @@ def _build_reason_facts(
     score_element: int,
     astro_bonus_enabled: bool,
     shrine_meaning_profile: Optional[Dict[str, Any]] = None,
+    matched_visit_style_tags: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     facts: List[Dict[str, Any]] = []
     profile = shrine_meaning_profile or {}
@@ -622,6 +634,21 @@ def _build_reason_facts(
                 label=tag,
                 evidence=[f"text_score:{text_score_by_tag.get(tag, 0)}"],
                 score=float(text_score_by_tag.get(tag, 0)),
+            )
+        )
+
+    visit_style_tags = [
+        str(tag).strip()
+        for tag in (matched_visit_style_tags or [])
+        if str(tag).strip()
+    ]
+    if visit_style_tags:
+        facts.append(
+            _make_reason_fact(
+                type_="visit_style",
+                label="visit_style",
+                evidence=list(visit_style_tags),
+                score=float(len(visit_style_tags)),
             )
         )
 
@@ -1421,6 +1448,7 @@ def _attach_breakdown(
         score_element=score_element,
         astro_bonus_enabled=astro_bonus_enabled,
         shrine_meaning_profile=shrine_meaning_profile,
+        matched_visit_style_tags=matched_visit_style_tags,
     )
     primary_reason = _resolve_primary_reason(reason_facts)
 

--- a/backend/temples/services/concierge_explanation_payload.py
+++ b/backend/temples/services/concierge_explanation_payload.py
@@ -143,38 +143,6 @@ def _normalize_reason_facts(value: Any, *, limit: int | None = None) -> List[Dic
     return out
 
 
-def _build_visit_style_primary_reason(rec: Dict[str, Any]) -> Dict[str, Any] | None:
-    breakdown_detail = (
-        rec.get("breakdown_detail")
-        if isinstance(rec.get("breakdown_detail"), dict)
-        else {}
-    )
-    features = breakdown_detail.get("features") if isinstance(breakdown_detail, dict) else {}
-    if not isinstance(features, dict):
-        return None
-
-    visit_style = features.get("visit_style")
-    if not isinstance(visit_style, dict):
-        return None
-
-    matched_tags = _safe_str_list(visit_style.get("matched_tags"), limit=5)
-    if not matched_tags:
-        return None
-
-    contribution = float(visit_style.get("contribution") or 0.0)
-    if contribution <= 0:
-        return None
-
-    return {
-        "type": "visit_style",
-        "label": matched_tags[0],
-        "label_ja": NEED_LABELS_JA["visit_style"],
-        "evidence": matched_tags,
-        "score": contribution,
-        "is_primary": True,
-    }
-
-
 def build_explanation_payload(rec: Dict[str, Any], *, birthdate: Optional[str] = None) -> Dict[str, Any]:
     """
     explanation 用の正規化 payload を作る。
@@ -231,20 +199,15 @@ def build_explanation_payload(rec: Dict[str, Any], *, birthdate: Optional[str] =
         limit=5,
     )
 
+    # Single Source of Truth (Recommendation Primary Reason Contract
+    # Unification): primary_reason comes exclusively from
+    # rec["_reason_facts"] (concierge_chat_ranking._build_reason_facts /
+    # _resolve_primary_reason), which now includes a "visit_style" fact
+    # type (PRIMARY_REASON_PRIORITY) -- no independent second resolver.
     primary_reason = next(
         (x for x in reason_facts if x.get("is_primary")),
         None,
     )
-
-    visit_style_primary_reason = _build_visit_style_primary_reason(rec)
-    if (
-        visit_style_primary_reason is not None
-        and (
-            primary_reason is None
-            or str(primary_reason.get("type") or "").strip() == "fallback"
-        )
-    ):
-        primary_reason = visit_style_primary_reason
 
     if primary_reason is None:
         source = str(rec.get("_primary_reason_source") or "").strip()

--- a/backend/temples/services/concierge_explanations.py
+++ b/backend/temples/services/concierge_explanations.py
@@ -221,6 +221,17 @@ def _build_summary_from_primary_reason(
         if reason_type == "element":
             return "生年月日から見た傾向も、補助情報として重ねています。"
 
+        if reason_type == "visit_style":
+            evidence = primary_reason.get("evidence") if isinstance(primary_reason.get("evidence"), list) else []
+            tags = [str(x).strip() for x in evidence if isinstance(x, str) and str(x).strip()]
+            if "quiet" in tags and "less_crowded" in tags:
+                return "静かで人が少なめの雰囲気を求める条件と重なる神社です。"
+            if "quiet" in tags:
+                return "静かで落ち着いた雰囲気を求める条件と重なる神社です。"
+            if "less_crowded" in tags:
+                return "人が少なめで落ち着いて参拝したい条件と重なる神社です。"
+            return "参拝スタイルの希望と重なる神社です。"
+
         if reason_type == "fallback":
             return "今の条件に近い神社として整理しています。"
 

--- a/backend/temples/tests/services/test_concierge_explanations.py
+++ b/backend/temples/tests/services/test_concierge_explanations.py
@@ -4,7 +4,20 @@ from temples.services.concierge_explanation_payload import build_explanation_pay
 from temples.services.concierge_explanations import build_explanation_for_chat_rec
 
 
-def test_build_explanation_payload_prefers_visit_style_over_fallback_primary_reason():
+def test_build_explanation_payload_is_single_source_of_truth_from_reason_facts_not_breakdown_detail():
+    """Recommendation Primary Reason Contract Unification (PR #2408):
+    build_explanation_payload() no longer independently derives a
+    visit_style primary_reason from breakdown_detail.features.visit_style
+    -- that was a second, independent resolver
+    (_build_visit_style_primary_reason, removed) that could disagree with
+    rec["_reason_facts"] (see PR #2407's Mismatch finding). primary_reason
+    is now read exclusively from rec["_reason_facts"]/is_primary, which
+    concierge_chat_ranking._build_reason_facts() populates with a
+    "visit_style" fact type (PRIMARY_REASON_PRIORITY) whenever a real
+    pipeline run has a visit_style match -- so this desync (fallback in
+    reason_facts, visit_style in breakdown_detail) can no longer arise from
+    the real pipeline; this test pins that the payload builder trusts
+    reason_facts even when handed such an (now-impossible) input."""
     payload = build_explanation_payload(
         {
             "reason": "候補としておすすめしています。",
@@ -37,14 +50,60 @@ def test_build_explanation_payload_prefers_visit_style_over_fallback_primary_rea
     )
 
     assert payload["primary_reason"] == {
-        "type": "visit_style",
-        "label": "quiet",
-        "label_ja": "参拝スタイル",
-        "evidence": ["quiet"],
-        "score": 0.35,
+        "type": "fallback",
+        "label": "fallback",
+        "label_ja": "近い候補",
+        "evidence": [],
+        "score": 0.0,
         "is_primary": True,
     }
     assert payload["matched_need_tags"] == []
+
+
+def test_build_explanation_payload_reads_visit_style_primary_reason_from_reason_facts():
+    """The correct (real pipeline) shape: _build_reason_facts() already
+    marks the visit_style fact is_primary=True when it wins
+    PRIMARY_REASON_PRIORITY -- build_explanation_payload() just passes it
+    through."""
+    payload = build_explanation_payload(
+        {
+            "reason": "候補としておすすめしています。",
+            "_reason_facts": [
+                {
+                    "type": "visit_style",
+                    "label": "visit_style",
+                    "label_ja": "参拝スタイル",
+                    "evidence": ["quiet"],
+                    "score": 1.0,
+                    "is_primary": True,
+                }
+            ],
+            "breakdown": {
+                "score_need": 0,
+                "score_total": 0.0,
+                "matched_need_tags": [],
+            },
+            "breakdown_detail": {
+                "features": {
+                    "visit_style": {
+                        "raw": 1,
+                        "matched_tags": ["quiet"],
+                        "contribution": 0.35,
+                    },
+                    "score_total_ranked": 0.35,
+                }
+            },
+        }
+    )
+
+    assert payload["primary_reason"] == {
+        "type": "visit_style",
+        "label": "visit_style",
+        "label_ja": "参拝スタイル",
+        "evidence": ["quiet"],
+        "score": 1.0,
+        "is_primary": True,
+    }
 
 
 # New test for user_selected_tag primary reason

--- a/backend/temples/tests/test_concierge_primary_reason_unification_contract.py
+++ b/backend/temples/tests/test_concierge_primary_reason_unification_contract.py
@@ -1,0 +1,314 @@
+# backend/temples/tests/test_concierge_primary_reason_unification_contract.py
+"""Recommendation Primary Reason Contract Unification.
+
+Covers docs/product/concierge-input-architecture.md Addendum: Primary
+Reason Single Source of Truth. Fixes the Mismatch discovered in PR #2407
+(Integrated Recommendation Intent Execution Contract): `rank_explanation
+.primary_reason_source` and `_explanation_payload.primary_reason.type`
+could disagree for the same recommendation, because
+`_build_visit_style_primary_reason()` (concierge_explanation_payload.py)
+was a second, independent primary-reason resolver bolted onto the
+explanation payload, separate from `reason_facts`/`_resolve_primary_reason`
+(concierge_chat_ranking.py).
+
+Fix: `visit_style` is now a proper `reason_facts` fact type
+(PRIMARY_REASON_PRIORITY), so both systems read the exact same
+`rec["_reason_facts"]`/`is_primary` value -- there is exactly one primary
+reason resolver.
+
+This PR does not change ranking weights, candidate filtering, or scoring
+-- reason_facts/primary_reason are purely descriptive fields computed
+after `_score_total`/`score_total_ranked` are already finalized.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_ranking import PRIMARY_REASON_PRIORITY
+
+
+CAREER_QUERY = "転職を考えていて、仕事の転機に向き合いたいです"
+REQUESTED_GORIYAKU_ID = 501
+
+
+def _shrine_match(**overrides):
+    base = {
+        "name": "Match",
+        "distance_m": 500.0,
+        "lat": 35.001,
+        "lng": 139.001,
+        "popular_score": 5.0,
+        "astro_tags": ["career"],
+        "astro_elements": ["火"],
+        "goriyaku_tag_ids": [REQUESTED_GORIYAKU_ID],
+        "visit_style_tags": ["quiet"],
+        "goriyaku": "",
+        "description": "",
+        "history_theme": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _shrine_quiet_only(**overrides):
+    base = {
+        "name": "QuietOnly",
+        "distance_m": 500.0,
+        "lat": 35.002,
+        "lng": 139.002,
+        "popular_score": 5.0,
+        "astro_tags": [],
+        "astro_elements": [],
+        "goriyaku_tag_ids": [],
+        "visit_style_tags": ["quiet"],
+        "goriyaku": "",
+        "description": "",
+        "history_theme": "",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def deterministic(monkeypatch, settings):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    import temples.domain.need_tags as need
+
+    class FakeNeedExtract:
+        def __init__(self):
+            self.tags = ["career"]
+            self.hits = {"career": ["転職"]}
+
+    monkeypatch.setattr(need, "extract_need_tags", lambda q, max_tags=3: FakeNeedExtract(), raising=True)
+
+    import temples.domain.astrology as astro
+
+    class _Prof:
+        sign = "牡羊座"
+        element = "火"
+
+    monkeypatch.setattr(astro, "sun_sign_and_element", lambda birthdate: _Prof(), raising=True)
+    monkeypatch.setattr(
+        astro,
+        "element_priority",
+        lambda user_elem, shrine_elems: 2 if "火" in (shrine_elems or []) else 0,
+        raising=True,
+    )
+    return None
+
+
+def _run(candidates, **kwargs):
+    kwargs.setdefault("query", CAREER_QUERY)
+    kwargs.setdefault("language", "ja")
+    kwargs.setdefault("candidates", candidates)
+    return build_chat_recommendations(**kwargs)
+
+
+def _rec_by_name(recs, name):
+    for r in recs["recommendations"]:
+        if r.get("name") == name:
+            return r
+    raise AssertionError(f"{name!r} not found: {[r.get('name') for r in recs['recommendations']]}")
+
+
+# ---------------------------------------------------------------------------
+# Task 1/2/3: Inventory sanity -- visit_style is now a first-class fact type
+# ---------------------------------------------------------------------------
+
+
+def test_visit_style_is_a_priority_tier_below_element_above_fallback():
+    assert PRIMARY_REASON_PRIORITY["element"] < PRIMARY_REASON_PRIORITY["visit_style"]
+    assert PRIMARY_REASON_PRIORITY["visit_style"] < PRIMARY_REASON_PRIORITY["fallback"]
+    # Consultation-Meaning-derived and Explicit-Constraint-derived types all
+    # outrank visit_style (Rule: Visit Preference is a "fallback primary
+    # reason candidate", Task 8).
+    for stronger in ("history_theme", "culture_translation", "need_tag", "text_hint", "user_selected_tag", "goriyaku_tag"):
+        assert PRIMARY_REASON_PRIORITY[stronger] < PRIMARY_REASON_PRIORITY["visit_style"]
+
+
+# ---------------------------------------------------------------------------
+# Task 13: PR #2407 Mismatch is fixed -- both systems agree
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_no_consultation_match_visit_style_only_becomes_unified_primary_reason(deterministic):
+    """Reproduces the exact PR #2407 Mismatch scenario: a candidate with
+    zero Consultation Meaning match but a visit_style match. Before this
+    fix: rank_explanation.primary_reason_source == "fallback" while
+    _explanation_payload.primary_reason.type == "visit_style" (disagreement).
+    After this fix: both agree on "visit_style"."""
+    recs = _run([_shrine_quiet_only()], visit_preferences=["quiet"])
+    rec = recs["recommendations"][0]
+
+    assert rec["_primary_reason_source"] == "visit_style"
+    assert rec["rank_explanation"]["primary_reason_source"] == "visit_style"
+    assert rec["_explanation_payload"]["primary_reason"]["type"] == "visit_style"
+
+    # Single Source of Truth: all three systems reference the exact same
+    # underlying fact (same evidence).
+    assert (
+        rec["_reason_facts"][0]["evidence"]
+        == rec["_explanation_payload"]["primary_reason"]["evidence"]
+    )
+
+
+@pytest.mark.django_db
+def test_visit_style_primary_reason_flows_into_explanation_summary(deterministic):
+    recs = _run([_shrine_quiet_only()], visit_preferences=["quiet"])
+    rec = recs["recommendations"][0]
+
+    from temples.services.concierge_explanations import build_explanation_for_chat_rec
+
+    explanation = build_explanation_for_chat_rec(
+        rec, query=CAREER_QUERY, bias=None, birthdate=None, extra_condition=None,
+    )
+    assert "静か" in explanation["summary"] or "参拝スタイル" in explanation["summary"]
+
+
+# ---------------------------------------------------------------------------
+# Task 15: primary reason must exist in reason_facts (no ungrounded reason)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "candidates,visit_preferences,goriyaku_tag_ids,birthdate",
+    [
+        ([_shrine_match()], None, None, None),
+        ([_shrine_quiet_only()], ["quiet"], None, None),
+        ([_shrine_match()], None, [REQUESTED_GORIYAKU_ID], None),
+        ([_shrine_match()], None, None, "1990-01-01"),
+        ([{"name": "NoMatch", "distance_m": 500.0, "lat": 35.0, "lng": 139.0, "popular_score": 1.0}], None, None, None),
+    ],
+)
+def test_primary_reason_is_always_grounded_in_reason_facts(
+    deterministic, candidates, visit_preferences, goriyaku_tag_ids, birthdate,
+):
+    recs = _run(
+        candidates,
+        visit_preferences=visit_preferences,
+        goriyaku_tag_ids=goriyaku_tag_ids,
+        birthdate=birthdate,
+    )
+    rec = recs["recommendations"][0]
+    primary_source = rec["_primary_reason_source"]
+    primary_label = rec["_primary_reason_label"]
+
+    fact_keys = {(f["type"], f["label"]) for f in rec["_reason_facts"]}
+    assert (primary_source, primary_label) in fact_keys or primary_source == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# Task 16: Full Integration Reason Contract Test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_full_integration_primary_reason_is_unified_and_consultation_led(deterministic):
+    recs = _run(
+        [_shrine_match(distance_m=100.0)],
+        visit_preferences=["quiet"],
+        birthdate="1990-01-01",
+        goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID],
+    )
+    rec = recs["recommendations"][0]
+
+    # Candidate constraint applied / consultation meaning maintained
+    assert rec["breakdown"]["matched_need_tags"] == ["career"]
+    assert recs["consultation_axis"] == "career_change"
+
+    # visit preference / element / context all present as secondary signal
+    visit_style = ((rec.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert visit_style.get("matched_tags") == ["quiet"]
+    assert rec["breakdown"]["score_element"] == 2
+
+    # Primary Reason unified across all three surfaces
+    assert rec["_primary_reason_source"] in {"need_tag", "text_hint", "user_selected_tag", "history_theme", "goriyaku_tag"}
+    assert rec["rank_explanation"]["primary_reason_source"] == rec["_primary_reason_source"]
+    assert rec["_explanation_payload"]["primary_reason"]["type"] == rec["_primary_reason_source"]
+
+    # reason_facts grounds the primary reason
+    fact_keys = {(f["type"], f["label"]) for f in rec["_reason_facts"]}
+    assert (rec["_primary_reason_source"], rec["_primary_reason_label"]) in fact_keys
+
+    # visible reason text does not contradict (career/consultation led, not
+    # a bare visit-style/element-only phrase)
+    assert "仕事" in rec["reason"] or "転機" in rec["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Task 17: Conflict Reason Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_plus_visit_preference_meaning_wins_primary(deterministic):
+    recs = _run([_shrine_match()], visit_preferences=["quiet"])
+    rec = recs["recommendations"][0]
+    assert rec["_primary_reason_source"] in {"need_tag", "text_hint", "history_theme", "goriyaku_tag"}
+    secondary_types = {f["type"] for f in rec["_reason_facts"] if not f.get("is_primary")}
+    assert "visit_style" in secondary_types
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_plus_profile_meaning_wins_primary(deterministic):
+    # element only becomes a reason_fact candidate at all in compat mode
+    # (astro_bonus_enabled = public_mode == "compat", Task 9) -- need mode
+    # never produces an "element" fact, matching existing behavior.
+    recs = _run([_shrine_match()], birthdate="1990-01-01", public_mode="compat")
+    rec = recs["recommendations"][0]
+    assert rec["_primary_reason_source"] in {"need_tag", "text_hint", "history_theme", "goriyaku_tag"}
+    secondary_types = {f["type"] for f in rec["_reason_facts"] if not f.get("is_primary")}
+    assert "element" in secondary_types
+
+
+@pytest.mark.django_db
+def test_conflict_consultation_plus_constraint_meaning_wins_when_present(deterministic):
+    recs = _run([_shrine_match()], goriyaku_tag_ids=[REQUESTED_GORIYAKU_ID])
+    rec = recs["recommendations"][0]
+    # Consultation Meaning (need_tag/text_hint/history_theme) outranks pure
+    # Explicit Constraint (user_selected_tag) per PRIMARY_REASON_PRIORITY.
+    assert rec["_primary_reason_source"] in {"need_tag", "text_hint", "history_theme", "goriyaku_tag"}
+
+
+@pytest.mark.django_db
+def test_context_only_never_becomes_primary_meaning_reason(deterministic):
+    """Context (distance/location) has no reason_facts type at all -- it
+    can never become the primary reason, regardless of how close the
+    candidate is."""
+    near = {"name": "Near", "distance_m": 10.0, "lat": 35.0, "lng": 139.0, "popular_score": 1.0}
+    recs = _run([near])
+    rec = recs["recommendations"][0]
+    assert rec["_primary_reason_source"] == "fallback"
+    for fact in rec["_reason_facts"]:
+        assert fact["type"] not in {"distance", "context", "location"}
+
+
+# ---------------------------------------------------------------------------
+# Task 18: No Ranking Change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_ranking_scores_unaffected_by_primary_reason_unification(deterministic):
+    """score_total / _score_total / score_need / score_element /
+    score_visit_style(raw) / distance contribution are computed before
+    reason_facts and are unaffected by this PR (reason_facts is
+    purely descriptive metadata attached afterward)."""
+    candidates = [_shrine_match(distance_m=250.0), _shrine_quiet_only(distance_m=250.0)]
+
+    recs = _run(candidates, visit_preferences=["quiet"], birthdate="1990-01-01")
+    names = [r["name"] for r in recs["recommendations"]]
+    assert names == ["Match", "QuietOnly"]
+
+    match = _rec_by_name(recs, "Match")
+    assert match["breakdown"]["score_need"] == 1
+    assert match["breakdown"]["score_element"] == 2
+    visit_style = ((match.get("breakdown_detail") or {}).get("features") or {}).get("visit_style") or {}
+    assert visit_style.get("raw") == 1
+    assert match["_score_total"] > 0

--- a/docs/product/concierge-input-architecture.md
+++ b/docs/product/concierge-input-architecture.md
@@ -1477,3 +1477,243 @@ Migration = 0
   `calculate_shrine_behavior_signal_breakdown`ループを超えた拡張）。
 - **Frontend IA**: L1→L2→L3段階UI表示。
 - **Responsive Polish**: 375/390/430px全体調整。
+
+---
+
+## Addendum: Recommendation Primary Reason Contract Unification
+
+> 本Addendumは「Recommendation Primary Reason Contract Unification」PR
+> の実装状況を記録する。Architecture Decision本文（§1〜§15）および
+> 前3つのAddendumは書き換えていない。Ranking weight・Candidate
+> filtering semantics・goriyaku hard filter・Level 1/2/3 scoring
+> semantics・distance/context scoring・Score v3 mode・DB schema・
+> Migration・Frontend UI・375px Information Architecture・Learning
+> Signalは、いずれも変更していない。
+
+### 背景：PR #2407で発見されたMismatch
+
+PR #2407（Integrated Recommendation Intent Execution Contract）は、
+Primary Reasonの生成経路が2系統に分裂していることを発見した:
+
+1. **`reason_facts`システム**
+   （`concierge_chat_ranking._build_reason_facts` +
+   `_resolve_primary_reason`、`PRIMARY_REASON_PRIORITY`で優先順位付け）
+2. **`_explanation_payload`システム**
+   （`concierge_explanation_payload._build_visit_style_primary_reason`が
+   独自にvisit_style判定を上書きする、2つ目の独立resolver）
+
+両者は同一Recommendationについて異なるprimary reasonを返しうる
+（例: `rank_explanation.primary_reason_source == "fallback"`かつ
+`_explanation_payload.primary_reason.type == "visit_style"`）。本PRは
+これを解消する。
+
+### Task 1: Primary Reason生成・加工・表示経路のInventory
+
+repo全体を検索して確認した実際の経路:
+
+| System | Producer | Input | Output field | Consumer | User visible | Ranking効果 |
+|---|---|---|---|---|---|---|
+| `reason_facts`（配列） | `concierge_chat_ranking._build_reason_facts` | matched_by_tag/gid/text, score_element, shrine_meaning_profile, **matched_visit_style_tags（本PRで追加）** | `rec["_reason_facts"]` / `rec["reason_facts"]` | `_resolve_primary_reason`、`_explanation_payload`、`concierge_explanations.py` | 間接（explanation経由） | なし（純粋に記述的、`_score_total`計算後に付与） |
+| `_resolve_primary_reason` | 同上 | `reason_facts` + `PRIMARY_REASON_PRIORITY` | `rec["_primary_reason_source"]` / `rec["_primary_reason_label"]` | `build_recommendation_reason`、`rank_explanation` | 間接 | なし |
+| `rank_explanation` | `_to_rank_explanation` | `rec`全体（breakdown, primary_reason等） | `rec["rank_explanation"]` | Frontend（debug/detail表示） | ✅（`ConciergeSectionsRenderer`等） | なし |
+| `_explanation_payload` | `concierge_explanation_payload.build_explanation_payload` | `rec["_reason_facts"]`（**visit_style override廃止、本PR**） | `rec["_explanation_payload"]` | `concierge_explanations.build_explanation_for_chat_rec` | 間接（explanation経由） | なし |
+| `explanation`（summary/reasons） | `concierge_explanations.build_explanation_for_chat_rec` | `_explanation_payload`, `breakdown_detail.features.visit_style` | `rec["explanation"]` | **Frontend表示カード**（"この神社について"等のsection） | **✅ 直接表示** | なし |
+| `build_recommendation_reason` | `concierge_chat_ranking.build_recommendation_reason` | `_primary_reason_label`, `matched_need_tags`, public_mode | `rec["reason"]` | **Frontend表示（見出し文）** | **✅ 直接表示** | なし |
+| `_attach_reason_source` | `concierge_chat_presentation.py` | `matched`, `public_mode`, `raw_reason` | `rec["reason_source"]` | Frontend（表示経路メタ情報） | 間接 | なし |
+| `api_views_concierge.build_reason_facts`（単数形、`ConciergeReasonFacts`型） | `api_views_concierge.py` | — | — | Frontend型のみ（`ConciergeReasonFacts`） | ❌ **未使用（dead code、一度も呼ばれていない）** | なし |
+
+**重要な発見**: `api_views_concierge.build_reason_facts()`（単数、
+`concierge_chat_ranking._build_reason_facts`とは別の関数）は定義されて
+いるが、repo全体で一度も呼び出されていない。対応するFrontend型
+`ConciergeReasonFacts`（`matched_element`/`shrine_benefit`/
+`visit_fit`/`distance_label`等）も常にnullである。これは既存のdead
+codeであり、本PRの対象外として記録するのみ（削除は行わない）。
+
+### Task 2: `reason_facts` / `_resolve_primary_reason`責務（Current）
+
+`_build_reason_facts()`が生成するfact typeとその条件:
+
+| Fact type | 生成条件 | Priority（`PRIMARY_REASON_PRIORITY`） |
+|---|---|---|
+| `history_theme` | `shrine_meaning_profile.matched_need_tags`かつ`history_theme`が存在 | 0 |
+| `culture_translation` | 同上かつ`culture_translation_present` | 1 |
+| `need_tag` | `matched_by_tag`（need_tagsとshrine astro_tagsの直接一致） | 2 |
+| `text_hint` | `matched_by_text`（goriyaku/description文中のキーワード一致） | 3 |
+| `user_selected_tag` | `matched_by_user_selected_gid`（ユーザーが明示選択したgoriyaku_tag_idsとcandidateの一致） | 4 |
+| `goriyaku_tag` | `matched_by_gid`（need_tag→goriyaku_id推定マッピングとcandidateの一致） | 5 |
+| `element` | `astro_bonus_enabled`（= `public_mode == "compat"`）かつ`score_element > 0` | 6 |
+| **`visit_style`（本PRで追加）** | **`matched_visit_style_tags`が非空** | **7** |
+| `fallback` | 他に何もない場合の`_resolve_primary_reason`のデフォルト | 9 |
+
+### Task 3: `_explanation_payload.primary_reason`責務（Fix後）
+
+`build_explanation_payload()`は、`rec["_reason_facts"]`から
+`is_primary: true`のfactを取得するだけになった
+（`_build_visit_style_primary_reason()`は削除）。独自のfallback判定
+（`_primary_reason_source`/`_primary_reason_label`からの再構成）は
+`reason_facts`が完全に空の防御的ケースのみに残す。
+
+### Task 5: Single Source of Truthの選定
+
+`reason_facts` + `_resolve_primary_reason`（`concierge_chat_ranking.py`）
+を正本とした。理由:
+
+- 唯一、実際のRanking根拠（`matched_by_tag`/`matched_by_gid`/
+  `score_element`等、`_attach_breakdown`が計算した値そのもの）から
+  直接構築されている。
+- `rank_explanation`は既にこれを参照している。
+- `_explanation_payload`は元々これを参照しつつ、visit_styleだけ独自
+  resolverを持っていた（Mismatchの原因）。
+
+新しい3つ目の独立ロジックは作っていない。`_explanation_payload`は
+`reason_facts`からの**派生**（is_primaryのpassthrough）に統一した。
+
+### Task 6: Reason責務の3分離（Contract）
+
+| 責務 | 説明 | 対応する既存構造 |
+|---|---|---|
+| **Candidate Eligibility** | なぜ候補として残ったか | `goriyaku_tag_ids`のDB-level hard filter（`build_chat_candidates`、Rankingより前の段階） |
+| **Rank Reason** | なぜこの候補が他より上位か | `breakdown_detail.features`（need/element/visit_style/distance等の重み付け合算、`_score_total`） |
+| **Primary Recommendation Reason** | なぜ今この人にこの神社を勧めるのか | `reason_facts` + `_resolve_primary_reason`（本Addendumの対象） |
+
+3つは既存実装上すでに別々の関数・別々のタイミングで計算されており、
+今回新たに分離したわけではない。今回はPrimary Recommendation Reason
+の**内部一貫性**（Single Source of Truth化）のみを扱った。
+
+### Task 7〜12: Priority Rules（既存優先順位を確認、最小限の追加のみ）
+
+- **Rule（Task 7）**: L1 Consultation由来（`history_theme`/
+  `culture_translation`/`need_tag`/`text_hint`）が最優先。Fact-backed
+  条件（`shrine_meaning_profile`/`matched_by_tag`等、実データに基づく
+  一致）を満たさない限りfact化されない — 根拠なしのReason生成は
+  現行実装でも発生しない。
+- **Rule（Task 8）**: Visit Preferenceは`visit_style`
+  priority=7として、element(6)より低くfallback(9)より高い位置に追加した。
+  これは、旧`_build_visit_style_primary_reason`のoverride条件
+  （`primary_reason is None or type == "fallback"`のときのみ発動 =
+  実質的にelementより弱い最終手段だった）と**同じ相対的な強さ**を
+  正式なpriority tierとして表現したものであり、既存の実効的な優先度を
+  変更していない。
+- **Rule（Task 9）**: `element`は`public_mode == "compat"`の場合のみ
+  fact化される（`astro_bonus_enabled`条件）。need modeでは`element`
+  factは一度も生成されない — 既存実装のまま、確認のみ
+  （`test_conflict_consultation_plus_profile_meaning_wins_primary`）。
+- **Rule（Task 10）**: `user_selected_tag`（Explicit Constraintかつ
+  Meaning Match、priority=4）と`goriyaku_tag`（間接推定一致、
+  priority=5）は区別されたまま。両方ともneed_tag/text_hint（Consultation
+  直接一致）より優先度が低い。
+- **Rule（Task 11）**: Context（distance/location/visit_date/direction）
+  に対応するfact typeは存在しない（`distance`/`context`/`location`は
+  `PRIMARY_REASON_PRIORITY`に含まれない）。ContextがPrimary
+  Recommendation Meaningになることは構造的にあり得ない
+  （`test_context_only_never_becomes_primary_meaning_reason`で固定化）。
+- **Rule（Task 12）**: Fallback順は既存の`PRIMARY_REASON_PRIORITY`を
+  そのまま正本とした（history_theme→culture_translation→need_tag→
+  text_hint→user_selected_tag→goriyaku_tag→element→**visit_style（新規）**
+  →fallback）。既存の6つのtierは並び替えていない。
+
+### Task 13: 二系統の不一致を解消
+
+```text
+Single Primary Reason Resolver
+  (concierge_chat_ranking._build_reason_facts + _resolve_primary_reason)
+  ↓
+rank_explanation.primary_reason_source
+  ↓ （同じ rec["_reason_facts"] を参照）
+_explanation_payload.primary_reason
+  ↓
+Frontend display metadata（explanation.summary / explanation.reasons）
+```
+
+`_build_visit_style_primary_reason()`（独立した2つ目のresolver）は
+削除した。表示用途ごとのlabel変換（`NEED_LABELS_JA`等、日本語ラベル
+辞書は複数ファイルに存在し続ける）は許容している — 意味の再判定は
+行わず、`type`/`label`の変換のみ。
+
+### Task 14: Recommendation Reason本文との整合
+
+`build_recommendation_reason()`（`rec["reason"]`、見出し文）は変更して
+いない — `_primary_reason_label`が需要タグ（study/mental/rest/love/
+career/money/courage）以外の場合、既存通り安全な汎用文言へfallbackし、
+矛盾する文言を生成しない（visit_style/elementが正本primary reasonで
+あっても、生年月日文言や矛盾する主張はしない）。
+
+`concierge_explanations._build_summary_from_primary_reason()`
+（`rec["explanation"]["summary"]`、実際にFrontendへ表示されるカード
+見出し）へは、`reason_type == "visit_style"`のケースを追加した
+（Task 14の「小さなsource selection修正」に該当）。これにより、
+visit_styleがprimary reasonの場合に`original_reason`（無関係な
+fallback文言）へ落ちることなく、参拝スタイルに言及する適切な文言が
+選ばれるようになった。本文の全面書き換えは行っていない。
+
+### Task 15〜18: Contract Tests
+
+`backend/temples/tests/test_concierge_primary_reason_unification_contract.py`
+（新規14件）:
+
+- Priority tier確認（visit_styleがelement/fallbackの間にあること）
+- PR #2407のMismatch再現 → 解消確認（`rank_explanation.primary_reason_source`
+  == `_explanation_payload.primary_reason.type`）
+- 5パターンのgrounding確認（primary reasonが必ず`reason_facts`内に存在
+  するか、fallbackであること）
+- Full Integration test（相談+Preference+Profile+Constraint+Context
+  同時投入で、Primary Reasonが統一され、reason_factsに根拠があり、
+  visible reasonが矛盾しないことを確認）
+- 4件のConflict Reason Test（Consultation+Visit Preference /
+  +Profile / +Constraint / Context only）
+- No Ranking Change確認（score_need/score_element/visit_style raw/
+  `_score_total`/順序が本PRで変化しないことを確認）
+
+既存の`test_concierge_explanations.py`中、旧`_build_visit_style_primary_reason`
+の挙動を直接pinしていたテスト1件を、新しいSingle Source of Truth契約
+（`_reason_facts`が空欄でbreakdown_detailにvisit_style一致がある、と
+いう新設計では発生しえない入力に対して安全にfallbackすること）を
+確認するテストへ更新し、正しい入力形状（`_reason_facts`に
+`is_primary`付きvisit_style factが存在する状態）を確認する新規テストを
+追加した。
+
+### Task 19: Frontend Contract
+
+Frontend側で複数のprimary reason fieldを独自に選択・判断しているコード
+は見つからなかった（`pickExplanationPayloadFromThread.ts`は単に
+`_explanation_payload`をそのまま正規化して受け渡すのみ）。したがって
+Frontendコード変更は不要と判断し、行っていない。
+
+`ConciergeReasonFacts`型（`apps/web/src/lib/api/concierge/types.ts`）は
+前述の通りbackendで未使用のdead fieldであり、これに依存する
+`buildRecommendationReasonViewModel.ts`等の分岐は常にfallback側へ
+流れる（既知の限界として記録、本PRでは変更しない）。
+
+### No Behavior Change Verification（実行結果）
+
+```
+Backend: python -m pytest -p no:dotenv temples/ -q
+  -> 1279 passed, 9 skipped（既存1265 + 新規14件）
+```
+
+Ranking weight変更 = 0
+Candidate filtering変更 = 0
+goriyaku hard filter変更 = 0
+Level 1/2/3 scoring semantics変更 = 0
+Score v3 mode変更 = 0
+DB schema変更 = 0
+Migration = 0
+Frontend UI変更 = 0（コード変更なし）
+375px Information Architecture変更 = 0
+
+Recommendation順位（`_score_total`/`score_total_ranked`/並び順）への
+影響 = 0（`reason_facts`/`primary_reason`は`_score_total`計算後に
+付与される、純粋に記述的なfieldであるため構造的に不可能）。
+
+### Known Limitations（Follow-upへ送るもの）
+
+- **Recommendation Reason Copy Brush-up**: `build_recommendation_reason()`
+  本文（見出し文）にvisit_style専用の文言を追加するかは、本PRでは
+  行わなかった（既存の安全な汎用fallbackのまま）。
+- **`api_views_concierge.build_reason_facts()` / `ConciergeReasonFacts`**:
+  未使用のdead code。削除判断はFollow-up。
+- **Fact-backed Reason Quality**: Knowledge Model（history_theme/
+  culture_translation）のcoverage改善は対象外。
+- **Weight Optimization**: 実利用データ後の判断。
+- **Frontend IA**: L1/L2/L3段階表示。
+- **Learning**: 行動feedbackの正式契約。


### PR DESCRIPTION
## Summary

PR #2407 (Integrated Recommendation Intent Execution Contract) が発見した Mismatch を解消し、Primary Reason を Single Source of Truth へ統一する。

**Mismatch**: 同一 Recommendation について `rank_explanation.primary_reason_source == "fallback"` かつ `_explanation_payload.primary_reason.type == "visit_style"` という食い違いが発生しうる（`concierge_explanation_payload._build_visit_style_primary_reason()` が `reason_facts`/`_resolve_primary_reason` とは独立した2つ目の primary reason resolver として存在していたため）。

## Fix

- **Single Source of Truth**: `reason_facts` + `_resolve_primary_reason`（`concierge_chat_ranking.py`）を正本とした — 唯一、実際の Ranking 根拠（`matched_by_tag`/`matched_by_gid`/`score_element`等）から直接構築されているため。
- `visit_style` を正式な `reason_facts` fact type として追加（`PRIMARY_REASON_PRIORITY` で element(6) と fallback(9) の間 = 7）。旧override条件（`reason_facts` が None/fallback の時のみ visit_style が勝つ）と**同じ相対的な強さ**を、独立resolverではなく単一のpriority tierとして表現しただけなので、実効的な優先順位は変えていない。
- `_build_visit_style_primary_reason()`（独立した2つ目のresolver）を削除。`_explanation_payload.primary_reason` は `reason_facts` の `is_primary` をそのまま参照するだけになった。
- `concierge_explanations.py` の `_build_summary_from_primary_reason` に visit_style ケースを追加 — Frontend へ実際に表示される `explanation.summary`（"この神社について" 等のカード見出し）が、visit_style が primary reason のときに無関係な文言へ落ちないようにする最小限の source-selection 修正（本文の全面書き換えではない）。

## Task 1 Inventory で見つかったこと

repo全体検索の結果、`api_views_concierge.build_reason_facts()`（`ConciergeReasonFacts` 型を返す関数）が**一度も呼び出されていない dead code** であることを発見した（削除は Follow-up）。Frontend 側は複数の primary reason field を独自に選択・判断するコードは持っておらず、`_explanation_payload` をそのまま受け渡すのみだったため、**Frontend コード変更は不要**と判断した。

## 禁止事項（変更なし）

Ranking weight・Candidate filtering semantics・goriyaku hard filter・Level 1/2/3 scoring semantics・distance/context scoring・Score v3 mode・DB schema・Migration・Frontend UI・375px Information Architecture・Learning Signal は、いずれも変更していません。`reason_facts`/`primary_reason` は `_score_total` 計算後に付与される純粋に記述的な field であり、Recommendation順位への影響は構造的にゼロです。

## Verification

- Backend: `pytest temples/` → **1279 passed, 9 skipped**（既存1265 + 新規14件、既存テスト1件をSingle Source of Truth契約に合わせて更新）
- Web: pre-push hookで **119 files / 769 tests passed**（フロントエンドコード変更なしのため件数不変）
- ruff lint: 新規findingsは0（既存baselineと完全一致を確認、`_attach_breakdown`のcomplexity scoreも不変）
- Migration: 0件
- Live browser QA: dev serverで相談文送信 + Visit Preference選択の実機確認を試みたが、匿名クォータ制限のためこのセッションでは完了できなかった。フロントエンドコード変更が0行であること、および新規14件のユニットテスト（`_explanation_payload.primary_reason`と`rank_explanation.primary_reason_source`の一致確認、`explanation.summary`テキストの整合確認を含む）で実際のパイプライン形状を直接検証済みであることをもって代替した。

## Behavior change disclosure

- Candidate filtering behavior change: **なし**
- Ranking behavior change: **なし**
- API compatibility change: **なし**
- Persistence change: **なし**
- Migration: **0件**

## Test plan

- [x] Backend: `cd backend && python -m pytest -p no:dotenv temples/ -q`
- [x] Web: pre-push hookのcontract test（コード変更なし、件数不変を確認）
- [ ] Manual browser QA: 匿名クォータ制限のため未完了（上記参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)