### PR TITLE
Fix frontend reason_facts consumption contract

### DIFF
--- a/apps/web/e2e/fixtures/directionScenario.ts
+++ b/apps/web/e2e/fixtures/directionScenario.ts
@@ -117,7 +117,7 @@ export async function installDirectionScenario(
       recommendation_reason_v4: "固定レスポンスによる推薦です。",
       recommendation_reason_v4_detail: buildReasonV4Detail(options.recommendationId),
       breakdown: { matched_need_tags: ["career"] },
-      reason_facts: { primary_axis: "benefit", shrine_benefit: "仕事運を整えるご利益" },
+      reason_facts: [{ type: "goriyaku_tag", label: "仕事運を整えるご利益", evidence: ["goriyaku_tag_ids"], score: 2, is_primary: true }],
       ...(options.directionReference ? { direction_reference: options.directionReference } : {}),
     };
     const recommendations = [recommendation];
@@ -130,7 +130,7 @@ export async function installDirectionScenario(
         recommendation_reason_v4: "固定レスポンスによる推薦です。",
         recommendation_reason_v4_detail: buildReasonV4Detail(options.additionalRecommendation.id),
         breakdown: { matched_need_tags: ["career"] },
-        reason_facts: { primary_axis: "benefit", shrine_benefit: "仕事運を整えるご利益" },
+        reason_facts: [{ type: "goriyaku_tag", label: "仕事運を整えるご利益", evidence: ["goriyaku_tag_ids"], score: 2, is_primary: true }],
         ...(options.additionalRecommendation.directionReference
           ? { direction_reference: options.additionalRecommendation.directionReference }
           : {}),

--- a/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.payload.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.payload.test.ts
@@ -118,12 +118,13 @@ it("reason_facts を recommendation item に通す", () => {
           shrine_id: 10,
           display_name: "S1",
           reason: "R1",
-          reason_facts: {
-            version: 1,
-            primary_axis: "need",
-            matched_need_tags: ["厄除け"],
-            shrine_feature: "静かに歩ける",
-          },
+          reason_facts: [{
+            type: "need_tag",
+            label: "厄除け",
+            evidence: ["厄除け"],
+            score: 2,
+            is_primary: true,
+          }],
         },
       ],
     },
@@ -132,12 +133,9 @@ it("reason_facts を recommendation item に通す", () => {
 
   const p = buildPayloadFromUnified(u, baseFilterState);
   const recSec = p?.sections.find((s: any) => s.type === "recommendations") as any;
-  expect(recSec.items[0].reasonFacts).toEqual(
-    expect.objectContaining({
-      primary_axis: "need",
-      matched_need_tags: ["厄除け"],
-    }),
-  );
+  expect(recSec.items[0].reasonFacts).toEqual([
+    expect.objectContaining({ type: "need_tag", label: "厄除け", is_primary: true }),
+  ]);
 });
 
 it("recommendation_reason_v4_detail と recommendation_reason_v4 を recommendation item に通す", () => {
@@ -281,7 +279,7 @@ it("place候補の詳細情報とresult_stateをpayloadへ通す", () => {
           photo_url: "https://example.com/photo.jpg",
           breakdown: { score_total: 1 },
           breakdownDetail: { features: { visit_style: "quiet" } },
-          reasonFacts: { primary_axis: "feature" },
+          reasonFacts: [{ type: "history_theme", label: "静寂", evidence: ["history_theme"], score: 4, is_primary: true }],
           trustMetadata: { rank_class: "local" },
           historyTheme: "静寂",
           historyContext: "静けさの文脈",
@@ -370,14 +368,8 @@ it("reason_facts を reasonFacts より優先する", () => {
           shrine_id: 10,
           display_name: "S1",
           reason: "R1",
-          reason_facts: {
-            primary_axis: "need",
-            shrine_feature: "snake_case側",
-          },
-          reasonFacts: {
-            primary_axis: "feature",
-            shrine_feature: "camelCase側",
-          },
+          reason_facts: [{ type: "need_tag", label: "snake_case側", evidence: ["need_tag"], score: 2, is_primary: true }],
+          reasonFacts: [{ type: "history_theme", label: "camelCase側", evidence: ["history_theme"], score: 4, is_primary: true }],
         },
       ],
     },
@@ -387,10 +379,7 @@ it("reason_facts を reasonFacts より優先する", () => {
   const p = buildPayloadFromUnified(u, baseFilterState);
   const recSec = p?.sections.find((s: any) => s.type === "recommendations") as any;
 
-  expect(recSec.items[0].reasonFacts).toEqual(
-    expect.objectContaining({
-      primary_axis: "need",
-      shrine_feature: "snake_case側",
-    }),
-  );
+  expect(recSec.items[0].reasonFacts).toEqual([
+    expect.objectContaining({ type: "need_tag", label: "snake_case側" }),
+  ]);
 });

--- a/apps/web/src/features/concierge/buildPayloadFromUnified.ts
+++ b/apps/web/src/features/concierge/buildPayloadFromUnified.ts
@@ -142,7 +142,8 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
   const imageUrl = asTrimmedString(r?.photo_url);
   const breakdown = r?.breakdown ?? null;
   const breakdownDetail = r?.breakdown_detail ?? r?.breakdownDetail ?? null;
-  const reasonFacts = r?.reason_facts ?? r?.reasonFacts ?? null;
+  const reasonFactsCandidate = r?.reason_facts ?? r?.reasonFacts ?? null;
+  const reasonFacts = Array.isArray(reasonFactsCandidate) ? reasonFactsCandidate : null;
   const reasonV4Detail = r?.recommendation_reason_v4_detail ?? r?.recommendationReasonV4Detail ?? null;
   const recommendationReasonV4 = asTrimmedString(r?.recommendation_reason_v4 ?? r?.recommendationReasonV4);
   const trustMetadata = r?.trust_metadata ?? r?.trustMetadata ?? null;

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -838,8 +838,8 @@ export default function ConciergeSectionsRenderer({
                             astro_elements: (heroItem as any).astro_elements ?? null,
                             astro_priority: (heroItem as any).astro_priority ?? null,
                             explanation: (heroItem as any).explanation ?? null,
-                            reason_facts: (heroItem as any).reasonFacts ?? null,
                           },
+                          reasonFacts: heroItem.reasonFacts ?? null,
                           index: 0,
                           mode: normalizedMode,
                           birthdate: filterState?.birthdate ?? null,
@@ -857,8 +857,8 @@ export default function ConciergeSectionsRenderer({
                           recommendationReasonV4: (heroItem as any).recommendationReasonV4 ?? null,
                           reason: heroItem.description ?? null,
                         });
-                        // primaryReason(相談内容・ご利益との一致)は新設のinterpretation/fact表示と役割が重なるため
-                        // Hero通常経路では使用しない(reasonVm.hero.*等の見出し系は変更しない)
+                        // 構造化Reason V4がある場合は重複を避ける。無い場合はBackendが指定した
+                        // reason_facts Primaryをadapter経由でVisible UIへ渡す。
                         const heroSecondaryReason = heroReasonV4.hasStructured ? null : heroReasonV4.fallbackText;
                         const trustMetadata = (heroItem as any).trustMetadata ?? null;
                         const trustLabels = [
@@ -898,7 +898,7 @@ export default function ConciergeSectionsRenderer({
                               subtitle={reasonVm.hero.subtitle ?? null}
                               catchCopy={reasonVm.hero.catchCopy}
                               whyTop={null}
-                              primaryReason={null}
+                              primaryReason={heroReasonV4.hasStructured ? null : reasonVm.list.primaryPhrase}
                               secondaryReason={heroSecondaryReason}
                               factReason={heroReasonV4.factText}
                               interpretationReason={heroReasonV4.interpretationText}
@@ -1058,8 +1058,8 @@ export default function ConciergeSectionsRenderer({
                                   astro_elements: (item as any).astro_elements ?? null,
                                   astro_priority: (item as any).astro_priority ?? null,
                                   explanation: (item as any).explanation ?? null,
-                                  reason_facts: (item as any).reasonFacts ?? null,
                                 },
+                                reasonFacts: item.reasonFacts ?? null,
                                 index: compactIdx + 1,
                                 mode: normalizedMode,
                                 birthdate: filterState?.birthdate ?? null,

--- a/apps/web/src/features/concierge/components/PrimaryRecommendationCard.tsx
+++ b/apps/web/src/features/concierge/components/PrimaryRecommendationCard.tsx
@@ -21,8 +21,10 @@ export default function PrimaryRecommendationCard({
   mode,
   birthdate,
 }: Props) {
+  const { reason_facts: reasonFacts, ...viewRec } = rec;
   const vm = buildRecommendationReasonViewModel({
-    rec,
+    rec: viewRec,
+    reasonFacts,
     index: primaryIndex,
     mode,
     birthdate,

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonFactsContract.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonFactsContract.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const analyticsMocks = vi.hoisted(() => ({ trackSearchEvent: vi.fn(), trackCardEvent: vi.fn() }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: analyticsMocks.trackSearchEvent }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: analyticsMocks.trackCardEvent }));
+vi.mock("@/lib/auth/AuthProvider", () => ({ useAuth: () => ({ isLoggedIn: false, loading: false }) }));
+
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+import { normalizeConciergeResponse } from "@/features/concierge/hooks";
+import { normalizeRecommendations } from "@/lib/api/concierge/normalize";
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+
+const filterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+  visitPreferences: [],
+};
+
+function fact(type: string, label: string, isPrimary = true) {
+  return { type, label, evidence: [`${type}:${label}`], score: 1, ...(isPrimary ? { is_primary: true } : {}) };
+}
+
+function renderBackendResponse(recommendations: any[]) {
+  const raw = { ok: true, data: { recommendations }, thread: { id: 2419 } };
+  const recs = normalizeRecommendations(raw.data.recommendations);
+  const unified = normalizeConciergeResponse(raw, recs);
+  const payload = buildPayloadFromUnified(unified, filterState);
+  if (!payload) throw new Error("payload should not be null");
+  render(<ConciergeSectionsRenderer payload={payload} threadId={2419} isPremiumActive />);
+  return { recs, unified, payload };
+}
+
+describe("Backend reason_facts[] end-to-end consumption", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("API normalize → Unified → Renderer → Hero visible textへelement Primaryを通す", () => {
+    const result = renderBackendResponse([{ shrine_id: 1, name: "火の神社", reason_facts: [fact("element", "火")] }]);
+
+    expect(Array.isArray(result.recs[0].reason_facts)).toBe(true);
+    expect(Array.isArray(result.unified.data.recommendations[0].reason_facts)).toBe(true);
+    const recommendationSection = result.payload.sections.find((section) => section.type === "recommendations");
+    expect(recommendationSection && Array.isArray(recommendationSection.items[0].reasonFacts)).toBe(true);
+    expect(screen.getByTestId("recommendation-match-reason")).toHaveTextContent("火");
+  });
+
+  it("history_theme PrimaryをHeroと詳細meaning文言へ通す", () => {
+    renderBackendResponse([{ shrine_id: 1, name: "再出発神社", reason_facts: [fact("history_theme", "再出発")] }]);
+    expect(screen.getByTestId("recommendation-match-reason")).toHaveTextContent("再出発");
+    expect(screen.getAllByText(/再出発/).length).toBeGreaterThan(0);
+  });
+
+  it("compact recommendationのPrimaryへBackend factを通す", () => {
+    renderBackendResponse([
+      { shrine_id: 1, name: "第一候補", reason_facts: [fact("need_tag", "仕事")] },
+      { shrine_id: 2, name: "第二候補", reason_facts: [fact("visit_style", "自然")] },
+    ]);
+    fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+    const compactCard = screen.getByText("第二候補").closest("article");
+    expect(compactCard?.querySelector('[data-testid="recommendation-match-reason"]')).toHaveTextContent("自然");
+  });
+
+  it("malformed factとis_primaryなしを安全に無視しPrimaryを推測しない", () => {
+    renderBackendResponse([{
+      shrine_id: 1,
+      name: "安全神社",
+      reason_facts: [
+        { type: "element", label: "不正", evidence: "invalid", score: 999, is_primary: true },
+        fact("need_tag", "推測禁止", false),
+      ],
+    }]);
+    expect(document.body).not.toHaveTextContent("不正");
+    expect(document.body).not.toHaveTextContent("推測禁止");
+  });
+});

--- a/apps/web/src/lib/api/concierge.ts
+++ b/apps/web/src/lib/api/concierge.ts
@@ -14,6 +14,7 @@ export type {
   ConciergeNeed,
   ConciergeBreakdown,
   ConciergeReasonFactAxis,
+  ConciergeReasonFact,
   ConciergeReasonFacts,
   RecommendationReasonV4Detail,
   RecommendationReasonV4Fact,

--- a/apps/web/src/lib/api/concierge/__tests__/normalize.test.ts
+++ b/apps/web/src/lib/api/concierge/__tests__/normalize.test.ts
@@ -2,6 +2,36 @@ import { describe, expect, it } from "vitest";
 import { normalizeRecommendations } from "../normalize";
 
 describe("normalizeRecommendations", () => {
+  it("Backend reason_facts wire shapeを順序と値を変えずに保持し、malformed factを除外する", () => {
+    const valid = {
+      type: "element",
+      label: "火",
+      evidence: ["astro_bonus"],
+      score: 1.25,
+      is_primary: true,
+    };
+    const secondary = {
+      type: "need_tag",
+      label: "仕事",
+      evidence: ["career"],
+      score: 9,
+    };
+
+    const [rec] = normalizeRecommendations([{
+      name: "A",
+      reason_facts: [valid, null, { type: "", label: "欠損", evidence: [], score: 1 }, secondary, { ...valid, evidence: "invalid" }],
+    }]);
+
+    expect(rec.reason_facts).toEqual([valid, secondary]);
+    expect(rec.reason_facts?.[0]).toBe(valid);
+    expect(rec.reason_facts?.[1]).toBe(secondary);
+  });
+
+  it.each([null, {}, "invalid", 1])("array以外のreason_factsを空配列として安全に扱う: %p", (reasonFacts) => {
+    const [rec] = normalizeRecommendations([{ name: "A", reason_facts: reasonFacts }]);
+    expect(rec.reason_facts).toEqual([]);
+  });
+
   it("reason_source など未知フィールドを保持する", () => {
     const input = [
       {

--- a/apps/web/src/lib/api/concierge/normalize.ts
+++ b/apps/web/src/lib/api/concierge/normalize.ts
@@ -1,5 +1,5 @@
 // apps/web/src/lib/api/concierge/normalize.ts
-import type { ConciergeRecommendation } from "./types";
+import type { ConciergeReasonFact, ConciergeRecommendation } from "./types";
 
 function toTrimmedString(v: unknown): string | null {
   if (v == null) return null;
@@ -22,6 +22,21 @@ function pickReason(r: Record<string, any>): string | null {
   );
 }
 
+export function normalizeReasonFacts(input: unknown): ConciergeReasonFact[] {
+  if (!Array.isArray(input)) return [];
+
+  return input.filter((fact): fact is ConciergeReasonFact => {
+    if (fact == null || typeof fact !== "object" || Array.isArray(fact)) return false;
+    const candidate = fact as Record<string, unknown>;
+    if (typeof candidate.type !== "string" || candidate.type.trim().length === 0) return false;
+    if (typeof candidate.label !== "string" || candidate.label.trim().length === 0) return false;
+    if (!Array.isArray(candidate.evidence) || !candidate.evidence.every((item) => typeof item === "string")) return false;
+    if (typeof candidate.score !== "number" || !Number.isFinite(candidate.score)) return false;
+    if (candidate.is_primary !== undefined && typeof candidate.is_primary !== "boolean") return false;
+    return true;
+  });
+}
+
 export function normalizeRecommendations(input: unknown): ConciergeRecommendation[] {
   if (!Array.isArray(input)) return [];
 
@@ -42,6 +57,7 @@ export function normalizeRecommendations(input: unknown): ConciergeRecommendatio
         display_name: (r.display_name ?? "").toString().trim() || name,
         display_address,
         reason,
+        reason_facts: normalizeReasonFacts(r.reason_facts),
         is_dummy: r.is_dummy === true || r.__dummy === true,
         __dummy: r.__dummy === true,
       } as ConciergeRecommendation;

--- a/apps/web/src/lib/api/concierge/types.ts
+++ b/apps/web/src/lib/api/concierge/types.ts
@@ -135,27 +135,16 @@ export type RecommendationReasonV4Detail = {
   action: RecommendationReasonV4Action;
 };
 
-export type ConciergeReasonFacts = {
-  version?: 1;
-  primary_axis?: ConciergeReasonFactAxis | null;
-  secondary_axis?: ConciergeReasonFactAxis | null;
-
-  matched_need_tags?: string[];
-  matched_benefits?: string[];
-
-  shrine_feature?: string | null;
-  shrine_benefit?: string | null;
-  visit_fit?: string | null;
-
-  matched_element?: string | null;
-  matched_sign?: string | null;
-
-  distance_label?: string | null;
-  popularity_label?: string | null;
-
-  fallback_reason?: string | null;
-  confidence?: "high" | "mid" | "low" | null;
+export type ConciergeReasonFact = {
+  type: string;
+  label: string;
+  evidence: string[];
+  score: number;
+  is_primary?: boolean;
 };
+
+/** Backend wire contract. This is intentionally not the legacy aggregate object shape. */
+export type ConciergeReasonFacts = ConciergeReasonFact[];
 
 export type ConciergeRecommendation = {
   id?: number | null;

--- a/apps/web/src/lib/concierge/__tests__/adaptReasonFactsForViewModel.test.ts
+++ b/apps/web/src/lib/concierge/__tests__/adaptReasonFactsForViewModel.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import type { ConciergeReasonFact } from "@/lib/api/concierge";
+import { adaptReasonFactsForViewModel } from "../adaptReasonFactsForViewModel";
+import { buildRecommendationReasonViewModel } from "../buildRecommendationReasonViewModel";
+
+function fact(type: string, label: string, overrides: Partial<ConciergeReasonFact> = {}): ConciergeReasonFact {
+  return { type, label, evidence: [`${type}:${label}`], score: 1, is_primary: true, ...overrides };
+}
+
+describe("adaptReasonFactsForViewModel", () => {
+  it.each([
+    ["element", "火", { primary_axis: "element", matched_element: "火" }],
+    ["need_tag", "仕事", { primary_axis: "need", matched_need_tags: ["仕事"] }],
+    ["user_selected_tag", "厄除け", { primary_axis: "need", matched_need_tags: ["厄除け"] }],
+    ["goriyaku_tag", "勝運", { primary_axis: "benefit", shrine_benefit: "勝運" }],
+    ["history_theme", "再出発", { primary_axis: "feature", shrine_feature: "再出発" }],
+    ["text_hint", "静かな境内", { primary_axis: "feature", shrine_feature: "静かな境内" }],
+    ["visit_style", "自然", { primary_axis: "feature", visit_fit: "自然" }],
+    ["fallback", "近隣候補から選定", { primary_axis: "fallback", fallback_reason: "近隣候補から選定" }],
+  ])("%s Primaryを既存表示slotへ写像する", (type, label, expected) => {
+    expect(adaptReasonFactsForViewModel([fact(type, label)])).toEqual(expect.objectContaining(expected));
+  });
+
+  it("unknown typeをfallbackへ変換せず無視する", () => {
+    expect(adaptReasonFactsForViewModel([fact("unknown", "未知")])).toBeNull();
+  });
+
+  it("is_primaryが無ければscoreや配列順からPrimaryを作らない", () => {
+    expect(adaptReasonFactsForViewModel([
+      fact("element", "火", { is_primary: undefined, score: 999 }),
+      fact("need_tag", "仕事", { is_primary: undefined, score: 1 }),
+    ])).toBeNull();
+  });
+
+  it("複数Primaryでもscoreで再ランキングせず、最初の明示Primaryを採用する", () => {
+    const adapted = adaptReasonFactsForViewModel([
+      fact("need_tag", "仕事", { score: 1 }),
+      fact("element", "火", { score: 999 }),
+    ]);
+    expect(adapted).toEqual(expect.objectContaining({ primary_fact_type: "need_tag", primary_fact_label: "仕事" }));
+  });
+});
+
+describe("buildRecommendationReasonViewModel Backend fact consumption", () => {
+  const build = (type: string, label: string) => buildRecommendationReasonViewModel({
+    rec: { id: 999, name: "契約神社" },
+    reasonFacts: [fact(type, label)],
+    index: 0,
+    mode: "need",
+    needTags: [],
+  });
+
+  it.each([
+    ["element", "火"],
+    ["need_tag", "仕事"],
+    ["history_theme", "再出発"],
+    ["visit_style", "自然"],
+    ["fallback", "近隣候補から選定"],
+  ])("%s Primaryのlabelがvisible text用ViewModelへ届く", (type, label) => {
+    const vm = build(type, label);
+    expect([vm.list.primaryPhrase, vm.hero.catchCopy, vm.detail.shrineMeaning].join(" ")).toContain(label);
+  });
+
+  it("element PrimaryをHero見出し・catch copyへ反映する", () => {
+    const vm = build("element", "火");
+    expect(vm.hero.topReasonLabel).toBe("内容との一致が強い");
+    expect(vm.hero.catchCopy).toBe("相性から無理なく選びたい時の神社");
+    expect(vm.list.primaryPhrase).toContain("火");
+  });
+
+  it("history_theme Primaryを詳細meaning文言へ反映する", () => {
+    const vm = build("history_theme", "再出発");
+    expect(vm.detail.shrineMeaning).toContain("再出発");
+  });
+
+  it("is_primaryなしではfact labelをvisible textへ採用しない", () => {
+    const vm = buildRecommendationReasonViewModel({
+      rec: { id: 999, name: "契約神社" },
+      reasonFacts: [fact("element", "Frontendで推測禁止", { is_primary: undefined, score: 999 })],
+      index: 0,
+      mode: "need",
+      needTags: [],
+    });
+    expect(JSON.stringify(vm)).not.toContain("Frontendで推測禁止");
+  });
+});

--- a/apps/web/src/lib/concierge/adaptReasonFactsForViewModel.ts
+++ b/apps/web/src/lib/concierge/adaptReasonFactsForViewModel.ts
@@ -1,0 +1,48 @@
+import type { ConciergeReasonFacts } from "@/lib/api/concierge";
+
+export type RecommendationReasonViewFacts = {
+  primary_axis?: "need" | "benefit" | "feature" | "element" | "distance" | "popularity" | "fallback" | null;
+  matched_need_tags?: string[] | null;
+  matched_element?: string | null;
+  shrine_benefit?: string | null;
+  shrine_feature?: string | null;
+  visit_fit?: string | null;
+  fallback_reason?: string | null;
+  primary_fact_type?: string | null;
+  primary_fact_label?: string | null;
+};
+
+/**
+ * Adapts the Backend wire fact chosen by Backend into existing display slots.
+ * It never compares scores, infers from array position, or duplicates Backend type priority.
+ */
+export function adaptReasonFactsForViewModel(reasonFacts: ConciergeReasonFacts | null | undefined): RecommendationReasonViewFacts | null {
+  if (!Array.isArray(reasonFacts)) return null;
+  const primary = reasonFacts.find((fact) => fact.is_primary === true);
+  if (!primary) return null;
+
+  const base = {
+    primary_fact_type: primary.type,
+    primary_fact_label: primary.label,
+  } satisfies RecommendationReasonViewFacts;
+
+  switch (primary.type) {
+    case "element":
+      return { ...base, primary_axis: "element", matched_element: primary.label };
+    case "need_tag":
+      return { ...base, primary_axis: "need", matched_need_tags: [primary.label] };
+    case "user_selected_tag":
+      return { ...base, primary_axis: "need", matched_need_tags: [primary.label] };
+    case "goriyaku_tag":
+      return { ...base, primary_axis: "benefit", shrine_benefit: primary.label };
+    case "history_theme":
+    case "text_hint":
+      return { ...base, primary_axis: "feature", shrine_feature: primary.label };
+    case "visit_style":
+      return { ...base, primary_axis: "feature", visit_fit: primary.label };
+    case "fallback":
+      return { ...base, primary_axis: "fallback", fallback_reason: primary.label };
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/lib/concierge/buildMeaningNarrative.ts
+++ b/apps/web/src/lib/concierge/buildMeaningNarrative.ts
@@ -293,6 +293,9 @@ function buildMeaningCore(args: {
   })();
 
   const shrineFact = (() => {
+    const feature = clean(args.shrine.feature);
+    if (feature) return `「${feature}」という意味・特徴を持つ場所で`;
+
     const place = (() => {
       if (args.context.place === "mountain") return "山や高低差の文脈";
       if (args.context.place === "forest") return "森や木々に囲まれた文脈";

--- a/apps/web/src/lib/concierge/buildReasonNarrative.ts
+++ b/apps/web/src/lib/concierge/buildReasonNarrative.ts
@@ -369,8 +369,37 @@ function buildFactsCandidates(params: BuildParams, inputType: ReturnType<typeof 
   const element = clean(rec.reason_facts?.matched_element) || getPrimaryElement(rec);
   const distance = formatDistance(rec.distance_m);
   const distanceLabel = clean(rec.reason_facts?.distance_label) || distance;
+  const primaryFactType = clean(rec.reason_facts?.primary_fact_type);
+  const primaryFactLabel = clean(rec.reason_facts?.primary_fact_label);
 
-  switch (match.primaryReasonType) {
+  if (primaryFactLabel) {
+    switch (primaryFactType) {
+      case "element":
+        out.push({ key: "element_match", text: `生年月日から見た「${primaryFactLabel}」の要素との相性が強く重なるため、この神社が候補に入っています。` });
+        break;
+      case "need_tag":
+        out.push({ key: "need_match", text: `相談内容の「${primaryFactLabel}」と一致するため、この神社が候補に入っています。` });
+        break;
+      case "user_selected_tag":
+        out.push({ key: "need_match", text: `明示的に指定した「${primaryFactLabel}」と一致するため、この神社が候補に入っています。` });
+        break;
+      case "goriyaku_tag":
+        out.push({ key: "need_match", text: `「${primaryFactLabel}」のご利益が相談に重なるため、この神社が候補に入っています。` });
+        break;
+      case "history_theme":
+      case "text_hint":
+        out.push({ key: "text_match", text: `「${primaryFactLabel}」という意味・特徴が相談に重なるため、この神社が候補に入っています。` });
+        break;
+      case "visit_style":
+        out.push({ key: "text_match", text: `参拝Preferenceの「${primaryFactLabel}」に合うため、この神社が候補に入っています。` });
+        break;
+      case "fallback":
+        out.push({ key: "distance", text: primaryFactLabel });
+        break;
+    }
+  }
+
+  if (out.length === 0) switch (match.primaryReasonType) {
     case "need_benefit_match": {
       const text = buildIntersectionPrimaryText({
         need: consultation.needPrimary,

--- a/apps/web/src/lib/concierge/buildRecommendationReasonViewModel.ts
+++ b/apps/web/src/lib/concierge/buildRecommendationReasonViewModel.ts
@@ -1,6 +1,8 @@
 import { buildReasonNarrative } from "./buildReasonNarrative";
 import { buildStateNarrative } from "./buildStateNarrative";
 import { buildMeaningNarrative } from "./buildMeaningNarrative";
+import { adaptReasonFactsForViewModel, type RecommendationReasonViewFacts } from "./adaptReasonFactsForViewModel";
+import type { ConciergeReasonFacts } from "@/lib/api/concierge";
 import {
   HERO_COMPAT_SUBTITLE,
   HERO_EYEBROW_LABELS,
@@ -36,7 +38,8 @@ export type RecommendationLike = {
     matched_need_tags?: string[] | null;
   } | null;
   breakdown_detail?: any | null;
-  reason_facts?: {
+  /** Display-only aggregate shape. Not a Backend/API contract. */
+  reason_facts?: RecommendationReasonViewFacts & {
     primary_axis?: "need" | "benefit" | "feature" | "element" | "distance" | "popularity" | "fallback" | null;
     confidence?: "high" | "mid" | "low" | null;
     matched_element?: string | null;
@@ -84,6 +87,7 @@ export type RecommendationReasonViewModel = {
 
 export type BuildParams = {
   rec: RecommendationLike;
+  reasonFacts?: ConciergeReasonFacts | null;
   index: number;
   mode?: "need" | "compat" | string | null;
   /**
@@ -482,25 +486,31 @@ export function buildRecommendationMatchModel(args: {
  * - UI shape に詰める
  */
 export function buildRecommendationReasonViewModel(params: BuildParams): RecommendationReasonViewModel {
-  const reason = buildReasonNarrative(params);
+  const adaptedReasonFacts = adaptReasonFactsForViewModel(params.reasonFacts);
+  const adaptedParams: BuildParams = adaptedReasonFacts
+    ? { ...params, rec: { ...params.rec, reason_facts: adaptedReasonFacts } }
+    : params.reasonFacts !== undefined
+      ? { ...params, rec: { ...params.rec, reason_facts: null } }
+      : params;
+  const reason = buildReasonNarrative(adaptedParams);
   const compactReason = compactReasonViewModel(reason);
 
-  const inputType = resolveInputType(params);
+  const inputType = resolveInputType(adaptedParams);
   const hero = buildHeroCopy({
-    mode: params.mode,
+    mode: adaptedParams.mode,
     inputType,
-    needTags: params.needTags,
+    needTags: adaptedParams.needTags,
     hero: compactReason.hero,
   });
 
   const state = buildStateNarrative({
-    params,
+    params: adaptedParams,
     primary: reason._meta.primary,
     secondary: reason._meta.secondary,
   });
 
   const meaning = buildMeaningNarrative({
-    params,
+    params: adaptedParams,
     primary: reason._meta.primary,
     secondary: reason._meta.secondary,
   });


### PR DESCRIPTION
## Summary

Backendの実wire shapeである `reason_facts: Fact[]` をFrontend contractの正本として固定し、旧集約objectとして誤解釈していたconsumption boundaryを修正します。

## Root cause

Backendは `type / label / evidence / score / is_primary` を持つfact配列を返していますが、Frontend型とViewModelは `primary_axis / matched_element / shrine_feature` 等を持つ集約objectを期待していました。normalizeとUnified payloadが配列をそのまま通した後、Rendererでobjectとして読むため、実Backend Primary Reasonがsilentに欠落していました。

## Changes

- `ConciergeReasonFact` と `ConciergeReasonFacts = ConciergeReasonFact[]` を追加
- `normalizeRecommendations()` で配列・必須fieldを検証し、malformed factのみ除外
- Backend配列から既存表示slotへの単一adapterを追加
- `is_primary === true` のfactだけをPrimaryとして採用
- element / need_tag / user_selected_tag / goriyaku_tag / history_theme / text_hint / visit_style / fallbackを表示slotへ写像
- unknown type、非配列、Primary指定なしを安全に無視
- Hero、compact recommendation、詳細meaningへの表示経路を修正
- API normalize → Unified → section payload → Renderer → Visible UIの契約テストを追加
- API/Unified相当のlegacy object fixtureをBackend list fixtureへ置換

Frontendはscore比較、配列順によるPrimary推測、type priority、Backend `PRIMARY_REASON_PRIORITY` の複製を行いません。複数の明示Primaryという異常入力でもscoreによる再ランキングは行いません。

## Scope

Frontend consumption boundaryのみです。Backend production code、Signal Authority、Ranking、Candidate Filtering、Reason生成、API Backend contract、migrationは変更していません。

## Validation

- Frontend suite: 123 files / 815 tests passed
- Frontend typecheck: passed
- Next.js production build (webpack): passed
- PR #2417 Authority Contract Tests: passed unmodified
- PR #2418 Context Override Guard Tests: passed unmodified
- PR #2419 Explanation Alignment Tests: passed unmodified
- Backend contract selection total: 31 passed
- pre-push OpenAPI lint and Web contract suite: passed
- Browser QA: 実BackendレスポンスでHeroの構造化Reason表示と、compact候補のhistory_theme Primary（「勝負」）がVisible UIへ届くことを確認

Note: default Turbopack buildは実装とは無関係なローカル環境のport bind制限でpanicしたため、Next.js webpack builderでproduction buildを完走しています。