### PR TITLE
relationship / love相談をConsultation Axisへ正式接続

### DIFF
--- a/backend/temples/domain/consultation_axis.py
+++ b/backend/temples/domain/consultation_axis.py
@@ -10,12 +10,23 @@ CONSULTATION_AXES: List[ConsultationAxis] = [
     "money_growth",
     "career_change",
     "independence",
+    "relationship_repair",
     "rest_healing",
     "restart_mindset",
     "nature_reset",
     "study_success",
     "other",
 ]
+# "relationship_repair" (恋愛・家族・職場・友人など、人との関係を整える
+# 相談) was already documented as the primary consultation_axis for the
+# `relationship` theme_key in docs/product/consultation-theme-taxonomy.md
+# and docs/audit/score-v3-consultation-axis-history-theme-mapping.md
+# §6.2, and already has real (non-shadow) ranking weights in
+# concierge_chat_ranking.HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS -- but was
+# never actually connected here, so every relationship/love consultation
+# fell through to "other" (docs/audit/concierge-l1-freetext-readiness.md
+# Finding A, PR #2409). Adding it to the official axis list only wires up
+# an axis the design docs and ranking layer already treat as real.
 
 CONSULTATION_AXIS_SET = set(CONSULTATION_AXES)
 
@@ -28,6 +39,16 @@ CONSULTATION_AXIS_ALIASES: Dict[str, ConsultationAxis] = {
     "independent": "independence",
     "startup": "independence",
     "freelance": "independence",
+    "relationship": "relationship_repair",
+    "human_relationship": "relationship_repair",
+    # score-v3-consultation-axis-history-theme-mapping.md §6.2 scopes
+    # relationship_repair to include 恋愛 (romantic love) alongside
+    # family/workplace/friend relationships -- love shares this axis at
+    # the consultation_axis layer while remaining a distinct need_tag
+    # (temples/domain/need_tags.py) and reason label (PR #2410). No
+    # independent "love_connection" axis exists in the taxonomy docs, so
+    # one is not invented here.
+    "love": "relationship_repair",
     "rest": "rest_healing",
     "healing": "rest_healing",
     "mental": "restart_mindset",
@@ -76,6 +97,22 @@ CONSULTATION_AXIS_KEYWORDS: Dict[ConsultationAxis, List[str]] = {
         "場所に縛られず",
         "自分のサービス",
         "経営者",
+    ],
+    # Query-level relationship phrasing only (Task 4). Love-specific
+    # keywords (恋愛/出会い/良縁) are intentionally NOT duplicated here --
+    # need_tags.py already extracts them as the "love" need tag, and
+    # NEED_TAG_TO_CONSULTATION_AXIS below routes "love" to this same axis
+    # via the need_tags fallback branch of resolve_consultation_axis().
+    "relationship_repair": [
+        "人間関係",
+        "職場の人間関係",
+        "家族との関係",
+        "友人との関係",
+        "対人関係",
+        "関係を整理",
+        "関係を修復",
+        "関係がうまくいかない",
+        "仲直り",
     ],
     "rest_healing": [
         "疲れ",
@@ -142,7 +179,12 @@ NEED_TAG_TO_CONSULTATION_AXIS: Dict[str, ConsultationAxis] = {
     "rest": "rest_healing",
     "study": "study_success",
     "focus": "study_success",
+    "relationship": "relationship_repair",
+    "love": "relationship_repair",
 }
+# "relationship" and "love" stay distinct need_tags (PR #2410) but share
+# the relationship_repair consultation_axis -- see the CONSULTATION_AXIS_ALIASES
+# comment above for the design rationale (score-v3-consultation-axis-history-theme-mapping.md §6.2).
 
 CONSULTATION_AXIS_PRIORITY: Dict[ConsultationAxis, int] = {
     axis: index for index, axis in enumerate(CONSULTATION_AXES)

--- a/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
+++ b/backend/temples/tests/services/test_concierge_l1_freetext_readiness.py
@@ -39,18 +39,28 @@ from temples.tests.fixtures.concierge_l1_freetext_readiness_queries import (
 SEED_PATH = Path(__file__).resolve().parents[2] / "seed" / "representative_shrines.yaml"
 
 # Axes that currently exist in temples.domain.consultation_axis.CONSULTATION_AXES
-# for each theme. "love" and "relationship" are deliberately absent --
-# Finding A (audit doc §7) documents that no love/relationship axis
-# exists, so those themes structurally resolve to "other". This mapping
-# pins that *documented, known* state, not an assumption.
+# for each theme.
+#
+# Finding A (audit doc §7) originally documented that no love/relationship
+# axis existed, so those themes structurally resolved to "other". This was
+# fixed by wiring "relationship_repair" into resolve_consultation_axis()
+# (feature/concierge-relationship-consultation-axis, see
+# docs/audit/concierge-relationship-axis-followup.md) -- love and
+# relationship share this one axis (need_tags stay distinct, PR #2410).
+# "rest_healing" stays an accepted alternative for l1_relationship_001:
+# "人間関係で少し疲れている" has 2 rest_healing keyword hits (疲れ/疲れて)
+# vs. 1 relationship_repair hit (人間関係), and CONSULTATION_AXIS_KEYWORDS
+# resolution is hit-count-ranked -- a pre-existing, unrelated tie-break
+# rule this PR does not change (Task 9: no scope expansion into keyword
+# priority tuning).
 EXPECTED_AXIS_FAMILY = {
     "career": {"career_change"},
     "rest": {"rest_healing"},
     "money": {"money_growth"},
     "courage": {"restart_mindset", "other"},  # keyword-coverage-dependent, see audit §8
     "study": {"study_success"},
-    "love": {"other"},  # Finding A: no love/relationship axis exists
-    "relationship": {"other", "rest_healing"},  # Finding A: no love/relationship axis exists (unaffected by the Finding C alias fix -- consultation_axis never routed through NEED_TAG_ALIASES)
+    "love": {"relationship_repair"},
+    "relationship": {"relationship_repair", "rest_healing"},
 }
 
 # Cases the audit confirmed reach a real (non-fallback) primary reason.
@@ -84,17 +94,19 @@ EXPECTED_NON_FALLBACK_IDS = {
 # Candidate Coverage Gap / Expected Fallback, never treated as a single
 # undifferentiated "L1 failed" bucket.
 #
-# l1_relationship_003 is now (post-fix) a genuine Candidate Coverage
-# Gap: need_tags correctly resolves to ["relationship"] (Interpretation
-# succeeded), consultation_axis is "other" only because no
-# love/relationship consultation_axis exists at all (Finding A,
-# pre-existing, unrelated to this fix), but matched_need_tags is empty
-# because this 82-shrine pool has zero shrines with "relationship" in
-# astro_tags, no NEED_TEXT_WEIGHTS["relationship"] entry, and these
-# test candidates carry no goriyaku_tag_ids (even though
-# NEED_TO_GORIYAKU_IDS["relationship"] = {1, 27, 34, 43} already exists
-# -- temples/domain/need_to_goriyaku_tag_ids.py). This is a real,
-# reported gap (Task 8), not fixed in this PR.
+# l1_relationship_003 is a genuine Candidate Coverage Gap: need_tags
+# correctly resolves to ["relationship"], and (since
+# feature/concierge-relationship-consultation-axis) consultation_axis
+# correctly resolves to "relationship_repair" too -- Finding A is fixed.
+# It still falls back because matched_need_tags is empty: this 82-shrine
+# pool has zero shrines with "relationship" in astro_tags, no
+# NEED_TEXT_WEIGHTS["relationship"] entry, no shrine here carries
+# history_theme="縁" either (representative_shrines.yaml has no
+# history_theme field at all yet), and these test candidates carry no
+# goriyaku_tag_ids (even though NEED_TO_GORIYAKU_IDS["relationship"] =
+# {1, 27, 34, 43} already exists -- temples/domain/need_to_goriyaku_tag_ids.py).
+# This is a real, reported gap (Task 8 of the axis-followup PR), not fixed
+# here -- see docs/audit/concierge-relationship-axis-followup.md.
 EXPECTED_FALLBACK_CLASSIFICATION = {
     "l1_relationship_002": "interpretation_gap",
     "l1_relationship_003": "candidate_coverage_gap",

--- a/backend/temples/tests/services/test_consultation_axis_contract.py
+++ b/backend/temples/tests/services/test_consultation_axis_contract.py
@@ -12,11 +12,18 @@ from temples.llm.schemas import complete_recommendations, normalize_recs
 from temples.services.concierge_chat import build_chat_recommendations
 
 
-def test_consultation_axis_taxonomy_has_seven_axes_plus_other():
+def test_consultation_axis_taxonomy_has_eight_axes_plus_other():
+    """relationship_repair was added to close PR #2409 Finding A: it was
+    already documented as the relationship theme_key's primary axis in
+    docs/product/consultation-theme-taxonomy.md and already had real
+    (non-shadow) ranking weights in concierge_chat_ranking.
+    HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS, but was never wired into
+    resolve_consultation_axis()."""
     assert CONSULTATION_AXES == [
         "money_growth",
         "career_change",
         "independence",
+        "relationship_repair",
         "rest_healing",
         "restart_mindset",
         "nature_reset",
@@ -37,6 +44,10 @@ def test_consultation_axis_taxonomy_has_seven_axes_plus_other():
         ("mental", "restart_mindset"),
         ("nature", "nature_reset"),
         ("study", "study_success"),
+        ("relationship_repair", "relationship_repair"),
+        ("relationship", "relationship_repair"),
+        ("human_relationship", "relationship_repair"),
+        ("love", "relationship_repair"),
         ("unknown", "other"),
     ],
 )
@@ -59,6 +70,10 @@ def test_normalize_consultation_axis(raw, expected):
         ("気持ちを切り替えて前向きになれる参拝がしたい", "restart_mindset"),
         ("自然を感じながら参拝したい", "nature_reset"),
         ("資格試験に合格したい", "study_success"),
+        ("職場の人間関係がうまくいかず悩んでいる", "relationship_repair"),
+        ("家族との関係を少し整えたい", "relationship_repair"),
+        ("大切な人との関係を整理したい", "relationship_repair"),
+        ("友人と仲直りしたい", "relationship_repair"),
     ],
 )
 def test_resolve_consultation_axis_from_query(query, expected):
@@ -66,6 +81,68 @@ def test_resolve_consultation_axis_from_query(query, expected):
 
     assert result.axis == expected
     assert result.source == "query"
+
+
+@pytest.mark.parametrize(
+    ("need_tags", "expected"),
+    [
+        (["relationship"], "relationship_repair"),
+        (["love"], "relationship_repair"),
+    ],
+)
+def test_resolve_consultation_axis_relationship_and_love_share_axis_via_need_tags(need_tags, expected):
+    """"職場の人間関係" etc. hit a query keyword directly, but queries
+    with no relationship_repair keyword (plain 恋愛/出会い/良縁 phrasing,
+    tested via need_tags here to isolate the fallback branch) must still
+    resolve through the need_tags fallback -- relationship and love are
+    PR #2410-distinct need_tags but share this one consultation_axis
+    (score-v3-consultation-axis-history-theme-mapping.md §6.2)."""
+    result = resolve_consultation_axis(query="", need_tags=need_tags)
+
+    assert result.axis == expected
+    assert result.source == "need_tags"
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "恋愛について悩んでいる",
+        "いい出会いがほしい",
+        "良縁を願いたい",
+    ],
+)
+def test_resolve_consultation_axis_love_phrasing_resolves_to_relationship_repair(query):
+    """Love phrasing has no dedicated CONSULTATION_AXIS_KEYWORDS entry
+    (intentionally not duplicating need_tags.py's love keyword list, see
+    the comment on CONSULTATION_AXIS_KEYWORDS["relationship_repair"]),
+    so it reaches relationship_repair via the need_tags="love" fallback."""
+    from temples.services.concierge_chat_need import resolve_need_payload
+
+    need = resolve_need_payload(query=query, need_tags=[], max_tags=3)
+    result = resolve_consultation_axis(query=query, need_tags=need["tags"])
+
+    assert result.axis == "relationship_repair"
+    assert result.source == "need_tags"
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_need_tag_family"),
+    [
+        ("転職で迷っていて、仕事の流れを整えたい", "career_change"),
+        ("最近疲れていて、静かに休みたい", "rest_healing"),
+        ("お金や収入の不安があり、金運を整えたい", "money_growth"),
+        ("資格試験の勉強と合格祈願について相談したい", "study_success"),
+    ],
+)
+def test_resolve_consultation_axis_non_relationship_axes_unaffected(query, expected_need_tag_family):
+    """Non-regression (Task 9): career/rest/money/study axis resolution
+    must be unaffected by adding relationship_repair."""
+    from temples.services.concierge_chat_need import resolve_need_payload
+
+    need = resolve_need_payload(query=query, need_tags=[], max_tags=3)
+    result = resolve_consultation_axis(query=query, need_tags=need["tags"])
+
+    assert result.axis == expected_need_tag_family
 
 
 def test_resolve_consultation_axis_prefers_valid_llm_axis():
@@ -126,3 +203,146 @@ def test_build_chat_recommendations_attaches_consultation_axis_to_payload(settin
     assert recs["_signals"]["consultation_axis"] == "restart_mindset"
     assert recs["_signals"]["result_state"]["consultation_axis"] == "restart_mindset"
     assert recs["recommendations"][0]["consultation_axis"] == "restart_mindset"
+
+
+# ---------------------------------------------------------------------------
+# Task 8: Ranking Activation -- proving history_theme_candidate_boost > 0
+# actually fires for relationship_repair, not just that the axis string
+# changed. HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS["relationship_repair"]
+# already existed in concierge_chat_ranking.py before this change (real,
+# non-shadow ranking weights) but could never be reached because no query
+# ever resolved to consultation_axis="relationship_repair".
+# ---------------------------------------------------------------------------
+
+
+def test_relationship_consultation_activates_history_theme_candidate_boost(settings):
+    settings.CONCIERGE_USE_LLM = False
+    recs = build_chat_recommendations(
+        query="職場の人間関係がうまくいかず悩んでいる",
+        language="ja",
+        candidates=[
+            {
+                "name": "つながりの杜神社",
+                "astro_tags": ["relationship"],
+                "history_theme": "縁",
+                "popular_score": 1.0,
+            }
+        ],
+    )
+
+    assert recs["consultation_axis"] == "relationship_repair"
+
+    top1 = recs["recommendations"][0]
+    boost = top1["breakdown_detail"]["features"]["history_theme_candidate_boost"]
+    assert boost["consultation_axis"] == "relationship_repair"
+    assert boost["history_theme"] == "縁"
+    assert boost["raw"] > 0
+    assert boost["raw"] == pytest.approx(1.0)
+
+
+def test_love_consultation_activates_same_history_theme_candidate_boost(settings):
+    """love shares the relationship_repair axis (Task 5 Option A), so a
+    love query against the same 縁-themed candidate must activate the
+    identical boost -- proving the axis sharing actually reaches ranking,
+    not just need_tags."""
+    settings.CONCIERGE_USE_LLM = False
+    recs = build_chat_recommendations(
+        query="良い出会いがほしい",
+        language="ja",
+        candidates=[
+            {
+                "name": "つながりの杜神社",
+                "astro_tags": ["love"],
+                "history_theme": "縁",
+                "popular_score": 1.0,
+            }
+        ],
+    )
+
+    assert recs["consultation_axis"] == "relationship_repair"
+
+    top1 = recs["recommendations"][0]
+    boost = top1["breakdown_detail"]["features"]["history_theme_candidate_boost"]
+    assert boost["consultation_axis"] == "relationship_repair"
+    assert boost["raw"] == pytest.approx(1.0)
+
+
+def test_relationship_consultation_axis_history_theme_boost_is_zero_without_relationship_axis(settings):
+    """Regression guard for the bug this whole PR fixes: before wiring
+    relationship_repair into resolve_consultation_axis, a relationship
+    query's consultation_axis was always "other", under which
+    HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS has no entry -- so the boost
+    was silently always 0 even for a perfectly-matched 縁-themed
+    candidate. Simulate the pre-fix axis explicitly via llm_axis to
+    prove the boost really is axis-gated, not just history_theme-gated."""
+    from temples.services.concierge_chat_ranking import _attach_breakdown
+
+    rec = {
+        "id": 1,
+        "name": "縁結び神社",
+        "astro_tags": ["relationship"],
+        "astro_elements": [],
+        "history_theme": "縁",
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "popular_score": 0,
+    }
+
+    _attach_breakdown(
+        rec,
+        birthdate=None,
+        need_tags=["relationship"],
+        weights={"element": 0.0, "need": 1.0, "popular": 0.0, "distance": 0.0},
+        astro_bonus_enabled=False,
+        visit_style_tags=set(),
+        query="職場の人間関係がうまくいかず悩んでいる",
+        requested_goriyaku_tag_ids=None,
+        goriyaku_tag_label_by_id={},
+        user=None,
+        consultation_axis="other",
+    )
+
+    assert rec["breakdown_detail"]["features"]["history_theme_candidate_boost"]["raw"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Task 13: Reason Sanity -- a shared consultation_axis must not resurrect
+# a love-only primary reason for a relationship consultation.
+# ---------------------------------------------------------------------------
+
+
+def test_relationship_consultation_axis_sharing_does_not_reintroduce_love_reason(settings):
+    """With the relationship_repair axis wired up, this candidate now
+    also earns a history_theme="縁" match, which legitimately outranks
+    the plain need_tag match under the existing (untouched) Primary
+    Reason priority -- so primary_reason_label becomes "縁", not
+    "relationship". That's a correct, thematically-appropriate upgrade
+    (Ranking behavior change: relationship queries only), not a
+    regression. The contract this test guards is narrower and must hold
+    regardless of which label wins: it must never be "love", and the
+    visible reason text must never contain love-only phrasing."""
+    settings.CONCIERGE_USE_LLM = False
+    recs = build_chat_recommendations(
+        query="職場の人間関係がうまくいかず悩んでいる",
+        language="ja",
+        candidates=[
+            {
+                "name": "つながりの杜神社",
+                "astro_tags": ["relationship"],
+                "history_theme": "縁",
+                "goriyaku": "心願成就",
+                "popular_score": 1.0,
+            }
+        ],
+    )
+
+    assert recs["consultation_axis"] == "relationship_repair"
+    assert "love" not in recs["_need"]["tags"]
+
+    top1 = recs["recommendations"][0]
+    assert top1["breakdown"]["matched_need_tags"] == ["relationship"]
+    assert top1["_primary_reason_label"] != "love"
+    assert top1["_primary_reason_source"] != "fallback"
+    for phrase in ("恋愛", "良縁", "縁結び", "恋愛成就", "片思い", "復縁", "両思い"):
+        assert phrase not in top1["reason"]

--- a/docs/audit/concierge-relationship-axis-followup.md
+++ b/docs/audit/concierge-relationship-axis-followup.md
@@ -1,0 +1,260 @@
+> **Status: Audit / Historical**
+>
+> 本監査は2026-08-13時点のdevelop（PR #2410適用後）に対する、
+> `feature/concierge-relationship-consultation-axis`ブランチでの
+> Consultation Axis Taxonomy修正の効果測定である。
+> `docs/audit/concierge-l1-freetext-readiness.md`（PR #2409、以下「原監査」）
+> §7 Finding Aおよび§13 Follow-up項目1・4に対応する。原監査本文は
+> 凍結されたHistorical Snapshotであり、本書とは別文書として追記する
+> （`docs/audit/README.md`の規約に従う）。Ranking weight・Candidate
+> filtering・goriyaku hard filter・Primary Reason priority・Level 2/3・
+> Score v3 mode・Frontend・DB schema・Migrationは、本監査対象の変更に
+> おいて一切変更していない。
+
+# Concierge Relationship / Love Consultation Axis Follow-up
+
+## 1. Purpose
+
+原監査Finding A（`docs/audit/concierge-l1-freetext-readiness.md` §7）が
+報告した、`consultation_axis`のtaxonomyに`love`/`relationship`に対応する
+axisが1つも存在せず、これらのテーマが構造的に`"other"`へ落ちる問題
+（Taxonomy Gap）を解消する。
+
+前提として、PR #2410（`fix/concierge-relationship-love-separation`）が
+`relationship`≠`love`というneed-tag semantic boundaryを既に確立して
+いる。本PRはこの分離を維持したまま、その1つ上のレイヤーである
+Consultation Axisを接続する。
+
+```
+L1 Free-text
+↓
+need_tags        -- PR #2410: relationship ≠ love (維持)
+↓
+consultation_axis -- 本PR: relationship_repair を接続
+↓
+history_theme candidate boost
+↓
+Recommendation
+```
+
+## 2. Scope
+
+- 対象: `backend/temples/domain/consultation_axis.py`
+  （`CONSULTATION_AXES`/`CONSULTATION_AXIS_ALIASES`/
+  `CONSULTATION_AXIS_KEYWORDS`/`NEED_TAG_TO_CONSULTATION_AXIS`）。
+- 対象外（変更していない）: `relationship`/`love`のneed-tag separation
+  （PR #2410）、Ranking weight、Candidate filtering、goriyaku hard
+  filter、Primary Reason priority、Level 2、Level 3、Score v3 mode、
+  Frontend、DB schema、Migration。
+- 前提正本: `docs/product/consultation-theme-taxonomy.md`、
+  `docs/product/meaning-translation-mapping.md`、
+  `docs/audit/score-v3-consultation-axis-history-theme-mapping.md` §6.2、
+  `docs/audit/concierge-l1-freetext-readiness.md`（原監査）。
+
+## 3. Axis Inventory（Task 1）
+
+| Axis vocabulary | 所在 | relationship/love対応 | 本番実効性 |
+|---|---|---|---|
+| `CONSULTATION_AXES` (`consultation_axis.py`) | domain正本 | **なし（本PR前）** → `relationship_repair`追加 | あり（`resolve_consultation_axis()`の戻り値） |
+| `NEED_TAG_TO_CONSULTATION_AXIS` (`consultation_axis.py`) | domain正本 | **なし（本PR前）** → `relationship`/`love`両方追加 | あり |
+| `HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS["relationship_repair"]` (`concierge_chat_ranking.py`) | ranking | **既に存在**（縁1.0/静寂0.7/守り0.5/再出発0.4/復興0.4/学び0.2/勝負0.1） | **あり（shadowではなく本番ranking、コード内注釈で明記済み）** |
+| `docs/product/consultation-theme-taxonomy.md` | 正本doc | 既に`relationship_repair`を`relationship` theme_keyの primary axisとして記載済み | ドキュメントのみ、コード未接続だった |
+| `docs/audit/score-v3-consultation-axis-history-theme-mapping.md` §6.2 | 設計監査 | `relationship_repair`の設計意図として「恋愛、家族、職場、友人など、人との関係を整える相談」と明記 | ドキュメントのみ |
+| `CONSULTATION_AXIS_COPY` (`recommendation_reason_v4.py`) | 別系統のcopy辞書 | `relationship_review`/`love_relationship`という**別のキー体系**を保持 | **本番未接続**（`interpret_consultation()`は`consultation_axis`キーを一切生成しないため、`resolve_consultation_axis()`の出力はこの辞書へ到達しない。§9参照） |
+| LLM prompt (`intent_prompt.py`/`prompts.py`) | LLM向け仕様 | `"relationship"`という値を仕様上使用 | `CONSULTATION_AXIS_ALIASES`に`"relationship"`エントリがなかったため、LLMがこの通り出力しても`normalize_consultation_axis()`で`"other"`へ丸められていた（本PRで解消） |
+| `ConciergeRecommendationSerializer.consultation_axis` (`api/serializers/concierge.py`) | DRFシリアライザ | 独自の`choices=[...]`リスト（`relationship`含む、`relationship_repair`は含まず） | **未使用（dead code、repo全体でimport元0件）**。本番レスポンスはこのシリアライザを経由しない |
+
+**結論（Task 2）**: `relationship_repair`は「今回新規発明したaxis」ではなく、
+すでにdesign docs（正本 + score-v3監査）が明記し、ranking層にも実効weight
+が存在していた「設計済みだが未接続だったaxis」である。新規axis名を
+発明せず、これを正本候補として採用した。
+
+## 4. Implementation（Task 3・4・6・7）
+
+`backend/temples/domain/consultation_axis.py`:
+
+- `CONSULTATION_AXES`へ`"relationship_repair"`を追加。
+- `NEED_TAG_TO_CONSULTATION_AXIS`へ`"relationship": "relationship_repair"`
+  と`"love": "relationship_repair"`を追加。
+- `CONSULTATION_AXIS_ALIASES`へ`"relationship"`/`"human_relationship"`/
+  `"love"`を`"relationship_repair"`へ正規化するエントリを追加
+  （LLM prompt仕様の`"relationship"`値、および将来の`"love"`値を
+  取りこぼさないため）。
+- `CONSULTATION_AXIS_KEYWORDS["relationship_repair"]`へ、関係性を表す
+  クエリレベルの語句（人間関係/職場の人間関係/家族との関係/友人との関係/
+  対人関係/関係を整理/関係を修復/関係がうまくいかない/仲直り）を追加。
+  **恋愛系キーワード（恋愛/出会い/良縁）は意図的に追加していない** --
+  `need_tags.py`が既にこれらを`love`として抽出しており、
+  `NEED_TAG_TO_CONSULTATION_AXIS`のneed_tags fallback経由で
+  `relationship_repair`へ到達するため、二重管理を避けた（Task 4の
+  「無駄な複製をしない」指示に従う）。
+
+`relationship`/`love`のneed-tagとしての分離（PR #2410）は一切変更して
+いない。両者は同じ`consultation_axis`を共有するが、`need_tags`・
+`matched_need_tags`・primary reasonのlabelとしては引き続き区別される。
+
+## 5. Love Axis Design Decision（Task 5）
+
+**採用: Option A（love は relationship_repair axis を共有する）。**
+
+比較:
+
+| | Option A（採用） | Option B（不採用） |
+|---|---|---|
+| 内容 | `love`は`relationship_repair`を共有、need_tag/reasonは分離のまま | 新規`love_connection` axisを追加 |
+| 既存design docsとの整合性 | **一致**（§6.2「恋愛、家族、職場、友人など」と明記済み） | 根拠なし（正本doc・監査doc・testのいずれにも`love_connection`という語は存在しない） |
+| 既存rankingとの整合性 | `HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS["relationship_repair"]`をそのまま再利用 | 新規history-theme score mappingの設計が必要（本番ranking挙動を新規定義することになり、Task 5が禁止する「根拠なしの新設計」に該当） |
+| 変更範囲 | 最小（既存axis 1件の接続） | 大（新規axis + 新規weight設計 + 検証） |
+
+Option Bを支持する根拠（docs/tests/data）は見つからなかったため、
+Task 5の指示（「根拠なしでOption Bを作らない」）に従いOption Aを採用した。
+新規axisが将来必要と判断された場合は、Follow-upとして扱う（§10）。
+
+## 6. Ranking Activation Test（Task 8）
+
+`temples/tests/services/test_consultation_axis_contract.py`へ、axis文字列の
+変更だけでなく`history_theme_candidate_boost`が実際に発火することを
+検証するテストを追加した。
+
+- `test_relationship_consultation_activates_history_theme_candidate_boost`:
+  relationship consultation + `history_theme="縁"`の候補で
+  `breakdown_detail.features.history_theme_candidate_boost.raw == 1.0`
+  （`HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS["relationship_repair"]["縁"]`）
+  を確認。
+- `test_love_consultation_activates_same_history_theme_candidate_boost`:
+  同じ候補・同じboostがlove consultationでも発火することを確認（axis共有
+  が実際にrankingへ到達することの証明）。
+- `test_relationship_consultation_axis_history_theme_boost_is_zero_without_relationship_axis`:
+  `consultation_axis="other"`（修正前の状態を明示的に再現）では同じ候補
+  でもboostが0のままであることを確認し、boostがaxis-gatedであることを
+  対照実験で示す。
+
+**この82-shrine seed pool（`representative_shrines.yaml`）自体には
+`history_theme`フィールドが1件も存在しない**ため、§8のfixture再実行では
+`history_theme_candidate_boost`は全件0.0のまま変化していない（§7参照）。
+Ranking Activationはunit test（合成candidate）で機構として正しいことを
+証明したが、この特定のseedデータでの実地発火は観測できていない。これは
+データカバレッジの制約であり、コード上の欠陥ではない（§10 Known
+Remaining Gapに記録）。
+
+## 7. PR #2409 Fixture再実行（Task 10）
+
+原監査と同一の20件fixture（`CONCIERGE_L1_FREETEXT_READINESS_QUERIES`）を
+`representative_shrines.yaml`（82件）に対して再実行した。Before（本PR
+適用前、PR #2410適用後の状態）とAfter（本PR適用後）を対比する。
+
+| id | theme | axis (Before) | axis (After) | history_boost (B/A) | primary_reason_source (B/A) |
+|---|---|---|---|---|---|
+| l1_relationship_001 | relationship | rest_healing | rest_healing | 0.0 / 0.0 | need_tag / need_tag |
+| l1_relationship_002 | relationship | **other** | **relationship_repair** | 0.0 / 0.0 | fallback / fallback |
+| l1_relationship_003 | relationship | **other** | **relationship_repair** | 0.0 / 0.0 | fallback / fallback |
+| l1_love_001 | love | **other** | **relationship_repair** | 0.0 / 0.0 | need_tag / need_tag |
+| l1_love_002 | love | **other** | **relationship_repair** | 0.0 / 0.0 | need_tag / need_tag |
+| その他16件（career/rest/money/study/courage/ambiguous） | — | 変化なし | 変化なし | 変化なし | 変化なし |
+
+`l1_relationship_001`（「人間関係で少し疲れている」）は変化していない:
+`CONSULTATION_AXIS_KEYWORDS`のhit-count-ranked resolutionにより、
+`rest_healing`側のキーワード一致数（疲れ/疲れて = 2件）が
+`relationship_repair`側（人間関係 = 1件）を上回るため。これは
+本PRが変更していない既存の優先順位ルールであり（Task 9: keyword priority
+tuningへのscope拡張は行わない）、意図的に手を加えていない。
+
+`l1_relationship_002`/`l1_relationship_003`は、axisは正しく
+`relationship_repair`になったが、依然fallbackのままである。これは
+candidate側データ不足（この82件poolに`relationship` astro_tags/
+`NEED_TEXT_WEIGHTS["relationship"]`/`history_theme="縁"`のいずれも
+存在しない）が原因であり、Taxonomy Gap（Finding A）とは別のCandidate
+Coverage Gapである（原監査Task 8・§10で既に報告済み、本PRのscope外）。
+
+## 8. Metrics再計測（Task 11）
+
+| Metric | Before（PR #2410適用後） | After（本PR適用後） |
+|---|---|---|
+| Recommendation 0率 | 0.0% (0/20) | 0.0% (0/20) |
+| clear-intent axis=other率 | **31.2% (5/16)** | **6.2% (1/16)** |
+| ambiguous-intent axis=other率 | 100.0% (4/4) | 100.0% (4/4)（変化なし、想定通り） |
+| fallback率（全体） | 35.0% (7/20) | 35.0% (7/20)（変化なし） |
+| fallback率（clear-intentのみ） | 18.8% (3/16) | 18.8% (3/16)（変化なし） |
+| semantic mismatch件数 | 0件（PR #2410で解消済み） | 0件（変化なし、悪化なし） |
+
+**clear-intent axis=other率は31.2%から6.2%へ改善した**（残る1件は
+`l1_courage_002`で、love/relationship非関連の既存keyword coverage gap、
+原監査§8既報）。fallback率が変化していない理由は§7に記載の通り、
+Taxonomy GapとCandidate Coverage Gapが別レイヤーの問題であるため
+（Task 12の指示通り、この2つを混同して無理に同時修正していない）。
+
+原監査§11のReadiness Decision基準（暫定基準）に当てはめると:
+
+| 指標 | GO | CONDITIONAL GO | 原監査実測値 | 本PR後実測値 |
+|---|---|---|---|---|
+| Recommendation 0率 | <= 5% | <= 10% | 0.0% | 0.0% |
+| clear-intent axis=other率 | <= 10% | <= 20% | 31.25%（NO-GO水準） | **6.2%（GO水準）** |
+| fallback率 | <= 20% | <= 30% | 30.0% | 35.0%（PR #2410適用による、本PRとは無関係な既知の変化） |
+
+clear-intent axis=other率は本PRによりGO水準（<=10%）まで改善した。
+fallback率のみ依然CONDITIONAL GO水準を超過しており、これはCandidate
+Coverage Gap（§7・原監査Task 8）に起因する別課題である。
+
+## 9. 発見した接続外の類似vocabulary（参考情報、本PR対象外）
+
+調査中、`recommendation_reason_v4.py`の`CONSULTATION_AXIS_COPY`が
+`career_decision`/`relationship_review`/`money_foundation`/
+`rest_or_action`/`mental_reset`/`study_growth`/`love_relationship`という、
+`CONSULTATION_AXES`ともLLM prompt仕様とも一致しない**第3のaxis語彙**を
+保持していることを確認した。ただし`interpret_consultation()`
+（`consultation_interpreter.py`）は`consultation_axis`キーを一切生成
+しないため、`resolve_consultation_axis()`の出力（本PRで`relationship_repair`
+を含むようになった値）はこの辞書へ実際には到達しない
+（`_copy_for_key()`のraw-key-fallback動作を含め、影響なしを確認済み）。
+これは本PR前から存在する、本PRとは独立した既存の設計上の非接続であり、
+本PRのscope（relationship/love axis接続のみ）には含まれない。Follow-up
+候補として記録するに留める。
+
+`ConciergeRecommendationSerializer`（`api/serializers/concierge.py`）の
+`consultation_axis` `ChoiceField`も、repo全体でimport元0件のdead code
+であることを確認した（本番レスポンスの検証には使用されていない）。
+
+## 10. Known Remaining Gap
+
+- **consultation_axisは接続されたが、candidate側データはまだ薄い**:
+  `representative_shrines.yaml`（82件）には`relationship` astro_tags、
+  `NEED_TEXT_WEIGHTS["relationship"]`、`history_theme="縁"`のいずれも
+  存在しない。Ranking Activationはunit testで機構として証明したが
+  （§6）、この特定のseed dataでの実地発火は未観測。Candidate/Knowledge
+  データ拡充はFollow-up。
+- **`l1_relationship_001`は`rest_healing`のまま**（§7）。keyword
+  hit-count優先順位の既存挙動であり、本PRでは変更していない。
+- **`recommendation_reason_v4.py`の`CONSULTATION_AXIS_COPY`は独立した
+  第3の語彙のまま**（§9）。本番未接続のため実害はないが、将来
+  `interpret_consultation()`が`consultation_axis`を実際に受け渡すよう
+  変更された場合、この不整合が顕在化する可能性がある。
+- **`NEED_TEXT_WEIGHTS`/`NEED_LABELS_JA`（`concierge_chat_ranking.py`）
+  には引き続き`relationship`エントリがない**（PR #2410 Task 8で既報、
+  本PRでも未対応、意図的にscope外）。
+
+## 11. Verification
+
+- `temples/tests/services/test_consultation_axis_contract.py`: axis
+  taxonomy契約テスト（48 passed）。
+- `temples/tests/services/test_concierge_l1_freetext_readiness.py`:
+  fixture再実行（68 passed, 4 skipped、pass数は変化なし。
+  `EXPECTED_AXIS_FAMILY`のみ実態に合わせて更新）。
+- `temples/tests/test_concierge_relationship_love_separation.py`
+  （PR #2410）: 29 passed、変化なし（need-tag separationは無傷）。
+- concierge関連suite、full backend suite、lint、migration checkの結果は
+  PR本文を参照。
+
+## 12. 関連ドキュメント
+
+- `docs/audit/concierge-l1-freetext-readiness.md`（原監査、Finding A/C）
+- `docs/product/consultation-theme-taxonomy.md`（正本）
+- `docs/product/meaning-translation-mapping.md`
+- `docs/audit/score-v3-consultation-axis-history-theme-mapping.md`
+
+## 更新ルール
+
+- 本書は`docs/audit/concierge-l1-freetext-readiness.md`（原監査）を
+  上書きしない。原監査は凍結されたHistorical Snapshotのまま保持する。
+- 本書自体もAudit / Historicalであり、今後のPRで本書の数値を無断更新
+  しない。後続のFollow-up PRが本書の指摘を解消した場合は、新規addendum
+  文書として追記する。


### PR DESCRIPTION
## 目的

PR #2409 Finding A（[docs/audit/concierge-l1-freetext-readiness.md](docs/audit/concierge-l1-freetext-readiness.md) §7）が報告した、`consultation_axis`のtaxonomyに`love`/`relationship`に対応するaxisが1つも存在せず、これらのテーマが構造的に`consultation_axis="other"`へ落ちる問題（Taxonomy Gap）を解消する。

PR #2410（Relationship / Love Interpretation Separation）で確立した `relationship ≠ love` というneed-tag semantic boundaryはそのまま維持し、その1つ上のレイヤーであるConsultation Axisのみを接続する。

```
L1 Free-text
↓
need_tags         -- PR #2410: relationship ≠ love（維持・変更なし）
↓
consultation_axis -- 本PR: relationship_repair を接続
↓
history_theme candidate boost
↓
Recommendation
```

## Axis added / activated

**`relationship_repair`** — 新規発明したaxisではない。以下がすでに文書化・実装済みだった、未接続のaxisを実際に有効化した。

- `docs/product/consultation-theme-taxonomy.md`（正本）: `relationship` theme_keyのprimary consultation_axisとして既に記載済み
- `docs/audit/score-v3-consultation-axis-history-theme-mapping.md` §6.2: 「恋愛、家族、職場、友人など、人との関係を整える相談」として設計意図が明記済み
- `concierge_chat_ranking.HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS["relationship_repair"]`: **shadowではなく本番rankingへ実効する**weightが既に存在（縁1.0/静寂0.7/守り0.5/再出発0.4/復興0.4/学び0.2/勝負0.1）

`backend/temples/domain/consultation_axis.py` へ以下を追加:

- `CONSULTATION_AXES` へ `"relationship_repair"` を追加
- `NEED_TAG_TO_CONSULTATION_AXIS` へ `"relationship"` / `"love"` を両方 `"relationship_repair"` へマッピング
- `CONSULTATION_AXIS_ALIASES` へ `"relationship"` / `"human_relationship"` / `"love"` を追加（LLM prompt仕様がaxis値として`"relationship"`を使用するため、正規化漏れを解消）
- `CONSULTATION_AXIS_KEYWORDS["relationship_repair"]` へ関係性クエリの語句を追加（人間関係/職場の人間関係/家族との関係/友人との関係/対人関係/関係を整理/関係を修復/関係がうまくいかない/仲直り）。**恋愛系キーワード（恋愛/出会い/良縁）は意図的に追加していない** — `need_tags.py`が既にこれらを`love`として抽出しており、`NEED_TAG_TO_CONSULTATION_AXIS`のneed_tags fallback経由で`relationship_repair`へ到達するため、二重管理を避けた

## relationship mapping

`need_tags=["relationship"]` → `consultation_axis="relationship_repair"`。need_tagとしての`relationship`はPR #2410の分離を維持したまま。

## love mapping decision

**Option A採用: loveはrelationship_repair axisを共有する。**

| | Option A（採用） | Option B（不採用: 新規`love_connection`軸） |
|---|---|---|
| 既存design docsとの整合性 | 一致（§6.2に明記済み） | 根拠なし |
| 既存rankingとの整合性 | 既存weightをそのまま再利用 | 新規history-theme score設計が必要 |
| 変更範囲 | 最小 | 大 |

Option Bを支持する根拠が正本doc・監査doc・testのいずれにも見当たらなかったため、「根拠なしで新規axisを作らない」という制約に従いOption Aを採用。need_tag/reasonラベルとしての`relationship`/`love`分離（PR #2410）は、このaxis共有と独立して維持される。

## history-theme ranking impact

`history_theme_candidate_boost`が実際に発火することを、合成candidateを用いたunit testで機構として証明した（`test_relationship_consultation_activates_history_theme_candidate_boost` / `test_love_consultation_activates_same_history_theme_candidate_boost` / 対照実験としての `..._is_zero_without_relationship_axis`）。

ただし、`representative_shrines.yaml`（82件seed）自体に`history_theme`フィールドが1件も存在しないため、この特定のfixtureでの実地発火は観測できていない。これはデータカバレッジの制約であり、コード上の欠陥ではない（Known Remaining Gap参照）。

## Before / After Metrics

PR #2409と同一の20件fixtureを`representative_shrines.yaml`（82件）に対して再実行（詳細: [docs/audit/concierge-relationship-axis-followup.md](docs/audit/concierge-relationship-axis-followup.md)）。

| Metric | Before（PR #2410適用後） | After（本PR適用後） |
|---|---|---|
| Recommendation 0率 | 0.0% (0/20) | 0.0% (0/20) |
| clear-intent axis=other率 | **31.2% (5/16)** | **6.2% (1/16)** |
| ambiguous-intent axis=other率 | 100.0% (4/4) | 100.0% (4/4)（想定通り変化なし） |
| fallback率（全体） | 35.0% (7/20) | 35.0% (7/20)（変化なし） |
| fallback率（clear-intentのみ） | 18.8% (3/16) | 18.8% (3/16)（変化なし） |
| semantic mismatch件数 | 0件（PR #2410で解消済み） | 0件（変化なし、悪化なし） |

clear-intent axis=other率は原監査のNO-GO水準（31.25%）からGO水準（<=10%）まで改善した。fallback率が変化していない理由: `l1_relationship_002`/`l1_relationship_003`はaxisが正しく`relationship_repair`になったが、依然fallbackのまま — この82件poolに`relationship` astro_tags / `NEED_TEXT_WEIGHTS["relationship"]` / `history_theme="縁"`のいずれも存在しないため（Taxonomy GapとCandidate Coverage Gapは別レイヤーの問題であり、意図的に混同して同時修正していない）。

## Remaining Interpretation Gap

- `l1_relationship_001`（「人間関係で少し疲れている」）は`rest_healing`のまま変化なし: `CONSULTATION_AXIS_KEYWORDS`のhit-count優先順位により、rest_healing側の一致数（疲れ/疲れて=2件）がrelationship_repair側（人間関係=1件）を上回るため。既存の優先順位ルールであり、本PRでは変更していない。
- `l1_relationship_002`（「大切な人との関係を整理したい」）は引き続きneed_tags=[]のInterpretation Gap（未変化、対象外）。

## Ranking behavior change

relationship/love queriesのみを対象とした意図的な意味接続。`HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS`のweight値自体は変更していない（既存の`relationship_repair`エントリをそのまま再利用）。他axis（career_change/money_growth/rest_healing/restart_mindset/nature_reset/study_success）の挙動は非対象クエリで re-verify 済み、変化なし。

## Candidate filtering change

なし。

## Frontend change

なし（`apps/web/`配下の変更ファイル0件）。

## Migration

0件（`backend/temples/migrations/`配下の変更ファイル0件）。

## Testing

```
targeted (axis contract):    48 passed  (test_consultation_axis_contract.py)
readiness (fixture re-run):  68 passed, 4 skipped (test_concierge_l1_freetext_readiness.py, EXPECTED_AXIS_FAMILYのみ実態に合わせ更新)
relationship/love separation: 29 passed (test_concierge_relationship_love_separation.py, PR #2410、無傷を確認)
full backend:                 1408 passed, 13 skipped, 0 failed
lint (ruff):                  新規/変更ファイルはクリーン（consultation_axis.pyの既存I001警告は本PRと無関係、baseコミットで再現確認済み）
migrations:                   変更なし
CONCIERGE_USE_LLM=1（CI再現）: targeted 145 passed, 4 skipped
```

## 関連ドキュメント

- [docs/audit/concierge-relationship-axis-followup.md](docs/audit/concierge-relationship-axis-followup.md)（本PRの詳細監査・Axis Inventory・Ranking Activation Test・Metrics）
- [docs/audit/concierge-l1-freetext-readiness.md](docs/audit/concierge-l1-freetext-readiness.md)（原監査、凍結・変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)