### PR TITLE
Recommendation Signal Authority Contract Tests

### DIFF
--- a/backend/temples/tests/services/test_signal_authority_conflict_contract.py
+++ b/backend/temples/tests/services/test_signal_authority_conflict_contract.py
@@ -1,0 +1,99 @@
+# backend/temples/tests/services/test_signal_authority_conflict_contract.py
+"""Recommendation Signal Authority: Conflict Rules (§9).
+
+Source of truth: docs/product/recommendation-signal-authority.md §9
+"Conflict Rules", which extends the 5 existing Priority/Override Rules of
+docs/product/concierge-input-architecture.md §9 with the Signals newly
+measured in the audit (PR #2415) and formally decided in PR #2416.
+
+This module covers the two Conflict Rules that had no existing regression
+test as of PR #2416 (confirmed by a dedicated test-coverage survey before
+writing this module):
+
+- Semantic Fit vs Distance: "現行default weights（public_mode="need",
+  flow="A"）でSemantic Fitが優位" -- a Semantic Fit match (need_tags) must
+  not be structurally dominated by Distance (Context) under current
+  default weights.
+- Semantic Fit vs Popularity: same relationship for Popularity (Secondary).
+
+The other 3 Conflict Rules already have dedicated regression coverage and
+are intentionally NOT duplicated here (Phase 9: "既存テストとの重複が多い
+場合は、既存テストを正本Decisionへ接続する形でも構いません"):
+
+- Intent vs Birth Profile (Intent wins):
+  test_concierge_primary_reason_unification_contract.py::test_conflict_consultation_plus_profile_meaning_wins_primary
+- Intent vs Visit Preference (Intent wins, need_tag priority(2) < visit_style priority(7)):
+  test_concierge_primary_reason_unification_contract.py::test_conflict_consultation_plus_visit_preference_meaning_wins_primary
+  test_concierge_primary_reason_unification_contract.py::test_visit_style_is_a_priority_tier_below_element_above_fallback
+- Intent vs Explicit Constraint (Explicit Constraint excludes at the
+  Candidate SET level, not a ranking-priority competition):
+  services/test_signal_authority_eligibility_contract.py::test_goriyaku_tag_ids_is_a_db_level_candidate_eligibility_filter
+
+This module does not change production code, ranking weight, candidate
+filtering, or reason generation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+
+
+def _shrine(id_, name, **overrides):
+    base = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+@pytest.mark.django_db
+def test_semantic_fit_vs_distance_conflict_favors_semantic_fit(deterministic):
+    """§9 Semantic Fit vs Distance: a candidate with a genuine need_tags
+    match must not be structurally dominated by a far-but-empty candidate's
+    proximity advantage alone, under current default weights (public_mode
+    ="need", flow="A")."""
+    a_semantic_far = _shrine(1, "A_semantic_far", astro_tags=["career"], distance_m=30000, popular_score=1.0)
+    b_weak_near = _shrine(2, "B_weak_near", astro_tags=[], distance_m=200, popular_score=1.0)
+
+    recs = build_chat_recommendations(
+        query="", language="ja", candidates=[a_semantic_far, b_weak_near], need_tags=["career"],
+    )
+    assert recs["recommendations"][0]["name"] == "A_semantic_far"
+    assert recs["recommendations"][0]["_primary_reason_source"] == "need_tag"
+
+
+@pytest.mark.django_db
+def test_semantic_fit_vs_popularity_conflict_favors_semantic_fit(deterministic):
+    """§9 Semantic Fit vs Popularity: a candidate with a genuine need_tags
+    match must not be structurally dominated by a popular-but-empty
+    candidate's popularity advantage alone, under current default weights."""
+    a_semantic_unpopular = _shrine(1, "A_semantic_unpopular", astro_tags=["career"], popular_score=0.0, distance_m=1000)
+    b_weak_popular = _shrine(2, "B_weak_popular", astro_tags=[], popular_score=10.0, distance_m=1000)
+
+    recs = build_chat_recommendations(
+        query="", language="ja", candidates=[a_semantic_unpopular, b_weak_popular], need_tags=["career"],
+    )
+    assert recs["recommendations"][0]["name"] == "A_semantic_unpopular"
+    assert recs["recommendations"][0]["_primary_reason_source"] == "need_tag"

--- a/backend/temples/tests/services/test_signal_authority_eligibility_contract.py
+++ b/backend/temples/tests/services/test_signal_authority_eligibility_contract.py
@@ -1,0 +1,130 @@
+# backend/temples/tests/services/test_signal_authority_eligibility_contract.py
+"""Recommendation Signal Authority: Eligibility Contract (goriyaku_tag_ids).
+
+Source of truth: docs/product/recommendation-signal-authority.md §5/§6/§9.
+`goriyaku_tag_ids` is the only Signal classified as **Eligibility**: it is
+the only current DB-level hard filter that can change the Candidate SET
+(§5 Eligibility Definition), and by design it contributes **zero** Rank
+score once a candidate has already passed that filter (§6 Decision Table
+row: "Eligibility + Explanation, Rank非寄与を維持"; §9 "Intent vs Explicit
+Constraint"). This module fixes both halves of that asymmetric contract as
+regression tests, plus the visible-reason condition under which the
+constraint shows up in Explanation.
+
+This module does not change production code, ranking weight, candidate
+filtering, or reason generation -- it only asserts against the existing
+`build_chat_candidates()` / `build_chat_recommendations()` facades.
+
+Cross-reference (already covered, not duplicated here): the general
+user_selected_tag reason-fact/priority behavior is covered by
+test_concierge_chat_observation.py::test_build_reason_facts_generates_user_selected_tag_reason,
+::test_resolve_primary_reason_prefers_need_tag_over_user_selected_tag,
+::test_attach_breakdown_sets_user_selected_tag_as_primary_reason, and
+test_concierge_primary_reason_unification_contract.py::test_conflict_consultation_plus_constraint_meaning_wins_when_present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.models import GoriyakuTag, Shrine
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_candidates import build_chat_candidates
+
+
+@pytest.fixture
+def shrine_factory(db):
+    def _factory(*, name: str, goriyaku_tags=None, **overrides) -> Shrine:
+        base = dict(
+            name_jp=name,
+            address="東京都千代田区1-1",
+            latitude=35.0,
+            longitude=139.0,
+            popular_score=1.0,
+        )
+        base.update(overrides)
+        shrine = Shrine.objects.create(**base)
+        if goriyaku_tags:
+            shrine.goriyaku_tags.set(goriyaku_tags)
+        return shrine
+
+    return _factory
+
+
+@pytest.mark.django_db
+def test_goriyaku_tag_ids_is_a_db_level_candidate_eligibility_filter(shrine_factory):
+    """§5/§9: requesting goriyaku_tag_ids removes non-matching shrines from
+    the Candidate SET itself (Eligibility), not just from the ranked
+    order."""
+    tag = GoriyakuTag.objects.create(name="健康祈願")
+    shrine_factory(name="条件を満たす神社", goriyaku_tags=[tag])
+    shrine_factory(name="条件を満たさない神社")
+
+    unfiltered = build_chat_candidates(lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=None, trace_id="test")
+    unfiltered_names = [c["name"] for c in unfiltered]
+    assert "条件を満たす神社" in unfiltered_names
+    assert "条件を満たさない神社" in unfiltered_names
+
+    filtered = build_chat_candidates(lat=35.0, lng=139.0, area=None, goriyaku_tag_ids=[tag.id], trace_id="test")
+    filtered_names = [c["name"] for c in filtered]
+    assert "条件を満たす神社" in filtered_names
+    assert "条件を満たさない神社" not in filtered_names
+
+
+def _shrine(id_, name, **overrides):
+    base = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.django_db
+def test_goriyaku_tag_ids_match_is_not_double_rewarded_in_rank_score(settings):
+    """§6: once a candidate has already passed the goriyaku_tag_ids hard
+    filter, matching it must not additionally raise
+    score_need_rank_weighted -- the only two rank contributors matched_by_tag
+    (need_tags <-> astro_tags) and matched_by_gid (need_tags <-> shrine's own
+    goriyaku_tag_ids) are untouched by matched_by_user_selected_gid
+    (requested goriyaku_tag_ids)."""
+    settings.CONCIERGE_USE_LLM = False
+    REQUESTED_GID = 501
+
+    matching = _shrine(1, "A_matches_requested_gid", goriyaku_tag_ids=[REQUESTED_GID])
+    non_matching = _shrine(2, "B_does_not_match", goriyaku_tag_ids=[])
+
+    recs = build_chat_recommendations(
+        query="", language="ja", candidates=[matching, non_matching],
+        goriyaku_tag_ids=[REQUESTED_GID],
+    )
+    by_name = {r["name"]: r for r in recs["recommendations"]}
+
+    a_need = by_name["A_matches_requested_gid"]["breakdown_detail"]["features"]["need"]
+    b_need = by_name["B_does_not_match"]["breakdown_detail"]["features"]["need"]
+    assert a_need["rank_weighted"] == b_need["rank_weighted"] == 0.0
+    assert a_need["matched_by_gid_count"] == b_need["matched_by_gid_count"] == 0
+    assert a_need["matched_by_tag_count"] == b_need["matched_by_tag_count"] == 0
+
+    # The Explicit Constraint match is still visible as a fact (Explanation
+    # half of the contract, score=3.0 fixed weight) -- it is Eligibility +
+    # Explanation, not silently invisible.
+    a_fact_types = {f["type"]: f for f in by_name["A_matches_requested_gid"]["_reason_facts"]}
+    assert "user_selected_tag" in a_fact_types
+    assert a_fact_types["user_selected_tag"]["score"] == 3.0
+    b_fact_types = {f["type"] for f in by_name["B_does_not_match"]["_reason_facts"]}
+    assert "user_selected_tag" not in b_fact_types

--- a/backend/temples/tests/services/test_signal_authority_knowledge_explanation_contract.py
+++ b/backend/temples/tests/services/test_signal_authority_knowledge_explanation_contract.py
@@ -1,0 +1,152 @@
+# backend/temples/tests/services/test_signal_authority_knowledge_explanation_contract.py
+"""Recommendation Signal Authority: Knowledge Authority (§8) + Explanation
+Contract (§10).
+
+Source of truth: docs/product/recommendation-signal-authority.md. This
+module fixes two related Decisions as regression tests:
+
+- §8 Knowledge Authority (Decision A, current-state Explanation-only):
+  `deity` / `shrine_history` / `knowledge_deities` / `knowledge_histories`
+  must never change the Candidate SET or Rank/score under the current
+  Contract ("Rank Changed = No"). This is not a data-coverage limitation
+  to work around -- it is a deliberate current decision (§8 reasons 1-4),
+  and this test asserts the Authority Contract (Rank never changes), not
+  private implementation detail of *how* knowledge is excluded from
+  scoring (so that a future Knowledge Ranking promotion, §8 Future
+  Candidate D, does not require touching this test).
+- §10 Explanation Contract: the visible "why this shrine" explanation
+  (`_reason_facts` / `_primary_reason_source` / `_explanation_payload`)
+  must never attribute Candidate/Rank authorship to an Explanation-only
+  Knowledge signal, even when a separate, independent pathway
+  (`recommendation_reason_v4`) legitimately uses the same Knowledge data
+  as a Fact layer.
+
+This module does not change production code, ranking weight, candidate
+filtering, reason generation, or UI.
+
+Cross-reference (already covered, not duplicated here):
+- Knowledge -> recommendation_reason_v4 Fact-layer wording rules:
+  services/test_recommendation_reason_v4.py (extensive dedicated coverage)
+- recommendation_reason_v4_detail is a separate field from reason/_reason_facts:
+  services/test_concierge_chat_observation.py::test_build_chat_recommendations_attaches_recommendation_reason_v4_detail
+- Internal consistency across primary_reason_source/_primary_reason_label/reason_facts:
+  test_concierge_primary_reason_unification_contract.py::test_full_integration_primary_reason_is_unified_and_consultation_led
+  test_concierge_primary_reason_unification_contract.py::test_no_consultation_match_visit_style_only_becomes_unified_primary_reason
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+
+
+def _shrine(id_, name, **overrides):
+    base = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+    base.update(overrides)
+    return base
+
+
+KNOWLEDGE_DEITIES = [{"display_name": "天照大神", "confidence": "high"}]
+KNOWLEDGE_HISTORIES = [
+    {"history_type": "founding", "title": "創建の由緒", "content": "天照大神を祀る由緒ある神社です。", "confidence": "high"}
+]
+
+
+@pytest.fixture
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+@pytest.mark.django_db
+def test_knowledge_fields_never_change_score_or_rank(deterministic):
+    """§8 Decision A: knowledge_deities/knowledge_histories (and their
+    Legacy-fallback counterparts deity/shrine_history) must contribute
+    exactly zero to _score_total, regardless of whether the query text
+    matches the knowledge content."""
+    without_knowledge = _shrine(1, "A_no_knowledge")
+    with_knowledge = _shrine(
+        1, "A_no_knowledge",
+        knowledge_deities=KNOWLEDGE_DEITIES,
+        knowledge_histories=KNOWLEDGE_HISTORIES,
+    )
+
+    recs_without = build_chat_recommendations(
+        query="天照大神にお参りしたいです", language="ja", candidates=[without_knowledge],
+    )
+    recs_with = build_chat_recommendations(
+        query="天照大神にお参りしたいです", language="ja", candidates=[with_knowledge],
+    )
+
+    score_without = recs_without["recommendations"][0]["_score_total"]
+    score_with = recs_with["recommendations"][0]["_score_total"]
+    assert score_without == score_with
+
+
+@pytest.mark.django_db
+def test_knowledge_richness_does_not_overtake_a_context_favored_candidate(deterministic):
+    """§8: a candidate with rich, query-matching Knowledge content but weak
+    distance/popularity must not be able to overtake a Context-favored
+    candidate purely on the strength of its Knowledge data -- Knowledge is
+    Explanation-only, it carries no Candidate/Rank authority at all (unlike
+    Primary-tier signals, which legitimately can order-flip, see
+    test_signal_authority_primary_and_guard_contract.py)."""
+    a_knowledge_rich = _shrine(
+        1, "A_knowledge_rich",
+        knowledge_deities=KNOWLEDGE_DEITIES, knowledge_histories=KNOWLEDGE_HISTORIES,
+        distance_m=20000, popular_score=0.0,
+    )
+    b_context_favored = _shrine(2, "B_context_favored", distance_m=100, popular_score=8.0)
+
+    recs = build_chat_recommendations(
+        query="天照大神にお参りしたいです", language="ja",
+        candidates=[a_knowledge_rich, b_context_favored],
+    )
+    assert recs["recommendations"][0]["name"] == "B_context_favored"
+
+
+@pytest.mark.django_db
+def test_explanation_never_attributes_ranking_to_knowledge_only_signal(deterministic):
+    """§10 Explanation Contract: _reason_facts / _primary_reason_source /
+    _explanation_payload must never contain a Knowledge-derived type
+    ("deity"/"shrine_history"), even though the independent
+    recommendation_reason_v4 pathway legitimately surfaces the same
+    Knowledge content as a Fact layer. A candidate with rich Knowledge data
+    but zero Consultation Meaning match must fall back to "fallback", not
+    a Knowledge-flavored reason."""
+    candidate = _shrine(
+        1, "A_knowledge_only",
+        knowledge_deities=KNOWLEDGE_DEITIES, knowledge_histories=KNOWLEDGE_HISTORIES,
+    )
+    recs = build_chat_recommendations(
+        query="天照大神にお参りしたいです", language="ja", candidates=[candidate],
+    )
+    rec = recs["recommendations"][0]
+
+    assert rec["_primary_reason_source"] == "fallback"
+    fact_types = {f["type"] for f in rec["_reason_facts"]}
+    assert fact_types.isdisjoint({"deity", "shrine_history", "knowledge", "knowledge_deities", "knowledge_histories"})
+    assert rec["_explanation_payload"]["primary_reason"]["type"] == "fallback"
+
+    # The separate recommendation_reason_v4 Fact-layer pathway is untouched
+    # by this Contract and may legitimately reference the deity.
+    assert rec.get("recommendation_reason_v4_detail", {}).get("fact") is not None

--- a/backend/temples/tests/services/test_signal_authority_primary_and_guard_contract.py
+++ b/backend/temples/tests/services/test_signal_authority_primary_and_guard_contract.py
@@ -1,0 +1,257 @@
+# backend/temples/tests/services/test_signal_authority_primary_and_guard_contract.py
+"""Recommendation Signal Authority: Primary Recommendation Contract + Non-Primary Guard.
+
+Source of truth: docs/product/recommendation-signal-authority.md (PR #2416,
+"Recommendation Signal Authority Decision"). This module fixes the Decision
+Document's §7 "Primary Recommendation Contract" as permanent regression
+tests -- NOT because this happens to be current production behavior, but
+because the Decision Document formally adopted this Authority.
+
+Recommendation Meaning (§7):
+    Recommendation Meaning
+      = User Consultation Meaning (need_tags / consultation_axis / history_theme)
+      x Shrine-side Meaning/Evidence (goriyaku match / history_theme)
+
+§7 also fixes that distance / popularity / birthdate / direction / behavior /
+visit_style must never, by themselves, constitute Primary Recommendation --
+even when they visibly move score/ranking (score contribution and Primary
+Recommendation Meaning are explicitly different claims per the Decision Doc).
+
+This module does not change production code, ranking weight, candidate
+filtering, reason generation, or UI. It only asserts against the existing
+`build_chat_recommendations()` facade with synthetic candidate dicts.
+
+Cross-references (already covered elsewhere, not duplicated here):
+- distance alone never Primary:
+  test_concierge_primary_reason_unification_contract.py::test_context_only_never_becomes_primary_meaning_reason
+- visit_style priority tier / Intent vs Visit Preference:
+  test_concierge_primary_reason_unification_contract.py::test_visit_style_is_a_priority_tier_below_element_above_fallback
+  test_concierge_primary_reason_unification_contract.py::test_conflict_consultation_plus_visit_preference_meaning_wins_primary
+- Intent vs Birth Profile (element):
+  test_concierge_primary_reason_unification_contract.py::test_conflict_consultation_plus_profile_meaning_wins_primary
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from temples.models import Shrine, ShrineInteractionLog
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_ranking import (
+    PRIMARY_REASON_PRIORITY,
+    resolve_history_theme_candidate_boost,
+)
+
+
+def _shrine(id_, name, **overrides):
+    base = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _run(*, query="", candidates, **kwargs):
+    kwargs.setdefault("language", "ja")
+    kwargs.setdefault("public_mode", "need")
+    kwargs.setdefault("flow", "A")
+    return build_chat_recommendations(query=query, candidates=candidates, **kwargs)
+
+
+@pytest.fixture
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+# ---------------------------------------------------------------------------
+# Primary Recommendation Contract (§7): Consultation Meaning x Shrine-side
+# Evidence order-flips a Context/Secondary-favored candidate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_need_tags_match_overtakes_context_favored_candidate(deterministic):
+    """need_tags is the Primary Recommendation Meaning's User Consultation
+    Meaning factor (§7). A candidate matching need_tags must be able to
+    overtake a candidate favored purely by distance/popularity (Context/
+    Secondary)."""
+    a_meaningful = _shrine(1, "A_career", astro_tags=["career"], distance_m=20000, popular_score=0.0)
+    b_context_favored = _shrine(2, "B_context_favored", distance_m=100, popular_score=8.0)
+    candidates = [a_meaningful, b_context_favored]
+
+    baseline = _run(candidates=candidates)
+    assert baseline["recommendations"][0]["name"] == "B_context_favored"
+
+    variant = _run(candidates=candidates, need_tags=["career"])
+    assert variant["recommendations"][0]["name"] == "A_career"
+    assert variant["recommendations"][0]["_primary_reason_source"] == "need_tag"
+
+
+@pytest.mark.django_db
+def test_goriyaku_free_text_semantic_match_overtakes_context_favored_candidate(deterministic):
+    """goriyaku (free text) is the Shrine-side Meaning/Evidence factor of
+    Recommendation Meaning (§7). A candidate whose goriyaku text
+    semantically matches need_tags (text_hint) must be able to overtake a
+    candidate favored purely by distance/popularity."""
+    a_semantic = _shrine(
+        1, "A_semantic_goriyaku",
+        goriyaku="縁結び・恋愛成就のご利益で知られています",
+        distance_m=20000, popular_score=0.0,
+    )
+    b_context_favored = _shrine(2, "B_context_favored", distance_m=100, popular_score=8.0)
+    candidates = [a_semantic, b_context_favored]
+
+    baseline = _run(candidates=candidates)
+    assert baseline["recommendations"][0]["name"] == "B_context_favored"
+
+    variant = _run(candidates=candidates, need_tags=["love"])
+    assert variant["recommendations"][0]["name"] == "A_semantic_goriyaku"
+    assert variant["recommendations"][0]["_primary_reason_source"] == "text_hint"
+
+
+@pytest.mark.django_db
+def test_consultation_axis_history_theme_boost_is_zero_when_axis_does_not_match():
+    assert resolve_history_theme_candidate_boost(consultation_axis="other", history_theme="縁") == 0.0
+    assert resolve_history_theme_candidate_boost(consultation_axis=None, history_theme="縁") == 0.0
+    assert resolve_history_theme_candidate_boost(consultation_axis="relationship_repair", history_theme="") == 0.0
+
+
+@pytest.mark.django_db
+def test_consultation_axis_history_theme_correspondence_is_primary_authority(deterministic):
+    """consultation_axis x history_theme correspondence (§6/§7): when the
+    resolved consultation_axis matches a candidate's history_theme, (a) the
+    history_theme_candidate_boost score contribution is nonzero, and (b) the
+    resulting reason_facts primary reason is "history_theme" (priority 0,
+    the doc's stated highest tier) rather than the weaker "need_tag" fact
+    that is also present on the same candidate."""
+    assert resolve_history_theme_candidate_boost(consultation_axis="relationship_repair", history_theme="縁") > 0.0
+
+    a_theme_match = _shrine(
+        1, "A_theme_match",
+        astro_tags=["relationship"], history_theme="縁",
+        distance_m=20000, popular_score=0.0,
+    )
+    b_context_favored = _shrine(2, "B_context_favored", distance_m=100, popular_score=8.0)
+    candidates = [a_theme_match, b_context_favored]
+
+    recs = _run(
+        candidates=candidates,
+        need_tags=["relationship"],
+        consultation_axis="relationship_repair",
+    )
+    assert recs["recommendations"][0]["name"] == "A_theme_match"
+    top = recs["recommendations"][0]
+    assert top["_primary_reason_source"] == "history_theme"
+    boost = top["breakdown_detail"]["features"]["history_theme_candidate_boost"]["raw"]
+    assert boost > 0.0
+
+    fact_types = {f["type"] for f in top["_reason_facts"]}
+    assert "need_tag" in fact_types  # weaker fact still present, but not chosen as primary
+    assert PRIMARY_REASON_PRIORITY["history_theme"] < PRIMARY_REASON_PRIORITY["need_tag"]
+
+
+# ---------------------------------------------------------------------------
+# Non-Primary Guard (§7): birthdate/direction/popularity/behavior never
+# leak into reason_facts at all (they are structurally absent from the
+# fact-building path); element/visit_style may appear as a fact but are
+# fixed at the bottom of PRIMARY_REASON_PRIORITY, below every
+# Consultation/Shrine-Evidence-derived type.
+# ---------------------------------------------------------------------------
+
+
+def test_non_primary_signal_priority_ordering_is_fixed():
+    """§7: distance/popularity/birthdate/direction/behavior must never be
+    presented as if they were a semantic match. The current implementation
+    encodes this by placing element (birthdate) and visit_style at the
+    bottom of PRIMARY_REASON_PRIORITY, below every Consultation-Meaning or
+    Shrine-side-Evidence type."""
+    primary_tier = ("history_theme", "culture_translation", "need_tag", "text_hint", "user_selected_tag", "goriyaku_tag")
+    for reason_type in primary_tier:
+        assert PRIMARY_REASON_PRIORITY[reason_type] < PRIMARY_REASON_PRIORITY["element"]
+        assert PRIMARY_REASON_PRIORITY[reason_type] < PRIMARY_REASON_PRIORITY["visit_style"]
+    assert PRIMARY_REASON_PRIORITY["element"] < PRIMARY_REASON_PRIORITY["fallback"]
+    assert PRIMARY_REASON_PRIORITY["visit_style"] < PRIMARY_REASON_PRIORITY["fallback"]
+
+
+@pytest.mark.django_db
+def test_popularity_alone_never_produces_a_reason_fact(deterministic):
+    """popularity (Secondary, §6) has no reason_facts type at all -- even a
+    maximal popularity gap must not surface as a Primary Reason."""
+    a_unpopular = _shrine(1, "A_unpopular", popular_score=0.0)
+    b_popular = _shrine(2, "B_popular", popular_score=10.0)
+    recs = _run(candidates=[a_unpopular, b_popular])
+
+    for rec in recs["recommendations"]:
+        assert rec["_primary_reason_source"] == "fallback"
+        assert all(f["type"] != "popularity" for f in rec["_reason_facts"])
+
+
+@pytest.mark.django_db
+def test_direction_alone_never_produces_a_reason_fact(deterministic):
+    """direction (Context, §6) can contribute up to DIRECTION_SIGNAL_MAX to
+    score_total_ranked via direction_signal_score, but must never surface
+    as a reason_facts type or Primary Reason."""
+    direction_profile = {
+        "visitDate": "2026-08-10",
+        "luckyDirections": ["東"],
+        "calculationMethod": "annual_monthly_kyusei_v1",
+        "source": "calculated",
+    }
+    user_origin = {"lat": 35.0, "lng": 139.0}
+    candidate = _shrine(1, "A_direction_match", lat=35.0, lng=140.0)
+
+    recs = _run(
+        candidates=[candidate],
+        profile_context={"direction_profile": direction_profile},
+        bias=user_origin,
+    )
+    rec = recs["recommendations"][0]
+    assert rec["breakdown_detail"]["features"]["direction_signal"]["raw"] > 0.0
+    assert rec["_primary_reason_source"] == "fallback"
+    assert all(f["type"] != "direction" for f in rec["_reason_facts"])
+
+
+@pytest.mark.django_db
+def test_behavior_alone_never_produces_a_reason_fact(deterministic):
+    """behavior (Personalization, §6) is capped at min(base*0.3, 0.5) and
+    can move score_total_ranked, but must never surface as a reason_facts
+    type or Primary Reason -- score contribution and Primary Recommendation
+    Meaning are different claims (§7 explicit warning)."""
+    shrine_row = Shrine.objects.create(
+        name_jp="行動履歴神社", address="東京都千代田区", latitude=35.0, longitude=139.0,
+    )
+    user = get_user_model().objects.create_user(username="behavior_guard_user", password="x")
+    for _ in range(5):
+        ShrineInteractionLog.objects.create(
+            user=user,
+            shrine=shrine_row,
+            action_type=ShrineInteractionLog.ActionType.DETAIL_VIEW,
+            created_at=timezone.now(),
+        )
+
+    candidate = _shrine(shrine_row.id, "A_behavior_heavy")
+    recs = _run(candidates=[candidate], user=user)
+    rec = recs["recommendations"][0]
+
+    assert rec["breakdown_detail"]["features"]["behavior"]["capped_contribution"] > 0.0
+    assert rec["_primary_reason_source"] == "fallback"
+    assert all(f["type"] != "behavior" for f in rec["_reason_facts"])


### PR DESCRIPTION
## Summary

- Fixes the Signal Authority Decision from [docs/product/recommendation-signal-authority.md](docs/product/recommendation-signal-authority.md) (#2416) as permanent regression tests. Assertions are grounded in "this Authority was formally adopted in the Decision Document," not "this happens to be current production behavior" — per explicit instruction for this task.
- Before writing new tests, surveyed 8 existing concierge test files for overlap; only wrote tests for the Decision Doc claims that had no existing coverage, and cross-referenced (rather than duplicated) claims already covered elsewhere (docstrings in each new file cite the existing test names).
- 4 new files, organized by responsibility per the task's Phase 9 guidance:
  - `test_signal_authority_primary_and_guard_contract.py` — Primary Recommendation Contract (need_tags / goriyaku free-text / consultation_axis×history_theme order-flip a Context-favored candidate) + Non-Primary Guard (priority-ordering lock, popularity/direction/behavior alone never producing a reason_fact).
  - `test_signal_authority_eligibility_contract.py` — goriyaku_tag_ids as a DB-level Candidate Eligibility filter, and as a zero-rank-contribution ("no double reward") signal once past that filter.
  - `test_signal_authority_conflict_contract.py` — Semantic Fit vs Distance / Popularity conflict rules (the two Decision Doc rules with no prior coverage).
  - `test_signal_authority_knowledge_explanation_contract.py` — Knowledge (deity/shrine_history/knowledge_deities/knowledge_histories) never changes Candidate/Rank, and never leaks into the ranking-attributed Explanation surface even though the independent `recommendation_reason_v4` Fact layer legitimately uses the same data.

**No production code, ranking weight, candidate filtering, reason generation, UI, or migration changes** — confirmed via `git diff --stat` (test files only) and `makemigrations --check --dry-run` (no changes detected).

## Test plan

- [x] New targeted tests: 15/15 pass standalone
- [x] Concierge-related backend suite: 748 passed, 4 skipped (pre-existing, unrelated)
- [x] Full backend suite: 1434 passed, 13 skipped (pre-existing environment gaps: GDAL/PostGIS unavailable locally)
- [x] CI parity: same 15 tests re-run with `CONCIERGE_USE_LLM=1` (matches CI's job-level setting, unlike local default `False`) — all pass, confirming no hidden LLM-route dependency
- [x] `ruff check` on all 4 new files: clean
- [x] Zero production/migration diff confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)