### PR TITLE
relationship相談がloveへ誤変換されるInterpretation契約を修正

### DIFF
--- a/backend/temples/services/concierge_chat_need.py
+++ b/backend/temples/services/concierge_chat_need.py
@@ -51,7 +51,6 @@ NEED_PRIORITY = {
 NEED_TAG_ALIASES: Dict[str, str] = {
     "marriage": "love",
     "romance": "love",
-    "relationship": "love",
     "anxiety": "mental",
     "healing": "rest",
     "career_change": "career",
@@ -61,6 +60,19 @@ NEED_TAG_ALIASES: Dict[str, str] = {
     "ambition": "courage",
     "success": "courage",
 }
+# "relationship" (人間関係全般: 職場/家族/友人/対人) is a distinct,
+# first-class need tag in temples/domain/need_tags.py -- with its own
+# keyword list, its own NEED_TO_GORIYAKU_IDS mapping ({1, 27, 34, 43},
+# temples/domain/need_to_goriyaku_tag_ids.py), and its own priority
+# slot -- deliberately separate from "love" (恋愛/出会い/良縁,
+# {1, 29}). It must NOT be aliased to "love" here: doing so collapsed
+# workplace/family/friend relationship consultations into romantic-love
+# recommendation reasons (docs/audit/concierge-l1-freetext-readiness.md
+# Finding C, PR #2409). "romance"/"marriage" (English synonyms an LLM
+# might emit for the same *romantic* concept as "love") remain aliased
+# above; "relationship" is not a synonym of "love", so it is not in
+# this table at all -- normalize_need_tag("relationship") now returns
+# "relationship" unchanged.
 
 
 def normalize_need_tag(tag: Any) -> str:

--- a/backend/temples/services/concierge_chat_ranking.py
+++ b/backend/temples/services/concierge_chat_ranking.py
@@ -373,7 +373,6 @@ def _score_profile_signal(
 NEED_TAG_ALIASES: Dict[str, str] = {
     "marriage": "love",
     "romance": "love",
-    "relationship": "love",
     "anxiety": "mental",
     "healing": "rest",
     "career_change": "career",
@@ -383,6 +382,13 @@ NEED_TAG_ALIASES: Dict[str, str] = {
     "ambition": "courage",
     "success": "courage",
 }
+# "relationship" (人間関係全般) is a distinct need tag from "love"
+# (恋愛) -- see the identical fix + rationale in
+# temples/services/concierge_chat_need.NEED_TAG_ALIASES (this module
+# has its own independent copy of the same table, used by
+# _attach_breakdown's matching path; both had to be fixed for the
+# alias removal to actually take effect end-to-end, see
+# docs/audit/concierge-l1-freetext-readiness.md Finding C / PR #2409).
 
 
 NEED_TEXT_WEIGHTS: Dict[str, Dict[str, int]] = {

--- a/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
+++ b/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
@@ -50,7 +50,7 @@ EXPECTED_AXIS_FAMILY = {
     "courage": {"restart_mindset", "other"},  # keyword-coverage-dependent, see audit §8
     "study": {"study_success"},
     "love": {"other"},  # Finding A: no love/relationship axis exists
-    "relationship": {"other", "rest_healing"},  # Finding A/C: alias + no axis
+    "relationship": {"other", "rest_healing"},  # Finding A: no love/relationship axis exists (unaffected by the Finding C alias fix -- consultation_axis never routed through NEED_TAG_ALIASES)
 }
 
 # Cases the audit confirmed reach a real (non-fallback) primary reason.
@@ -58,10 +58,21 @@ EXPECTED_AXIS_FAMILY = {
 # (l1_relationship_002, l1_courage_002) are intentionally excluded --
 # their empty need_tags is itself the audited finding, not a regression
 # to guard against here.
+#
+# l1_relationship_003 was moved out of this set by the
+# relationship/love separation fix (see fix/concierge-relationship-love
+# -separation): before the fix, "relationship" was force-aliased to
+# "love", and this candidate pool happens to have a real love-themed
+# shrine (恋木神社) that matched -- a *wrong* match, not a real one.
+# After the fix, "relationship" is preserved and correctly finds no
+# match in this 82-shrine pool (no astro_tags/text_weights/goriyaku
+# coverage for "relationship" yet -- a genuine, now-honest Candidate
+# Coverage Gap, see EXPECTED_FALLBACK_CLASSIFICATION below). Losing a
+# wrong match is the intended outcome, not a regression.
 EXPECTED_NON_FALLBACK_IDS = {
     "l1_career_001", "l1_career_002", "l1_career_003",
     "l1_rest_001", "l1_rest_002", "l1_rest_003",
-    "l1_relationship_001", "l1_relationship_003",
+    "l1_relationship_001",
     "l1_love_001", "l1_love_002",
     "l1_money_001", "l1_money_002",
     "l1_courage_001",
@@ -71,13 +82,22 @@ EXPECTED_NON_FALLBACK_IDS = {
 # Failure Handling Rule (audit doc §8.1-8.3): a fallback primary_reason
 # must be attributed to one of Interpretation Gap / Matching Gap /
 # Candidate Coverage Gap / Expected Fallback, never treated as a single
-# undifferentiated "L1 failed" bucket. At audit time, all 6 observed
-# fallback cases were Layer-1 (Interpretation) -- either Expected
-# (ambiguous queries with no thematic hook) or a genuine keyword-coverage
-# gap for a clear-intent query. Zero cases reached Layer 2 (Matching) or
-# Layer 3 (Candidate/Knowledge Coverage).
+# undifferentiated "L1 failed" bucket.
+#
+# l1_relationship_003 is now (post-fix) a genuine Candidate Coverage
+# Gap: need_tags correctly resolves to ["relationship"] (Interpretation
+# succeeded), consultation_axis is "other" only because no
+# love/relationship consultation_axis exists at all (Finding A,
+# pre-existing, unrelated to this fix), but matched_need_tags is empty
+# because this 82-shrine pool has zero shrines with "relationship" in
+# astro_tags, no NEED_TEXT_WEIGHTS["relationship"] entry, and these
+# test candidates carry no goriyaku_tag_ids (even though
+# NEED_TO_GORIYAKU_IDS["relationship"] = {1, 27, 34, 43} already exists
+# -- temples/domain/need_to_goriyaku_tag_ids.py). This is a real,
+# reported gap (Task 8), not fixed in this PR.
 EXPECTED_FALLBACK_CLASSIFICATION = {
     "l1_relationship_002": "interpretation_gap",
+    "l1_relationship_003": "candidate_coverage_gap",
     "l1_courage_002": "interpretation_gap",
     "l1_ambiguous_001": "expected_fallback",
     "l1_ambiguous_002": "expected_fallback",
@@ -85,13 +105,11 @@ EXPECTED_FALLBACK_CLASSIFICATION = {
     "l1_ambiguous_004": "expected_fallback",
 }
 
-# Expected semantic need_tag family per case (audit doc §5/§10). For the
-# two relationship cases that Finding C documents as mis-aliased to
-# "love", the expected family includes both the intended tag
-# ("relationship") and the currently-observed one ("love") -- this pins
-# the *current* (buggy) behavior as a known state without asserting it
-# is correct, so a future fix (removing the alias) does not spuriously
-# fail this test.
+# Expected semantic need_tag family per case (audit doc §5/§10). Prior
+# to the relationship/love separation fix, the two relationship cases
+# were pinned to accept both "relationship" (intended) and "love"
+# (then-observed, buggy) -- now that the alias is removed, this is
+# tightened to assert only the correct value.
 EXPECTED_NEED_TAG_FAMILY = {
     "l1_career_001": {"career"},
     "l1_career_002": {"career"},
@@ -99,8 +117,8 @@ EXPECTED_NEED_TAG_FAMILY = {
     "l1_rest_001": {"mental", "rest"},
     "l1_rest_002": {"rest"},
     "l1_rest_003": {"rest"},
-    "l1_relationship_001": {"relationship", "love"},
-    "l1_relationship_003": {"relationship", "love"},
+    "l1_relationship_001": {"relationship"},
+    "l1_relationship_003": {"relationship"},
     "l1_love_001": {"love"},
     "l1_love_002": {"love"},
     "l1_money_001": {"money", "career"},
@@ -320,15 +338,26 @@ def test_l1_freetext_fallback_cases_match_documented_set(readiness_results):
 
 
 @pytest.mark.django_db
-def test_l1_freetext_no_fallback_reaches_matching_or_coverage_layer(readiness_results):
-    """At audit time, all fallback cases were Layer-1 (Interpretation):
-    need_tags was empty, so matched_need_tags and
-    history_theme_candidate_boost are structurally zero too -- Layer 2
-    (Matching Gap) and Layer 3 (Candidate/Knowledge Coverage Gap) were
-    never reached. This does not prove Matching/Coverage gaps can't
-    occur (audit doc §12 Risks) -- it pins what was actually observed
-    with this 82-shrine candidate pool."""
-    for case_id in EXPECTED_FALLBACK_CLASSIFICATION:
+def test_l1_freetext_fallback_layer_matches_classification(readiness_results):
+    """Each fallback case's actual need_tags/matched_need_tags shape must
+    match its EXPECTED_FALLBACK_CLASSIFICATION category:
+
+    - interpretation_gap / expected_fallback (Layer 1): need_tags is
+      empty -- Interpretation itself produced nothing, so
+      matched_need_tags/score_need/history_theme_candidate_boost are
+      structurally zero too.
+    - candidate_coverage_gap (Layer 3): need_tags is *non-empty*
+      (Interpretation succeeded) but matched_need_tags is still empty
+      because this 82-shrine pool has no astro_tags/text_weights/
+      goriyaku coverage for that tag yet.
+
+    This does not prove Matching Gaps (Layer 2: consultation_axis
+    correct + need_tags present, but still no match) can't occur (audit
+    doc §12 Risks) -- it pins what was actually observed with this
+    82-shrine candidate pool, now including the one Layer 3 case
+    introduced by the relationship/love separation fix
+    (l1_relationship_003)."""
+    for case_id, category in EXPECTED_FALLBACK_CLASSIFICATION.items():
         _, recs = readiness_results[case_id]
         top1 = recs["recommendations"][0]
         need = recs.get("_need") or {}
@@ -336,7 +365,11 @@ def test_l1_freetext_no_fallback_reaches_matching_or_coverage_layer(readiness_re
         features = ((top1.get("breakdown_detail") or {}).get("features")) or {}
         history_boost = (features.get("history_theme_candidate_boost") or {}).get("raw")
 
-        assert need.get("tags") == [], f"{case_id}: expected empty need_tags (Layer 1), got {need.get('tags')}"
+        if category == "candidate_coverage_gap":
+            assert need.get("tags"), f"{case_id}: expected non-empty need_tags (Layer 3), got {need.get('tags')}"
+        else:
+            assert need.get("tags") == [], f"{case_id}: expected empty need_tags (Layer 1), got {need.get('tags')}"
+
         assert breakdown.get("matched_need_tags") == [], f"{case_id}: unexpected matched_need_tags"
         assert breakdown.get("score_need") == 0, f"{case_id}: unexpected non-zero score_need"
         assert not history_boost, f"{case_id}: unexpected history_theme_candidate_boost={history_boost}"

--- a/backend/temples/tests/services/test_recommendation_core_contract.py
+++ b/backend/temples/tests/services/test_recommendation_core_contract.py
@@ -52,14 +52,21 @@ def test_consultation_theme_study_resolves_to_study():
     assert "study" in payload["tags"]
 
 
-def test_consultation_theme_relationship_is_currently_mapped_to_love_not_relationship():
+def test_consultation_theme_relationship_resolves_to_relationship_not_love():
+    """"relationship" (人間関係全般: 職場/家族/友人/対人) is a domain-
+    distinct need tag from "love" (恋愛/出会い/良縁) -- it must not be
+    force-converted to "love" by NEED_TAG_ALIASES. Previously this test
+    asserted the opposite as documented-buggy behavior; see
+    docs/audit/concierge-l1-freetext-readiness.md Finding C (PR #2409)
+    and the fix in concierge_chat_need.NEED_TAG_ALIASES /
+    concierge_chat_ranking.NEED_TAG_ALIASES."""
     payload = resolve_need_payload(
         query="人間関係や職場の関係を整えたい",
         max_tags=3,
     )
 
-    assert "relationship" not in payload["tags"]
-    assert "love" in payload["tags"] or "mental" in payload["tags"] or "career" in payload["tags"]
+    assert "relationship" in payload["tags"]
+    assert "love" not in payload["tags"]
 
 
 def test_consultation_theme_challenge_resolves_to_courage():

--- a/backend/temples/tests/test_concierge_relationship_love_separation.py
+++ b/backend/temples/tests/test_concierge_relationship_love_separation.py
@@ -1,0 +1,391 @@
+# backend/temples/tests/test_concierge_relationship_love_separation.py
+"""L1 Relationship / Love Interpretation Separation.
+
+Fixes the Finding C bug from docs/audit/concierge-l1-freetext-readiness.md
+(PR #2409): `NEED_TAG_ALIASES["relationship"] = "love"` collapsed the
+domain layer's distinct `relationship` need tag (人間関係全般: 職場/
+家族/友人/対人, temples/domain/need_tags.py) into `love` (恋愛/出会い/
+良縁), so workplace/family/friend relationship consultations produced
+romantic-love recommendation reasons.
+
+Root cause had TWO independent copies of the same alias table:
+  - temples/services/concierge_chat_need.NEED_TAG_ALIASES
+  - temples/services/concierge_chat_ranking.NEED_TAG_ALIASES
+Both had to drop the `"relationship": "love"` entry for the fix to take
+effect end-to-end (the ranking-layer copy is what `_attach_breakdown`
+actually uses for matching).
+
+Scope: relationship/love semantic separation only. consultation_axis
+taxonomy, ranking weights, candidate filtering, goriyaku hard filter,
+Primary Reason priority, Level 2/3, Score v3, Frontend, DB schema are
+all unchanged -- see docs/product/concierge-input-architecture.md for
+the layers this PR does not touch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.domain.need_tags import extract_need_tags
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_need import (
+    NEED_TAG_ALIASES as SERVICE_NEED_TAG_ALIASES,
+    normalize_need_tag,
+    resolve_need_payload,
+)
+from temples.services.concierge_chat_ranking import (
+    NEED_TAG_ALIASES as RANKING_NEED_TAG_ALIASES,
+    _normalize_need_tag,
+)
+
+LOVE_ONLY_PHRASES = ("恋愛", "良縁", "縁結び", "恋愛成就", "片思い", "復縁", "両思い")
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Alias table contract (both independent copies)
+# ---------------------------------------------------------------------------
+
+
+def test_relationship_is_not_in_either_alias_table():
+    assert "relationship" not in SERVICE_NEED_TAG_ALIASES
+    assert "relationship" not in RANKING_NEED_TAG_ALIASES
+
+
+@pytest.mark.parametrize(
+    "normalize_fn",
+    [normalize_need_tag, _normalize_need_tag],
+    ids=["concierge_chat_need", "concierge_chat_ranking"],
+)
+def test_relationship_normalizes_to_relationship_not_love(normalize_fn):
+    assert normalize_fn("relationship") == "relationship"
+
+
+@pytest.mark.parametrize(
+    "normalize_fn",
+    [normalize_need_tag, _normalize_need_tag],
+    ids=["concierge_chat_need", "concierge_chat_ranking"],
+)
+def test_love_normalizes_to_love(normalize_fn):
+    assert normalize_fn("love") == "love"
+
+
+@pytest.mark.parametrize(
+    "normalize_fn",
+    [normalize_need_tag, _normalize_need_tag],
+    ids=["concierge_chat_need", "concierge_chat_ranking"],
+)
+def test_love_does_not_normalize_to_relationship(normalize_fn):
+    assert normalize_fn("love") != "relationship"
+
+
+@pytest.mark.parametrize(
+    "normalize_fn",
+    [normalize_need_tag, _normalize_need_tag],
+    ids=["concierge_chat_need", "concierge_chat_ranking"],
+)
+@pytest.mark.parametrize("alias", ["marriage", "romance"])
+def test_love_synonym_aliases_are_unchanged(normalize_fn, alias):
+    """Task 4 backward compatibility: "marriage"/"romance" (English
+    synonyms for the *romantic* concept "love", not human-relationship
+    synonyms) remain aliased to "love" -- only "relationship" itself was
+    removed from the table."""
+    assert normalize_fn(alias) == "love"
+
+
+# ---------------------------------------------------------------------------
+# Task 2/5/9: Domain-level need tag lifecycle for natural-language fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "query,expected_in",
+    [
+        ("職場の人間関係がうまくいかず悩んでいる", "relationship"),
+        ("家族との関係を少し整えたい", "relationship"),
+    ],
+)
+def test_relationship_phrasing_preserves_relationship_tag(query, expected_in):
+    extracted = extract_need_tags(query)
+    assert expected_in in extracted.tags
+    payload = resolve_need_payload(query=query, need_tags=[], max_tags=3)
+    assert expected_in in payload["tags"]
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "職場の人間関係がうまくいかず悩んでいる",
+        "大切な人との関係を整理したい",
+        "家族との関係を少し整えたい",
+        "友人との関係で疲れている",
+    ],
+)
+def test_relationship_phrasing_never_produces_love_tag(query):
+    """Task 5: even in cases where "relationship" itself isn't extracted
+    (e.g. "友人との関係で疲れている" doesn't literally contain a
+    KEYWORDS-matched relationship word -- a pre-existing, unrelated
+    Interpretation coverage gap, not touched here), the query must never
+    be force-converted to "love" -- that's the specific bug this PR
+    fixes."""
+    payload = resolve_need_payload(query=query, need_tags=[], max_tags=3)
+    assert "love" not in payload["tags"], f"{query!r} unexpectedly resolved to love: {payload}"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "恋愛について悩んでいる",
+        "いい出会いがほしい",
+    ],
+)
+def test_love_phrasing_still_resolves_to_love(query):
+    """Task 4 backward compatibility: real love/romance consultations are
+    unaffected by removing the relationship->love alias."""
+    payload = resolve_need_payload(query=query, need_tags=[], max_tags=3)
+    assert "love" in payload["tags"]
+
+
+def test_marriage_keyword_phrasing_still_resolves_to_love_via_unchanged_alias():
+    """"良縁" is a domain-level "marriage" keyword (temples/domain/
+    need_tags.py KEYWORDS["marriage"]), not "relationship" -- it reaches
+    "love" via the untouched marriage->love alias, exactly as before
+    this fix (Task 3: marriage/romance aliases are explicitly out of
+    scope, only relationship was removed)."""
+    payload = resolve_need_payload(query="良縁を願いたい", need_tags=[], max_tags=3)
+    assert payload["tags"] == ["love"]
+
+
+# ---------------------------------------------------------------------------
+# Task 6/11: Reason Contract -- relationship match must not produce a
+# love-only Reason, end to end through the real ranking/reason pipeline
+# ---------------------------------------------------------------------------
+
+
+def _shrine(name, astro_tags, **overrides):
+    base = {
+        "name": name,
+        "distance_m": 500.0,
+        "lat": 35.001,
+        "lng": 139.001,
+        "popular_score": 5.0,
+        "astro_tags": astro_tags,
+        "goriyaku": "",
+        "description": "",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.django_db
+def test_relationship_match_produces_relationship_reason_not_love(settings, monkeypatch):
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    import temples.domain.need_tags as need
+
+    class FakeNeedExtract:
+        tags = ["relationship"]
+        hits = {"relationship": ["職場", "人間関係"]}
+
+    monkeypatch.setattr(need, "extract_need_tags", lambda q, max_tags=3: FakeNeedExtract(), raising=True)
+
+    candidates = [_shrine("対人円満神社", ["relationship"])]
+    recs = build_chat_recommendations(
+        query="職場の人間関係がうまくいかず悩んでいる",
+        language="ja",
+        candidates=candidates,
+        public_mode="need",
+        flow="A",
+    )
+    top1 = recs["recommendations"][0]
+
+    assert top1["breakdown"]["matched_need_tags"] == ["relationship"]
+    assert top1["_primary_reason_source"] == "need_tag"
+    assert top1["_primary_reason_label"] == "relationship"
+
+    for phrase in LOVE_ONLY_PHRASES:
+        assert phrase not in top1["reason"], f"unexpected love phrase {phrase!r} in reason: {top1['reason']!r}"
+        summary = ((top1.get("explanation") or {}).get("summary")) or ""
+        assert phrase not in summary, f"unexpected love phrase {phrase!r} in summary: {summary!r}"
+
+
+@pytest.mark.django_db
+def test_love_match_is_unaffected_and_still_produces_love_reason(settings, monkeypatch):
+    """Task 4 backward compatibility at the full pipeline level: a real
+    love-need match still produces love-specific reasoning."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    import temples.domain.need_tags as need
+
+    class FakeNeedExtract:
+        tags = ["love"]
+        hits = {"love": ["恋愛", "出会い"]}
+
+    monkeypatch.setattr(need, "extract_need_tags", lambda q, max_tags=3: FakeNeedExtract(), raising=True)
+
+    candidates = [_shrine("恋木神社", ["love"], goriyaku="恋愛成就")]
+    recs = build_chat_recommendations(
+        query="恋愛について悩んでいる",
+        language="ja",
+        candidates=candidates,
+        public_mode="need",
+        flow="A",
+    )
+    top1 = recs["recommendations"][0]
+
+    assert top1["breakdown"]["matched_need_tags"] == ["love"]
+    assert top1["_primary_reason_source"] == "need_tag"
+    assert top1["_primary_reason_label"] == "love"
+    assert "恋愛" in top1["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Task 10: PR #2409 regression (l1_relationship_001/002/003), before/after
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_pr2409_l1_relationship_001_no_longer_gets_love_primary_reason(settings, monkeypatch):
+    """Before this fix: need_tags=['mental','love','rest'], primary_reason
+    = need_tag/love, Top1 reason mentioned "恋愛や良縁" (縁結びのご利益で
+    知られる高千穂神社は、恋愛や良縁を願う参拝先として適しています。).
+    After this fix: need_tags=['mental','relationship','rest'] (relationship
+    preserved), and since this fixture's shrine has no relationship-tagged
+    match, "mental" wins instead -- primary_reason_source stays a real
+    need_tag match, just no longer a wrong love-themed one."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [
+        _shrine("高千穂神社", ["love"], goriyaku="縁結び"),
+        _shrine("鎮守の森神社", ["mental", "rest"], goriyaku="厄除け・開運"),
+    ]
+    recs = build_chat_recommendations(
+        query="人間関係で少し疲れている",
+        language="ja",
+        candidates=candidates,
+        public_mode="need",
+        flow="A",
+    )
+
+    need_tags = recs["_need"]["tags"]
+    assert "relationship" in need_tags
+    assert "love" not in need_tags
+
+    top1 = recs["recommendations"][0]
+    assert top1["_primary_reason_label"] != "love"
+    for phrase in LOVE_ONLY_PHRASES:
+        assert phrase not in top1["reason"]
+
+
+@pytest.mark.django_db
+def test_pr2409_l1_relationship_002_interpretation_gap_unchanged(settings, monkeypatch):
+    """l1_relationship_002 ("大切な人との関係を整理したい") was, and
+    remains, an Interpretation Gap (empty need_tags) -- unaffected by
+    this fix, confirmed as a non-regression."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [_shrine("三光稲荷神社", [], goriyaku="金運")]
+    recs = build_chat_recommendations(
+        query="大切な人との関係を整理したい",
+        language="ja",
+        candidates=candidates,
+        public_mode="need",
+        flow="A",
+    )
+
+    assert recs["_need"]["tags"] == []
+    top1 = recs["recommendations"][0]
+    assert top1["_primary_reason_source"] == "fallback"
+    for phrase in LOVE_ONLY_PHRASES:
+        assert phrase not in top1["reason"]
+
+
+@pytest.mark.django_db
+def test_pr2409_l1_relationship_003_no_longer_gets_love_primary_reason(settings, monkeypatch):
+    """Before this fix: need_tags=['love'], primary_reason = need_tag/love,
+    Top1 reason: "恋愛成就のご利益で知られる恋木神社は、恋愛や良縁を願う
+    参拝先として適しています。" -- a workplace-relationship complaint
+    recommended with a romantic-love justification.
+    After this fix: need_tags=['relationship'] (correctly preserved, not
+    converted). Whether it then matches a candidate or falls back
+    depends on candidate coverage (Task 8, a separate concern) -- either
+    outcome is acceptable here, the only forbidden outcome is a
+    love-labeled primary reason for this workplace-relationship query.
+
+    The candidate's static `goriyaku` text is deliberately neutral here
+    (unlike the real 恋木神社/"恋愛成就" fixture in the 82-shrine
+    readiness pool): the fallback reason template quotes a candidate's
+    own static goriyaku text verbatim regardless of matched need tags,
+    so a real "恋愛成就"-goriyaku shrine would legitimately mention 恋愛
+    in fallback mode purely as its own real-world description, not as a
+    love-biased *primary reason* -- that's a Candidate Coverage Gap
+    (Task 8), not the Interpretation bug this test targets."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [_shrine("恋木神社", ["love"], goriyaku="心願成就")]
+    recs = build_chat_recommendations(
+        query="職場の人間関係がうまくいかず悩んでいる",
+        language="ja",
+        candidates=candidates,
+        public_mode="need",
+        flow="A",
+    )
+
+    need_tags = recs["_need"]["tags"]
+    assert need_tags == ["relationship"]
+    assert "love" not in need_tags
+
+    top1 = recs["recommendations"][0]
+    assert top1["_primary_reason_label"] != "love"
+    for phrase in LOVE_ONLY_PHRASES:
+        assert phrase not in top1["reason"]
+
+
+# ---------------------------------------------------------------------------
+# Task 11: Semantic assertion -- relationship consultation != love
+# recommendation meaning, as an explicit, reusable Contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "query",
+    [
+        "職場の人間関係がうまくいかず悩んでいる",
+        "大切な人との関係を整理したい",
+        "家族との関係を少し整えたい",
+        "友人との関係で疲れている",
+    ],
+)
+def test_relationship_consultation_never_produces_love_only_reason(query, settings, monkeypatch):
+    """A candidate astro-tagged "love" stays in the pool (proving it is
+    not spuriously matched via a relationship->love need-tag conversion)
+    but uses neutral static goriyaku text -- unlike a real 恋愛成就-type
+    shrine, whose own descriptive text would legitimately mention 恋愛
+    regardless of the query's need tags if it were ranked to the top by
+    distance/popularity alone (a Candidate Coverage Gap concern, Task 8,
+    not the Interpretation contract this test targets)."""
+    settings.CONCIERGE_USE_LLM = False
+    monkeypatch.setenv("CHAT_MAX_ADDRESS_LOOKUPS", "0")
+
+    candidates = [
+        _shrine("恋木神社", ["love"], goriyaku="心願成就"),
+        _shrine("近隣神社", [], goriyaku=""),
+    ]
+    recs = build_chat_recommendations(
+        query=query,
+        language="ja",
+        candidates=candidates,
+        public_mode="need",
+        flow="A",
+    )
+
+    assert "love" not in recs["_need"]["tags"]
+    top1 = recs["recommendations"][0]
+    assert top1["_primary_reason_label"] != "love"
+    for phrase in LOVE_ONLY_PHRASES:
+        assert phrase not in top1["reason"]


### PR DESCRIPTION
## Root Cause

`NEED_TAG_ALIASES["relationship"] = "love"` が、`temples/domain/need_tags.py` のドメイン層で first-class な need tag として定義されている `relationship`（人間関係全般: 職場/家族/友人/対人）を `love`（恋愛・出会い・良縁）へ強制変換していた。

`NEED_TAG_ALIASES` は独立した2つの定義を持っており、両方が同じ誤変換を行っていた:
- [`temples/services/concierge_chat_need.py`](backend/temples/services/concierge_chat_need.py) — `resolve_need_payload()` が使用（`_need.tags` の source）
- [`temples/services/concierge_chat_ranking.py`](backend/temples/services/concierge_chat_ranking.py) — `_attach_breakdown()` の matching path が使用（実際の score_need / primary_reason を決定）

片方だけ修正した場合、`_need.tags` の表示上は `relationship` に見えても、`_attach_breakdown` 内の独自コピーが裏で再度 `love` へ変換してしまい、matched_need_tags / primary_reason は love のままになることを実際に確認した（このPRでは両方修正済み）。

docs/audit/concierge-l1-freetext-readiness.md Finding C（PR #2409）で報告されたバグ。

## Before

「職場の人間関係がうまくいかず悩んでいる」のような相談が:
- `need_tags = ['mental', 'love', 'rest']`（relationshipがloveに変換される）
- `primary_reason_source = 'need_tag'`, `primary_reason_label = 'love'`
- 表示Reason: 「〜恋愛や良縁を願う参拝先として適しています。」

という、相談内容と無関係な恋愛文脈のReasonで案内されていた。

## After

同じ相談が:
- `need_tags = ['mental', 'relationship', 'rest']`（relationshipのまま保持）
- `love` は決して混入しない
- matched_need_tags / primary_reason は正しく relationship（または、該当候補が無ければ fallback）になる

`marriage`/`romance`（loveの同義語として使われる英語表現）は引き続き `love` へ変換される。scope外・意図的に維持。

## Affected queries（PR #2409 l1_relationship_001/002/003 再検証）

| ケース | Before need_tags | Before primary_reason | After need_tags | After primary_reason |
|---|---|---|---|---|
| l1_relationship_001（人間関係で少し疲れている） | `['mental','love','rest']` | `need_tag/love` | `['mental','relationship','rest']` | love以外（`love`ラベルが出ないことを確認） |
| l1_relationship_002（大切な人との関係を整理したい） | `[]`（Interpretation Gap, 未変化） | `fallback` | `[]`（未変化） | `fallback`（未変化・非対象） |
| l1_relationship_003（職場の人間関係がうまくいかず悩んでいる） | `['love']` | `need_tag/love` | `['relationship']` | love以外（この82神社seedにrelationship候補が無いため`fallback`。Candidate Coverage Gapとして分類、Interpretation自体は修正済み） |

L1 readiness audit test (`test_concierge_l1_freetext_readiness.py`) の `l1_relationship_003` は `EXPECTED_NON_FALLBACK_IDS` から `EXPECTED_FALLBACK_CLASSIFICATION["candidate_coverage_gap"]` へ移動。誤った love マッチを失う代わりに、正しい relationship分類のもとでの（正直な）fallbackになったという意図した結果。

## Ranking影響（意図的な意味修正）

Ranking behavior change: relationship queries only / intentional semantic correction。

`relationship` タグを持つ相談が、以前は `love` タグを持つ候補に対して誤ってマッチしていたが、このPR以降は正しくマッチしなくなる（= その相談にrelationship候補が無ければ非マッチ/fallbackになる）。これは relationship クエリのみに影響する意図的な意味修正であり、Ranking の重み・アルゴリズム自体は一切変更していない。

## Unchanged areas

- consultation_axis taxonomy（`temples/domain/consultation_axis.py`）
- Ranking weights
- Candidate filtering
- goriyaku hard filter
- Primary Reason priority
- Level 2 / Level 3
- Score v3
- Frontend（apps/web、変更ファイル無し）
- DB schema / migrations（`backend/temples/migrations/` 変更無し）

`marriage`/`romance` → `love` のアライアスも維持（scope外）。

## Known remaining gap

consultation_axis taxonomyにはrelationship/love axisがまだ存在しない（Finding A, 別スコープ）。`relationship` の consultation_axis は今回も `other` のまま。

`NEED_TEXT_WEIGHTS` / `NEED_LABELS_JA`（`concierge_chat_ranking.py`）にも `relationship` エントリはまだ無く、テキストヒントによる追加マッチやJAラベル表示は今回拡張していない（未マップのラベルは汎用文言に degrade するため、love色のついた誤ったテキストが漏れることは無いことを確認済み）。

`temples/domain/need_tags.py` の `KEYWORDS["relationship"]` は「友人」を含まないため、「友人との関係で疲れている」のような文言は relationship として抽出されない（既存のキーワードカバレッジの制約、今回は変更していない — need tag extraction logic自体は変更対象外）。この場合でも `love` への誤変換は発生しないことをテストで保証。

## Testing

- `backend/temples/tests/test_concierge_relationship_love_separation.py`（新規）: alias契約の単体テスト（両ファイルの `normalize_need_tag`）、backward compat（love/marriage/romance）、自然文fixture（職場人間関係/家族関係/友人関係/恋愛/出会い/良縁）、reason contract（relationship match → love-only reasonの禁止）、PR #2409のl1_relationship_001/002/003再現、Semantic Assertion Contract
- `backend/temples/tests/services/test_concierge_l1_freetext_readiness.py`: l1_relationship_003 の期待値を `candidate_coverage_gap` に更新
- `backend/temples/tests/services/test_recommendation_core_contract.py`: 旧バグを「現状のドキュメント」として明示的に固定していたテストを正しい契約へ更新

```
targeted:      29 passed  (test_concierge_relationship_love_separation.py)
readiness:     68 passed, 4 skipped (test_concierge_l1_freetext_readiness.py)
concierge全体: 600 passed, 4 skipped
full backend:  1387 passed, 13 skipped, 0 failed
lint (ruff):   新規/変更ファイルはクリーン（既存の事前存在するI001/C901警告2ファイル分は今回のdiffと無関係、baseコミットで再現確認済み）
migrations:    変更なし
CONCIERGE_USE_LLM=1（CI再現）: targeted 108 passed, 4 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)