### PR TITLE
Context Override Guard / Primary Semantic Authority Protection

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -49,6 +49,7 @@ from temples.services.concierge_chat_ranking import (
     _diversify_by_need,
     _resolve_mode_weights,
     build_recommendation_reason,
+    has_primary_tier_reason,
     resolve_score_sort_key,
     resolve_score_v3_mode,
     resolve_score_v3_mode_detail,
@@ -238,9 +239,18 @@ def _sort_chat_recommendations(
     distance_mode = "sort_distance" in sort_tags
 
     if distance_mode:
+        # Context (distance) may re-rank within Recommendation Meaning, but
+        # must not decide Recommendation Meaning itself (docs/product/
+        # recommendation-signal-authority.md §5/§7/§9 Semantic Fit vs
+        # Distance). A candidate with a Primary-tier reason (need_tags /
+        # consultation_axis / goriyaku / history_theme match) is tiered
+        # ahead of one without, and only sorted by distance within each
+        # tier -- distance still fully controls order when no candidate
+        # has established Recommendation Meaning at all.
         recommendations = sorted(
             recommendations,
             key=lambda r: (
+                0 if has_primary_tier_reason(r.get("_reason_facts")) else 1,
                 float(r.get("distance_m") or 1e12),
                 -resolve_score_sort_key(r, score_v3_mode=score_v3_mode),
                 str(r.get("name") or ""),

--- a/backend/temples/services/concierge_chat_ranking.py
+++ b/backend/temples/services/concierge_chat_ranking.py
@@ -522,6 +522,30 @@ PRIMARY_REASON_PRIORITY: Dict[str, int] = {
     "fallback": 9,
 }
 
+# Signal Authority boundary (docs/product/recommendation-signal-authority.md
+# §5/§7 Primary Recommendation Contract): only these reason_facts types are
+# grounded in Consultation Meaning x Shrine-side Evidence. "element"
+# (birthdate/Personalization) and "visit_style" (Secondary/Context
+# boundary) may still surface as a reason, but per §7 must never alone
+# constitute Recommendation Meaning -- used to keep Context-driven
+# re-ranking (e.g. distance_mode) from promoting a candidate with no
+# Primary Recommendation Meaning ahead of one that has it.
+PRIMARY_TIER_REASON_TYPES: frozenset[str] = frozenset(
+    reason_type
+    for reason_type, priority in PRIMARY_REASON_PRIORITY.items()
+    if priority < PRIMARY_REASON_PRIORITY["element"]
+)
+
+
+def has_primary_tier_reason(reason_facts: List[Dict[str, Any]] | None) -> bool:
+    """True if any reason_fact is grounded in Recommendation Meaning
+    (Primary tier), as opposed to Context/Secondary/Personalization only."""
+    return any(
+        str(fact.get("type") or "") in PRIMARY_TIER_REASON_TYPES
+        for fact in (reason_facts or [])
+        if isinstance(fact, dict)
+    )
+
 
 def _make_reason_fact(
     *,
@@ -2060,4 +2084,6 @@ __all__ = [
     "resolve_score_sort_key",
     "resolve_score_v3_history_signal",
     "resolve_history_theme_candidate_boost",
+    "PRIMARY_TIER_REASON_TYPES",
+    "has_primary_tier_reason",
 ]

--- a/backend/temples/tests/services/test_signal_authority_context_override_guard.py
+++ b/backend/temples/tests/services/test_signal_authority_context_override_guard.py
@@ -1,0 +1,153 @@
+# backend/temples/tests/services/test_signal_authority_context_override_guard.py
+"""Context Override Guard: Primary Semantic Authority Protection.
+
+Audit follow-up to docs/product/recommendation-signal-authority.md (#2416)
+and its regression tests (#2417). Phase 2 conflict experiments found one
+Contract Violation not covered by the existing Signal Authority Contract
+Tests: `_sort_chat_recommendations()`'s `distance_mode` (triggered when
+free text matches a "sort_distance" trigger word -- "近い"/"近く"/"徒歩"/
+"できるだけ近"/"最寄り"/"距離優先", see temples/domain/extra_condition_tags.py)
+sorted purely by `distance_m`, demoting `_score_total` (which carries 100%
+of Consultation Meaning / Shrine-side Evidence) to a tiebreaker. That let a
+candidate with zero semantic connection to the user's stated need (
+`_primary_reason_source == "fallback"`) outrank a candidate with a genuine
+`need_tags` match, purely because it happened to sit closer.
+
+Fix (`has_primary_tier_reason()` in concierge_chat_ranking.py, used only
+inside `_sort_chat_recommendations()`'s distance_mode branch): tier
+distance_mode candidates by whether they have an established Primary
+Recommendation Meaning (§7) first, then sort by distance within each tier.
+This still gives Context (distance) full authority to *reorder* -- both
+within the Primary tier, and across all candidates when nobody has
+established Primary Recommendation Meaning at all (the legitimate "just
+show me something nearby" case) -- but Context can no longer *decide*
+Recommendation Meaning by promoting a semantically-empty candidate over a
+genuine match.
+
+This module does not change ranking weight, candidate filtering, Primary
+Reason resolution logic (`_resolve_primary_reason`/`_build_reason_facts`
+are untouched), or the API response shape -- only the sort comparator used
+inside the pre-existing distance_mode branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_ranking import (
+    PRIMARY_TIER_REASON_TYPES,
+    has_primary_tier_reason,
+)
+
+
+def _shrine(id_, name, **overrides):
+    base = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+def test_primary_tier_reason_types_excludes_element_and_visit_style():
+    """has_primary_tier_reason() must only recognize the Consultation
+    Meaning / Shrine-side Evidence types (§7) -- element (birthdate) and
+    visit_style must never count, since §7 fixes that neither alone
+    constitutes Recommendation Meaning."""
+    assert PRIMARY_TIER_REASON_TYPES == {
+        "history_theme", "culture_translation", "need_tag", "text_hint", "user_selected_tag", "goriyaku_tag",
+    }
+    assert has_primary_tier_reason([{"type": "element"}]) is False
+    assert has_primary_tier_reason([{"type": "visit_style"}]) is False
+    assert has_primary_tier_reason([{"type": "fallback"}]) is False
+    assert has_primary_tier_reason([{"type": "need_tag"}]) is True
+    assert has_primary_tier_reason([]) is False
+    assert has_primary_tier_reason(None) is False
+
+
+@pytest.mark.django_db
+def test_sort_distance_does_not_override_a_genuine_need_tags_match(deterministic):
+    """Reproduces the Contract Violation found in Phase 2 Case A2: a query
+    that both establishes a real need_tags match AND triggers the
+    sort_distance override ("近くの神社で仕事の相談をしたいです") must
+    still keep the semantically-matched candidate on top, even though a
+    semantically-empty candidate is much closer."""
+    a_semantic_far = _shrine(1, "A_semantic_far", astro_tags=["career"], distance_m=30000)
+    b_near_empty = _shrine(2, "B_near_empty", distance_m=200)
+
+    recs = build_chat_recommendations(
+        query="近くの神社で仕事の相談をしたいです", language="ja",
+        candidates=[a_semantic_far, b_near_empty],
+    )
+    assert recs["recommendations"][0]["name"] == "A_semantic_far"
+    assert recs["recommendations"][0]["_primary_reason_source"] == "need_tag"
+
+
+@pytest.mark.django_db
+def test_sort_distance_does_not_let_personalization_hijack_primary_reason(deterministic):
+    """Phase 2 Case D2: once distance_mode incorrectly won the sort, a
+    Personalization signal (birthdate/element) on the semantically-empty
+    near candidate opportunistically became the visible Primary Reason.
+    The tiering fix must prevent this too."""
+    a_semantic_far = _shrine(1, "A_semantic_far", astro_tags=["career"], distance_m=30000, astro_elements=["水"])
+    b_near_birth_match = _shrine(2, "B_near_birth_match", distance_m=200, astro_elements=["火"])
+
+    recs = build_chat_recommendations(
+        query="近くの神社で仕事の相談をしたいです", language="ja",
+        candidates=[a_semantic_far, b_near_birth_match],
+        birthdate="1990-08-01", public_mode="compat",
+    )
+    assert recs["recommendations"][0]["name"] == "A_semantic_far"
+    assert recs["recommendations"][0]["_primary_reason_source"] == "need_tag"
+
+
+@pytest.mark.django_db
+def test_sort_distance_still_orders_purely_by_distance_when_nothing_is_semantically_matched(deterministic):
+    """Legitimate Context authority is preserved: when no candidate has
+    established Primary Recommendation Meaning at all, distance_mode must
+    still sort purely by distance -- the guard only activates when there
+    is a genuine conflict to protect, not unconditionally."""
+    a_far = _shrine(1, "A_far_no_semantic", distance_m=30000)
+    b_near = _shrine(2, "B_near_no_semantic", distance_m=200)
+
+    recs = build_chat_recommendations(
+        query="近くの神社を教えて", language="ja", candidates=[a_far, b_near],
+    )
+    names = [r["name"] for r in recs["recommendations"]]
+    assert names == ["B_near_no_semantic", "A_far_no_semantic"]
+
+
+@pytest.mark.django_db
+def test_sort_distance_orders_by_distance_within_the_primary_tier(deterministic):
+    """Within the Primary tier, distance_mode must still fully control
+    order (Context legitimately re-ranks among candidates that already
+    have Recommendation Meaning)."""
+    near_match = _shrine(1, "Near_match", astro_tags=["career"], distance_m=300)
+    far_match = _shrine(2, "Far_match", astro_tags=["career"], distance_m=3000)
+
+    recs = build_chat_recommendations(
+        query="近くの神社で仕事の相談をしたいです", language="ja",
+        candidates=[far_match, near_match],
+    )
+    names = [r["name"] for r in recs["recommendations"]]
+    assert names == ["Near_match", "Far_match"]


### PR DESCRIPTION
## Summary

Audits [docs/product/recommendation-signal-authority.md](docs/product/recommendation-signal-authority.md) (#2416) / its Contract Tests (#2417) for cases where Secondary/Personalization/Context Signals unduly override Primary Recommendation Meaning, and implements the one minimal guard needed.

### Phase 1 — Ranking trace
Traced every signal's raw/weight/contribution/final-sort path (`_attach_breakdown()`, `_sort_chat_recommendations()`). Found two sort modes: normal mode (`-_score_total, distance_m, name`, Semantic-Fit-first) and `distance_mode` (triggered by free text matching "近い"/"近く"/"徒歩"/"できるだけ近"/"最寄り"/"距離優先" via substring match), which sorts by `(distance_m, -_score_total, name)` — **demoting `_score_total`, which carries 100% of Consultation Meaning, to a tiebreaker.**

### Phase 2 — Conflict experiments (Case A–D + 2 extra probes)
- Case A (weighted mode, Semantic Fit vs Distance): Semantic Fit wins, as正本 requires.
- **Case A2 (distance_mode, NEW finding): a semantically-empty near candidate outranked a genuine `need_tags` match, and the winner's `primary_reason_source` became `"fallback"`** — a Contract Violation.
- Case B (Popularity), C (Visit Preference), D (Birth Profile, normal mode): all match正本, no violation.
- Case D2 (distance_mode + Birth Profile): same root cause as A2 — a Personalization signal opportunistically "won" the visible Primary Reason only because distance_mode had already discarded semantic ordering.

### Phase 3 — Classification
One Contract Violation found, confined entirely to `_sort_chat_recommendations()`'s `distance_mode` branch. No other signal, weight, or code path shows a structural override.

### Phase 4 — Guard (minimal)
Added `has_primary_tier_reason()` (`concierge_chat_ranking.py`), derived from the *existing* `PRIMARY_REASON_PRIORITY` dict (no new Authority concept). Used only inside `distance_mode`'s sort key: candidates with an established Primary Recommendation Meaning are tiered ahead of those without, sorted by distance *within* each tier. When nobody has Primary Recommendation Meaning at all (a legitimate "just show me something nearby" query), behavior is unchanged — pure distance order.

**No change to**: Signal Authority classification, ranking weight, candidate filtering, Primary Reason resolution logic (`_resolve_primary_reason`/`_build_reason_facts` untouched), API response shape, DB schema, migrations.

## Test plan

- [x] New guard regression tests (`test_signal_authority_context_override_guard.py`, 5 tests): reproduces Case A2/D2 as fixed, confirms legitimate pure-distance behavior is preserved, confirms in-tier distance ordering still works
- [x] PR #2417's Signal Authority Contract Tests (15 tests): pass **unmodified**
- [x] Existing `sort_distance`-related tests (`test_concierge_chat_sort_distance.py`, `test_concierge_visit_preference_contract.py`): pass unmodified
- [x] Concierge-related backend suite: 753 passed, 4 skipped (pre-existing, unrelated)
- [x] Full backend suite: 1439 passed, 13 skipped (pre-existing environment gaps)
- [x] CI parity (`CONCIERGE_USE_LLM=1`): 20 relevant tests pass
- [x] `ruff check` on changed files: only pre-existing findings (confirmed identical against `origin/develop` copies), nothing new introduced
- [x] Zero migration diff (`makemigrations --check --dry-run`: no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)