### PR TITLE
Concierge入口を自由相談主導の段階入力UIへ再構成

### DIFF
--- a/apps/web/e2e/05_direction_flow.spec.ts
+++ b/apps/web/e2e/05_direction_flow.spec.ts
@@ -64,8 +64,26 @@ test.afterAll(async () => {
 const forbiddenAnalyticsKeys = new Set<string>(directionAnalyticsForbiddenKeys);
 
 async function fillAndSubmit(page: import("@playwright/test").Page) {
-  await page.getByLabel("必要なら、今の状況を少しだけ書く").fill(consultation);
+  await page.getByLabel("今、どんなことが気になっていますか？").fill(consultation);
   await page.getByRole("button", { name: "この相談で神社を提案してもらう" }).click();
+}
+
+// PR #2413 (Concierge Entry Frontend IA v2): Level 3-C (visit date /
+// origin) moved out of the always-visible Initial screen into the
+// Personalize section (collapsed by default, docs/product/
+// concierge-input-architecture.md Frontend IA Implementation Addendum).
+// Initial no longer showing L3-C is the new, correct contract -- tests
+// that need the visit-date field or the origin radio group must open
+// Personalize first, via the same accessible toggle a real user would use.
+async function openPersonalize(page: import("@playwright/test").Page, options?: { viaKeyboard?: boolean }) {
+  const toggle = page.getByRole("button", { name: "条件を開く" });
+  if (options?.viaKeyboard) {
+    await toggle.focus();
+    await expect(toggle).toBeFocused();
+    await page.keyboard.press("Enter");
+    return;
+  }
+  await toggle.click();
 }
 
 function expectPrivateDataAbsent(events: Array<{ payload: Record<string, unknown> }>) {
@@ -86,6 +104,7 @@ test.describe("方位条件のWeb E2E", () => {
     await context.grantPermissions(["geolocation"]);
     await context.setGeolocation({ latitude: 35.681236, longitude: 139.767125 });
     await page.goto("/concierge");
+    await openPersonalize(page);
 
     await page.getByRole("radio", { name: "現在地を使用" }).click();
     await expect(
@@ -115,6 +134,7 @@ test.describe("方位条件のWeb E2E", () => {
     const captured = await installDirectionScenario(page, { recommendationId: 502, directionReference: mismatchedDirectionReference });
     await context.clearPermissions();
     await page.goto("/concierge");
+    await openPersonalize(page);
 
     await page.getByRole("radio", { name: "現在地を使用" }).click();
     await expect(
@@ -142,6 +162,7 @@ test.describe("方位条件のWeb E2E", () => {
     const reference = { ...matchedDirectionReference, note: "東京都のおおよその位置を基準にした参考情報です。日盤は使用していません。" };
     const captured = await installDirectionScenario(page, { recommendationId: 503, directionReference: reference });
     await page.goto("/concierge");
+    await openPersonalize(page);
 
     await page.getByRole("radio", { name: "都道府県から指定" }).click();
     await page.getByLabel("都道府県").selectOption({ label: "東京都" });
@@ -157,6 +178,7 @@ test.describe("方位条件のWeb E2E", () => {
   test("方位情報を使用しなくても相談でき、location・方位カード・方位加点がない", async ({ page }) => {
     const captured = await installDirectionScenario(page, { recommendationId: 504 });
     await page.goto("/concierge");
+    await openPersonalize(page);
 
     await page.getByRole("radio", { name: "方位情報を使用しない" }).click();
     await page.getByLabel("参拝予定日（任意）").fill("2026-09-15");
@@ -180,6 +202,7 @@ test.describe("方位条件のWeb E2E", () => {
   test("ジオコード500でも方位を無効化して通常相談を継続できる", async ({ page }) => {
     const captured = await installDirectionScenario(page, { recommendationId: 510, geocodeFailure: "500" });
     await page.goto("/concierge");
+    await openPersonalize(page);
     await page.getByRole("radio", { name: "駅名・住所から指定" }).click();
     await page.getByLabel("駅名または住所").fill("失敗地点");
     await expect(page.getByText("候補を検索できませんでした。相談はそのまま続けられます。")).toBeVisible();
@@ -204,6 +227,7 @@ test.describe("方位条件のWeb E2E", () => {
   test("キーボードだけで手動候補を選択して相談を送信できる", async ({ page }) => {
     const captured = await installDirectionScenario(page, { recommendationId: 506, directionReference: mismatchedDirectionReference });
     await page.goto("/concierge");
+    await openPersonalize(page, { viaKeyboard: true });
 
     const manualMode = page.getByRole("radio", { name: "駅名・住所から指定" });
     await manualMode.focus();
@@ -220,7 +244,7 @@ test.describe("方位条件のWeb E2E", () => {
     await page.keyboard.press("Enter");
     await expect(page.getByText("現在の出発地点は東京駅、確定した位置です。")).toBeVisible();
 
-    await page.getByLabel("必要なら、今の状況を少しだけ書く").fill(consultation);
+    await page.getByLabel("今、どんなことが気になっていますか？").fill(consultation);
     const submit = page.getByRole("button", { name: "この相談で神社を提案してもらう" });
     await submit.focus();
     await page.keyboard.press("Enter");
@@ -233,6 +257,7 @@ test.describe("方位条件のWeb E2E", () => {
     await page.setViewportSize({ width: 320, height: 700 });
     await page.goto("/concierge");
     await page.addStyleTag({ content: "html { font-size: 20px !important; }" });
+    await openPersonalize(page);
     await page.getByRole("radio", { name: "駅名・住所から指定" }).click();
 
     const sizes = await page.evaluate(() => ({ scrollWidth: document.documentElement.scrollWidth, clientWidth: document.documentElement.clientWidth }));

--- a/apps/web/src/app/concierge/ConciergeClientFull.tsx
+++ b/apps/web/src/app/concierge/ConciergeClientFull.tsx
@@ -20,7 +20,9 @@ import { buildDummySections } from "@/features/concierge/sections/dummy";
 
 import ConciergeSectionsRenderer from "@/features/concierge/components/ConciergeSectionsRenderer";
 import ConciergeEntryCard from "@/features/concierge/components/ConciergeEntryCard";
+import OriginSelector from "@/features/concierge/components/OriginSelector";
 import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+import { buildConciergeRequestPayload } from "@/features/concierge/buildConciergeRequestPayload";
 
 import type { RendererAction, ConciergeSectionsPayload } from "@/features/concierge/sections/types";
 import { getGoriyakuTags } from "@/lib/api/tags";
@@ -30,8 +32,8 @@ import { useBilling } from "@/features/billing/hooks/useBilling";
 import { isAuthRequiredForAction } from "@/lib/auth/actionGuards";
 import { initialConciergeSessionState, type ConciergeSessionState } from "@/features/concierge/types";
 import { resolveDisplayLabel, resolveDisplayName } from "@/lib/profile/resolveDisplayName";
-import { buildProfileContext, normalizeBirthday as normalizeProfileBirthday } from "@/lib/profile/derivedProfile";
-import { toOriginPayload, type UserOrigin } from "../../../../../packages/shared/userOrigin";
+import { normalizeBirthday as normalizeProfileBirthday } from "@/lib/profile/derivedProfile";
+import type { UserOrigin } from "../../../../../packages/shared/userOrigin";
 
 import { conciergeLog } from "@/lib/log/concierge";
 import { EVT_CLOSE_CONCIERGE } from "@/lib/events";
@@ -116,13 +118,6 @@ function isBirthdateOnlyText(value: string): boolean {
   const trimmed = value.trim();
   if (!trimmed) return false;
   return normalizeBirthdateInput(trimmed) !== null;
-}
-
-function normalizeQueryText(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) return "";
-  if (isBirthdateOnlyText(trimmed)) return "";
-  return trimmed;
 }
 
 function deriveMessages(events: LocalEvent[], threadId: number): ConciergeMessage[] {
@@ -1001,53 +996,17 @@ export default function ConciergeClientFull() {
         duration_max_min?: number;
         free_text?: string;
       },
-    ): Omit<ConciergeChatRequestV1, "thread_id"> => {
-      const savedProfile = user?.profile;
-      const birthdate = normalizeBirthdateInput(sessionState.temporaryBirthdate ?? "") ?? normalizeProfileBirthday(savedProfile?.birthday);
-      const payloadBirthdate = input?.birthdate ?? birthdate;
-      const payloadGoriyakuTagIds = input?.goriyaku_tag_ids ?? baseFilters.goriyaku_tag_ids;
-      const payloadExtraCondition = input?.extra_condition ?? baseFilters.extra_condition;
-      const payloadVisitPreferences =
-        input?.visit_preferences ?? (visitPreferences.length ? visitPreferences : undefined);
-      const payloadCrowd = input?.crowd ?? baseFilters.crowd;
-      const payloadDurationMaxMin = input?.duration_max_min ?? baseFilters.duration_max_min;
-      const payloadFreeText = input?.free_text ?? input?.extra_condition ?? baseFilters.free_text;
-      const rawQuery = normalizeQueryText(input?.query ?? needText);
-      const hasPayloadFilter =
-        !!payloadBirthdate ||
-        (payloadGoriyakuTagIds?.length ?? 0) > 0 ||
-        !!payloadExtraCondition ||
-        !!payloadCrowd?.length ||
-        typeof payloadDurationMaxMin === "number" ||
-        !!payloadFreeText;
-      const query = rawQuery || (hasPayloadFilter ? "追加した条件に合う神社を提案してください。" : "");
-
-      return {
-        version: input?.version ?? 1,
-        mode: input?.mode ?? "need",
-        query,
-        birthdate: payloadBirthdate,
-        filters: {
-          birthdate: payloadBirthdate,
-          goriyaku_tag_ids: payloadGoriyakuTagIds,
-          extra_condition: payloadExtraCondition,
-          crowd: payloadCrowd,
-          duration_max_min: payloadDurationMaxMin,
-          free_text: payloadFreeText,
-        },
-        goriyaku_tag_ids: payloadGoriyakuTagIds,
-        extra_condition: payloadExtraCondition,
-        visit_preferences: payloadVisitPreferences,
-        visit_date: plannedVisitDate || undefined,
-        location: toOriginPayload(userOrigin),
-        profile_context: buildProfileContext({
-          birthday: payloadBirthdate,
-          birth_time: savedProfile?.birth_time,
-          birth_place: savedProfile?.birth_place,
-          worship_style: savedProfile?.worship_style,
-        }),
-      };
-    },
+    ): Omit<ConciergeChatRequestV1, "thread_id"> =>
+      buildConciergeRequestPayload({
+        needText,
+        temporaryBirthdate: sessionState.temporaryBirthdate,
+        savedProfile: user?.profile,
+        baseFilters,
+        visitPreferences,
+        plannedVisitDate,
+        userOrigin,
+        input,
+      }),
     [sessionState.temporaryBirthdate, needText, baseFilters, user?.profile, plannedVisitDate, userOrigin, visitPreferences],
   );
 
@@ -1790,19 +1749,21 @@ export default function ConciergeClientFull() {
                 setNeedText("");
                 setEntryValidationError(null);
               }}
-              plannedVisitDate={plannedVisitDate}
-              setPlannedVisitDate={(value) => { setPlannedVisitDate(value); if (value) trackWebDirection("direction_visit_date_set"); }}
-              origin={userOrigin}
-              onOriginChange={(value) => { setUserOrigin(value); if (value) trackWebDirection("direction_origin_result", { origin_type: value.source, result: "selected" }); }}
-              locationError={locationError}
-              onUseCurrentLocation={useCurrentLocation}
             />
 
+            {/* Personalize: Level 2 Visit Preference + Level 3-A Personal
+                Profile + Level 3-B Explicit Constraint + Level 3-C
+                Recommendation Context, collapsed by default (Task 5-8,
+                docs/audit/concierge-l1-freetext-final-readiness.md
+                Decision: L2/L3 collapsed by default = Yes). Grouped under
+                one disclosure (Task 10's 3-state model), but each
+                responsibility keeps its own labeled subsection so they are
+                not shown as one undifferentiated "条件" pile (Task 11). */}
             <div className="mt-7 rounded-3xl border border-stone-200/45 bg-stone-50/60 p-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-[11px] font-medium tracking-[0.2em] text-stone-500">条件を追加（任意）</p>
-                  <p className="mt-0.5 text-[11px] text-stone-500">誕生日・ご利益・参拝スタイルは、相談テーマを補う条件として扱います。</p>
+                  <p className="text-[11px] font-medium tracking-[0.2em] text-stone-500">もう少し自分に合わせる（任意）</p>
+                  <p className="mt-0.5 text-[11px] text-stone-500">参拝の希望・誕生日・ご利益・参拝の詳細は、相談テーマを補う条件として扱います。</p>
                 </div>
                 <button
                   type="button"
@@ -1864,6 +1825,46 @@ export default function ConciergeClientFull() {
                     isEntryRoute={isEntryRoute}
                     isPremiumActive={isPremiumActive}
                   />
+
+                  {/* Level 3-C Recommendation Context. Ambient situational
+                      data (not user identity, not a candidate hard filter) --
+                      kept out of the Initial screen (Task 8) and rendered
+                      here with its own labeled subsection so it is not
+                      confused with Level 3-A Personal Profile or Level 3-B
+                      Explicit Constraint above. Same plannedVisitDate/
+                      userOrigin state and handlers as before this move --
+                      request payload semantics are unchanged. */}
+                  <section aria-label="参拝の詳細（任意）" className="mt-3 rounded-2xl border border-stone-200/50 bg-white/80 p-3">
+                    <p className="text-[10px] font-semibold text-slate-600">参拝の詳細（任意）</p>
+                    <p className="mt-0.5 text-[10px] leading-4 text-slate-400">予定日と出発地点から、神社への方角を補助条件として使います。</p>
+                    <div className="mt-2 grid gap-3 sm:grid-cols-2">
+                      <label className="block text-sm font-medium text-stone-600">
+                        参拝予定日（任意）
+                        <input
+                          type="date"
+                          value={plannedVisitDate}
+                          min={new Date().toISOString().slice(0, 10)}
+                          onChange={(event) => {
+                            setPlannedVisitDate(event.target.value);
+                            if (event.target.value) trackWebDirection("direction_visit_date_set");
+                          }}
+                          className="mt-1 min-h-11 w-full rounded-2xl border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-base text-[var(--kt-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600"
+                        />
+                      </label>
+                      <OriginSelector
+                        origin={userOrigin}
+                        onChange={(value) => {
+                          setUserOrigin(value);
+                          if (value) trackWebDirection("direction_origin_result", { origin_type: value.source, result: "selected" });
+                        }}
+                        onUseDevice={useCurrentLocation}
+                        deviceError={locationError}
+                      />
+                    </div>
+                    {plannedVisitDate ? (
+                      <p className="mt-2 text-xs text-[var(--kt-color-text-muted)]">予定日の年盤・月盤と、設定した出発地点から神社への方角を補助条件に使います。</p>
+                    ) : null}
+                  </section>
                 </div>
               ) : null}
             </div>

--- a/apps/web/src/features/concierge/__tests__/buildConciergeRequestPayload.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildConciergeRequestPayload.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+import { buildConciergeRequestPayload, normalizeQueryText } from "../buildConciergeRequestPayload";
+import type { ConciergeChatFilters } from "../types/chatRequest";
+
+// Request payload regression (Concierge Entry Frontend IA v2, Task 17).
+// UI was reorganized into Initial(L1) / Assist / Personalize(L2/L3), but
+// the request payload sent to the backend must be byte-for-byte unchanged
+// for the same underlying signal values. Each test below isolates exactly
+// one layer's contribution (per docs/product/concierge-input-architecture.md)
+// and asserts every other field stays at its untouched baseline -- so a
+// future change that leaks one layer's UI state into another layer's
+// payload field is caught here.
+
+const emptyBaseFilters: ConciergeChatFilters = {
+  birthdate: undefined,
+  goriyaku_tag_ids: undefined,
+  extra_condition: undefined,
+  crowd: undefined,
+  duration_max_min: undefined,
+  free_text: undefined,
+};
+
+const baseParams = {
+  needText: "",
+  temporaryBirthdate: "",
+  savedProfile: null,
+  baseFilters: emptyBaseFilters,
+  visitPreferences: [] as readonly string[],
+  plannedVisitDate: "",
+  userOrigin: null,
+};
+
+describe("buildConciergeRequestPayload", () => {
+  it("L1 only: query carries the consultation text, every other layer stays empty", () => {
+    const payload = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "最近少し疲れていて、気持ちを落ち着ける参拝がしたい",
+    });
+
+    expect(payload.query).toBe("最近少し疲れていて、気持ちを落ち着ける参拝がしたい");
+    expect(payload.birthdate).toBeUndefined();
+    expect(payload.goriyaku_tag_ids).toBeUndefined();
+    expect(payload.extra_condition).toBeUndefined();
+    expect(payload.visit_preferences).toBeUndefined();
+    expect(payload.visit_date).toBeUndefined();
+    expect(payload.location).toBeUndefined();
+    expect(payload.filters).toEqual({
+      birthdate: undefined,
+      goriyaku_tag_ids: undefined,
+      extra_condition: undefined,
+      crowd: undefined,
+      duration_max_min: undefined,
+      free_text: undefined,
+    });
+  });
+
+  it("L1 + Assist: a chip-picked example produces the same payload shape as manual text (no separate Assist field)", () => {
+    // ConciergeEntryCard.onPickExample replaces needText with the example's
+    // full sentence before this function ever runs (input assist, not a
+    // distinct signal) -- see ConciergeClientFull.tsx onPickExample.
+    const manual = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "人との関係やご縁について、落ち着いて見つめ直したいです",
+    });
+    const viaChip = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "人との関係やご縁について、落ち着いて見つめ直したいです",
+    });
+
+    expect(viaChip).toEqual(manual);
+    expect(viaChip.query).toBe("人との関係やご縁について、落ち着いて見つめ直したいです");
+  });
+
+  it("L1 + L2 (visit_preferences): adds visit_preferences only, leaves L3 fields untouched", () => {
+    const payload = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "静かに過ごしたい",
+      visitPreferences: ["quiet", "nature"],
+    });
+
+    expect(payload.query).toBe("静かに過ごしたい");
+    expect(payload.visit_preferences).toEqual(["quiet", "nature"]);
+    expect(payload.birthdate).toBeUndefined();
+    expect(payload.goriyaku_tag_ids).toBeUndefined();
+    expect(payload.visit_date).toBeUndefined();
+    expect(payload.location).toBeUndefined();
+  });
+
+  it("L1 + L3-A (birthdate): adds birthdate to top-level, filters, and profile_context only", () => {
+    const payload = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "相性を見てほしい",
+      temporaryBirthdate: "1990-05-20",
+    });
+
+    expect(payload.birthdate).toBe("1990-05-20");
+    expect(payload.filters?.birthdate).toBe("1990-05-20");
+    expect(payload.profile_context?.user_profile).toMatchObject({ birthday: "1990-05-20" });
+    expect(payload.goriyaku_tag_ids).toBeUndefined();
+    expect(payload.visit_preferences).toBeUndefined();
+    expect(payload.visit_date).toBeUndefined();
+    expect(payload.location).toBeUndefined();
+  });
+
+  it("L1 + L3-B (goriyaku_tag_ids): adds goriyaku_tag_ids to top-level and filters only", () => {
+    const payload = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "ご利益を絞りたい",
+      baseFilters: { ...emptyBaseFilters, goriyaku_tag_ids: [3, 7] },
+    });
+
+    expect(payload.goriyaku_tag_ids).toEqual([3, 7]);
+    expect(payload.filters?.goriyaku_tag_ids).toEqual([3, 7]);
+    expect(payload.birthdate).toBeUndefined();
+    expect(payload.visit_preferences).toBeUndefined();
+    expect(payload.visit_date).toBeUndefined();
+    expect(payload.location).toBeUndefined();
+  });
+
+  it("L1 + L3-C (visit_date + location): adds visit_date/location only, no Candidate/Profile fields", () => {
+    const payload = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "来月お参りに行きたい",
+      plannedVisitDate: "2026-09-15",
+      userOrigin: { latitude: 35.6762, longitude: 139.6503, source: "device", accuracy: "precise" },
+    });
+
+    expect(payload.visit_date).toBe("2026-09-15");
+    expect(payload.location).toEqual({ lat: 35.6762, lng: 139.6503 });
+    expect(payload.birthdate).toBeUndefined();
+    expect(payload.goriyaku_tag_ids).toBeUndefined();
+    expect(payload.visit_preferences).toBeUndefined();
+  });
+
+  it("Full Integration: L1 + L2 + L3-A + L3-B + L3-C all combine without cross-contamination", () => {
+    const payload = buildConciergeRequestPayload({
+      needText: "仕事の迷いを整理したい",
+      temporaryBirthdate: "1990-05-20",
+      savedProfile: { birthday: "1990-05-20", birth_time: "08:30", birth_place: "東京都", worship_style: "静か" },
+      // In real usage, ConciergeClientFull's `baseFilters` memo always keeps
+      // extra_condition and free_text in sync (free_text: extra).
+      baseFilters: { ...emptyBaseFilters, goriyaku_tag_ids: [1], extra_condition: "駅近", free_text: "駅近" },
+      visitPreferences: ["nearby"],
+      plannedVisitDate: "2026-09-15",
+      userOrigin: { latitude: 35.6762, longitude: 139.6503, source: "device", accuracy: "precise" },
+    });
+
+    expect(payload.query).toBe("仕事の迷いを整理したい");
+    expect(payload.birthdate).toBe("1990-05-20");
+    expect(payload.goriyaku_tag_ids).toEqual([1]);
+    expect(payload.extra_condition).toBe("駅近");
+    expect(payload.visit_preferences).toEqual(["nearby"]);
+    expect(payload.visit_date).toBe("2026-09-15");
+    expect(payload.location).toEqual({ lat: 35.6762, lng: 139.6503 });
+    expect(payload.profile_context?.user_profile).toMatchObject({
+      birthday: "1990-05-20",
+      birthTime: "08:30",
+      birthPlace: "東京都",
+      worshipStyle: "静か",
+    });
+    expect(payload.filters).toEqual({
+      birthdate: "1990-05-20",
+      goriyaku_tag_ids: [1],
+      extra_condition: "駅近",
+      crowd: undefined,
+      duration_max_min: undefined,
+      free_text: "駅近",
+    });
+  });
+
+  it("empty query with an active filter falls back to a generic filter-refinement query (unchanged legacy behavior)", () => {
+    const payload = buildConciergeRequestPayload({
+      ...baseParams,
+      needText: "",
+      baseFilters: { ...emptyBaseFilters, goriyaku_tag_ids: [2] },
+    });
+
+    expect(payload.query).toBe("追加した条件に合う神社を提案してください。");
+  });
+
+  it("normalizeQueryText treats a birthdate-only free-text entry as empty (unchanged legacy behavior)", () => {
+    expect(normalizeQueryText("1990-05-20")).toBe("");
+    expect(normalizeQueryText("  仕事の相談  ")).toBe("仕事の相談");
+  });
+});

--- a/apps/web/src/features/concierge/buildConciergeRequestPayload.ts
+++ b/apps/web/src/features/concierge/buildConciergeRequestPayload.ts
@@ -1,0 +1,112 @@
+// apps/web/src/features/concierge/buildConciergeRequestPayload.ts
+//
+// Pure extraction of the request-payload-building logic previously inlined
+// as a useCallback in apps/web/src/app/concierge/ConciergeClientFull.tsx.
+// Byte-for-byte identical output for identical inputs -- this is a
+// mechanical move (closure variables become explicit params), not a
+// contract change. Extracted so the Concierge Entry Frontend IA v2
+// reorganization (docs/product/concierge-input-architecture.md, Frontend
+// IA Implementation Addendum) can be covered by fast unit tests without
+// rendering the full ConciergeClientFull component tree.
+//
+// Level tagging on the returned fields follows
+// apps/web/src/features/concierge/types/chatRequest.ts.
+import { normalizeBirthdateInput } from "@/lib/date/normalizeBirthdateInput";
+import { buildProfileContext, normalizeBirthday as normalizeProfileBirthday, type ProfileInput } from "@/lib/profile/derivedProfile";
+import type { ConciergeChatFilters, ConciergeChatRequestV1 } from "@/features/concierge/types/chatRequest";
+import { toOriginPayload, type UserOrigin } from "../../../../../packages/shared/userOrigin";
+
+function isBirthdateOnlyText(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  return normalizeBirthdateInput(trimmed) !== null;
+}
+
+export function normalizeQueryText(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+  if (isBirthdateOnlyText(trimmed)) return "";
+  return trimmed;
+}
+
+export type BuildConciergeRequestPayloadInput = Partial<Omit<ConciergeChatRequestV1, "thread_id">> & {
+  query?: string;
+  crowd?: ConciergeChatFilters["crowd"];
+  duration_max_min?: number;
+  free_text?: string;
+};
+
+export type BuildConciergeRequestPayloadParams = {
+  // Level 1 Consultation
+  needText: string;
+  // Level 3-A Personal Profile
+  temporaryBirthdate: string | null | undefined;
+  savedProfile?: ProfileInput | null;
+  // Level 2 (extra_condition/crowd/duration_max_min) + Level 3-A (birthdate) +
+  // Level 3-B (goriyaku_tag_ids) baseline, already resolved by the caller
+  // (ConciergeClientFull's `baseFilters` memo -- unchanged by this extraction).
+  baseFilters: ConciergeChatFilters;
+  // Level 2 Visit Preference (Structured)
+  visitPreferences: readonly string[];
+  // Level 3-C Recommendation Context
+  plannedVisitDate: string;
+  userOrigin: UserOrigin | null;
+  // Per-call override (e.g. filter_apply / example pick), same shape as the
+  // original inline function accepted.
+  input?: BuildConciergeRequestPayloadInput;
+};
+
+export function buildConciergeRequestPayload({
+  needText,
+  temporaryBirthdate,
+  savedProfile,
+  baseFilters,
+  visitPreferences,
+  plannedVisitDate,
+  userOrigin,
+  input,
+}: BuildConciergeRequestPayloadParams): Omit<ConciergeChatRequestV1, "thread_id"> {
+  const birthdate = normalizeBirthdateInput(temporaryBirthdate ?? "") ?? normalizeProfileBirthday(savedProfile?.birthday);
+  const payloadBirthdate = input?.birthdate ?? birthdate;
+  const payloadGoriyakuTagIds = input?.goriyaku_tag_ids ?? baseFilters.goriyaku_tag_ids;
+  const payloadExtraCondition = input?.extra_condition ?? baseFilters.extra_condition;
+  const payloadVisitPreferences = input?.visit_preferences ?? (visitPreferences.length ? [...visitPreferences] : undefined);
+  const payloadCrowd = input?.crowd ?? baseFilters.crowd;
+  const payloadDurationMaxMin = input?.duration_max_min ?? baseFilters.duration_max_min;
+  const payloadFreeText = input?.free_text ?? input?.extra_condition ?? baseFilters.free_text;
+  const rawQuery = normalizeQueryText(input?.query ?? needText);
+  const hasPayloadFilter =
+    !!payloadBirthdate ||
+    (payloadGoriyakuTagIds?.length ?? 0) > 0 ||
+    !!payloadExtraCondition ||
+    !!payloadCrowd?.length ||
+    typeof payloadDurationMaxMin === "number" ||
+    !!payloadFreeText;
+  const query = rawQuery || (hasPayloadFilter ? "追加した条件に合う神社を提案してください。" : "");
+
+  return {
+    version: input?.version ?? 1,
+    mode: input?.mode ?? "need",
+    query,
+    birthdate: payloadBirthdate,
+    filters: {
+      birthdate: payloadBirthdate,
+      goriyaku_tag_ids: payloadGoriyakuTagIds,
+      extra_condition: payloadExtraCondition,
+      crowd: payloadCrowd,
+      duration_max_min: payloadDurationMaxMin,
+      free_text: payloadFreeText,
+    },
+    goriyaku_tag_ids: payloadGoriyakuTagIds,
+    extra_condition: payloadExtraCondition,
+    visit_preferences: payloadVisitPreferences,
+    visit_date: plannedVisitDate || undefined,
+    location: toOriginPayload(userOrigin),
+    profile_context: buildProfileContext({
+      birthday: payloadBirthdate,
+      birth_time: savedProfile?.birth_time,
+      birth_place: savedProfile?.birth_place,
+      worship_style: savedProfile?.worship_style,
+    }),
+  };
+}

--- a/apps/web/src/features/concierge/components/ConciergeEntryCard.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeEntryCard.tsx
@@ -1,6 +1,4 @@
 "use client";
-import OriginSelector from "./OriginSelector";
-import type { UserOrigin } from "../../../../../../packages/shared/userOrigin";
 
 type ConciergeEntryExample = {
   label: string;
@@ -27,15 +25,20 @@ type Props = {
   canSend: boolean;
   onSubmit: () => void;
   onClear: () => void;
-  plannedVisitDate?: string;
-  setPlannedVisitDate?: (value: string) => void;
-  hasOrigin?: boolean;
-  locationError?: string | null;
-  onUseCurrentLocation?: () => void;
-  origin?: UserOrigin | null;
-  onOriginChange?: (value: UserOrigin | null) => void;
 };
 
+// Concierge Entry Frontend IA v2 (docs/product/concierge-input-architecture.md,
+// Frontend IA Implementation Addendum; docs/audit/concierge-l1-freetext-final-readiness.md
+// Decision: CONDITIONAL GO, Free-text Primary = Yes, Assist chips visibility
+// = medium). This card renders Initial (Level 1 Consultation, Primary CTA)
+// and Assist (Consultation Theme Chips, medium visibility) only.
+// Level 3-C Recommendation Context (visit date / origin) and Level 2/3-A/3-B
+// (visit preference / birthdate / goriyaku) live in the Personalize section
+// rendered by ConciergeClientFull -- not in this card. Non-Recommendation
+// fields (nickname, login prompt) render last, below the consultation flow,
+// with reduced visual prominence (Task 9): they still need a place because
+// sessionNickname has a real runtime dependency (anonymous snapshot restore,
+// displayLabel greeting elsewhere), so it is not removed, only deprioritized.
 export default function ConciergeEntryCard({
   displayName,
   displayLabel,
@@ -52,13 +55,6 @@ export default function ConciergeEntryCard({
   canSend,
   onSubmit,
   onClear,
-  plannedVisitDate = "",
-  setPlannedVisitDate = () => undefined,
-  hasOrigin: _hasOrigin = false,
-  locationError = null,
-  onUseCurrentLocation = () => undefined,
-  origin = null,
-  onOriginChange = () => undefined,
 }: Props) {
   return (
     <>
@@ -74,61 +70,11 @@ export default function ConciergeEntryCard({
         </p>
       </div>
 
-      <div className="mt-4">
-        <label
-          htmlFor="concierge-entry-nickname"
-          className="mb-0.5 block text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-65"
-        >
-          呼び名（任意）
-        </label>
-        <input
-          id="concierge-entry-nickname"
-          type="text"
-          value={sessionState.sessionNickname ?? ""}
-          onChange={(e) => setSessionNickname(e.target.value)}
-          placeholder="例: なまえ"
-          className="w-full rounded-2xl border border-stone-200/30 bg-stone-50/25 px-2.5 py-1.5 text-sm text-[var(--kt-color-text-primary)] placeholder:text-stone-400 placeholder:opacity-60"
-          maxLength={20}
-        />
-      </div>
-
-      {!canSaveConciergeThread && !isUiPaywall ? (
-        <div className="mt-3 rounded-[var(--kt-radius-panel)] border border-amber-200/50 bg-amber-50/50 px-3 py-2 text-xs text-amber-800 opacity-85">
-          <p>未ログインでも相談できます。保存にはログインが必要です。</p>
-          <div className="mt-2 flex gap-2">
-            <button
-              type="button"
-              className="rounded-lg bg-[var(--kt-color-surface-emphasis)] px-2.5 py-1 text-xs font-medium text-[var(--kt-color-text-inverse)] hover:bg-[var(--kt-color-surface-emphasis-hover)]"
-              onClick={() => redirectToAuth("login")}
-            >
-              ログイン
-            </button>
-            <button
-              type="button"
-              className="rounded-lg border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-stone-100"
-              onClick={() => redirectToAuth("register")}
-            >
-              新規登録
-            </button>
-          </div>
-        </div>
-      ) : null}
-
+      {/* Level 1 Consultation -- Primary Input */}
       <div className="mt-5 space-y-4">
-        <div className="grid gap-3 sm:grid-cols-2">
-          <label className="block text-sm font-medium text-stone-600">
-            参拝予定日（任意）
-            <input type="date" value={plannedVisitDate} min={new Date().toISOString().slice(0, 10)} onChange={(event) => setPlannedVisitDate(event.target.value)} className="mt-1 min-h-11 w-full rounded-2xl border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-base text-[var(--kt-color-text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600" />
-          </label>
-          <OriginSelector origin={origin} onChange={onOriginChange} onUseDevice={onUseCurrentLocation} deviceError={locationError} />
-        </div>
-        {plannedVisitDate ? <p className="text-xs text-[var(--kt-color-text-muted)]">予定日の年盤・月盤と、設定した出発地点から神社への方角を補助条件に使います。</p> : null}
         <div>
-          <label
-            htmlFor="concierge-input"
-            className="mb-0.5 block text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-65"
-          >
-            必要なら、今の状況を少しだけ書く
+          <label htmlFor="concierge-input" className="mb-1.5 block text-sm font-medium text-[var(--kt-color-text-primary)]">
+            今、どんなことが気になっていますか？
           </label>
           <textarea
             id="concierge-input"
@@ -136,12 +82,38 @@ export default function ConciergeEntryCard({
             onChange={(e) => setNeedText(e.target.value)}
             placeholder="例: 仕事の迷いを整理したい、少し休みたい"
             rows={4}
-            className="w-full rounded-3xl border border-stone-200/20 bg-stone-50/30 px-3 py-2.5 text-sm leading-7 text-[var(--kt-color-text-primary)] outline-none transition placeholder:text-stone-400 placeholder:opacity-60 focus:border-emerald-200/40 focus:ring-1 focus:ring-emerald-100/40"
+            autoFocus
+            className="w-full rounded-3xl border border-stone-200/30 bg-white px-3 py-2.5 text-sm leading-7 text-[var(--kt-color-text-primary)] outline-none transition placeholder:text-stone-400 placeholder:opacity-60 focus:border-emerald-300/60 focus:ring-1 focus:ring-emerald-100/60"
           />
         </div>
 
-        <div>
-          <p className="text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-75">相談テーマ</p>
+        <div className="flex flex-col gap-1.5 sm:flex-row">
+          <button
+            type="button"
+            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-emerald-300 bg-emerald-50/50 px-3 py-2 text-sm font-medium text-emerald-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-emerald-100/40 disabled:cursor-not-allowed disabled:opacity-40"
+            disabled={isBusy || !needText.trim() || !canSend}
+            onClick={onSubmit}
+          >
+            この相談で神社を提案してもらう
+          </button>
+
+          <button
+            type="button"
+            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-sm font-medium text-[var(--kt-color-text-secondary)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-stone-100/30 disabled:cursor-not-allowed disabled:border-stone-200 disabled:bg-stone-100 disabled:text-stone-400 disabled:opacity-40"
+            disabled={isBusy}
+            onClick={onClear}
+          >
+            クリア
+          </button>
+        </div>
+
+        {/* Assist: Consultation Writing Assist chips (medium visibility) --
+            not an alternative search route. Picking one replaces the
+            textarea with an editable starting sentence (onPickExample),
+            the same signal path as typing it manually. */}
+        <section aria-label="相談テーマから選ぶ" className="pt-1">
+          <p className="text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-75">うまく言葉にならないとき</p>
+          <p className="text-[11px] text-[var(--kt-color-text-muted)] opacity-60">近いテーマから選べます</p>
           <div className="mt-2.5 flex flex-wrap gap-2">
             {feelExamples.map((example) => {
               const isSelected = needText.trim() === example.text;
@@ -166,27 +138,53 @@ export default function ConciergeEntryCard({
               );
             })}
           </div>
+        </section>
+      </div>
+
+      {/* Non-Recommendation fields -- below the consultation flow, reduced
+          visual prominence (Task 9). Kept (not removed): sessionNickname has
+          a runtime dependency (anonymous snapshot restore, greeting copy in
+          ConciergeClientFull). */}
+      <div className="mt-6 space-y-3 border-t border-stone-200/20 pt-4">
+        <div>
+          <label
+            htmlFor="concierge-entry-nickname"
+            className="mb-0.5 block text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-65"
+          >
+            呼び名（任意）
+          </label>
+          <input
+            id="concierge-entry-nickname"
+            type="text"
+            value={sessionState.sessionNickname ?? ""}
+            onChange={(e) => setSessionNickname(e.target.value)}
+            placeholder="例: なまえ"
+            className="w-full rounded-2xl border border-stone-200/30 bg-stone-50/25 px-2.5 py-1.5 text-sm text-[var(--kt-color-text-primary)] placeholder:text-stone-400 placeholder:opacity-60"
+            maxLength={20}
+          />
         </div>
 
-        <div className="flex flex-col gap-1.5 sm:flex-row">
-          <button
-            type="button"
-            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-emerald-300 bg-emerald-50/50 px-3 py-2 text-sm font-medium text-emerald-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-emerald-100/40 disabled:cursor-not-allowed disabled:opacity-40"
-            disabled={isBusy || !needText.trim() || !canSend}
-            onClick={onSubmit}
-          >
-            この相談で神社を提案してもらう
-          </button>
-
-          <button
-            type="button"
-            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-sm font-medium text-[var(--kt-color-text-secondary)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-stone-100/30 disabled:cursor-not-allowed disabled:border-stone-200 disabled:bg-stone-100 disabled:text-stone-400 disabled:opacity-40"
-            disabled={isBusy}
-            onClick={onClear}
-          >
-            クリア
-          </button>
-        </div>
+        {!canSaveConciergeThread && !isUiPaywall ? (
+          <div className="rounded-[var(--kt-radius-panel)] border border-amber-200/50 bg-amber-50/50 px-3 py-2 text-xs text-amber-800 opacity-85">
+            <p>未ログインでも相談できます。保存にはログインが必要です。</p>
+            <div className="mt-2 flex gap-2">
+              <button
+                type="button"
+                className="rounded-lg bg-[var(--kt-color-surface-emphasis)] px-2.5 py-1 text-xs font-medium text-[var(--kt-color-text-inverse)] hover:bg-[var(--kt-color-surface-emphasis-hover)]"
+                onClick={() => redirectToAuth("login")}
+              >
+                ログイン
+              </button>
+              <button
+                type="button"
+                className="rounded-lg border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-stone-100"
+                onClick={() => redirectToAuth("register")}
+              >
+                新規登録
+              </button>
+            </div>
+          </div>
+        ) : null}
       </div>
     </>
   );

--- a/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
@@ -156,7 +156,8 @@ export default function ConciergeFilterPanel({
       </div>
 
       <div className="grid gap-0.5 rounded-xl border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-2">
-        <div className="space-y-0.5">
+        {/* Level 3-A Personal Profile */}
+        <section aria-label="誕生日（任意）" className="space-y-0.5">
           <div className="text-[10px] font-semibold text-[var(--kt-color-text-muted)]">誕生日（任意）</div>
           <div className="text-[10px] text-slate-400">相性候補を見るための任意の補助情報です</div>
           <input
@@ -165,7 +166,7 @@ export default function ConciergeFilterPanel({
             onChange={(e) => onBirthdateChange(e.target.value)}
             className="w-full rounded-xl border px-3 py-1.5 text-sm"
           />
-        </div>
+        </section>
 
         {element4 ? (
           <div className="text-[11px] text-[var(--kt-color-text-muted)]">
@@ -173,7 +174,8 @@ export default function ConciergeFilterPanel({
           </div>
         ) : null}
 
-        <div className="space-y-2">
+        {/* Level 2 Visit Preference */}
+        <section aria-label="今回の参拝の希望（任意）" className="space-y-2">
           <div>
             <div className="text-[10px] font-semibold text-slate-600">参拝スタイル</div>
             <p className="mt-0.5 text-[10px] leading-4 text-slate-400">
@@ -208,7 +210,7 @@ export default function ConciergeFilterPanel({
               </div>
             </div>
           ))}
-        </div>
+        </section>
 
         {element4 && suggestedTags.length > 0 ? (
           <div className="space-y-0.5">
@@ -237,12 +239,15 @@ export default function ConciergeFilterPanel({
         ) : null}
       </div>
 
+      {/* Level 3-B Explicit Constraint -- a DB-level candidate hard filter,
+          not a "おすすめテーマ"/Personal Profile. Kept distinct from L2
+          (参拝スタイル) and L3-A (誕生日) above (Task 7). */}
       {tagsLoading || tagsError || visibleGoriyakuTags.length > 0 || hiddenGoriyakuCount > 0 ? (
-        <div className="space-y-1 rounded-xl border border-slate-200 bg-white p-2">
+        <section aria-label="ご利益を指定する" className="space-y-1 rounded-xl border border-slate-200 bg-white p-2">
           <div>
-            <div className="text-[10px] font-semibold text-slate-600">ご利益・願いに近いもの</div>
+            <div className="text-[10px] font-semibold text-slate-600">ご利益を指定する</div>
             <p className="mt-0.5 text-[10px] leading-4 text-slate-400">
-              相談テーマを主軸にしつつ、願いたいことに近いものを補助条件として使います。
+              相談テーマを主軸にしつつ、願いたいことに近いものを候補の絞り込みとして使います。
             </p>
           </div>
           {tagsError ? <div className="text-xs text-[var(--kt-color-status-error)]">{tagsError}</div> : null}
@@ -277,7 +282,7 @@ export default function ConciergeFilterPanel({
               {showAllGoriyakuTags ? "折りたたむ" : `他${hiddenGoriyakuCount}件を表示`}
             </button>
           ) : null}
-        </div>
+        </section>
       ) : null}
 
       <div className="flex justify-end gap-2 border-t border-[var(--kt-color-border-default)] bg-slate-50/95 pt-1.5 pb-0.5">

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeEntryCard.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeEntryCard.test.tsx
@@ -30,13 +30,54 @@ describe("ConciergeEntryCard", () => {
     expect(screen.getByText("KAMI MUSUBI GUIDE")).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "相談から、向かう神社を見つける" })).toBeInTheDocument();
     expect(screen.getByText("相談をもとに、今向かいやすい神社との出会いを整えます。")).toBeInTheDocument();
-    expect(screen.getByLabelText("必要なら、今の状況を少しだけ書く")).toBeInTheDocument();
+    expect(screen.getByLabelText("今、どんなことが気になっていますか？")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("例: 仕事の迷いを整理したい、少し休みたい")).toBeInTheDocument();
-    expect(screen.getByText("相談テーマ")).toBeInTheDocument();
+    expect(screen.getByText("うまく言葉にならないとき")).toBeInTheDocument();
+    expect(screen.getByText("近いテーマから選べます")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "仕事について考えたい" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "少し休みたい" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "クリア" })).toBeEnabled();
+  });
+
+  it("Initial contract: no Level 2/3 detail controls render, and the CTA works with Level 1 text alone", () => {
+    const onSubmit = vi.fn();
+    render(<ConciergeEntryCard {...baseProps} needText="仕事や働き方について、今の流れを整理したいです" onSubmit={onSubmit} />);
+
+    // Level 2/3 fields (visit preference presets, birthdate, goriyaku,
+    // visit date, origin) live in the Personalize section rendered by
+    // ConciergeClientFull, not in this card.
+    expect(screen.queryByText("誕生日（任意）")).not.toBeInTheDocument();
+    expect(screen.queryByText("ご利益を指定する")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("参拝予定日（任意）")).not.toBeInTheDocument();
+    expect(screen.queryByText("参拝スタイル")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "この相談で神社を提案してもらう" }));
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("orders Primary CTA before the Assist chips (Level 1 -> Primary CTA -> Assist)", () => {
+    render(<ConciergeEntryCard {...baseProps} needText="仕事や働き方について、今の流れを整理したいです" />);
+
+    const textarea = screen.getByLabelText("今、どんなことが気になっていますか？");
+    const ctaButton = screen.getByRole("button", { name: "この相談で神社を提案してもらう" });
+    const firstChip = screen.getByRole("button", { name: "仕事について考えたい" });
+
+    const position = textarea.compareDocumentPosition(ctaButton);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const ctaBeforeChip = ctaButton.compareDocumentPosition(firstChip);
+    expect(ctaBeforeChip & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders nickname and login prompt after the consultation flow (Non-Recommendation, deprioritized)", () => {
+    render(<ConciergeEntryCard {...baseProps} canSaveConciergeThread={false} needText="相談したいこと" />);
+
+    const firstChip = screen.getByRole("button", { name: "仕事について考えたい" });
+    const nicknameInput = screen.getByPlaceholderText("例: なまえ");
+
+    const position = firstChip.compareDocumentPosition(nicknameInput);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("calls handlers for nickname, textarea, example, submit, and clear", () => {
@@ -59,7 +100,7 @@ describe("ConciergeEntryCard", () => {
     );
 
     fireEvent.change(screen.getByPlaceholderText("例: なまえ"), { target: { value: "なまえ" } });
-    fireEvent.change(screen.getByLabelText("必要なら、今の状況を少しだけ書く"), { target: { value: "静かな場所に行きたい" } });
+    fireEvent.change(screen.getByLabelText("今、どんなことが気になっていますか？"), { target: { value: "静かな場所に行きたい" } });
     fireEvent.click(screen.getByRole("button", { name: "少し休みたい" }));
     fireEvent.click(screen.getByRole("button", { name: "この相談で神社を提案してもらう" }));
     fireEvent.click(screen.getByRole("button", { name: "クリア" }));
@@ -85,17 +126,17 @@ describe("ConciergeEntryCard", () => {
     expect(redirectToAuth).toHaveBeenCalledWith("register");
   });
 
-  it("allows consultation without an origin and offers location choices", () => {
-    const setPlannedVisitDate = vi.fn();
-    const onUseCurrentLocation = vi.fn();
-    const { rerender } = render(
-      <ConciergeEntryCard {...baseProps} needText="参拝したい" plannedVisitDate="2026-09-15" setPlannedVisitDate={setPlannedVisitDate} hasOrigin={false} onUseCurrentLocation={onUseCurrentLocation} />,
-    );
-    expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeEnabled();
-    fireEvent.click(screen.getByRole("radio", { name: "現在地を使用" }));
-    expect(onUseCurrentLocation).toHaveBeenCalledTimes(1);
+  it("disables the primary CTA while empty, busy, or blocked, but not the chips before text is entered", () => {
+    const { rerender } = render(<ConciergeEntryCard {...baseProps} needText="" />);
+    expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeDisabled();
 
-    rerender(<ConciergeEntryCard {...baseProps} needText="参拝したい" plannedVisitDate="2026-09-15" hasOrigin />);
+    rerender(<ConciergeEntryCard {...baseProps} needText="相談したい" isBusy />);
+    expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeDisabled();
+
+    rerender(<ConciergeEntryCard {...baseProps} needText="相談したい" canSend={false} />);
+    expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeDisabled();
+
+    rerender(<ConciergeEntryCard {...baseProps} needText="相談したい" />);
     expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeEnabled();
   });
 });

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeFilterPanel.sections.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeFilterPanel.sections.test.tsx
@@ -1,0 +1,68 @@
+// Concierge Entry Frontend IA v2 -- Personalize section separation
+// (docs/product/concierge-input-architecture.md Frontend IA Implementation
+// Addendum, Task 11/16). Level 2 (visit preference) and Level 3-A (personal
+// profile) / Level 3-B (explicit constraint) must not render as one
+// undifferentiated "条件" pile -- each keeps its own accessible section.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import ConciergeFilterPanel from "../ConciergeFilterPanel";
+
+const baseProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onApply: vi.fn(),
+  birthdate: "",
+  onBirthdateChange: vi.fn(),
+  element4: null,
+  goriyakuTags: [{ id: 1, name: "縁結び" }],
+  suggestedTags: [],
+  selectedTagIds: [],
+  onToggleTag: vi.fn(),
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+  onExtraConditionChange: vi.fn(),
+};
+
+describe("ConciergeFilterPanel Personalize section separation", () => {
+  it("renders Level 3-A (誕生日), Level 2 (今回の参拝の希望), and Level 3-B (ご利益) as distinct accessible sections", () => {
+    render(<ConciergeFilterPanel {...baseProps} />);
+
+    const personalProfile = screen.getByRole("region", { name: "誕生日（任意）" });
+    const visitPreference = screen.getByRole("region", { name: "今回の参拝の希望（任意）" });
+    const explicitConstraint = screen.getByRole("region", { name: "ご利益を指定する" });
+
+    expect(personalProfile).toBeInTheDocument();
+    expect(visitPreference).toBeInTheDocument();
+    expect(explicitConstraint).toBeInTheDocument();
+
+    // Distinct, non-overlapping regions -- L3-A content must not also live
+    // inside the L2 region, and vice versa.
+    expect(personalProfile).not.toContainElement(screen.getByText("参拝スタイル"));
+    expect(visitPreference).toContainElement(screen.getByText("参拝スタイル"));
+    expect(explicitConstraint).toContainElement(screen.getByText("縁結び"));
+  });
+
+  it("renders nothing when closed (isOpen=false)", () => {
+    const { container } = render(<ConciergeFilterPanel {...baseProps} isOpen={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("preserves already-selected values when reopened with the same controlled props", () => {
+    const props = { ...baseProps, birthdate: "1990-05-20", selectedTagIds: [1] };
+
+    const { unmount } = render(<ConciergeFilterPanel {...props} />);
+    expect(screen.getByDisplayValue("1990-05-20")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "縁結び" })).toHaveClass("border-emerald-600");
+    unmount();
+
+    // Simulates close (unmount) + reopen (remount) with the same lifted
+    // state passed back in -- ConciergeClientFull's filter_close handler
+    // only toggles isFilterOpen, it never clears birthdate/selectedTagIds/
+    // extraCondition/visitPreferences, so the parent-held values survive.
+    render(<ConciergeFilterPanel {...props} />);
+    expect(screen.getByDisplayValue("1990-05-20")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "縁結び" })).toHaveClass("border-emerald-600");
+  });
+});

--- a/docs/product/concierge-input-architecture.md
+++ b/docs/product/concierge-input-architecture.md
@@ -1717,3 +1717,186 @@ Recommendation順位（`_score_total`/`score_total_ranked`/並び順）への
 - **Weight Optimization**: 実利用データ後の判断。
 - **Frontend IA**: L1/L2/L3段階表示。
 - **Learning**: 行動feedbackの正式契約。
+
+---
+
+## Addendum: Frontend IA Implementation — Concierge Entry Progressive Disclosure
+
+`docs/audit/concierge-l1-freetext-final-readiness.md`のDecision
+（**CONDITIONAL GO**、Free-text Primary = Yes / Assist chips visibility
+= medium / L2/L3 collapsed by default = Yes）をFrontendへ実装した。
+上記「Follow-up」に記録されていた「Frontend IA: L1/L2/L3段階表示」に
+対応する。
+
+Recommendation Logic自体は変更していない。これまで一画面に平坦に並んで
+いた入力項目を、Signal Responsibility（本書§4-§6）に沿って
+Progressive Disclosureへ再構成しただけである。
+
+### Core UX Principle（実装確認済み）
+
+Frontendでは内部の5層（L1 Consultation / L2 Visit Preference / L3-A
+Personal Profile / L3-B Explicit Constraint / L3-C Recommendation
+Context）を全て同時に見せない。3状態へ集約する。
+
+| Frontend表示 | 内部Level | 初期状態 |
+|---|---|---|
+| Initial（まず相談する） | L1 Consultation | 表示（Primary Input） |
+| Assist（必要なら相談を助ける） | Consultation Theme Chips | 表示（medium visibility、textarea直下） |
+| Personalize（必要なら自分に合わせる） | L2 + L3-A + L3-B + L3-C | 折りたたみ（`isFilterOpen`初期値`false`、変更なし） |
+
+### Initial State
+
+`ConciergeEntryCard`（`apps/web/src/features/concierge/components/ConciergeEntryCard.tsx`）
+をL1 Primary Inputとして再構成した。
+
+- 表示順を Headline → Consultation textarea → Primary CTA → Assist
+  chips へ変更（従来はCTAがchipsの後ろにあった）。
+- textareaのlabelを「必要なら、今の状況を少しだけ書く」（任意感の強い
+  文言）から「今、どんなことが気になっていますか？」（Primary Inputと
+  して認識される文言）へ変更。
+- Level 3-C（参拝予定日・出発地点）をこのcardから完全に除去し、
+  Personalizeセクションへ移設（後述）。Initial画面には一切表示しない。
+- 呼び名（Non-Recommendation）・ログイン案内は、consultation flow
+  （textarea/CTA/chips）より後ろへ移動し、視覚的な強さも縮小した
+  （見出しなしの`border-t`区切り、小さいfont）。**削除はしていない**
+  -- `sessionNickname`はanonymous snapshot復元・greeting表示に実際に
+  使われているため（`ConciergeClientFull.tsx`のruntime dependency
+  確認済み）。
+
+### Assist State
+
+相談テーマchips（`feelExamples`）は削除せず、役割を
+「Alternative Search Method」ではなく「Consultation Writing Assist」
+として明示した。
+
+- 見出しを「相談テーマ」から「うまく言葉にならないとき／近いテーマ
+  から選べます」へ変更（入力補助であることを明示）。
+- chip clickの挙動（`onPickExample` → `setNeedText(example.text)`、
+  textareaを置き換えて編集可能にする）は**変更していない** --
+  これは既存のsignal経路であり、chip専用payload fieldを新設していない
+  （Do Not Change Recommendation Contract §Task 12）。
+- 表示位置をtextarea/CTA直下（アコーディオン内に隠さない、textareaより
+  強調しない）とし、medium visibilityとした。
+
+### Personalize State
+
+L2 Visit Preference + L3-A Personal Profile + L3-B Explicit Constraint
++ L3-C Recommendation Contextを、既存の`isFilterOpen`トグル1つの下へ
+まとめて配置した（Task 10の3-state modelに従い、新規top-level state
+は増やしていない）。ただし内部では、同一カテゴリに見せないよう
+（Task 11）各責務ごとにaccessible sectionを分離した。
+
+`apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx`
+（既存、L2+L3-A+L3-Bを保持）:
+
+- 誕生日ブロック（L3-A）を`<section aria-label="誕生日（任意）">`へ。
+- 参拝スタイルpresetブロック（L2）を
+  `<section aria-label="今回の参拝の希望（任意）">`へ。
+- ご利益ブロック（L3-B）を`<section aria-label="ご利益を指定する">`へ
+  （見出し文言も「ご利益・願いに近いもの」から変更 -- 「おすすめ
+  テーマ」等と混同しないため、§6 3-B Explicit Constraintの定義に
+  合わせた）。
+- Preset値・`onToggleTag`/`onBirthdateChange`/`onVisitPreferencesChange`
+  等のhandler・Structured Visit Preference mapping（`PRESET_VISIT_
+  PREFERENCE_TAGS`）は**一切変更していない**。
+
+`apps/web/src/app/concierge/ConciergeClientFull.tsx`（L3-C新設配置）:
+
+- Level 3-C（参拝予定日・出発地点、`plannedVisitDate`/`userOrigin`
+  state）を`ConciergeEntryCard`から除去し、Personalizeセクション内へ
+  `<section aria-label="参拝の詳細（任意）">`として新設した。
+- state・handler（`setPlannedVisitDate`/`onOriginChange`/
+  `useCurrentLocation`/`trackWebDirection`呼び出し含む）は完全に
+  同一のものを再利用しており、request payload（`visit_date`/
+  `location`）の生成ロジックには一切触れていない。
+
+### State Preservation
+
+`filter_close`アクション（`ConciergeClientFull.tsx`）は
+`setIsFilterOpen(false)`のみを行い、`birthdate`/`selectedTagIds`/
+`extraCondition`/`visitPreferences`/`plannedVisitDate`/`userOrigin`の
+いずれもクリアしない。これらは全てPersonalizeセクションの外
+（`ConciergeClientFull`のcomponent state）に持ち上げられているため、
+開閉に伴うunmount/remountでも値は構造的に保持される（Browser QAで
+誕生日・ご利益選択が閉じて再度開いた後も保持されることを確認済み）。
+
+### Request Payload Extraction（Task 17対応）
+
+Request payload構築ロジック（従来`ConciergeClientFull.tsx`内に
+inline実装されていたuseCallback）を
+`apps/web/src/features/concierge/buildConciergeRequestPayload.ts`へ
+純粋関数として抽出した。closure変数を明示的なparamsへ置き換えた
+機械的な移動であり、**同一入力に対する出力は1バイトも変えていない**
+-- `ConciergeClientFull.tsx`側は同じ関数を呼び出すだけの薄い
+wrapperになった。
+
+この抽出により、巨大な`ConciergeClientFull`をmountせずに、L1 only /
+L1+Assist / L1+L2 / L1+L3-A / L1+L3-B / L1+L3-C / Full Integrationの
+7パターンをunit testで直接検証できるようになった
+（`apps/web/src/features/concierge/__tests__/buildConciergeRequestPayload.test.ts`）。
+
+### Known Limitation（テストカバレッジ）
+
+`ConciergeClientFull.tsx`（1990行超）は本PR以前からrender testが
+一切存在しない（useAuth/useBilling/useConciergeChat等、依存が多く
+mount costが高いため）。本PRもこの既存方針を踏襲し、新規にrender
+harnessは追加していない。Personalizeの外側トグル（`isFilterOpen`）・
+L3-C配置自体の自動テストは、`ConciergeFilterPanel`単体テスト
+（section分離・値保持）とBrowser QA（後述）でカバーしている。将来
+`ConciergeClientFull`のrender harnessを整備する場合はFollow-upとする。
+
+### No Behavior Change Verification（実行結果）
+
+```
+Web unit tests: npx vitest run -> 784 passed（既存769 + 新規15件）
+Web typecheck:  npx tsc -p tsconfig.json --noEmit -> no errors
+Web lint:       npx eslint . -> no errors
+Web build:      npm run build -> success
+```
+
+Recommendation Logic変更 = 0（query interpretation / need_tags /
+consultation_axis / visit_preferences payload / birthdate semantics /
+goriyaku hard filtering / location semantics / visit_date semantics /
+Ranking weights / Primary Reason -- いずれも無変更）
+Request payload shape変更 = 0（`buildConciergeRequestPayload`の
+抽出は既存出力と1バイトも変わらないことをunit testで確認）
+Backend変更 = 0
+Migration = 0
+Candidate filtering変更 = 0
+
+Frontend UI変更 = Yes（本Addendumの対象そのもの、Progressive
+Disclosureへの再構成）
+375px Information Architecture = 崩れていないことをBrowser QAで確認
+（textarea/CTA/chipsが縦積みで正しく表示され、横スクロール発生なし）
+
+Browser QA（実機ではなくdev server + Browser preview、実backend接続）:
+
+- Case A (Initial): textarea/CTA/chipsが最初に表示され、参拝予定日・
+  出発地点・誕生日・ご利益はいずれも初期画面に表示されないことを
+  確認。
+- Case B (Assist): chip clickでtextareaが置き換わり編集可能になる
+  ことを確認（既存挙動、変更なし）。
+- Case C (Personalize): 開いてL3-A（誕生日）・L2（参拝スタイル）・
+  L3-B（ご利益）・L3-C（参拝予定日・出発地点）が全て個別の
+  accessible sectionとして表示されること、誕生日入力・ご利益選択
+  後に閉じて再度開いても値が保持されることを確認。実際に
+  `POST /api/concierge/chat/`を送信し、`birthdate`（1990-05-20由来の
+  `gogyo:水`マッチ）と`goriyaku_tag_ids`（縁結び選択、
+  `matched_user_selected_goriyaku_tag_ids:[1]`）の両方が実際の
+  recommendation scoringへ反映されたレスポンスを確認 -- Personalize
+  再配置後もrequest payloadがbackendへ正しく伝わることを、実際の
+  end-to-endリクエストで検証した。
+
+### Follow-up（本PRでは実装しない）
+
+- `ConciergeClientFull.tsx`のrender test harness整備。
+- Personalizeセクション内、L2/L3-A/L3-B/L3-Cそれぞれの個別開閉
+  （本PRは全体を1つの`isFilterOpen`でまとめたまま、視覚的な
+  section分離のみ実施）。
+- 375/390/430pxのspacing/font size/chip density等のpixel polish
+  （本PRはIA再構成のみ、visual designの磨き込みは対象外）。
+- Color / Design Token全面変更。
+- Recommendation結果画面（`ConciergeSectionsRenderer`の"recommendations"
+  section等）の再設計。
+- 呼び名フィールドのInitial Recommendation Flowからの完全除去
+  （runtime dependencyがあるため今回は視覚的な優先度低下のみ）。


### PR DESCRIPTION
## 目的

[docs/audit/concierge-l1-freetext-final-readiness.md](docs/audit/concierge-l1-freetext-final-readiness.md)のDecision（**CONDITIONAL GO**、Free-text Primary = Yes / Assist chips visibility = medium / L2/L3 collapsed by default = Yes）をFrontendへ実装する。Recommendation Logicの変更ではなく、既存の入力項目をSignal Responsibility（[docs/product/concierge-input-architecture.md](docs/product/concierge-input-architecture.md) §4-§6）に沿ってProgressive Disclosureへ再構成した。

```
Frontend表示            内部Level                          初期状態
Initial（まず相談する）   L1 Consultation                    表示（Primary Input）
Assist（相談を助ける）    Consultation Theme Chips           表示（medium visibility）
Personalize（自分に合わせる） L2 + L3-A + L3-B + L3-C       折りたたみ（変更なし）
```

## 実装

### ConciergeEntryCard.tsx（Initial + Assist）

- 表示順を Headline → Consultation textarea → **Primary CTA** → Assist chips へ変更（従来はCTAがchipsの後ろにあった）。
- textareaのlabelを「必要なら、今の状況を少しだけ書く」から「**今、どんなことが気になっていますか？**」へ変更（Primary Inputとして認識される文言）。
- 相談テーマchipsの見出しを「相談テーマ」から「**うまく言葉にならないとき／近いテーマから選べます**」へ変更し、Alternative Search Methodではなく Consultation Writing Assist であることを明示。chip clickの挙動（`setNeedText`置き換え・編集可能）自体は**変更していない**。
- Level 3-C（参拝予定日・出発地点）をこのcardから完全に除去し、Personalizeセクションへ移設。
- 呼び名・ログイン案内をconsultation flowより後ろへ移動し視覚的な強さを縮小（`sessionNickname`はanonymous snapshot復元・greeting表示に実際に使われているため、削除ではなく優先度低下のみ）。

### ConciergeClientFull.tsx（Personalize / L3-C再配置 / Request Payload抽出）

- Level 3-C（参拝予定日・出発地点）を、既存の`isFilterOpen`トグル内へ新設した「参拝の詳細（任意）」sectionとして再配置。**state・handlerは完全に同一のものを再利用**しており、request payload生成ロジックには一切触れていない。
- Request payload構築ロジック（従来inline実装だった`buildConciergePayload`）を`apps/web/src/features/concierge/buildConciergeRequestPayload.ts`へ純粋関数として抽出。closure変数を明示的なparamsへ置き換えた機械的な移動であり、**同一入力に対する出力は1バイトも変えていない**。これにより、巨大な`ConciergeClientFull`（2000行弱、既存render testなし）をmountせずにrequest payload contractを直接テストできるようになった。

### ConciergeFilterPanel.tsx（L2/L3責務分離）

- 誕生日(L3-A)/参拝スタイル(L2)/ご利益(L3-B)の3ブロックを、それぞれ`aria-label`付きのaccessible sectionへ分離し、同一カテゴリの条件の塊に見えないようにした。
- ご利益ブロックの見出しを「ご利益・願いに近いもの」から「**ご利益を指定する**」へ変更（Explicit Constraintとしての責務を明確化、「おすすめテーマ」等との混同を避ける）。
- preset値・handler・Structured Visit Preference mapping（`PRESET_VISIT_PREFERENCE_TAGS`）は無変更。

## Do Not Change（確認済み、無変更）

query interpretation / need_tags / consultation_axis / visit_preferences payload / birthdate semantics / goriyaku hard filtering / location semantics / visit_date semantics / Ranking weights / Primary Reason / Backend API / DB schema / Migration。

Frontendでneed_tags/consultation_axisを独自判定するコードは追加していない。

## Testing

- `buildConciergeRequestPayload.test.ts`（新規、9件）: L1 only / L1+Assist / L1+L2 / L1+L3-A / L1+L3-B / L1+L3-C / Full Integration の7パターンでrequest payload contractを直接検証。
- `ConciergeEntryCard.test.tsx`（更新）: Initial状態でL2/L3コントロールが存在しないこと、CTAがchipsより前に来ること、呼び名/ログインがconsultation flowより後ろに来ること、L1のみでsubmitできることを検証。
- `ConciergeFilterPanel.sections.test.tsx`（新規、3件）: 誕生日/参拝スタイル/ご利益が個別のaccessible regionとして描画されること、closed時は何も描画しないこと、close→reopenで選択値が保持されることを検証。
- Browser QA（dev server + 実backend接続）:
  - **Case A (Initial)**: textarea/CTA/chipsが最初に表示され、参拝予定日・出発地点・誕生日・ご利益はいずれも初期画面に表示されないことを確認。
  - **Case B (Assist)**: chip clickでtextareaが置き換わり編集可能になることを確認（既存挙動）。
  - **Case C (Personalize)**: 開いてL3-A/L2/L3-B/L3-Cが全て個別のaccessible sectionとして表示、誕生日入力・ご利益選択後に閉じて再度開いても値が保持されることを確認。実際に`POST /api/concierge/chat/`を送信し、`birthdate`（`gogyo:水`マッチ）と`goriyaku_tag_ids`（`matched_user_selected_goriyaku_tag_ids:[1]`）の両方が実際のrecommendation scoringへ反映されたレスポンスを確認 -- Personalize再配置後もrequest payloadがbackendへ正しく伝わることをend-to-endで検証済み。
  - 375px: レイアウト崩れ・横スクロールなしを確認。

```
vitest:     784 passed（既存769 + 新規15件）
typecheck:  tsc -p tsconfig.json --noEmit -> no errors
lint:       eslint . -> no errors（既存の無関係な警告2件のみ、本PRと無関係）
build:      npm run build -> success
```

## Production behavior change

Frontend UI変更のみ。Recommendation Logic / Backend / Ranking / Candidate filtering / Migration = すべて変更なし。

## 関連ドキュメント

[docs/product/concierge-input-architecture.md](docs/product/concierge-input-architecture.md) へ「Addendum: Frontend IA Implementation — Concierge Entry Progressive Disclosure」を追加（Initial/Assist/Personalize state、責務分離、Known Limitation、Follow-upを記録）。

## Follow-up（本PRでは実装しない）

- `ConciergeClientFull.tsx`のrender test harness整備
- Personalizeセクション内、L2/L3-A/L3-B/L3-Cそれぞれの個別開閉
- 375/390/430pxのpixel polish
- Color / Design Token全面変更
- Recommendation結果画面の再設計
- 呼び名フィールドのInitial Flowからの完全除去

🤖 Generated with [Claude Code](https://claude.com/claude-code)