### PR TITLE
fix: align recommendation reason v4 with ranking authority

### DIFF
--- a/backend/temples/services/concierge_chat.py
+++ b/backend/temples/services/concierge_chat.py
@@ -439,7 +439,9 @@ def _build_score_v3_candidate_profile(rec: dict[str, Any]) -> dict[str, Any]:
         "name": rec.get("name") or source.get("nameJp"),
         "history_theme": rec.get("history_theme") or source.get("historyTheme"),
         "goriyaku": rec.get("goriyaku") or source.get("goriyaku"),
-        "goriyaku_tags": rec.get("goriyaku_tags") or source.get("goriyakuTags") or breakdown.get("matched_need_tags") or [],
+        # Consultation-side matched_need_tags are ranking evidence, not raw
+        # shrine facts.  Do not re-label them as the shrine's goriyaku here.
+        "goriyaku_tags": rec.get("goriyaku_tags") or source.get("goriyakuTags") or [],
         "visit_style_tags": rec.get("visit_style_tags") or features.get("visit_style") or [],
         # Fact-ready ShrineDeity/ShrineHistory（新Knowledge）をfield単位で優先し、
         # 存在しない場合のみLegacy（sajin/description）へfallbackする。
@@ -508,6 +510,7 @@ def _build_reason_v4_preview_payload(
         )
         preview = build_recommendation_reason_v4(
             recommendation_input_profile=recommendation_input_profile,
+            authority_context=_build_reason_v4_authority_context(rec),
         )
 
         previews.append({
@@ -517,6 +520,25 @@ def _build_reason_v4_preview_payload(
             "preview": preview,
         })
     return previews
+
+
+def _build_reason_v4_authority_context(rec: dict[str, Any]) -> dict[str, Any]:
+    """Pass through the already-resolved Primary Reason; never resolve it again."""
+    reason_facts = rec.get("_reason_facts") if isinstance(rec.get("_reason_facts"), list) else []
+    primary_fact = next(
+        (
+            fact
+            for fact in reason_facts
+            if isinstance(fact, dict) and fact.get("is_primary") is True
+        ),
+        {},
+    )
+    primary_source = str(rec.get("_primary_reason_source") or "fallback").strip() or "fallback"
+    return {
+        "primary_reason_source": primary_source,
+        "primary_reason_fact": primary_fact,
+        "is_fallback": primary_source == "fallback",
+    }
 
 
 def _attach_recommendation_reason_quality(
@@ -557,6 +579,7 @@ def _attach_recommendation_reason_quality(
         )
         preview = build_recommendation_reason_v4(
             recommendation_input_profile=recommendation_input_profile,
+            authority_context=_build_reason_v4_authority_context(rec),
         )
         rec["recommendation_reason_v4"] = str(preview.get("reason_text") or "")
         quality = dict(preview.get("quality") or {})

--- a/backend/temples/services/recommendation_reason_v4.py
+++ b/backend/temples/services/recommendation_reason_v4.py
@@ -200,7 +200,9 @@ def _build_fact(
     `_build_fact_text()`がテンプレート選択にのみ使う内部専用の値であり、
     RecommendationReasonV4の公開dictへは含めない。
     """
-    history_theme = _first_string(candidate_profile.get("history_theme"), meaning_translation.get("history_theme"))
+    # culture_translation is Derived Meaning (Explanation-only), not a raw
+    # shrine fact.  It remains available to Interpretation/Action below.
+    history_theme = _first_string(candidate_profile.get("history_theme"))
     deity = _first_string(candidate_profile.get("deity"), candidate_profile.get("main_deity"), candidate_profile.get("enshrined_deity"))
     shrine_history = _first_string(candidate_profile.get("history"), candidate_profile.get("shrine_history"), candidate_profile.get("origin"))
     place_context = _first_string(candidate_profile.get("place_context"), candidate_profile.get("area_context"), candidate_profile.get("location_context"))
@@ -383,6 +385,29 @@ def _build_used_interpretation(
     }
 
 
+def _align_interpretation_with_authority(
+    interpretation: dict[str, Any],
+    authority_context: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Keep consultation understanding without inventing ranking authority."""
+    authority = _as_dict(authority_context)
+    primary_source = _first_string(authority.get("primary_reason_source"))
+    text = _first_string(interpretation.get("text")) or "相談内容から、今扱いたいテーマを読み取っています。"
+
+    if primary_source == "user_selected_tag":
+        text = (
+            f"{text.rstrip('。')}。"
+            "指定された条件を満たす候補ですが、順位への意味的一致を示すものではありません。"
+        )
+    elif primary_source in {"element", "visit_style", "fallback"}:
+        text = (
+            f"{text.rstrip('。')}。"
+            "今回は明確な意味的一致が確認できないため、条件に近い候補として整理しています。"
+        )
+
+    return {**interpretation, "text": text}
+
+
 def _build_action(interpretation_profile: dict[str, Any], meaning_translation: dict[str, Any]) -> dict[str, Any]:
     """Build the Action layer as one concrete next step.
 
@@ -561,7 +586,7 @@ def _build_fact_text(fact: dict[str, Any], reason_strength: dict[str, str] | Non
         # deity / shrine_history / goriyaku / history_theme が一つもない場合。
         # （confidence=lowによりsuppressされた場合を含む。）
         # place_context(住所)や神社名だけでは神社固有Factがあるとは表現しない。
-        fact_text = "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
+        fact_text = "神社固有情報が十分でないため、確認できる情報をもとに候補として整理しています。"
 
     if visit_style_copies:
         fact_details.extend(visit_style_copies[:2])
@@ -578,12 +603,38 @@ def _build_reason_text(
     interpretation: dict[str, Any],
     action: dict[str, Any],
     reason_strength: dict[str, str] | None = None,
+    authority_context: dict[str, Any] | None = None,
 ) -> str:
     """Compose reason_text as Fact -> Interpretation -> Action.
 
     Keep each sentence responsible for one layer only.
     """
+    authority = _as_dict(authority_context)
+    primary_source = _first_string(authority.get("primary_reason_source"))
+    primary_fact = _as_dict(authority.get("primary_reason_fact"))
+    semantic_authority = primary_source in {
+        "history_theme",
+        "need_tag",
+        "text_hint",
+        "goriyaku_tag",
+    }
+
     fact_text = _build_fact_text(fact, reason_strength)
+    has_shrine_fact = any(
+        _is_present_fact_value(fact.get(key)) for key in QUALITY_FACT_KEYS
+    )
+    if semantic_authority and not has_shrine_fact:
+        primary_label = _first_string(primary_fact.get("label"))
+        if primary_label:
+            label_copy = _copy_for_key(NEED_COPY, primary_label) or primary_label
+            subject = _first_string(fact.get("name")) or "この神社"
+            fact_text = f"{subject}には、{label_copy}ことに関わる登録情報があります。"
+    elif primary_source and not semantic_authority and has_shrine_fact:
+        fact_text = (
+            f"{fact_text.rstrip('。')}。"
+            "この情報は神社を説明する補助情報であり、今回の順位根拠ではありません。"
+        )
+
     interpretation_text = _first_string(interpretation.get("text")) or "相談内容から、今扱いたいテーマを読み取っています。"
     action_text = _first_string(action.get("text")) or "次に確認したいことを一つだけ決めます。"
 
@@ -597,6 +648,7 @@ def build_recommendation_reason_v4(
     interpretation_profile: dict[str, Any] | None = None,
     meaning_translation: dict[str, Any] | None = None,
     candidate_profile: dict[str, Any] | None = None,
+    authority_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a preview-only Recommendation Reason v4 payload.
 
@@ -610,14 +662,23 @@ def build_recommendation_reason_v4(
     candidate = _as_dict(candidate_profile) or _as_dict(recommendation_input.get("candidate_profile"))
 
     fact, reason_strength = _build_fact(candidate, meaning)
-    interpretation_layer = _build_interpretation(interpretation, meaning)
+    interpretation_layer = _align_interpretation_with_authority(
+        _build_interpretation(interpretation, meaning),
+        authority_context,
+    )
     action = _build_action(interpretation, meaning)
     used_fact = _build_used_fact(fact)
     used_interpretation = _build_used_interpretation(interpretation, meaning, interpretation_layer, fact)
     used_action = _build_used_action(interpretation, meaning, action)
 
     reason = RecommendationReasonV4(
-        reason_text=_build_reason_text(fact, interpretation_layer, action, reason_strength),
+        reason_text=_build_reason_text(
+            fact,
+            interpretation_layer,
+            action,
+            reason_strength,
+            authority_context,
+        ),
         fact=fact,
         interpretation=interpretation_layer,
         action=action,

--- a/backend/temples/tests/services/test_recommendation_reason_v4.py
+++ b/backend/temples/tests/services/test_recommendation_reason_v4.py
@@ -340,7 +340,9 @@ def test_build_recommendation_reason_v4_uses_recommendation_input_profile_when_d
         }
     )
 
-    assert result["fact"]["label"] == "縁"
+    # translation_result.history_theme is Derived Meaning, not a raw Shrine Fact.
+    assert result["fact"]["label"] == "縁結び"
+    assert result["fact"]["history_theme"] is None
     assert result["interpretation"]["theme"] == "縁"
     assert result["action"]["text"] == "参拝前に、気持ちを落ち着け、今の状態を静かに見直すことを一つだけ決めておくと、行動につなげやすくなります。"
 
@@ -427,7 +429,7 @@ def test_build_recommendation_reason_v4_handles_missing_inputs_safely():
     result = build_recommendation_reason_v4()
 
     assert result == {
-        "reason_text": "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。相談内容から、今扱いたいテーマを読み取っています。参拝前に、次に確認したいことを一つだけ決めておきます。",
+        "reason_text": "神社固有情報が十分でないため、確認できる情報をもとに候補として整理しています。相談内容から、今扱いたいテーマを読み取っています。参拝前に、次に確認したいことを一つだけ決めておきます。",
         "fact": {
             "label": "候補神社",
             "name": None,
@@ -584,7 +586,7 @@ def test_build_recommendation_reason_v4_place_context_only_does_not_state_addres
     assert "東京都渋谷区代々木神園町1-1" not in result["reason_text"]
     assert "の特徴があります" not in result["reason_text"]
     assert (
-        "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
+        "神社固有情報が十分でないため、確認できる情報をもとに候補として整理しています。"
         in result["reason_text"]
     )
 
@@ -860,7 +862,7 @@ def test_build_recommendation_reason_v4_no_facts_falls_back_without_fabricating_
     )
 
     assert (
-        "神社固有情報が十分でないため、相談条件との一致を中心に整理しています。"
+        "神社固有情報が十分でないため、確認できる情報をもとに候補として整理しています。"
         in result["reason_text"]
     )
     assert result["quality"]["fallback_source"] == "fallback"

--- a/backend/temples/tests/services/test_recommendation_reason_v4_authority_alignment.py
+++ b/backend/temples/tests/services/test_recommendation_reason_v4_authority_alignment.py
@@ -1,0 +1,203 @@
+"""Reason v4 consumes the existing Primary Authority without resolving it again."""
+
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+
+
+def _shrine(id_: int, name: str, **overrides):
+    candidate = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": name,
+        "address": f"テスト所在地{id_}",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _run(candidate, **overrides):
+    params = {
+        "query": "",
+        "language": "ja",
+        "candidates": [candidate],
+        "public_mode": "need",
+        "flow": "A",
+    }
+    params.update(overrides)
+    rec = build_chat_recommendations(**params)["recommendations"][0]
+    return rec, rec["recommendation_reason_v4_detail"]
+
+
+@pytest.fixture(autouse=True)
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "case,candidate,params,expected_primary,expected_fact,expected_text",
+    [
+        (
+            "need_tag Primary",
+            _shrine(1, "仕事神社", astro_tags=["career"]),
+            {"query": "仕事を見直したい", "need_tags": ["career"]},
+            "need_tag",
+            None,
+            "登録情報があります",
+        ),
+        (
+            "history_theme Primary",
+            _shrine(2, "縁神社", astro_tags=["relationship"], history_theme="縁"),
+            {
+                "query": "関係を修復したい",
+                "need_tags": ["relationship"],
+                "consultation_axis": "relationship_repair",
+            },
+            "history_theme",
+            "縁",
+            "縁という文脈",
+        ),
+        (
+            "goriyaku Primary",
+            _shrine(3, "恋愛神社", goriyaku="縁結び・恋愛成就"),
+            {"query": "恋愛の縁を結びたい", "need_tags": ["love"]},
+            "text_hint",
+            "縁結び・恋愛成就",
+            "縁結び・恋愛成就に関する情報",
+        ),
+    ],
+)
+def test_primary_authority_keeps_grounded_reason_strength(
+    case, candidate, params, expected_primary, expected_fact, expected_text
+):
+    rec, detail = _run(candidate, **params)
+
+    assert rec["_primary_reason_source"] == expected_primary, case
+    if expected_primary == "history_theme":
+        assert detail["fact"]["history_theme"] == expected_fact
+    if expected_primary == "text_hint":
+        assert detail["fact"]["goriyaku"] == expected_fact
+    if expected_primary == "need_tag":
+        assert detail["fact"]["goriyaku"] is None
+    assert expected_text in detail["reason_text"]
+    assert "明確な意味的一致が確認できない" not in detail["interpretation"]["text"]
+    assert rec["recommendation_reason_quality"]["fallback_source"] in {None, "fallback"}
+
+
+@pytest.mark.django_db
+def test_explicit_constraint_is_not_described_as_ranking_meaning_match():
+    rec, detail = _run(
+        _shrine(4, "指定神社", goriyaku_tag_ids=[501]),
+        query="条件に合う神社",
+        goriyaku_tag_ids=[501],
+    )
+
+    assert rec["_primary_reason_source"] == "user_selected_tag"
+    assert "指定された条件を満たす候補" in detail["interpretation"]["text"]
+    assert "順位への意味的一致を示すものではありません" in detail["reason_text"]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "case,candidate,params,expected_primary",
+    [
+        (
+            "Personalization-only",
+            _shrine(5, "五行神社", astro_elements=["火", "水", "木", "金", "土"]),
+            {"birthdate": "1990-01-01", "public_mode": "compat"},
+            "element",
+        ),
+        ("Secondary-only", _shrine(6, "人気神社", popular_score=10.0), {}, "fallback"),
+        (
+            "Context-only",
+            _shrine(7, "近隣神社", distance_m=50),
+            {"bias": {"lat": 35.0, "lng": 139.0}},
+            "fallback",
+        ),
+        ("fallback", _shrine(10, "情報なし神社"), {}, "fallback"),
+    ],
+)
+def test_non_semantic_authority_does_not_claim_a_match(
+    case, candidate, params, expected_primary
+):
+    rec, detail = _run(candidate, **params)
+
+    assert rec["_primary_reason_source"] == expected_primary, case
+    assert detail["fact"]["goriyaku"] is None
+    assert "明確な意味的一致が確認できない" in detail["interpretation"]["text"]
+    assert "相談条件との一致" not in detail["reason_text"]
+    assert "あなたの相談に合う" not in detail["reason_text"]
+    assert rec["recommendation_reason_quality"]["fallback_source"] == "fallback"
+
+
+@pytest.mark.django_db
+def test_knowledge_fact_is_explicitly_separate_from_ranking_attribution():
+    rec, detail = _run(
+        _shrine(
+            8,
+            "知識神社",
+            knowledge_deities=[{"display_name": "天照大神", "confidence": "high"}],
+            knowledge_histories=[
+                {
+                    "history_type": "founding",
+                    "content": "古くから地域を見守る由緒があります。",
+                    "confidence": "high",
+                }
+            ],
+        ),
+        query="天照大神にお参りしたい",
+    )
+
+    assert rec["_primary_reason_source"] == "fallback"
+    assert detail["fact"]["deity"] == "天照大神"
+    assert "今回の順位根拠ではありません" in detail["reason_text"]
+    assert "明確な意味的一致が確認できない" in detail["interpretation"]["text"]
+    assert rec["recommendation_reason_quality"]["fallback_source"] == "fallback"
+
+
+@pytest.mark.django_db
+def test_culture_translation_stays_derived_meaning_not_shrine_fact():
+    rec, detail = _run(
+        _shrine(
+            9,
+            "翻訳神社",
+            astro_tags=["career"],
+            culture_translation={"present": True},
+            meaning_payload={
+                "source": {
+                    "translationResult": {
+                        "history_theme": "再出発",
+                        "shrine_context_need": "仕事の流れを見直す",
+                        "action_context": "今の仕事を一つ整理する",
+                    }
+                }
+            },
+        ),
+        query="仕事を見直したい",
+        need_tags=["career"],
+    )
+
+    assert rec["_primary_reason_source"] == "need_tag"
+    assert detail["fact"]["history_theme"] is None
+    assert detail["fact"]["goriyaku"] is None
+    assert detail["interpretation"]["theme"] == "再出発"
+    assert detail["action"]["source"] == "meaning_translation.action_context"
+    assert "再出発という文脈で整理" not in detail["reason_text"]
+    assert rec["recommendation_reason_quality"]["fallback_source"] is None


### PR DESCRIPTION
## Summary
- passes the Backend-resolved primary reason source/fact/fallback state into Reason v4 as read-only authority context
- removes consultation matched tags and culture_translation-derived history_theme from the raw Shrine Fact path
- weakens fallback, Personalization-only, Context-only, Secondary-only, and Explicit Constraint wording without suppressing consultation interpretation
- keeps Knowledge/culture_translation available as Explanation material while separating them from ranking attribution
- leaves Action generation unchanged

## Guardrails
- Ranking: unchanged
- Candidate filtering: unchanged
- Signal Authority / Primary priority: unchanged
- Knowledge Ranking: unchanged
- Frontend UI / API shape: unchanged
- schema / migrations: unchanged

## Verification
- new 10-scenario Authority Alignment suite: 10 passed
- targeted Reason v4 + PR #2417-#2422 contracts: 76 passed
- full backend suite: 1454 passed, 13 skipped
- frontend contract suite: 123 files / 815 tests passed
- makemigrations --check --dry-run: No changes detected
- pre-push OpenAPI lint and Web contract checks: passed

Action grounding strength/UI differentiation remains intentionally deferred to the follow-up identified by PR #2423.