### PR TITLE
Recommendation Explanation Alignment Hardening

### DIFF
--- a/backend/temples/services/concierge_chat_ranking.py
+++ b/backend/temples/services/concierge_chat_ranking.py
@@ -594,6 +594,7 @@ def _build_reason_facts(
     astro_bonus_enabled: bool,
     shrine_meaning_profile: Optional[Dict[str, Any]] = None,
     matched_visit_style_tags: Optional[List[str]] = None,
+    history_theme_candidate_boost: float = 0.0,
 ) -> List[Dict[str, Any]]:
     facts: List[Dict[str, Any]] = []
     profile = shrine_meaning_profile or {}
@@ -605,7 +606,16 @@ def _build_reason_facts(
     history_theme = str(profile.get("history_theme") or "").strip()
     culture_translation_present = bool(profile.get("culture_translation_present"))
 
-    if profile_matched_need_tags and history_theme:
+    # docs/product/recommendation-signal-authority.md §6: history_theme is
+    # "Primary（条件付き）" -- Rank寄与はconsultation_axis一致時のみ
+    # (history_theme_candidate_boost). A candidate whose theme does not
+    # correspond to the resolved axis (boost == 0.0) had zero ranking
+    # authority from history_theme, so it must not be presented as the
+    # (or a) reason this candidate ranked -- gating this fact on the same
+    # boost signal that actually reached the score keeps the Explanation
+    # SSOT aligned with the real Ranking Authority (Explanation Alignment
+    # Hardening audit finding).
+    if profile_matched_need_tags and history_theme and history_theme_candidate_boost > 0:
         facts.append(
             _make_reason_fact(
                 type_="history_theme",
@@ -1479,6 +1489,7 @@ def _attach_breakdown(
         astro_bonus_enabled=astro_bonus_enabled,
         shrine_meaning_profile=shrine_meaning_profile,
         matched_visit_style_tags=matched_visit_style_tags,
+        history_theme_candidate_boost=history_theme_candidate_boost,
     )
     primary_reason = _resolve_primary_reason(reason_facts)
 

--- a/backend/temples/services/concierge_explanation_payload.py
+++ b/backend/temples/services/concierge_explanation_payload.py
@@ -59,6 +59,20 @@ def _build_history_context(rec: Dict[str, Any]) -> Dict[str, Any] | None:
     if not raw_theme:
         return None
 
+    # docs/product/recommendation-signal-authority.md §6: history_theme
+    # only has Rank Authority when consultation_axis corresponds to it
+    # (history_theme_candidate_boost > 0, already computed in
+    # _attach_breakdown's breakdown_detail). Reusing that same signal here
+    # keeps history_context (and the action_suggestions derived from it)
+    # from presenting a candidate's history_theme as relevant context when
+    # it had zero actual ranking authority (Explanation Alignment
+    # Hardening audit finding, mirrors the _build_reason_facts() gate).
+    boost_detail = (
+        ((rec.get("breakdown_detail") or {}).get("features") or {}).get("history_theme_candidate_boost") or {}
+    )
+    if not (float(boost_detail.get("raw") or 0.0) > 0):
+        return None
+
     return {
         "theme": raw_theme,
         "label": HISTORY_THEME_LABELS_JA.get(raw_theme, raw_theme),

--- a/backend/temples/tests/services/test_concierge_explanations_contract.py
+++ b/backend/temples/tests/services/test_concierge_explanations_contract.py
@@ -287,6 +287,16 @@ def test_attach_explanation_payload_adds_action_suggestions_from_history_theme()
                     "score_total": 1.0,
                     "matched_need_tags": ["career"],
                 },
+                # history_context/action_suggestions only surface when
+                # history_theme actually had ranking authority (Explanation
+                # Alignment Hardening: docs/product/recommendation-signal-
+                # authority.md §6, history_theme_candidate_boost > 0 means
+                # consultation_axis corresponded to this theme).
+                "breakdown_detail": {
+                    "features": {
+                        "history_theme_candidate_boost": {"raw": 0.8},
+                    },
+                },
             }
         ]
     }

--- a/backend/temples/tests/services/test_signal_authority_explanation_alignment_contract.py
+++ b/backend/temples/tests/services/test_signal_authority_explanation_alignment_contract.py
@@ -1,0 +1,150 @@
+# backend/temples/tests/services/test_signal_authority_explanation_alignment_contract.py
+"""Recommendation Explanation Alignment Hardening.
+
+Audit follow-up to docs/product/recommendation-signal-authority.md (#2416),
+its Contract Tests (#2417), and the Context Override Guard (#2418). This
+module fixes the one live Authority Mismatch found while auditing whether
+"the Authority that actually drove Recommendation" and "the reason shown
+to the user" agree across all Explanation surfaces (reason_facts,
+_primary_reason_source, rank_explanation, _explanation_payload.primary_reason,
+_explanation_payload.history_context/action_suggestions).
+
+Finding: `history_theme` is classified in the Decision Doc §6 as "Primary
+（条件付き）" -- it only has Rank Authority when `consultation_axis`
+corresponds to the candidate's `history_theme`
+(`history_theme_candidate_boost > 0`). But both `_build_reason_facts()`
+(concierge_chat_ranking.py) and `_build_history_context()`
+(concierge_explanation_payload.py) independently read
+`rec.get("history_theme")` truthiness alone, with no check on whether the
+boost actually fired. That let a candidate whose history_theme had ZERO
+ranking contribution (axis genuinely does not correspond, boost == 0.0)
+be presented as if history_theme were its Primary Reason -- via
+reason_facts (the field the main concierge chat card's narrative reads),
+_primary_reason_source, rank_explanation, _explanation_payload.primary_reason,
+and _explanation_payload.history_context/action_suggestions all at once,
+since they all ultimately derive from the same reason_facts SSOT (or, for
+history_context, independently duplicated the same unguarded check).
+
+Fix: both call sites now gate on the same already-computed
+`history_theme_candidate_boost` value (no new resolver, no ranking
+change, no candidate filtering change, no Signal Authority classification
+change -- history_theme's Authority remains exactly "Primary（条件付き）"
+as already defined; this only makes the implementation match that
+existing, already-adopted classification faithfully).
+
+This module does not change production code beyond that single gate
+(applied in two closely related places), and does not touch ranking
+weight, candidate filtering, or the Primary Reason priority ordering.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_ranking import resolve_history_theme_candidate_boost
+
+
+def _shrine(id_, name, **overrides):
+    base = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+@pytest.mark.django_db
+def test_history_theme_reason_is_suppressed_when_axis_does_not_correspond(deterministic):
+    """§6: history_theme only has Rank Authority when consultation_axis
+    corresponds (boost > 0). When it genuinely does not (boost == 0.0,
+    e.g. axis=nature_reset vs theme=勝負, per
+    HISTORY_THEME_CANDIDATE_BOOST_BY_AXIS), the candidate's actual driving
+    signal (need_tag) must be the one shown across every Explanation
+    surface -- not history_theme."""
+    assert resolve_history_theme_candidate_boost(consultation_axis="nature_reset", history_theme="勝負") == 0.0
+
+    candidate = _shrine(1, "A", astro_tags=["career"], history_theme="勝負")
+    recs = build_chat_recommendations(
+        query="", language="ja", candidates=[candidate],
+        need_tags=["career"], consultation_axis="nature_reset",
+    )
+    rec = recs["recommendations"][0]
+
+    assert rec["_primary_reason_source"] == "need_tag"
+    fact_types = {f["type"] for f in rec["_reason_facts"]}
+    assert "history_theme" not in fact_types
+
+    assert rec["rank_explanation"]["primary_reason_source"] == "need_tag"
+    assert rec["_explanation_payload"]["primary_reason"]["type"] == "need_tag"
+    assert rec["_explanation_payload"]["history_context"] is None
+    # action_suggestions falls back to the theme-less default set, not the
+    # (unrelated) 勝負 theme's suggestions.
+    action_theme = rec["_explanation_payload"]["action_suggestions"][0].get("history_theme")
+    assert action_theme != "勝負"
+
+
+@pytest.mark.django_db
+def test_history_theme_reason_still_surfaces_when_axis_does_correspond(deterministic):
+    """Non-regression: when consultation_axis genuinely corresponds to the
+    candidate's history_theme (boost > 0), history_theme legitimately has
+    Rank Authority and must still be presented as Primary -- this is the
+    same scenario PR #2417's Primary Contract test covers, re-asserted
+    here for the Explanation-surface consistency angle."""
+    assert resolve_history_theme_candidate_boost(consultation_axis="relationship_repair", history_theme="縁") > 0.0
+
+    candidate = _shrine(1, "A", astro_tags=["relationship"], history_theme="縁")
+    recs = build_chat_recommendations(
+        query="", language="ja", candidates=[candidate],
+        need_tags=["relationship"], consultation_axis="relationship_repair",
+    )
+    rec = recs["recommendations"][0]
+
+    assert rec["_primary_reason_source"] == "history_theme"
+    assert rec["rank_explanation"]["primary_reason_source"] == "history_theme"
+    assert rec["_explanation_payload"]["primary_reason"]["type"] == "history_theme"
+    assert rec["_explanation_payload"]["history_context"] == {
+        "theme": "縁", "label": "縁", "tone": "人や機会とのつながりを見直す文脈",
+    }
+
+
+@pytest.mark.django_db
+def test_explanation_surfaces_agree_even_when_history_theme_is_present_but_ungrounded(deterministic):
+    """All Explanation surfaces (reason_facts / _primary_reason_source /
+    rank_explanation / _explanation_payload.primary_reason) must agree
+    with each other and with the actual ranking driver, even when a
+    candidate happens to carry a history_theme value that had zero
+    influence on its ranking."""
+    candidate = _shrine(1, "A", astro_tags=["career"], history_theme="勝負")
+    recs = build_chat_recommendations(
+        query="", language="ja", candidates=[candidate],
+        need_tags=["career"], consultation_axis="nature_reset",
+    )
+    rec = recs["recommendations"][0]
+
+    primary_type_from_facts = next(
+        (f["type"] for f in rec["_reason_facts"] if f.get("is_primary")), None,
+    )
+    assert primary_type_from_facts == "need_tag"
+    assert rec["_primary_reason_source"] == primary_type_from_facts
+    assert rec["rank_explanation"]["primary_reason_source"] == primary_type_from_facts
+    assert rec["_explanation_payload"]["primary_reason"]["type"] == primary_type_from_facts


### PR DESCRIPTION
## Summary

Audits whether "the Authority that actually drove Recommendation" and "the reason shown to the user" agree, across every Explanation-surface field, for the 9 required scenarios (need_tags Primary / consultation_axis×history_theme Primary / goriyaku semantic Primary / goriyaku_tag_ids Eligibility / birthdate Personalization / visit_style Secondary / distance Context / Knowledge Explanation-only / fallback), following [docs/product/recommendation-signal-authority.md](docs/product/recommendation-signal-authority.md) (#2416), its Contract Tests (#2417), and the Context Override Guard (#2418).

### Field trace
Traced `reason_facts` / `_primary_reason_source` / `rank_explanation` / `_explanation_payload.primary_reason` / `_explanation_payload.history_context`+`action_suggestions` / `recommendation_reason_v4` / `recommendation_reason_v4_detail` through to actual frontend consumers. Confirmed `reason_facts` is the field the main concierge chat card's narrative reads, and `_explanation_payload.primary_reason`/`.action_suggestions` reach the shrine-detail page / main flow respectively — so a mismatch there is a real, user-visible issue, not academic.

### 9 scenarios: 1 Authority Mismatch found
history_theme is classified in the正本 §6 as **"Primary（条件付き）"** — it only has Rank Authority when `consultation_axis` corresponds to the candidate's `history_theme` (`history_theme_candidate_boost > 0`). But `_build_reason_facts()` (the reason_facts/primary_reason SSOT) and `_build_history_context()` (`_explanation_payload.history_context`/`action_suggestions`) both independently checked only `rec.get("history_theme")` truthiness — not whether the boost actually fired. A candidate whose theme did NOT correspond to the axis (boost == 0.0, zero ranking contribution) was still shown as if history_theme were its Primary Reason, across `reason_facts`, `_primary_reason_source`, `rank_explanation`, `_explanation_payload.primary_reason`, and `_explanation_payload.history_context`/`action_suggestions` all at once. All 8 other scenarios were **Aligned** (or, for legacy-`reason`-text wording on non-need-tag primary types, a lower-severity "Wording Weakness" that doesn't reach the main card per the field trace — left unchanged).

### Fix (minimal)
Both call sites now gate on the already-computed `history_theme_candidate_boost` value. No new resolver added — reuses the existing Primary Reason SSOT and the already-computed `breakdown_detail.features.history_theme_candidate_boost.raw`. No ranking, candidate filtering, Signal Authority classification (history_theme remains exactly "Primary（条件付き）"), or Primary Reason priority change.

### Found but NOT fixed (flagged as separate follow-ups)
- `culture_translation` reason_fact has `PRIMARY_REASON_PRIORITY = 1` (second-highest) but zero ranking-score contribution anywhere — currently unreachable (never set by `build_chat_candidates()`) and not one of the正本's 17 classified signals, so per this task's explicit rule this is a Decision question, not something to implement unilaterally.
- Frontend `reason_facts` type mismatch (backend sends a list of fact dicts, frontend's `buildRecommendationReasonViewModel.ts`/`buildReasonNarrative.ts` expects an object) — likely means the main card's narrative never actually reads real backend reason_facts data. Backend-only scope for this PR, so flagged for a separate frontend PR.

## Test plan

- [x] New regression tests (`test_signal_authority_explanation_alignment_contract.py`, 3 tests): reproduces the boost=0 mismatch as fixed, confirms legitimate boost>0 case still surfaces history_theme, confirms all Explanation surfaces agree
- [x] PR #2417's Signal Authority Contract Tests (15) + PR #2418's Context Guard Tests (5): pass **unmodified**
- [x] `test_concierge_explanations_contract.py`'s pre-existing `test_attach_explanation_payload_adds_action_suggestions_from_history_theme` fixture updated to include a realistic `breakdown_detail` (it previously hand-built a rec with `history_theme` set but no breakdown_detail at all, a state that can't occur in the real pipeline where `_attach_breakdown()` always runs first) — same assertions, same intent, now testing a realistic boost>0 fixture
- [x] Concierge-related backend suite: 756 passed, 4 skipped (pre-existing, unrelated)
- [x] Full backend suite: 1442 passed, 13 skipped (pre-existing environment gaps)
- [x] CI parity (`CONCIERGE_USE_LLM=1`): 23 relevant tests pass
- [x] `ruff check` on changed files: only pre-existing findings (confirmed identical against `origin/develop` copies)
- [x] Zero migration diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)