### PR TITLE
Concierge入口のモバイル情報密度とレスポンシブ表示を調整

### DIFF
--- a/apps/web/src/app/concierge/ConciergeClientFull.tsx
+++ b/apps/web/src/app/concierge/ConciergeClientFull.tsx
@@ -1759,7 +1759,7 @@ export default function ConciergeClientFull() {
                 one disclosure (Task 10's 3-state model), but each
                 responsibility keeps its own labeled subsection so they are
                 not shown as one undifferentiated "条件" pile (Task 11). */}
-            <div className="mt-7 rounded-3xl border border-stone-200/45 bg-stone-50/60 p-4">
+            <div className="mt-5 rounded-3xl border border-stone-200/45 bg-stone-50/60 p-3.5">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="text-[11px] font-medium tracking-[0.2em] text-stone-500">もう少し自分に合わせる（任意）</p>
@@ -1834,10 +1834,10 @@ export default function ConciergeClientFull() {
                       Explicit Constraint above. Same plannedVisitDate/
                       userOrigin state and handlers as before this move --
                       request payload semantics are unchanged. */}
-                  <section aria-label="参拝の詳細（任意）" className="mt-3 rounded-2xl border border-stone-200/50 bg-white/80 p-3">
-                    <p className="text-[10px] font-semibold text-slate-600">参拝の詳細（任意）</p>
+                  <section aria-label="参拝の詳細（任意）" className="mt-2.5 rounded-2xl border border-stone-200/50 bg-white/80 p-2.5">
+                    <p className="text-xs font-semibold text-slate-700">参拝の詳細（任意）</p>
                     <p className="mt-0.5 text-[10px] leading-4 text-slate-400">予定日と出発地点から、神社への方角を補助条件として使います。</p>
-                    <div className="mt-2 grid gap-3 sm:grid-cols-2">
+                    <div className="mt-2 grid gap-2.5 sm:grid-cols-2">
                       <label className="block text-sm font-medium text-stone-600">
                         参拝予定日（任意）
                         <input

--- a/apps/web/src/features/concierge/components/ConciergeEntryCard.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeEntryCard.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState } from "react";
+
 type ConciergeEntryExample = {
   label: string;
   text: string;
@@ -26,6 +28,13 @@ type Props = {
   onSubmit: () => void;
   onClear: () => void;
 };
+
+// Assist chips shown before "ほかのテーマも見る" (Concierge Entry
+// Responsive / Density Polish Task 4): a display-only cap over the same
+// feelExamples array. onPickExample/signal semantics are unchanged --
+// every example remains reachable, just not all visible by default, so
+// Assist stays medium visibility instead of dominating the page height.
+const INITIAL_VISIBLE_EXAMPLES = 4;
 
 // Concierge Entry Frontend IA v2 (docs/product/concierge-input-architecture.md,
 // Frontend IA Implementation Addendum; docs/audit/concierge-l1-freetext-final-readiness.md
@@ -56,12 +65,16 @@ export default function ConciergeEntryCard({
   onSubmit,
   onClear,
 }: Props) {
+  const [showAllExamples, setShowAllExamples] = useState(false);
+  const hasMoreExamples = feelExamples.length > INITIAL_VISIBLE_EXAMPLES;
+  const visibleExamples = showAllExamples ? feelExamples : feelExamples.slice(0, INITIAL_VISIBLE_EXAMPLES);
+
   return (
     <>
-      <div className="space-y-1.5 rounded-3xl border border-stone-200/10 bg-stone-50/30 px-4 py-4">
+      <div className="space-y-1 rounded-3xl border border-stone-200/10 bg-stone-50/30 px-4 py-3.5">
         <div>
           <p className="text-[9px] font-normal tracking-[0.24em] text-[var(--kt-color-text-muted)] opacity-70">KAMI MUSUBI GUIDE</p>
-          <h1 className="mt-1.5 text-lg font-medium leading-7 text-[var(--kt-color-text-primary)]">相談から、向かう神社を見つける</h1>
+          <h1 className="mt-1 text-lg font-medium leading-6 text-[var(--kt-color-text-primary)]">相談から、向かう神社を見つける</h1>
         </div>
         <p className="text-sm leading-6 text-[var(--kt-color-text-muted)] opacity-85">
           {displayName
@@ -71,7 +84,7 @@ export default function ConciergeEntryCard({
       </div>
 
       {/* Level 1 Consultation -- Primary Input */}
-      <div className="mt-5 space-y-4">
+      <div className="mt-4 space-y-3.5">
         <div>
           <label htmlFor="concierge-input" className="mb-1.5 block text-sm font-medium text-[var(--kt-color-text-primary)]">
             今、どんなことが気になっていますか？
@@ -81,7 +94,7 @@ export default function ConciergeEntryCard({
             value={needText}
             onChange={(e) => setNeedText(e.target.value)}
             placeholder="例: 仕事の迷いを整理したい、少し休みたい"
-            rows={4}
+            rows={3}
             autoFocus
             className="w-full rounded-3xl border border-stone-200/30 bg-white px-3 py-2.5 text-sm leading-7 text-[var(--kt-color-text-primary)] outline-none transition placeholder:text-stone-400 placeholder:opacity-60 focus:border-emerald-300/60 focus:ring-1 focus:ring-emerald-100/60"
           />
@@ -90,7 +103,7 @@ export default function ConciergeEntryCard({
         <div className="flex flex-col gap-1.5 sm:flex-row">
           <button
             type="button"
-            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-emerald-300 bg-emerald-50/50 px-3 py-2 text-sm font-medium text-emerald-800 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-emerald-100/40 disabled:cursor-not-allowed disabled:opacity-40"
+            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] bg-[var(--kt-color-action-primary)] px-3 py-2 text-sm font-semibold text-[var(--kt-color-action-primary-text)] shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-[var(--kt-color-action-primary-hover)] disabled:cursor-not-allowed disabled:bg-stone-200 disabled:text-stone-400 disabled:shadow-none"
             disabled={isBusy || !needText.trim() || !canSend}
             onClick={onSubmit}
           >
@@ -99,7 +112,7 @@ export default function ConciergeEntryCard({
 
           <button
             type="button"
-            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-strong)] bg-stone-50/25 px-3 py-2 text-sm font-medium text-[var(--kt-color-text-secondary)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-stone-100/30 disabled:cursor-not-allowed disabled:border-stone-200 disabled:bg-stone-100 disabled:text-stone-400 disabled:opacity-40"
+            className="min-h-11 w-full rounded-[var(--kt-radius-pill)] border border-transparent bg-transparent px-3 py-2 text-sm font-medium text-[var(--kt-color-text-muted)] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-600 focus-visible:ring-offset-2 hover:bg-stone-100/50 hover:text-[var(--kt-color-text-secondary)] disabled:cursor-not-allowed disabled:opacity-40 sm:w-auto sm:shrink-0 sm:px-4"
             disabled={isBusy}
             onClick={onClear}
           >
@@ -110,12 +123,13 @@ export default function ConciergeEntryCard({
         {/* Assist: Consultation Writing Assist chips (medium visibility) --
             not an alternative search route. Picking one replaces the
             textarea with an editable starting sentence (onPickExample),
-            the same signal path as typing it manually. */}
-        <section aria-label="相談テーマから選ぶ" className="pt-1">
+            the same signal path as typing it manually. A border-t marks a
+            clear visual break from the Primary CTA above (Task 3/4). */}
+        <section aria-label="相談テーマから選ぶ" className="border-t border-stone-200/25 pt-3.5">
           <p className="text-[11px] font-medium text-[var(--kt-color-text-muted)] opacity-75">うまく言葉にならないとき</p>
           <p className="text-[11px] text-[var(--kt-color-text-muted)] opacity-60">近いテーマから選べます</p>
-          <div className="mt-2.5 flex flex-wrap gap-2">
-            {feelExamples.map((example) => {
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {visibleExamples.map((example) => {
               const isSelected = needText.trim() === example.text;
               return (
                 <button
@@ -138,6 +152,16 @@ export default function ConciergeEntryCard({
               );
             })}
           </div>
+          {hasMoreExamples ? (
+            <button
+              type="button"
+              className="mt-2 text-xs font-medium text-[var(--kt-color-text-muted)] underline-offset-2 hover:text-[var(--kt-color-text-secondary)] hover:underline"
+              onClick={() => setShowAllExamples((prev) => !prev)}
+              aria-expanded={showAllExamples}
+            >
+              {showAllExamples ? "テーマを閉じる" : `ほかのテーマも見る（他${feelExamples.length - INITIAL_VISIBLE_EXAMPLES}件）`}
+            </button>
+          ) : null}
         </section>
       </div>
 
@@ -145,7 +169,7 @@ export default function ConciergeEntryCard({
           visual prominence (Task 9). Kept (not removed): sessionNickname has
           a runtime dependency (anonymous snapshot restore, greeting copy in
           ConciergeClientFull). */}
-      <div className="mt-6 space-y-3 border-t border-stone-200/20 pt-4">
+      <div className="mt-5 space-y-2.5 border-t border-stone-200/20 pt-3.5">
         <div>
           <label
             htmlFor="concierge-entry-nickname"

--- a/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeFilterPanel.tsx
@@ -149,7 +149,7 @@ export default function ConciergeFilterPanel({
   return (
     <section className="mx-auto w-full max-w-md min-w-0 space-y-2 rounded-xl border border-slate-200 bg-slate-50/60 p-2 sm:max-h-none">
       <div className="flex items-center justify-between">
-        <div className="text-[10px] font-semibold text-slate-600">{title}</div>
+        <div className="text-xs font-semibold text-slate-700">{title}</div>
         <button type="button" className="text-[11px] font-semibold text-slate-600 hover:underline" onClick={onClose}>
           閉じる
         </button>
@@ -175,7 +175,7 @@ export default function ConciergeFilterPanel({
         ) : null}
 
         {/* Level 2 Visit Preference */}
-        <section aria-label="今回の参拝の希望（任意）" className="space-y-2">
+        <section aria-label="今回の参拝の希望（任意）" className="space-y-1.5">
           <div>
             <div className="text-[10px] font-semibold text-slate-600">参拝スタイル</div>
             <p className="mt-0.5 text-[10px] leading-4 text-slate-400">
@@ -184,17 +184,17 @@ export default function ConciergeFilterPanel({
           </div>
 
           {QUICK_PRESET_GROUPS.map((group) => (
-            <div key={group.title} className="space-y-1 rounded-lg border border-slate-100 bg-slate-50/60 p-2">
+            <div key={group.title} className="space-y-1 rounded-lg border border-slate-100 bg-slate-50/60 p-1.5">
               <div>
                 <div className="text-[10px] font-semibold text-slate-600">{group.title}</div>
                 <p className="mt-0.5 text-[10px] leading-4 text-slate-400">{group.description}</p>
               </div>
-              <div className="flex flex-wrap gap-1.5">
+              <div className="flex flex-wrap gap-1">
                 {group.items.map((p) => (
                   <button
                     key={p.label}
                     type="button"
-                    className="rounded-full border bg-[var(--kt-color-surface-default)] px-3 py-1 text-xs font-semibold hover:bg-slate-50"
+                    className="rounded-full border bg-[var(--kt-color-surface-default)] px-2.5 py-1 text-xs font-semibold hover:bg-slate-50"
                     onClick={() => {
                       onExtraConditionChange(mergeExtra(extraCondition, p.value));
                       const tags = PRESET_VISIT_PREFERENCE_TAGS[p.label];
@@ -225,7 +225,7 @@ export default function ConciergeFilterPanel({
                   <button
                     key={t.id}
                     type="button"
-                    className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
                       on ? "border-emerald-600 bg-emerald-50" : "bg-white"
                     }`}
                     onClick={() => onToggleTag(t.id)}
@@ -261,7 +261,7 @@ export default function ConciergeFilterPanel({
                   <button
                     key={t.id}
                     type="button"
-                    className={`rounded-full border px-3 py-1 text-xs font-semibold ${
+                    className={`rounded-full border px-2.5 py-1 text-xs font-semibold ${
                       on ? "border-emerald-600 bg-emerald-50" : "bg-white"
                     }`}
                     onClick={() => onToggleTag(t.id)}

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -697,38 +697,41 @@ export default function ConciergeSectionsRenderer({
               );
             }
 
+            // ConciergeFilterPanel already renders its own title + close
+            // control as a self-contained bordered section (see
+            // ConciergeFilterPanel.tsx). Wrapping it in DetailSection here
+            // duplicated the same title text twice and added a second
+            // nested border/padding layer -- Concierge Entry Responsive /
+            // Density Polish Task 6 removed that redundancy; no signal or
+            // behavior change.
             return (
               <div key={`filter-${i}-open`}>
-                <DetailSection title={title}>
-                  <div>
-                    <ConciergeFilterPanel
-                      isOpen
-                      title={title}
-                      onClose={() => onAction?.({ type: "filter_close" })}
-                      onApply={() => {
-                        onAction?.({ type: "filter_apply" });
-                      }}
-                      canApply={canApplyCompatFilter}
-                      birthdate={state.birthdate}
-                      onBirthdateChange={(v: string) => onAction?.({ type: "filter_set_birthdate", birthdate: v })}
-                      element4={state.element4}
-                      goriyakuTags={state.goriyakuTags}
-                      suggestedTags={state.suggestedTags}
-                      selectedTagIds={state.selectedTagIds}
-                      onToggleTag={(tagId: number) => onAction?.({ type: "filter_toggle_tag", tagId })}
-                      tagsLoading={state.tagsLoading}
-                      tagsError={state.tagsError}
-                      extraCondition={state.extraCondition}
-                      onExtraConditionChange={(v: string) =>
-                        onAction?.({ type: "filter_set_extra", extraCondition: v })
-                      }
-                      visitPreferences={state.visitPreferences}
-                      onVisitPreferencesChange={(tags: string[]) =>
-                        onAction?.({ type: "filter_set_visit_preferences", visitPreferences: tags })
-                      }
-                    />
-                  </div>
-                </DetailSection>
+                <ConciergeFilterPanel
+                  isOpen
+                  title={title}
+                  onClose={() => onAction?.({ type: "filter_close" })}
+                  onApply={() => {
+                    onAction?.({ type: "filter_apply" });
+                  }}
+                  canApply={canApplyCompatFilter}
+                  birthdate={state.birthdate}
+                  onBirthdateChange={(v: string) => onAction?.({ type: "filter_set_birthdate", birthdate: v })}
+                  element4={state.element4}
+                  goriyakuTags={state.goriyakuTags}
+                  suggestedTags={state.suggestedTags}
+                  selectedTagIds={state.selectedTagIds}
+                  onToggleTag={(tagId: number) => onAction?.({ type: "filter_toggle_tag", tagId })}
+                  tagsLoading={state.tagsLoading}
+                  tagsError={state.tagsError}
+                  extraCondition={state.extraCondition}
+                  onExtraConditionChange={(v: string) =>
+                    onAction?.({ type: "filter_set_extra", extraCondition: v })
+                  }
+                  visitPreferences={state.visitPreferences}
+                  onVisitPreferencesChange={(tags: string[]) =>
+                    onAction?.({ type: "filter_set_visit_preferences", visitPreferences: tags })
+                  }
+                />
               </div>
             );
           }

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeEntryCard.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeEntryCard.test.tsx
@@ -126,6 +126,52 @@ describe("ConciergeEntryCard", () => {
     expect(redirectToAuth).toHaveBeenCalledWith("register");
   });
 
+  it("Assist density: caps visible chips and reveals the rest via ほかのテーマも見る (Concierge Entry Responsive/Density Polish Task 4)", () => {
+    const eightExamples = [
+      { label: "仕事について考えたい", text: "仕事の相談です" },
+      { label: "人との関係を整えたい", text: "人間関係の相談です" },
+      { label: "お金の流れを整えたい", text: "お金の相談です" },
+      { label: "一歩踏み出したい", text: "一歩踏み出したいです" },
+      { label: "少し休みたい", text: "休みたいです" },
+      { label: "体調を整えたい", text: "体調の相談です" },
+      { label: "学びを深めたい", text: "学びの相談です" },
+      { label: "これからを考えたい", text: "これからの相談です" },
+    ];
+
+    render(<ConciergeEntryCard {...baseProps} feelExamples={eightExamples} />);
+
+    // Signal semantics are unchanged -- every example is still reachable
+    // via the same onPickExample handler, only display visibility is
+    // capped so Assist stays medium visibility instead of dominating the
+    // page (Core Principle: chips must not visually outweigh Consultation).
+    for (const example of eightExamples.slice(0, 4)) {
+      expect(screen.getByRole("button", { name: example.label })).toBeInTheDocument();
+    }
+    for (const example of eightExamples.slice(4)) {
+      expect(screen.queryByRole("button", { name: example.label })).not.toBeInTheDocument();
+    }
+
+    const expandButton = screen.getByRole("button", { name: /ほかのテーマも見る/ });
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(expandButton);
+
+    for (const example of eightExamples) {
+      expect(screen.getByRole("button", { name: example.label })).toBeInTheDocument();
+    }
+    const collapseButton = screen.getByRole("button", { name: "テーマを閉じる" });
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(collapseButton);
+    for (const example of eightExamples.slice(4)) {
+      expect(screen.queryByRole("button", { name: example.label })).not.toBeInTheDocument();
+    }
+  });
+
+  it("does not show ほかのテーマも見る when there are 4 or fewer examples", () => {
+    render(<ConciergeEntryCard {...baseProps} />);
+    expect(screen.queryByRole("button", { name: /ほかのテーマも見る/ })).not.toBeInTheDocument();
+  });
+
   it("disables the primary CTA while empty, busy, or blocked, but not the chips before text is entered", () => {
     const { rerender } = render(<ConciergeEntryCard {...baseProps} needText="" />);
     expect(screen.getByRole("button", { name: "この相談で神社を提案してもらう" })).toBeDisabled();

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.coverage.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.coverage.test.tsx
@@ -141,6 +141,20 @@ describe("ConciergeSectionsRenderer - 既存経路のCoverage補完", () => {
     expect(onAction).toHaveBeenCalledWith({ type: "filter_apply" });
   });
 
+  it("補助条件(開いた状態)ではConciergeFilterPanelのタイトルが重複表示されない(Concierge Entry Responsive/Density Polish)", () => {
+    const onAction = vi.fn();
+    const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
+    const payload = buildTestPayload(u, { ...baseFilterState, isOpen: true });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} onAction={onAction} />);
+
+    // ConciergeFilterPanel renders its own title + close header as a
+    // self-contained section; the outer DetailSection wrapper that used
+    // to duplicate the same title text was removed. Guards against that
+    // regression coming back. (buildPayloadFromUnified sets this filter
+    // section's title to "条件を追加".)
+    expect(screen.getAllByText("条件を追加")).toHaveLength(1);
+  });
+
   it("window custom event concierge:open-filterでadd_conditionが発火する", () => {
     const onAction = vi.fn();
     const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };


### PR DESCRIPTION
## 目的

PR #2413で実装したFrontend IA（Initial=L1自由相談 / Assist=相談テーマchips / Personalize=L2/L3）の構造は維持したまま、375/390/430pxにおける情報密度・余白・視線誘導・操作性を整える。今回の目的は構造の再設計ではなく、完成したIAのモバイル最適化。

## Before / After（375px, first viewport）

**Before**: header + hero card(大) + textarea(4行) + pale outlineのCTA/クリア(同格の見た目) + 8件のchipsが常時全部縦積み → Assistまでたどり着くのに複数スクロールが必要。

**After**: header + hero card(詰め) + textarea(3行) + solid fillのCTA(クリアは控えめなテキストリンク) + border区切り + chips初期4件+「ほかのテーマも見る」展開 → 375x812でCTAはもちろん、Assistの展開リンクまでfirst viewportに収まる。

## 実装

### ConciergeEntryCard.tsx
- Primary CTAを、pale outlineから既存の`--kt-color-action-primary`系トークンを使うsolid fillへ変更。クリアは透明背景のテキストリンク調へ変更し、CTAと視覚的に同格に見えないようにした（Core Principle: chips/Personalize/nickname/loginがConsultationより強くならない、の裏返しとしてCTA自体の優位性も明確化）。
- textareaを`rows=4`→`rows=3`へ、hero cardのpadding/marginを詰めた。
- CTA/クリアとAssist chipsの間に`border-t`の視覚的区切りを追加。
- Assist chipsを**初期4件表示+「ほかのテーマも見る」展開**へ変更。表示件数を制限するだけの純粋なUI状態で、`feelExamples`配列・`onPickExample`ハンドラ・signal semanticsは無変更（8件全部が常時1列に並んでいた状態を解消）。
- 呼び名/ログイン案内のmargin/paddingを詰めてさらに優先度を下げた。

### ConciergeSectionsRenderer.tsx
- Personalize展開時、`ConciergeFilterPanel`を包む外側の`DetailSection`wrapperを削除。`ConciergeFilterPanel`自身が同じ`title`を持つheader（+閉じるボタン）を既に描画しており、**タイトルの二重表示と入れ子borderの二重描画**になっていた（Browser QAで実際に確認して修正、regressionテストも追加）。

### ConciergeFilterPanel.tsx
- 唯一のheadingになったpanel titleを少し強調（`text-[10px]`→`text-xs`、色も一段濃く）。
- L2 参拝スタイルのpreset group padding/gap/chip paddingを詰めた。
- preset値・handler・Structured Visit Preference mappingは無変更。

### ConciergeClientFull.tsx
- Personalize toggleカードとL3-C「参拝の詳細」sectionのpadding/marginを詰めた。state・handlerは無変更、request payload生成ロジックには一切触れていない。
- L2/L3-A/L3-B/L3-Cの個別開閉（accordion nesting）は、実装コストと今回のscopeを鑑みて見送り、Follow-upとした（既存のsection分離+Personalize全体トグルのままで対応）。

## Do Not Change（確認済み、無変更）

query handling / chips behavior / visit_preferences / birthdate / goriyaku_tag_ids / location / visit_date / request payload / Backend API / Recommendation scoring / Ranking / Candidate filtering / Primary Reason / Migration。Color / Design Tokenの新規追加はなし（既存トークンの再利用のみ）。Recommendation結果画面は変更していない。

## Testing

- 新規: Assist density（初期4件表示 + 展開/折りたたみ、`feelExamples`が4件以下では展開リンクが出ないこと）
- 新規: Personalize展開時のtitle重複解消のregressionテスト
- 既存784件テストは変更なしで全てpass

```
vitest:      787 passed（既存784 + 新規3件）
typecheck:   tsc -p tsconfig.json --noEmit -> no errors
lint:        eslint . -> no errors（既存の無関係な警告2件のみ）
build:       npm run build -> success
E2E:         pnpm test:e2e:ci -> 12 passed（05_direction_flow.spec.ts、375px+文字拡大ケース含む）
```

## Browser QA

375px / 390px / 430px / desktopでInitial・Assist・Personalizeを確認。

- 横スクロールなし（`scrollWidth <= clientWidth`を確認）
- 375x812では、CTAはもちろんAssistの「ほかのテーマも見る」展開リンクまでfirst viewportに収まる
- Personalize展開でL3-A(誕生日)/L2(参拝スタイル)/L3-B(ご利益)/L3-C(参拝の詳細)が個別のaccessible sectionとして表示され、titleの重複が解消されていることを確認
- 誕生日入力→Personalize閉じる→再度開く、で入力値が保持されることを確認
- desktopではCTA/クリアが横並びになり、クリアが控えめなテキストリンクとして自然に収まることを確認

## 関連ドキュメント

- [docs/product/concierge-input-architecture.md](docs/product/concierge-input-architecture.md)（Frontend IA Implementation Addendum、PR #2413で追加済み、本PRは同Addendumの実装を維持したままの密度調整のため追記なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)