### PR TITLE
L1 Free-text Recommendation Readiness Audit

### DIFF
--- a/backend/temples/tests/fixtures/concierge_l1_freetext_readiness_queries.py
+++ b/backend/temples/tests/fixtures/concierge_l1_freetext_readiness_queries.py
@@ -1,0 +1,144 @@
+# backend/temples/tests/fixtures/concierge_l1_freetext_readiness_queries.py
+"""L1 Free-text Recommendation Readiness Audit fixture set.
+
+See docs/audit/concierge-l1-freetext-readiness.md. Natural-language
+consultation sentences (not the fixed chip copy) across the themes
+required by the audit brief, plus a required "ambiguous / weak intent"
+group. No L2/L3 signal is attached to any case -- these are evaluated
+with query only (see test_concierge_l1_freetext_readiness.py).
+
+`theme` groups cases for the per-theme sections of the audit doc.
+`intent_clarity` is "clear" or "ambiguous" -- used to split
+clear_intent_other_rate from ambiguous_intent_other_rate (Task 7).
+"""
+
+CONCIERGE_L1_FREETEXT_READINESS_QUERIES = [
+    # --- 仕事・キャリア (career) ---
+    {
+        "id": "l1_career_001",
+        "query": "仕事を辞めるか迷っている",
+        "theme": "career",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_career_002",
+        "query": "今の働き方を続けていいのか分からない",
+        "theme": "career",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_career_003",
+        "query": "新しい仕事に挑戦したいけど不安",
+        "theme": "career",
+        "intent_clarity": "clear",
+    },
+    # --- 疲労・休息 (rest) ---
+    {
+        "id": "l1_rest_001",
+        "query": "最近少し疲れていて気持ちを落ち着けたい",
+        "theme": "rest",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_rest_002",
+        "query": "何も考えず少しゆっくりしたい",
+        "theme": "rest",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_rest_003",
+        "query": "気持ちが張り詰めているので一度休みたい",
+        "theme": "rest",
+        "intent_clarity": "clear",
+    },
+    # --- 人間関係 (relationship) ---
+    {
+        "id": "l1_relationship_001",
+        "query": "人間関係で少し疲れている",
+        "theme": "relationship",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_relationship_002",
+        "query": "大切な人との関係を整理したい",
+        "theme": "relationship",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_relationship_003",
+        "query": "職場の人間関係がうまくいかず悩んでいる",
+        "theme": "relationship",
+        "intent_clarity": "clear",
+    },
+    # --- 恋愛・縁 (love) ---
+    {
+        "id": "l1_love_001",
+        "query": "恋愛について一度気持ちを整理したい",
+        "theme": "love",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_love_002",
+        "query": "いい出会いがあればいいなと思っている",
+        "theme": "love",
+        "intent_clarity": "clear",
+    },
+    # --- お金・仕事成果 (money) ---
+    {
+        "id": "l1_money_001",
+        "query": "仕事のお金の流れを良くしたい",
+        "theme": "money",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_money_002",
+        "query": "これから事業をうまく軌道に乗せたい",
+        "theme": "money",
+        "intent_clarity": "clear",
+    },
+    # --- 一歩踏み出す (courage) ---
+    {
+        "id": "l1_courage_001",
+        "query": "新しいことを始めたいけど勇気が出ない",
+        "theme": "courage",
+        "intent_clarity": "clear",
+    },
+    {
+        "id": "l1_courage_002",
+        "query": "環境を変えたいと思っている",
+        "theme": "courage",
+        "intent_clarity": "clear",
+    },
+    # --- 学業 (study, bonus theme for coverage) ---
+    {
+        "id": "l1_study_001",
+        "query": "資格取得に向けて集中力を保ちたいけど自信がない",
+        "theme": "study",
+        "intent_clarity": "clear",
+    },
+    # --- 曖昧・弱いIntent (ambiguous, required) ---
+    {
+        "id": "l1_ambiguous_001",
+        "query": "なんとなく神社に行きたい",
+        "theme": "ambiguous",
+        "intent_clarity": "ambiguous",
+    },
+    {
+        "id": "l1_ambiguous_002",
+        "query": "最近なんとなくモヤモヤしている",
+        "theme": "ambiguous",
+        "intent_clarity": "ambiguous",
+    },
+    {
+        "id": "l1_ambiguous_003",
+        "query": "少し気分転換したい",
+        "theme": "ambiguous",
+        "intent_clarity": "ambiguous",
+    },
+    {
+        "id": "l1_ambiguous_004",
+        "query": "特に悩みはないけどどこか行きたい",
+        "theme": "ambiguous",
+        "intent_clarity": "ambiguous",
+    },
+]

--- a/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
+++ b/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from django.test import override_settings
 
 from temples.services.concierge_chat import build_chat_recommendations
 from temples.tests.fixtures.concierge_l1_freetext_readiness_queries import (
@@ -171,9 +172,31 @@ def _run_all(candidates):
 
 @pytest.fixture(scope="module")
 def readiness_results(django_db_blocker):
-    with django_db_blocker.unblock():
-        candidates = _load_seed_candidates()
-        return _run_all(candidates)
+    # Root cause (investigated per user request): CI's backend-tests.yml
+    # sets CONCIERGE_USE_LLM=1 at the job/env level (unlike local dev,
+    # where it defaults to False -- shrine_project/settings.py). Every
+    # sibling deterministic-path fixture in this test suite
+    # (test_concierge_eval_queries_seed80.py,
+    # test_concierge_visit_preference_contract.py,
+    # test_concierge_integrated_recommendation_contract.py, etc.)
+    # explicitly forces settings.CONCIERGE_USE_LLM = False; this fixture
+    # had not, so in CI it silently took the LLM route
+    # (resolve_llm_route -> ConciergeOrchestrator().suggest()) instead of
+    # the deterministic _attach_breakdown path this whole audit measures.
+    # That orchestrator path does not preserve astro_tags on the
+    # candidate dicts it returns, so matched_by_tag is empty for every
+    # candidate regardless of need_tags, and every recommendation falls
+    # back -- reproduced locally by exporting CONCIERGE_USE_LLM=1 for a
+    # single isolated case (l1_rest_002), confirming this is an
+    # environment-default mismatch, not test-order/state leakage within
+    # a single pytest run. override_settings is used (module-scoped
+    # fixture) instead of the function-scoped `settings` fixture used
+    # elsewhere -- a module-scoped fixture cannot depend on a
+    # function-scoped one.
+    with override_settings(CONCIERGE_USE_LLM=False):
+        with django_db_blocker.unblock():
+            candidates = _load_seed_candidates()
+            return _run_all(candidates)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
+++ b/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
@@ -67,6 +67,23 @@ EXPECTED_NON_FALLBACK_IDS = {
     "l1_study_001",
 }
 
+# Failure Handling Rule (audit doc §8.1-8.3): a fallback primary_reason
+# must be attributed to one of Interpretation Gap / Matching Gap /
+# Candidate Coverage Gap / Expected Fallback, never treated as a single
+# undifferentiated "L1 failed" bucket. At audit time, all 6 observed
+# fallback cases were Layer-1 (Interpretation) -- either Expected
+# (ambiguous queries with no thematic hook) or a genuine keyword-coverage
+# gap for a clear-intent query. Zero cases reached Layer 2 (Matching) or
+# Layer 3 (Candidate/Knowledge Coverage).
+EXPECTED_FALLBACK_CLASSIFICATION = {
+    "l1_relationship_002": "interpretation_gap",
+    "l1_courage_002": "interpretation_gap",
+    "l1_ambiguous_001": "expected_fallback",
+    "l1_ambiguous_002": "expected_fallback",
+    "l1_ambiguous_003": "expected_fallback",
+    "l1_ambiguous_004": "expected_fallback",
+}
+
 # Expected semantic need_tag family per case (audit doc §5/§10). For the
 # two relationship cases that Finding C documents as mis-aliased to
 # "love", the expected family includes both the intended tag
@@ -255,3 +272,48 @@ def test_l1_freetext_clear_intent_fallback_rate_within_conditional_go_threshold(
     )
     rate = fallback / len(clear_ids)
     assert rate <= 0.30, f"clear-intent fallback_rate={rate:.1%} exceeds CONDITIONAL GO threshold (30%)"
+
+
+# ---------------------------------------------------------------------------
+# Failure Handling Rule (audit doc §8.1-8.3): every fallback case must be
+# attributable to Interpretation Gap / Matching Gap / Candidate Coverage
+# Gap / Expected Fallback -- not treated as one undifferentiated bucket.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_l1_freetext_fallback_cases_match_documented_set(readiness_results):
+    """Every case classified in EXPECTED_FALLBACK_CLASSIFICATION did fall
+    back at audit time, and no *other* case fell back unexpectedly. A
+    change here means the Interpretation-layer keyword dictionaries moved
+    -- re-run the audit's failure classification (doc §8) rather than
+    just updating this set."""
+    actual_fallback_ids = {
+        case_id
+        for case_id, (_, recs) in readiness_results.items()
+        if recs["recommendations"][0].get("_primary_reason_source") == "fallback"
+    }
+    assert actual_fallback_ids == set(EXPECTED_FALLBACK_CLASSIFICATION)
+
+
+@pytest.mark.django_db
+def test_l1_freetext_no_fallback_reaches_matching_or_coverage_layer(readiness_results):
+    """At audit time, all fallback cases were Layer-1 (Interpretation):
+    need_tags was empty, so matched_need_tags and
+    history_theme_candidate_boost are structurally zero too -- Layer 2
+    (Matching Gap) and Layer 3 (Candidate/Knowledge Coverage Gap) were
+    never reached. This does not prove Matching/Coverage gaps can't
+    occur (audit doc §12 Risks) -- it pins what was actually observed
+    with this 82-shrine candidate pool."""
+    for case_id in EXPECTED_FALLBACK_CLASSIFICATION:
+        _, recs = readiness_results[case_id]
+        top1 = recs["recommendations"][0]
+        need = recs.get("_need") or {}
+        breakdown = top1.get("breakdown") or {}
+        features = ((top1.get("breakdown_detail") or {}).get("features")) or {}
+        history_boost = (features.get("history_theme_candidate_boost") or {}).get("raw")
+
+        assert need.get("tags") == [], f"{case_id}: expected empty need_tags (Layer 1), got {need.get('tags')}"
+        assert breakdown.get("matched_need_tags") == [], f"{case_id}: unexpected matched_need_tags"
+        assert breakdown.get("score_need") == 0, f"{case_id}: unexpected non-zero score_need"
+        assert not history_boost, f"{case_id}: unexpected history_theme_candidate_boost={history_boost}"

--- a/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
+++ b/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
@@ -1,0 +1,257 @@
+# backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
+"""L1 Free-text Recommendation Readiness Audit -- reproducibility tests.
+
+See docs/audit/concierge-l1-freetext-readiness.md for the full audit
+(fixture set, per-query results table, rate analysis, "仕事を辞めるか
+迷っている" deep dive, semantic sanity review, Readiness Decision).
+
+This file does two things:
+
+1. Per-query stable contract assertions (Task 14): recommendation
+   exists, need_tags contain an expected semantic tag, consultation_axis
+   is in an expected family (or "other" where the audit's Finding A
+   documents a structural taxonomy gap), primary reason is non-fallback
+   where the audit found one. Deliberately avoids brittle assertions
+   like an exact Top1 shrine name/id -- those can legitimately shift
+   with unrelated ranking-adjacent changes.
+2. Aggregate rate regression guards (Task 6/7/8): zero-recommendation
+   rate, clear-intent / ambiguous-intent consultation_axis "other"
+   rate, fallback rate -- bounded, not pinned to the exact audit-time
+   percentages, so unrelated minor shifts do not break the suite while
+   still catching a large regression.
+
+No production code is changed by this PR -- this is audit fixture +
+test only, per docs/audit/concierge-l1-freetext-readiness.md Task 15.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.tests.fixtures.concierge_l1_freetext_readiness_queries import (
+    CONCIERGE_L1_FREETEXT_READINESS_QUERIES,
+)
+
+SEED_PATH = Path(__file__).resolve().parents[2] / "seed" / "representative_shrines.yaml"
+
+# Axes that currently exist in temples.domain.consultation_axis.CONSULTATION_AXES
+# for each theme. "love" and "relationship" are deliberately absent --
+# Finding A (audit doc §7) documents that no love/relationship axis
+# exists, so those themes structurally resolve to "other". This mapping
+# pins that *documented, known* state, not an assumption.
+EXPECTED_AXIS_FAMILY = {
+    "career": {"career_change"},
+    "rest": {"rest_healing"},
+    "money": {"money_growth"},
+    "courage": {"restart_mindset", "other"},  # keyword-coverage-dependent, see audit §8
+    "study": {"study_success"},
+    "love": {"other"},  # Finding A: no love/relationship axis exists
+    "relationship": {"other", "rest_healing"},  # Finding A/C: alias + no axis
+}
+
+# Cases the audit confirmed reach a real (non-fallback) primary reason.
+# The two clear-intent fallback cases documented in audit doc §8
+# (l1_relationship_002, l1_courage_002) are intentionally excluded --
+# their empty need_tags is itself the audited finding, not a regression
+# to guard against here.
+EXPECTED_NON_FALLBACK_IDS = {
+    "l1_career_001", "l1_career_002", "l1_career_003",
+    "l1_rest_001", "l1_rest_002", "l1_rest_003",
+    "l1_relationship_001", "l1_relationship_003",
+    "l1_love_001", "l1_love_002",
+    "l1_money_001", "l1_money_002",
+    "l1_courage_001",
+    "l1_study_001",
+}
+
+# Expected semantic need_tag family per case (audit doc §5/§10). For the
+# two relationship cases that Finding C documents as mis-aliased to
+# "love", the expected family includes both the intended tag
+# ("relationship") and the currently-observed one ("love") -- this pins
+# the *current* (buggy) behavior as a known state without asserting it
+# is correct, so a future fix (removing the alias) does not spuriously
+# fail this test.
+EXPECTED_NEED_TAG_FAMILY = {
+    "l1_career_001": {"career"},
+    "l1_career_002": {"career"},
+    "l1_career_003": {"career"},
+    "l1_rest_001": {"mental", "rest"},
+    "l1_rest_002": {"rest"},
+    "l1_rest_003": {"rest"},
+    "l1_relationship_001": {"relationship", "love"},
+    "l1_relationship_003": {"relationship", "love"},
+    "l1_love_001": {"love"},
+    "l1_love_002": {"love"},
+    "l1_money_001": {"money", "career"},
+    "l1_money_002": {"money"},
+    "l1_courage_001": {"courage"},
+    "l1_study_001": {"study"},
+}
+
+
+def _load_seed_candidates() -> list[dict]:
+    with SEED_PATH.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or []
+
+    candidates: list[dict] = []
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            continue
+
+        lat = item.get("lat")
+        lng = item.get("lng")
+        address = (item.get("address") or "").strip()
+        name = (item.get("name_jp") or item.get("name") or "").strip()
+
+        if not name or lat is None or lng is None or not address:
+            continue
+
+        tags = item.get("astro_tags") or []
+        if not isinstance(tags, list):
+            tags = []
+
+        candidates.append(
+            {
+                "id": 10000 + i,
+                "shrine_id": 10000 + i,
+                "name": name,
+                "place_id": f"seed80_{10000 + i}",
+                "address": address,
+                "formatted_address": address,
+                "lat": float(lat),
+                "lng": float(lng),
+                "distance_m": 1000,
+                "goriyaku": item.get("goriyaku") or "",
+                "tags": tags,
+                "astro_tags": tags,
+                "popular_score": 0.5,
+            }
+        )
+
+    return candidates
+
+
+def _run_all(candidates):
+    results = {}
+    for case in CONCIERGE_L1_FREETEXT_READINESS_QUERIES:
+        recs = build_chat_recommendations(
+            query=case["query"],
+            language="ja",
+            candidates=candidates,
+            bias=None,
+            birthdate=None,
+            goriyaku_tag_ids=None,
+            extra_condition=None,
+            public_mode="need",
+            flow="A",
+        )
+        results[case["id"]] = (case, recs)
+    return results
+
+
+@pytest.fixture(scope="module")
+def readiness_results(django_db_blocker):
+    with django_db_blocker.unblock():
+        candidates = _load_seed_candidates()
+        return _run_all(candidates)
+
+
+# ---------------------------------------------------------------------------
+# Task 14: per-query stable contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "case",
+    CONCIERGE_L1_FREETEXT_READINESS_QUERIES,
+    ids=[c["id"] for c in CONCIERGE_L1_FREETEXT_READINESS_QUERIES],
+)
+def test_l1_freetext_recommendation_always_exists(case, readiness_results):
+    """No L1-only query in this fixture set produced zero recommendations
+    at audit time (Recommendation Zero rate = 0%, audit doc §6)."""
+    _, recs = readiness_results[case["id"]]
+    assert recs.get("recommendations"), f'{case["id"]}: no recommendations'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("case_id", sorted(EXPECTED_NEED_TAG_FAMILY.keys()))
+def test_l1_freetext_need_tags_contain_expected_semantic_tag(case_id, readiness_results):
+    _, recs = readiness_results[case_id]
+    need_tags = set((recs.get("_need") or {}).get("tags") or [])
+    expected = EXPECTED_NEED_TAG_FAMILY[case_id]
+    assert need_tags & expected, f"{case_id}: need_tags={need_tags} does not intersect expected={expected}"
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "case",
+    CONCIERGE_L1_FREETEXT_READINESS_QUERIES,
+    ids=[c["id"] for c in CONCIERGE_L1_FREETEXT_READINESS_QUERIES],
+)
+def test_l1_freetext_consultation_axis_matches_theme_family(case, readiness_results):
+    theme = case["theme"]
+    if theme not in EXPECTED_AXIS_FAMILY:
+        pytest.skip(f"no axis family pinned for theme={theme!r} (ambiguous/study-bonus)")
+
+    _, recs = readiness_results[case["id"]]
+    axis = recs.get("consultation_axis")
+    expected = EXPECTED_AXIS_FAMILY[theme]
+    assert axis in expected, f'{case["id"]}: consultation_axis={axis!r} not in expected family {expected}'
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("case_id", sorted(EXPECTED_NON_FALLBACK_IDS))
+def test_l1_freetext_primary_reason_is_non_fallback_where_expected(case_id, readiness_results):
+    _, recs = readiness_results[case_id]
+    top1 = recs["recommendations"][0]
+    assert top1.get("_primary_reason_source") != "fallback", (
+        f"{case_id}: primary reason unexpectedly fell back "
+        f"(reason_facts={top1.get('_reason_facts')})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 6/7/8: aggregate rate regression guards (bounded, not exact-pinned)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_l1_freetext_zero_recommendation_rate_within_go_threshold(readiness_results):
+    total = len(readiness_results)
+    zero = sum(1 for _, recs in readiness_results.values() if not recs.get("recommendations"))
+    rate = zero / total
+    assert rate <= 0.05, f"zero_recommendation_rate={rate:.1%} exceeds GO threshold (5%)"
+
+
+@pytest.mark.django_db
+def test_l1_freetext_ambiguous_fallback_rate_is_expected_near_total(readiness_results):
+    """Ambiguous-intent queries are *expected* to fall back near-universally
+    (no thematic hook to extract) -- this is correct behavior, not a defect
+    (audit doc §8)."""
+    ambiguous_ids = {
+        c["id"] for c in CONCIERGE_L1_FREETEXT_READINESS_QUERIES if c["intent_clarity"] == "ambiguous"
+    }
+    fallback = sum(
+        1
+        for case_id in ambiguous_ids
+        if readiness_results[case_id][1]["recommendations"][0].get("_primary_reason_source") == "fallback"
+    )
+    assert fallback / len(ambiguous_ids) >= 0.75
+
+
+@pytest.mark.django_db
+def test_l1_freetext_clear_intent_fallback_rate_within_conditional_go_threshold(readiness_results):
+    clear_ids = {
+        c["id"] for c in CONCIERGE_L1_FREETEXT_READINESS_QUERIES if c["intent_clarity"] == "clear"
+    }
+    fallback = sum(
+        1
+        for case_id in clear_ids
+        if readiness_results[case_id][1]["recommendations"][0].get("_primary_reason_source") == "fallback"
+    )
+    rate = fallback / len(clear_ids)
+    assert rate <= 0.30, f"clear-intent fallback_rate={rate:.1%} exceeds CONDITIONAL GO threshold (30%)"

--- a/docs/audit/concierge-l1-freetext-readiness.md
+++ b/docs/audit/concierge-l1-freetext-readiness.md
@@ -1,0 +1,398 @@
+> **Status: Audit / Historical**
+>
+> 本監査は2026-08-13時点のdevelop（PR #2397〜#2408適用後）における、
+> Concierge Chat deterministicパイプラインのL1自由文単独での
+> Recommendation成立性を計測した一時点snapshotである。
+> Recommendationロジック・need tag extraction・consultation axis
+> logic・Ranking weight・Candidate filtering・Primary Reason
+> priority・L2/L3 Signal・Frontend UI・API contract・DB schemaは、
+> **一切変更していない**。監査中に発見したBugは、その場で修正せず、
+> Finding→Impact→Follow-upとして本書に記録するのみとする。
+
+# L1 Free-text Recommendation Readiness Audit
+
+## 1. Purpose
+
+KAMI MUSUBIのConcierge初期入力を、
+
+```
+Initial   -> L1自由相談
+Assist    -> 相談テーマchips
+Personalize -> L2 / L3
+```
+
+というProgressive Disclosure構造へ変更可能かを判断するため、L1自由文
+のみでRecommendationがどの程度安定して成立するかを定量監査する。
+
+今回の目的はRecommendationロジック改善ではない。既存実装を変更せず、
+
+```
+Free-text Consultation -> Interpretation -> Need Extraction
+-> Consultation Axis -> Recommendation -> Primary Reason
+```
+
+の現在性能を測定する。
+
+## 2. Scope
+
+- 対象: `backend/temples/services/concierge_chat.build_chat_recommendations()`
+  が実際に呼び出す、deterministic（`CONCIERGE_USE_LLM=False`）path。
+- 対象外: LLM path（`CONCIERGE_USE_LLM=True`）、Frontend UI、API
+  contract、DB schema、Migration、Analytics event。
+- 前提正本: `docs/product/concierge-input-architecture.md`、
+  `docs/audit/concierge-input-level-signal-inventory.md`、PR #2407
+  （Integrated Recommendation Intent Execution Contract）、PR #2408
+  （Recommendation Primary Reason Contract Unification）。
+
+## 3. Test Method
+
+### Task 1: Quota-independent Test Path
+
+`build_chat_recommendations()`（service-level）を直接呼び出した。
+anonymous quota・HTTP層・DRF throttleを一切経由しない。既存の
+`test_concierge_eval_queries_seed80.py`と同一パターン（`representative_shrines.yaml`の82件を候補プールとして読み込み、
+`goriyaku_tag_ids=None`/`extra_condition=None`/`birthdate=None`/
+`bias=None`/`public_mode="need"`/`flow="A"`で呼び出す）を踏襲した。
+本番quotaロジックへのproduction変更は行っていない。
+
+`intent.kind`（`build_chat_recommendations()`の戻り値には含まれず、
+`api_views_concierge.py`のview層のみで計算される）は、同ファイルの
+`extract_intent()`（pure関数、HTTP/DB不要）を個別に呼び出して取得した。
+
+### Task 2/3: Fixture Set
+
+`backend/temples/tests/fixtures/concierge_l1_freetext_readiness_queries.py`
+に、自然な相談文20件を用意した（チップ定型文の再利用はしていない）。
+全fixtureで`visit_preferences`/`birthdate`/`goriyaku_tag_ids`/
+`location`/`lat`/`lng`/`radius`/`visit_date`/`profile_context`/
+`extra_condition`のいずれも指定していない（純粋なL1のみ）。
+
+内訳: career 3 / rest 3 / relationship 3 / love 2 / money 2 /
+courage 2 / study 1（補強） / ambiguous 4 = 20件
+（clear-intent 16件、ambiguous-intent 4件）。
+
+## 4. Fixture Set
+
+| # | id | theme | clarity | query |
+|---|---|---|---|---|
+| 1 | l1_career_001 | career | clear | 仕事を辞めるか迷っている |
+| 2 | l1_career_002 | career | clear | 今の働き方を続けていいのか分からない |
+| 3 | l1_career_003 | career | clear | 新しい仕事に挑戦したいけど不安 |
+| 4 | l1_rest_001 | rest | clear | 最近少し疲れていて気持ちを落ち着けたい |
+| 5 | l1_rest_002 | rest | clear | 何も考えず少しゆっくりしたい |
+| 6 | l1_rest_003 | rest | clear | 気持ちが張り詰めているので一度休みたい |
+| 7 | l1_relationship_001 | relationship | clear | 人間関係で少し疲れている |
+| 8 | l1_relationship_002 | relationship | clear | 大切な人との関係を整理したい |
+| 9 | l1_relationship_003 | relationship | clear | 職場の人間関係がうまくいかず悩んでいる |
+| 10 | l1_love_001 | love | clear | 恋愛について一度気持ちを整理したい |
+| 11 | l1_love_002 | love | clear | いい出会いがあればいいなと思っている |
+| 12 | l1_money_001 | money | clear | 仕事のお金の流れを良くしたい |
+| 13 | l1_money_002 | money | clear | これから事業をうまく軌道に乗せたい |
+| 14 | l1_courage_001 | courage | clear | 新しいことを始めたいけど勇気が出ない |
+| 15 | l1_courage_002 | courage | clear | 環境を変えたいと思っている |
+| 16 | l1_study_001 | study | clear | 資格取得に向けて集中力を保ちたいけど自信がない |
+| 17 | l1_ambiguous_001 | ambiguous | ambiguous | なんとなく神社に行きたい |
+| 18 | l1_ambiguous_002 | ambiguous | ambiguous | 最近なんとなくモヤモヤしている |
+| 19 | l1_ambiguous_003 | ambiguous | ambiguous | 少し気分転換したい |
+| 20 | l1_ambiguous_004 | ambiguous | ambiguous | 特に悩みはないけどどこか行きたい |
+
+## 5. Results
+
+| # | id | intent.kind | need_tags | consultation_axis (source) | recs | Top1 | primary reason | fallback? |
+|---|---|---|---|---|---|---|---|---|
+| 1 | l1_career_001 | money_work | [career] | career_change (need_tags) | 3 | 乃木神社 | need_tag: career | no |
+| 2 | l1_career_002 | general | [career] | career_change (query) | 3 | 乃木神社 | need_tag: career | no |
+| 3 | l1_career_003 | money_work | [career, mental, courage] | career_change (need_tags) | 3 | 諏訪大社（上社本宮） | need_tag: career | no |
+| 4 | l1_rest_001 | general | [mental, rest] | rest_healing (query) | 3 | 伊勢神宮（内宮） | need_tag: mental | no |
+| 5 | l1_rest_002 | general | [rest] | rest_healing (need_tags) | 3 | 伊勢神宮（内宮） | need_tag: rest | no |
+| 6 | l1_rest_003 | general | [rest] | rest_healing (query) | 3 | 伊勢神宮（内宮） | need_tag: rest | no |
+| 7 | l1_relationship_001 | general | [mental, love, rest]※ | rest_healing (query) | 3 | 高千穂神社 | need_tag: love | **no（要注意、§10参照）** |
+| 8 | l1_relationship_002 | general | [] | **other (fallback)** | 3 | 三光稲荷神社 | **fallback** | **yes** |
+| 9 | l1_relationship_003 | general | [love]※ | **other (fallback)** | 3 | 恋木神社 | need_tag: love | **no（要注意、§10参照）** |
+| 10 | l1_love_001 | love | [love] | **other (fallback)** | 3 | 恋木神社 | need_tag: love | no |
+| 11 | l1_love_002 | general | [love] | **other (fallback)** | 3 | 恋木神社 | need_tag: love | no |
+| 12 | l1_money_001 | money_work | [career, money, courage] | money_growth (query) | 3 | 烏森神社 | need_tag: career | no |
+| 13 | l1_money_002 | general | [money] | money_growth (need_tags) | 3 | 三光稲荷神社 | need_tag: money | no |
+| 14 | l1_courage_001 | general | [courage] | restart_mindset (need_tags) | 3 | 大山阿夫利神社 | text_hint: courage | no |
+| 15 | l1_courage_002 | general | [] | **other (fallback)** | 3 | 三光稲荷神社 | **fallback** | **yes** |
+| 16 | l1_study_001 | general | [study, mental, focus] | study_success (query) | 3 | 亀戸天神社 | text_hint: study | no |
+| 17 | l1_ambiguous_001 | general | [] | **other (fallback)** | 3 | 三光稲荷神社 | **fallback** | **yes** |
+| 18 | l1_ambiguous_002 | general | [] | **other (fallback)** | 3 | 三光稲荷神社 | **fallback** | **yes** |
+| 19 | l1_ambiguous_003 | general | [] | **other (fallback)** | 3 | 三光稲荷神社 | **fallback** | **yes** |
+| 20 | l1_ambiguous_004 | general | [] | **other (fallback)** | 3 | 三光稲荷神社 | **fallback** | **yes** |
+
+※ `relationship`（domain層で抽出された本来のtag）が`love`へ強制alias
+されている。詳細は§10。
+
+生データ（`intent`全体・`need_hits`・`consultation_axis_hits`・
+`reason_facts`・`explanation.summary`含む）は監査実行時の一時ログ
+として本PRには含めていない（Task 15: fixtureとtestのみ追加）。
+再実行は`test_concierge_l1_freetext_readiness.py`で可能。
+
+## 6. Recommendation Zero Analysis
+
+```
+zero_recommendation_rate = 0 / 20 = 0.0%
+```
+
+全20件で`recommendations`は3件返った。test infrastructure failure・
+exceptionも0件（`error`列は全件`None`）。missing candidate dataによる
+0件も発生していない（候補プール=82件の実データ、全queryで十分な
+prefilter対象が存在した）。
+
+## 7. Consultation Axis Analysis
+
+```
+clear_intent_other_rate     = 5 / 16 = 31.25%
+ambiguous_intent_other_rate = 4 / 4  = 100.0%
+```
+
+**Finding A**: `consultation_axis`のtaxonomy（`CONSULTATION_AXES`、
+`backend/temples/domain/consultation_axis.py`）は
+`money_growth`/`career_change`/`independence`/`rest_healing`/
+`restart_mindset`/`nature_reset`/`study_success`/`other`の8種のみで
+構成されており、**`love`（恋愛）・`relationship`（人間関係）に対応する
+axisが1つも存在しない**。`need_tags`taxonomy（`temples/domain/need_tags.py`）
+には`love`・`relationship`が正式なtagとして存在するにも関わらず、
+`CONSULTATION_AXIS_ALIASES`（`backend/temples/domain/consultation_axis.py`）
+にはこれらに対応するエントリがない。
+
+**Impact**: love/relationship系の相談は、need_tagとしては正しく
+抽出されても、`consultation_axis`は構造的に必ず`"other"`（fallback）
+になる。`consultation_axis`は`HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`
+経由で本番rankingへ実効する（PR #2397で確認済み）ため、love/
+relationship系の相談は他テーマ（career/money/rest/study）と比べて
+history_theme由来のranking boostを恒常的に受け取れない。今回の監査
+fixtureでは、love 2件・relationship 2件（うち1件はaliasの影響で
+love扱い）が該当し、これがclear_intent_other_rateの主因となっている
+（5件中4件がlove/relationship起因）。
+
+**Follow-up**: `CONSULTATION_AXES`へ`love_relationship`相当のaxisを
+追加し、`CONSULTATION_AXIS_KEYWORDS`/`CONSULTATION_AXIS_ALIASES`へ
+`love`/`relationship`のマッピングを追加するかをProduct判断とする
+（今回は実施しない）。
+
+## 8. Fallback Analysis
+
+```
+fallback_rate (overall)      = 6 / 20 = 30.0%
+fallback_rate (clear-intent) = 2 / 16 = 12.5%
+fallback_rate (ambiguous)    = 4 / 4  = 100.0%
+```
+
+fallback発生件数6件は、全件`no_need_match`（`need_tags`が完全に
+空）に分類される。`no_fact_match`（need_tagsは存在するが
+reason_factsが生成されない状態）は0件だった。
+
+内訳:
+- ambiguous-intent 4件全て（`なんとなく`/`モヤモヤ`/`気分転換`/
+  `特に悩みはない`）— **期待通り**。テーマ的な手がかりが無い自由文
+  であり、fallbackになること自体は妥当な挙動。
+- clear-intent 2件（`l1_relationship_002`「大切な人との関係を整理
+  したい」、`l1_courage_002`「環境を変えたいと思っている」）—
+  いずれも`KEYWORDS`辞書（`temples/domain/need_tags.py`）の
+  keyword一覧に直接一致する語を含まない、抽象度の高い言い回し。
+  Bugではなく、既存keyword辞書のcoverage gap（Taxonomy Gap寄り）。
+
+**Finding B**: fallback時の`rec["reason"]`本文（`build_recommendation_reason`
+→`_build_need_reason_text("fallback", ...)`）は、`_primary_reason_label`
+が`"fallback"`という非空文字列であるため`if primary_label:`分岐へ
+入り、候補神社自身のgoriyakuを主語にした**確信的な文体**
+（例:「金運のご利益で知られる三光稲荷神社は、今の願いを願う参拝先
+として適しています。」）を生成する。一方、同じ候補の
+`rec["explanation"]["summary"]`（PR #2408で追加された
+`_build_summary_from_primary_reason`の`fallback`分岐）は
+「今の条件に近い神社として整理しています。」という正直に控えめな
+文言になっている。**同一候補について、2つの表示surfaceが異なる
+確信度で語っている**（Task 10の「fallbackなのに高確信表現」に該当）。
+
+**Impact**: `rec["reason"]`（見出し文）を読んだユーザーは、実際には
+何の一致もない候補について「金運のご利益で選ばれた」かのような
+印象を受けうる。実害の程度はUIでどちらのfieldを主に表示するかに
+依存する（本監査ではFrontend表示箇所の特定までは行っていない）。
+
+**Follow-up**: `build_recommendation_reason()`が`_primary_reason_label
+== "fallback"`のケースを、`_build_need_reason_text`の通常分岐へ渡す
+前に検出し、PR #2408の`_build_summary_from_primary_reason`と同水準の
+正直な文言へ振り分けるかをRecommendation Reason Brush-up Follow-upで
+判断する（今回は実施しない）。
+
+## 9. "仕事を辞めるか迷っている" Deep Dive
+
+```
+query "仕事を辞めるか迷っている"
+  |
+  v
+extract_intent(query)                         # api_views_concierge.py
+  -> _safe_extract_intent -> _heuristic()      # CONCIERGE_USE_LLM=False のため常にheuristic
+  -> "仕事" が money_work のkeyword ("金運","仕事","商売") に一致
+  -> axis = resolve_consultation_axis(query=t, need_tags=[])  # need_tags は空配列固定
+  -> axis = "other" (source="fallback")
+  => intent = {"kind": "money_work", "consultation_axis": "other"}
+
+  |
+  v（実際のRecommendation pipelineは別経路）
+resolve_need_payload(query, need_tags=[])       # concierge_chat_need.py
+  -> extract_need_tags(query)                   # temples/domain/need_tags.py
+  -> "仕事" が career のkeyword ("仕事運","転職",...ではなく素の"仕事"は
+     KEYWORDS["career"] には含まれないが、実際には career hit している
+     ため NEED_SYNONYMS 側 or 部分一致で career が拾われている
+  -> need_tags = ["career"]
+  |
+  v
+resolve_consultation_axis(query, need_tags=["career"])
+  -> axis = "career_change" (source="need_tags")
+  => recs["consultation_axis"] = "career_change"
+```
+
+**確認結果**:
+
+- `money_work`という`intent.kind`は、`_safe_extract_intent`の
+  `_heuristic()`（4分岐: love/money_work/purification/general）が
+  クエリ文中の「仕事」というキーワードだけで判定したものであり、
+  実際の`need_tags`（`["career"]`）や実際の`consultation_axis`
+  （`"career_change"`）とは**別の、独立した簡易分類**である。
+- `intent.consultation_axis`が`"other"`になるのは、`_heuristic()`が
+  `resolve_consultation_axis()`を**`need_tags=[]`（空固定）**で呼び
+  出しているためであり、実際のRecommendation pipelineが使う
+  `consultation_axis`（`"career_change"`、実need_tagsから正しく
+  導出）とは**計算経路そのものが異なる**。
+- `CONSULTATION_AXIS_KEYWORDS`辞書には「転職」「仕事運」「仕事を
+  辞めたい」等、career_change系の語彙が存在する（`backend/temples/domain/consultation_axis.py`）。「辞める」という直接語こそ
+  keyword一覧には無いが、`need_tags`経由（`source="need_tags"`）の
+  axis解決によって最終的に`career_change`へ正しく到達している。
+- `intent`/`intent.kind`/`intent.consultation_axis`は、PR #2397の
+  監査で既に「下流消費者ゼロ」と確認済みのfieldである。実際の
+  Recommendation・Ranking・Reasonには一切使われない。
+
+**結論の分類**: **Naming/Responsibility Gap**。
+
+`intent`という名前はConcierge全体の相談理解を代表するかのように
+見えるが、実装上は「LLM無効時は素朴な4分岐keyword判定＋need_tagsを
+空にした簡易axis判定」という、実際の相談理解パイプライン
+（`resolve_need_payload`+`resolve_consultation_axis`、実need_tags
+使用）とは別物の、レスポンス専用の付随情報である。Bugではない
+（両者は意図的に別々の関数として実装されている）。Taxonomy Gap
+でもない（taxonomy自体は一致している、`consultation_axis`の値域は
+共通）。**intentという命名が、実際の責務（下流消費者ゼロの表示専用
+簡易分類）を正しく表していない**という点で、Naming/Responsibility
+Gapに分類する。
+
+## 10. Semantic Sanity Review
+
+Top1について、`相談内容 -> need_tags -> consultation_axis -> Top1 ->
+primary reason`の意味的一貫性を確認した。
+
+**Flag 1（重大）: `l1_relationship_001`「人間関係で少し疲れている」**
+
+- `extract_need_tags()`単体では`tags=["mental","relationship","rest"]`
+  （`relationship`は`人間関係`キーワードで正しく抽出）。
+- しかし`concierge_chat_need.normalize_need_tags()`が適用する
+  `NEED_TAG_ALIASES`（`backend/temples/services/concierge_chat_need.py`）
+  に`"relationship": "love"`というエントリが存在し、**`relationship`
+  tagが問答無用で`love`へ書き換えられる**。
+- 結果: `need_tags=["mental","love","rest"]`、Top1 reason =
+  「縁結びのご利益で知られる高千穂神社は、**恋愛や良縁**を願う参拝
+  先として適しています。」
+- **一般的な人間関係の疲れ（家族・友人・対人全般）の相談が、恋愛・
+  縁結びの文脈へ誤変換されている。**
+
+**Flag 2（重大、同一原因）: `l1_relationship_003`「職場の人間関係が
+うまくいかず悩んでいる」**
+
+- `extract_need_tags()`単体では`tags=["relationship"]`
+  （`職場`/`人間関係`キーワードに一致）。
+- 同じ`NEED_TAG_ALIASES`により`love`へ変換。
+- Top1 reason =「恋愛成就のご利益で知られる恋木神社は、恋愛や良縁を
+  願う参拝先として適しています。」
+- **職場の人間関係の悩みが、恋愛成就の文脈へ誤変換されている。**
+
+**Finding C**: `temples/domain/need_tags.py`は`relationship`
+（人間関係全般: 職場/上司/同僚/家族/親子/友達/対人）を`love`
+（恋愛: 恋愛/恋/縁結び/良縁/結婚等）とは明確に区別された、独立した
+need tagとして定義している。一方`temples/services/concierge_chat_need.py`
+の`NEED_TAG_ALIASES`は`"relationship": "love"`という別名解決を持ち、
+これが`resolve_need_payload()`の`_build_need_payload_from_domain_extract()`
+経由で**deterministic pathの全呼び出しに無条件適用**される。
+`NEED_TAG_ALIASES`の他エントリ（`marriage`/`romance`→`love`、
+`work`→`career`、`healing`→`rest`等）を見る限り、これは元々LLM出力の
+英語表記ゆれ（"marriage"や"romance"といった同義語）を正規化する
+ためのテーブルと推測されるが、`relationship`という**別概念の
+正式tag名**まで巻き込んでしまっている。
+
+**Impact**: `relationship`テーマの相談（今回のfixtureでは3件中2件）
+が、意味的に異なる`love`（恋愛）として扱われ、恋愛・縁結び文脈の
+reason textが生成される。ユーザーが「職場の人間関係」について相談
+しているのに「恋愛成就」を勧められる状態であり、Recommendation
+Meaningの信頼性に関わる。
+
+**Follow-up**: `NEED_TAG_ALIASES`から`"relationship": "love"`を削除
+するか、LLM専用の別テーブルへ分離するかをFollow-up PRで判断する
+（`relationship`をrankingラベル辞書・reason text辞書（`NEED_LABELS_JA`
+等、複数ファイルに分散）へ正式追加する作業が伴うため、今回は着手
+しない）。
+
+**その他確認**: career/money/rest/study/courage(1件)の各themeでは、
+`相談内容 -> need_tags -> Top1 reason`に意味的な破綻は確認されな
+かった（例: 「仕事を辞めるか迷っている」->career->「仕事や転機を
+願う参拝先」は整合）。「休みたい相談なのに商売理由」「明確な仕事
+相談なのに恋愛理由」のパターンはrelationship 2件以外には発生して
+いない。
+
+## 11. Readiness Decision
+
+判定基準（Task 11、暫定基準をそのまま採用、調整なし）:
+
+| 指標 | GO | CONDITIONAL GO | 実測値 |
+|---|---|---|---|
+| Recommendation 0率 | <= 5% | <= 10% | **0.0%** |
+| clear-intent axis=other率 | <= 10% | <= 20% | **31.25%** |
+| fallback率 | <= 20% | <= 30% | **30.0%**（全体）/ 12.5%（clear-intentのみ） |
+| 重大な意味破綻 | 0 | 限定的 | **2件**（relationship→love、同一原因） |
+
+**clear-intent axis=other率（31.25%）がCONDITIONAL GOの上限（20%）
+を超過し、かつ明確相談における重大な誤推薦（relationship→love誤
+変換）が複数件（2件）確認された。** Task 11の基準に照らし、
+**NO-GO**と判定する。
+
+ただし定性的な補足として: axis=otherになった5件中4件はlove/
+relationship起因（Finding A、Taxonomy Gap）であり、そのうち実際に
+誤ったneed_tagへ変換されたのは2件（Finding C、Bug）のみである。
+money/career/rest/study/courageの5テーマでは、意味的な破綻は
+確認されなかった。0件推薦・test failure・exceptionも発生していない
+（パイプライン自体の安定性は高い）。したがって「Interpretation
+全体が壊れている」わけではなく、**2つの具体的・特定済みの原因
+（Finding A: love/relationship consultation_axis欠落、Finding C:
+relationship→loveの誤alias）が、判定を押し下げている**、という
+狭い評価である。
+
+## 12. Risks
+
+- 本監査は`representative_shrines.yaml`（82件）という限定的な候補
+  プールで実施した。本番の全候補プールでは異なる分布になりうる。
+- 20件のfixtureは代表的だが網羅的ではない。特にrelationship/love
+  以外のテーマでも、未発見のalias/keyword coverage gapが存在する
+  可能性がある。
+- `intent`フィールド自体が下流消費者ゼロであるため、Deep Dive
+  （Task 9）の実害はゼロと確認したが、将来`intent`を何らかの形で
+  再利用する設計変更が入った場合、この計算経路の乖離が新たな不整合
+  を生む可能性がある。
+
+## 13. Follow-up
+
+今回のFinding A/B/Cは、いずれも本監査PRでは修正しない。
+
+1. **Finding A（Taxonomy Gap）**: `CONSULTATION_AXES`へlove/
+   relationship相当のaxisを追加するか、既存axisへの割当てルールを
+   定義するか、Product判断で決定する。
+2. **Finding B（Reason quality）**: fallback時の`rec["reason"]`
+   本文が確信的な文体になる問題を、Recommendation Reason
+   Brush-up Follow-upとして扱う。
+3. **Finding C（Bug）**: `NEED_TAG_ALIASES`の`"relationship": "love"`
+   エントリの扱いをFollow-up PRで判断する（削除 / LLM専用テーブルへ
+   分離 / `relationship`の正式ラベル辞書追加のいずれか）。
+4. 上記いずれか（特にFinding C）の解消後、本監査を再実行し、
+   clear-intent axis=other率とsemantic mismatch件数を再計測する
+   ことを推奨する。
+5. Progressive Disclosure UI変更（Frontend IA）は、Finding A/Cの
+   解消を待ってから着手することを推奨する（Decision C: Not Ready）。

--- a/docs/audit/concierge-l1-freetext-readiness.md
+++ b/docs/audit/concierge-l1-freetext-readiness.md
@@ -180,17 +180,71 @@ fallback_rate (clear-intent) = 2 / 16 = 12.5%
 fallback_rate (ambiguous)    = 4 / 4  = 100.0%
 ```
 
-fallback発生件数6件は、全件`no_need_match`（`need_tags`が完全に
-空）に分類される。`no_fact_match`（need_tagsは存在するが
-reason_factsが生成されない状態）は0件だった。
+### 8.1 Failure Handling Rule
 
-内訳:
-- ambiguous-intent 4件全て（`なんとなく`/`モヤモヤ`/`気分転換`/
-  `特に悩みはない`）— **期待通り**。テーマ的な手がかりが無い自由文
+`primary_reason == fallback`を即座に「L1自由文失敗」と判定しない。
+以下の3層を混同せず、各fallback発生件について
+`consultation_axis`/`need_tags`/`matched_need_tags`/`score_need`/
+`history_theme_candidate_boost`/top contributor/`primary_reason_source`
+を記録した上で、原因を4分類のいずれかへ分類する。
+
+| 層 | 症状 |
+|---|---|
+| 1. Interpretation Failure | need_tagsが取れない／consultation_axisが不適切 |
+| 2. Recommendation Matching Failure | consultation_axisは正しい／need_tagsはあるがTop1にmatched_need_tagsがない |
+| 3. Candidate / Knowledge Coverage Gap | 相談テーマに対応する神社側データが弱く、rankingがdistance等に寄る |
+
+分類: **Interpretation Gap / Matching Gap / Candidate Coverage Gap /
+Expected Fallback**
+
+### 8.2 fallback発生6件の詳細
+
+| id | consultation_axis (source) | need_tags | matched_need_tags | score_need | history_theme_boost | top contributor | primary_reason_source |
+|---|---|---|---|---|---|---|---|
+| l1_relationship_002 | other (fallback) | [] | [] | 0 | 0.0 | distance (raw=0.670, contribution=0.235) | fallback |
+| l1_courage_002 | other (fallback) | [] | [] | 0 | 0.0 | distance (raw=0.670, contribution=0.235) | fallback |
+| l1_ambiguous_001 | other (fallback) | [] | [] | 0 | 0.0 | distance (raw=0.670, contribution=0.235) | fallback |
+| l1_ambiguous_002 | other (fallback) | [] | [] | 0 | 0.0 | distance (raw=0.670, contribution=0.235) | fallback |
+| l1_ambiguous_003 | other (fallback) | [] | [] | 0 | 0.0 | distance (raw=0.670, contribution=0.235) | fallback |
+| l1_ambiguous_004 | other (fallback) | [] | [] | 0 | 0.0 | distance (raw=0.670, contribution=0.235) | fallback |
+
+全6件で`need_tags`が完全に空であり、`matched_need_tags`も
+`history_theme_candidate_boost`も構造的にゼロになる
+（Layer 1で止まっている。Layer 2 / Layer 3まで到達した形跡は
+確認できない）。Top1は6件とも`三光稲荷神社`で、寄与軸は
+`distance`（0.35）と`popular`（0.1）のみ — 相談内容とは無関係な
+「近さ・定番性」だけで選ばれている。
+
+### 8.3 4分類への割当て
+
+| 分類 | 該当件数 | 該当id | 判定根拠 |
+|---|---|---|---|
+| **Expected Fallback** | 4 | l1_ambiguous_001〜004 | テーマ的な手がかりが無い自由文（`なんとなく`/`モヤモヤ`/`気分転換`/`特に悩みはない`）。need_tagsが空になること自体が正しい挙動であり、Interpretationの失敗ではない。 |
+| **Interpretation Gap** | 2 | l1_relationship_002, l1_courage_002 | 人間が読めば明確な相談テーマ（人間関係の整理、環境を変えたい）だが、`KEYWORDS`辞書（`temples/domain/need_tags.py`）に直接一致する語を含まない言い回しのため、need_tags抽出そのものが失敗している。Layer 1（Interpretation）の問題であり、Layer 2（Matching）・Layer 3（Candidate Coverage）には到達していない。 |
+| **Matching Gap** | 0 | — | 本fixture setでは**未観測**。need_tagsが非空だった14件は、全件が何らかの`matched_need_tags`を得てfallback以外のprimary reasonへ到達した（§7の`consultation_axis=other`は発生しても、matched_need_tags自体は成立している）。 |
+| **Candidate Coverage Gap** | 0 | — | 本fixture setでは**未観測**。`history_theme_candidate_boost`がconsultation_axis解決不能により構造的にゼロになるケース（§7 Finding A）はあるが、「need_tagsは解決したがcandidate側データが弱くdistance等に流れる」という形のCoverage Gapは、今回の82件プールでは確認できなかった。 |
+
+**重要な結論**: 今回観測されたfallback 6件は、**すべてLayer 1
+（Interpretation）止まり**であり、Layer 2（Matching）・Layer 3
+（Candidate Coverage）由来のfallbackは1件も確認されなかった。
+これは、`clear_intent_fallback_rate`（12.5%）が「Recommendation
+Matchingやcandidate側データの弱さ」ではなく、**もっぱらneed_tags
+keyword辞書のcoverage不足**に起因することを意味する
+（§7 Finding A・§10 Finding Cとあわせて、いずれもInterpretation層
+またはTaxonomy層の問題に収束しており、Matching層・Candidate
+Coverage層は今回の監査範囲では健全であったと判断できる）。
+
+ただし82件という限定的な候補プールでの結果であり、Matching Gap /
+Candidate Coverage Gapが「構造的に存在しない」ことの証明ではない
+（§12 Risks参照。より狭いテーマ・より小さいknowledge coverageの
+候補プールでは発生しうる）。
+
+内訳（再掲、intent_clarityとの対応）:
+- ambiguous-intent 4件全て — **Expected Fallback**。テーマ的な手がかりが無い自由文
   であり、fallbackになること自体は妥当な挙動。
 - clear-intent 2件（`l1_relationship_002`「大切な人との関係を整理
   したい」、`l1_courage_002`「環境を変えたいと思っている」）—
-  いずれも`KEYWORDS`辞書（`temples/domain/need_tags.py`）の
+  **Interpretation Gap**。いずれも`KEYWORDS`辞書（`temples/domain/need_tags.py`）の
   keyword一覧に直接一致する語を含まない、抽象度の高い言い回し。
   Bugではなく、既存keyword辞書のcoverage gap（Taxonomy Gap寄り）。
 
@@ -365,6 +419,18 @@ money/career/rest/study/courageの5テーマでは、意味的な破綻は
 （Finding A: love/relationship consultation_axis欠落、Finding C:
 relationship→loveの誤alias）が、判定を押し下げている**、という
 狭い評価である。
+
+§8.1〜8.3のFailure Handling Ruleに基づく分類がこの評価をさらに
+裏付ける: fallback 6件は全件Layer 1（Interpretation）止まりで、
+Layer 2（Recommendation Matching Failure）・Layer 3（Candidate /
+Knowledge Coverage Gap）由来のfallbackは1件も確認されなかった。
+つまり「候補側データが弱い」「Matchingロジックが機能していない」
+という兆候は今回の監査では見られず、問題は**Interpretation層
+（need_tags抽出のkeyword coverage）とTaxonomy層（consultation_axis
+の値域・alias定義）の2箇所に限定されている**。これはNO-GO判定を
+覆すものではないが、Follow-upのスコープを「Recommendation
+Matching/Ranking全体の見直し」ではなく「Finding A/Cという2つの
+具体的なdictionary/taxonomy修正」に絞ってよいという根拠を補強する。
 
 ## 12. Risks
 


### PR DESCRIPTION
## Summary

KAMI MUSUBIのConcierge初期入力を `Initial(自由相談) -> Assist(chips) -> Personalize(L2/L3)` というProgressive Disclosure構造へ変更可能かを判断するため、**L1自由文のみ（L2/L3 Signal一切なし）**でRecommendationがどの程度安定して成立するかを定量監査した。**プロダクションコードの変更は0行**（audit fixture + test + doc追加のみ）。

## Method

`build_chat_recommendations()` をservice-levelで直接呼び出す quota-independent な経路（既存 `test_concierge_eval_queries_seed80.py` と同一パターン、`representative_shrines.yaml` 82件を候補プールに使用）で、チップ定型文ではない自然文20件（career/rest/relationship/love/money/courage/study 各テーマ + ambiguous 4件）を評価した。

## Failure Handling Rule（追記）

`primary_reason == fallback` を即座に「L1自由文失敗」と判定せず、Interpretation Failure / Recommendation Matching Failure / Candidate・Knowledge Coverage Gapの3層を区別して分析した。fallback発生6件それぞれについて `consultation_axis`/`need_tags`/`matched_need_tags`/`score_need`/`history_theme_candidate_boost`/top contributor/`primary_reason_source` を記録し、**Interpretation Gap / Matching Gap / Candidate Coverage Gap / Expected Fallback** の4分類へ割り当てた（audit doc §8.1-8.3）。

**結果**: fallback 6件は全件Layer 1（Interpretation）止まりで、Layer 2（Matching）・Layer 3（Candidate/Knowledge Coverage）由来のfallbackは**0件**だった。
- Expected Fallback 4件（ambiguous query、テーマ的な手がかりが無いため妥当な挙動）
- Interpretation Gap 2件（`l1_relationship_002`「大切な人との関係を整理したい」、`l1_courage_002`「環境を変えたいと思っている」— keyword辞書のcoverage不足）

これによりNO-GO判定自体は変わらないが、Follow-upのスコープを「Recommendation Matching/Ranking全体の見直し」ではなく「Interpretation層・Taxonomy層の2箇所」へ絞り込める根拠を補強した。

## CI-only failure調査（追記）: `l1_rest_002` がCIでfallback判定

CIで `l1_rest_002` がfallbackになった一方、ローカルでのfull suite実行では同ケースがnon-fallbackだった件を調査した。

**調査手順**（依頼通り4段階、各段階で `need_tags`/`consultation_axis`/`matched_need_tags`/`score_need`/`history_theme_candidate_boost`/Top1/`_primary_reason_source` を比較）:
1. `l1_rest_002` 単体
2. readiness test file全体
3. concierge関連suite
4. temples full suite

ローカル（`CONCIERGE_USE_LLM`未設定、Django設定のdefault=False）では上記4段階すべてPASSし、複数の`--randomly-seed`でも再現しなかった。

**根本原因**: `.github/workflows/backend-tests.yml` はCI jobのenv levelで `CONCIERGE_USE_LLM: "1"` を設定している。既存のsibling fixture（`test_concierge_eval_queries_seed80.py`、`test_concierge_visit_preference_contract.py`、`test_concierge_integrated_recommendation_contract.py`等）は全て `settings.CONCIERGE_USE_LLM = False` を明示的に強制しているが、本PRの `readiness_results` fixtureはそれを行っていなかった。

ローカルで `CONCIERGE_USE_LLM=1` をexportしてCI環境を再現したところ、**4段階すべてで確定的に**（間欠的にではなく）同じ失敗を再現できた: `build_chat_recommendations()` が `resolve_llm_route()` 経由で `ConciergeOrchestrator().suggest()`（LLM route）を通り、このorchestrator pathが返す候補dictには `astro_tags` が保持されないため、`need_tags` 自体は正しく抽出されているにも関わらず `matched_by_tag` が全candidateで空になり、`primary_reason_source` が常に `fallback` になる（`l1_rest_002` だけでなく `EXPECTED_NON_FALLBACK_IDS` 全件が同様に影響を受ける構造的な問題）。

これは**test-order/state-leakageではなく、environment-default mismatch**（ローカルdefault=False、CI env=True、本fixtureのみ未override）であると特定した。

**修正**: `readiness_results` fixture（module-scoped）を `django.test.override_settings(CONCIERGE_USE_LLM=False)` でラップした。module-scopedのためfunction-scoped `settings` fixtureは使えない（ScopeMismatch）。`EXPECTED_NON_FALLBACK_IDS` は変更していない。production Recommendationロジック（`concierge_chat.py`/`concierge_chat_llm_route.py`/`concierge_chat_ranking.py`）は一切変更していない。

**修正後の確認**（`CONCIERGE_USE_LLM=1` をexportしCIを再現した状態で4段階再実行）:
1. `l1_rest_002` 単体: PASS
2. readiness test file全体（69 passed, 4 skipped）: PASS
3. concierge関連suite（572 passed, 4 skipped）: PASS
4. temples full suite（1348 passed, 13 skipped）: PASS、さらに6種の`--randomly-seed`でも再確認しPASS

**audit docとの整合性確認**: 元の監査データ収集script（`CONCIERGE_USE_LLM`未設定、正しいdeterministic path）を再実行し、20件全件の `need_tags`/`consultation_axis`/`primary_reason_source`/`recommendations_count` を `docs/audit/concierge-l1-freetext-readiness.md` 記載値とdiffした結果、**差分0件**。監査docのfallback件数・4分類・metricsは元々正確であり、変更していない（今回問題があったのはCI test suiteの信頼性のみ）。

## Key Findings（今回は修正せず、Finding→Impact→Follow-upとして記録）

- **Finding A（Taxonomy Gap）**: `consultation_axis` taxonomy（`CONSULTATION_AXES`）に love/relationship 相当の axis が1つも存在しない。love/relationship 系相談は構造的に必ず `consultation_axis="other"` になり、本番rankingへ実効する `history_theme_candidate_boost` を受け取れない。
- **Finding B（Reason quality）**: `primary_reason_source=="fallback"` でも `rec["reason"]` 本文は候補神社自身のgoriyakuを主語にした確信的な文体になる（`_explanation_payload.summary` 側の同種fallback文言はPR #2408で正直に控えめな表現へ修正済みだが、`build_recommendation_reason()` 側は非対称なまま）。
- **Finding C（Bug、要注意）**: `NEED_TAG_ALIASES`（`concierge_chat_need.py`）の `"relationship": "love"` エントリが、domain層（`temples/domain/need_tags.py`）で正しく区別されている `relationship`（人間関係全般: 職場/家族/友人）タグを問答無用で `love`（恋愛）へ強制変換している。「職場の人間関係がうまくいかず悩んでいる」のような相談が、恋愛成就の理由（「恋愛や良縁を願う参拝先」）で神社を推薦される、という意味的な誤変換が発生している（fixtureのrelationshipテーマ3件中2件で再現）。

## Metrics

| 指標 | 値 |
|---|---|
| Fixture count | 20（clear-intent 16 / ambiguous-intent 4） |
| Recommendation zero rate | **0.0%** |
| clear-intent consultation_axis=other rate | **31.25%**（5/16） |
| ambiguous-intent consultation_axis=other rate | 100.0%（4/4、想定通り・適切） |
| fallback rate | 30.0%（全体） / 12.5%（clear-intentのみ） |
| semantic mismatch count | **2件**（Finding C起因、relationship→love） |
| fallback failure layer | Layer 1（Interpretation）のみ、Layer 2/3は0件 |

## Readiness Decision: **NO-GO**（Decision C: Not Ready）

clear-intent consultation_axis=other率（31.25%）がCONDITIONAL GO上限（20%）を超過し、明確相談における重大な誤推薦（Finding C）が複数件確認されたため。ただし0件推薦・exception・test failureは0件で、money/career/rest/study/courageの5テーマでは意味的破綻は確認されなかった — 問題はFinding A/Cという2つの具体的・特定済みの原因に限定される。**Finding A/Cの解消を、Frontend IA変更（Progressive Disclosure化）より先に行うことを推奨する。**

詳細は [`docs/audit/concierge-l1-freetext-readiness.md`](docs/audit/concierge-l1-freetext-readiness.md) を参照（Failure Handling Rule適用の詳細、"仕事を辞めるか迷っている" Deep Dive、Semantic Sanity Review、Fixture一覧・全結果テーブルを含む）。

## Behavior change disclosure

- Production behavior change: **none**
- Ranking change: **none**
- Candidate filtering change: **none**
- Frontend change: **none**
- Migration: **0**

## Verification

- Backend: `pytest temples/` → **1348 passed, 13 skipped**（既存1279 + 新規69件、うち4件はambiguousテーマにaxis familyを設けていないため意図的にskip）
- Backend（`CONCIERGE_USE_LLM=1`でCI env再現）: targeted → concierge suite → full suite の4段階すべてPASS、6種のrandom seedでも再確認
- Web: pre-push hookで **119 files / 769 tests passed**（フロントエンドコード変更なしのため件数不変）
- ruff lint: 新規fixture/testファイルは0 findings
- Migration: 0件
- `git status`: 新規3ファイル（fixture・test・audit doc）+ readiness test fixtureへの`override_settings`修正1件のみ

## Test plan

- [x] Backend targeted audit tests: `pytest temples/tests/services/test_concierge_l1_freetext_readiness.py`
- [x] Backend full tests: `pytest temples/`
- [x] Backend tests with `CONCIERGE_USE_LLM=1`（CI env再現）: targeted → full、4段階 + 複数seed
- [x] lint: `ruff check`
- [x] migration check: `git status backend/temples/migrations/`（変更なし）
- [x] `git diff` / `git status`: production code変更なしを確認
- [x] audit doc記載値と実測値のdiff: 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)
