### PR TITLE
fix: align action suggestion grounding provenance

### DIFF
--- a/backend/temples/services/action_suggestion_builder.py
+++ b/backend/temples/services/action_suggestion_builder.py
@@ -281,6 +281,8 @@ def build_action_suggestion(
     interpretation_profile: dict[str, Any] | None = None,
     meaning_translation: dict[str, Any] | None = None,
     recommendation_reason_v4: dict[str, Any] | None = None,
+    action_source_override: ActionSource | None = None,
+    source_keys_override: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build a preview-only Action Suggestion v4 payload.
 
@@ -331,7 +333,7 @@ def build_action_suggestion(
         primary_decision=primary_decision,
         primary_outcome=primary_outcome,
     )
-    action_source = _build_action_source(
+    action_source = action_source_override or _build_action_source(
         action_context=action_context,
         reflection_question_seed=reflection_question_seed,
         primary_constraint=primary_constraint,
@@ -339,16 +341,20 @@ def build_action_suggestion(
         primary_outcome=primary_outcome,
     )
 
-    source_keys = [
-        key
-        for key, value in {
-            "recommendation_input_profile": recommendation_input,
-            "interpretation_profile": interpretation,
-            "meaning_translation": meaning,
-            "recommendation_reason_v4": reason,
-        }.items()
-        if value
-    ]
+    source_keys = (
+        source_keys_override
+        if source_keys_override is not None
+        else [
+            key
+            for key, value in {
+                "recommendation_input_profile": recommendation_input,
+                "interpretation_profile": interpretation,
+                "meaning_translation": meaning,
+                "recommendation_reason_v4": reason,
+            }.items()
+            if value
+        ]
+    )
 
     return ActionSuggestionV4(
         primary_action=primary_action,
@@ -375,23 +381,45 @@ def attach_action_suggestion_v4_preview(recs: dict[str, Any]) -> dict[str, Any]:
         explanation_payload = _as_dict(rec.get("_explanation_payload"))
         history_context = _as_dict(explanation_payload.get("history_context"))
         action_suggestions = _as_list(explanation_payload.get("action_suggestions"))
-        first_action_suggestion = action_suggestions[0] if action_suggestions and isinstance(action_suggestions[0], dict) else {}
-
-        meaning_translation = {
-            "history_theme": _first_string(history_context.get("label"), rec.get("history_theme")),
-            "action_context": _first_string(
-                first_action_suggestion.get("description"),
-                rec.get("action_meaning"),
-            ),
-            "reflection_question_seed": _first_string(
-                first_action_suggestion.get("title"),
-                "この神社を見たあと、何を整理したいですか？",
-            ),
-        }
-
-        rec["action_suggestion_v4_preview"] = build_action_suggestion(
-            meaning_translation=meaning_translation,
+        first_action_suggestion = (
+            action_suggestions[0]
+            if action_suggestions and isinstance(action_suggestions[0], dict)
+            else {}
         )
+
+        ranked_history_theme = _first_string(history_context.get("theme"))
+        if ranked_history_theme and first_action_suggestion:
+            rec["action_suggestion_v4_preview"] = build_action_suggestion(
+                meaning_translation={
+                    "history_theme": ranked_history_theme,
+                    "action_context": _first_string(first_action_suggestion.get("description")),
+                    "reflection_question_seed": _first_string(first_action_suggestion.get("title")),
+                },
+                action_source_override=ActionSource(
+                    source="action_context",
+                    reason=f"ランキングに寄与したhistory_theme「{ranked_history_theme}」の行動カタログから提案した",
+                ),
+                source_keys_override=["ranked_history_theme", "action_catalog"],
+            )
+            continue
+
+        reason_detail = _as_dict(rec.get("recommendation_reason_v4_detail"))
+        reason_action = _as_dict(reason_detail.get("action"))
+        reason_action_source = _first_string(reason_action.get("source"))
+        if reason_action_source and reason_action_source.startswith("meaning_translation."):
+            rec["action_suggestion_v4_preview"] = build_action_suggestion(
+                recommendation_reason_v4=reason_detail,
+                action_source_override=ActionSource(
+                    source="action_context",
+                    reason="culture_translationの行動文脈を相談に基づく説明素材として提案した",
+                ),
+                source_keys_override=["recommendation_reason_v4", "culture_translation"],
+            )
+            continue
+
+        # Keep a Generic Safe action for the existing UX, but preserve its
+        # actual ungrounded provenance instead of synthesizing meaning data.
+        rec["action_suggestion_v4_preview"] = build_action_suggestion()
 
     return recs
 

--- a/backend/temples/services/concierge_explanation_payload.py
+++ b/backend/temples/services/concierge_explanation_payload.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-
 from typing import Any, Dict, List, Optional
 
-from temples.services.action_suggestions import get_action_suggestions_for_theme
-
+from temples.services.action_suggestions import (
+    HISTORY_THEME_ACTION_SUGGESTIONS,
+    get_action_suggestions_for_theme,
+)
 
 NEED_LABELS_JA: Dict[str, str] = {
     "study": "学業・合格",
@@ -240,9 +241,20 @@ def build_explanation_payload(rec: Dict[str, Any], *, birthdate: Optional[str] =
 
     gogyou_context = _build_gogyou_context(birthdate)
     history_context = _build_history_context(rec)
-    action_suggestions = get_action_suggestions_for_theme(
-        history_context.get("theme") if isinstance(history_context, dict) else None,
+    # Preserve the legacy Generic Safe copy for UX compatibility, while
+    # making its actual grounding explicit.  A catalog action is grounded in
+    # history_theme only when that theme had Rank Authority.
+    ranked_history_theme = (
+        history_context.get("theme") if isinstance(history_context, dict) else None
     )
+    action_suggestions = get_action_suggestions_for_theme(ranked_history_theme)
+    has_grounded_history_theme = ranked_history_theme in HISTORY_THEME_ACTION_SUGGESTIONS
+    grounding = (
+        {"grounding_class": "consultation_grounded", "grounding_source": "ranked_history_theme"}
+        if has_grounded_history_theme
+        else {"grounding_class": "generic_safe", "grounding_source": "fallback"}
+    )
+    action_suggestions = [{**suggestion, **grounding} for suggestion in action_suggestions]
 
     return {
         "version": 2,

--- a/backend/temples/tests/services/test_action_suggestion_builder.py
+++ b/backend/temples/tests/services/test_action_suggestion_builder.py
@@ -200,3 +200,111 @@ def test_attach_action_suggestion_v4_preview_handles_missing_recommendations_saf
     recs = {"recommendations": None}
 
     assert attach_action_suggestion_v4_preview(recs) == {"recommendations": None}
+
+
+def test_attach_preview_preserves_ranked_history_theme_grounding():
+    recs = {
+        "recommendations": [
+            {
+                "_explanation_payload": {
+                    "history_context": {"theme": "勝負", "label": "勝負"},
+                    "action_suggestions": [
+                        {
+                            "title": "今週勝負したいことを1つ決める",
+                            "description": "今週動かす対象を1つに絞ります。",
+                            "grounding_class": "consultation_grounded",
+                            "grounding_source": "ranked_history_theme",
+                        }
+                    ],
+                },
+            }
+        ],
+    }
+
+    preview = attach_action_suggestion_v4_preview(recs)["recommendations"][0][
+        "action_suggestion_v4_preview"
+    ]
+
+    assert preview["primary_action"]["description"] == "今週動かす対象を1つに絞ります。"
+    assert preview["action_source"] == {
+        "source": "action_context",
+        "reason": "ランキングに寄与したhistory_theme「勝負」の行動カタログから提案した",
+    }
+    assert preview["source_keys"] == ["ranked_history_theme", "action_catalog"]
+
+
+def test_attach_preview_preserves_culture_translation_as_consultation_grounding():
+    recs = {
+        "recommendations": [
+            {
+                "_explanation_payload": {"history_context": None, "action_suggestions": []},
+                "recommendation_reason_v4_detail": {
+                    "action": {
+                        "text": "今の仕事を一つ整理する",
+                        "source": "meaning_translation.action_context",
+                    },
+                },
+            }
+        ],
+    }
+
+    preview = attach_action_suggestion_v4_preview(recs)["recommendations"][0][
+        "action_suggestion_v4_preview"
+    ]
+
+    assert preview["primary_action"]["description"] == "今の仕事を一つ整理する"
+    assert preview["action_source"] == {
+        "source": "action_context",
+        "reason": "culture_translationの行動文脈を相談に基づく説明素材として提案した",
+    }
+    assert preview["source_keys"] == ["recommendation_reason_v4", "culture_translation"]
+
+
+def test_attach_preview_uses_generic_safe_fallback_without_grounding_claim():
+    scenarios = {
+        "themeなし": {},
+        "fallback Recommendation": {"action": {"text": "詳細を確認する", "source": "fallback"}},
+        "Knowledge Explanation-only": {
+            "fact": {"deity": "天照大神"},
+            "action": {"source": "fallback"},
+        },
+        "Context-only": {"interpretation": {"text": "近い候補"}, "action": {"source": "fallback"}},
+        "Personalization-only": {"fact": {"element": "火"}, "action": {"source": "fallback"}},
+    }
+
+    recs = {
+        "recommendations": [
+            {
+                "name": case,
+                "_explanation_payload": {
+                    "history_context": None,
+                    "action_suggestions": [
+                        {
+                            "title": "3分だけ通知を切る",
+                            "description": "通知を切り、今考えすぎていることを1行だけメモします。",
+                            "history_theme": "静寂",
+                            "grounding_class": "generic_safe",
+                            "grounding_source": "fallback",
+                        }
+                    ],
+                },
+                "recommendation_reason_v4_detail": detail,
+            }
+            for case, detail in scenarios.items()
+        ],
+    }
+
+    previews = attach_action_suggestion_v4_preview(recs)["recommendations"]
+    for rec in previews:
+        preview = rec["action_suggestion_v4_preview"]
+        assert preview["primary_action"] == {
+            "label": "まず詳細を見て、行く理由を確認する",
+            "description": "入力が少ないため、この神社の詳細を見て判断材料を増やします。",
+            "action_type": "detail_open",
+            "confidence": 0.66,
+        }, rec["name"]
+        assert preview["action_source"] == {
+            "source": "fallback",
+            "reason": "入力が不足しているため、詳細確認と保存を安全な初期提案にした",
+        }, rec["name"]
+        assert preview["source_keys"] == [], rec["name"]

--- a/backend/temples/tests/services/test_action_suggestion_grounding_alignment.py
+++ b/backend/temples/tests/services/test_action_suggestion_grounding_alignment.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import pytest
+
+from temples.services.concierge_chat import build_chat_recommendations
+
+
+def _shrine(id_: int, **overrides):
+    candidate = {
+        "id": id_,
+        "shrine_id": id_,
+        "name": f"神社{id_}",
+        "address": "テスト所在地",
+        "lat": 35.0,
+        "lng": 139.0,
+        "distance_m": 1000,
+        "goriyaku": "",
+        "description": "",
+        "goriyaku_tag_ids": [],
+        "astro_tags": [],
+        "astro_elements": [],
+        "astro_priority": 0,
+        "visit_style_tags": [],
+        "history_theme": "",
+        "popular_score": 0.5,
+        "knowledge_deities": [],
+        "knowledge_histories": [],
+    }
+    candidate.update(overrides)
+    return candidate
+
+
+def _run(candidate, **overrides):
+    params = {
+        "query": "",
+        "language": "ja",
+        "candidates": [candidate],
+        "public_mode": "need",
+        "flow": "A",
+    }
+    params.update(overrides)
+    return build_chat_recommendations(**params)["recommendations"][0]
+
+
+@pytest.fixture(autouse=True)
+def deterministic(settings):
+    settings.CONCIERGE_USE_LLM = False
+
+
+@pytest.mark.django_db
+def test_ranked_history_theme_action_keeps_catalog_grounding():
+    rec = _run(
+        _shrine(1, astro_tags=["relationship"], history_theme="縁"),
+        query="関係を修復したい",
+        need_tags=["relationship"],
+        consultation_axis="relationship_repair",
+    )
+
+    selected = rec["_explanation_payload"]["action_suggestions"][0]
+    preview = rec["action_suggestion_v4_preview"]
+    assert selected["grounding_class"] == "consultation_grounded"
+    assert selected["grounding_source"] == "ranked_history_theme"
+    assert preview["primary_action"]["description"] == selected["description"]
+    assert preview["action_source"] == {
+        "source": "action_context",
+        "reason": "ランキングに寄与したhistory_theme「縁」の行動カタログから提案した",
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "case,candidate,params",
+    [
+        ("themeなし", _shrine(2, astro_tags=["career"]), {"need_tags": ["career"]}),
+        ("fallback Recommendation", _shrine(3), {}),
+        (
+            "Knowledge Explanation-only",
+            _shrine(4, knowledge_deities=[{"display_name": "天照大神", "confidence": "high"}]),
+            {"query": "天照大神にお参りしたい"},
+        ),
+        ("Context-only", _shrine(5, distance_m=50), {"bias": {"lat": 35.0, "lng": 139.0}}),
+        (
+            "Personalization-only",
+            _shrine(6, astro_elements=["火", "水", "木", "金", "土"]),
+            {"birthdate": "1990-01-01", "public_mode": "compat"},
+        ),
+    ],
+)
+def test_ungrounded_scenarios_keep_generic_safe_action_with_fallback_provenance(
+    case, candidate, params
+):
+    rec = _run(candidate, **params)
+
+    selected = rec["_explanation_payload"]["action_suggestions"][0]
+    preview = rec["action_suggestion_v4_preview"]
+    assert selected["grounding_class"] == "generic_safe", case
+    assert selected["grounding_source"] == "fallback", case
+    assert preview["primary_action"]["action_type"] == "detail_open", case
+    assert preview["action_source"] == {
+        "source": "fallback",
+        "reason": "入力が不足しているため、詳細確認と保存を安全な初期提案にした",
+    }, case
+
+
+@pytest.mark.django_db
+def test_culture_translation_action_keeps_consultation_provenance():
+    rec = _run(
+        _shrine(
+            7,
+            astro_tags=["career"],
+            culture_translation={"present": True},
+            meaning_payload={
+                "source": {
+                    "translationResult": {
+                        "history_theme": "再出発",
+                        "action_context": "今の仕事を一つ整理する",
+                    }
+                }
+            },
+        ),
+        query="仕事を見直したい",
+        need_tags=["career"],
+    )
+
+    selected = rec["_explanation_payload"]["action_suggestions"][0]
+    preview = rec["action_suggestion_v4_preview"]
+    assert selected["grounding_class"] == "generic_safe"
+    assert selected["grounding_source"] == "fallback"
+    assert "今の仕事を一つ整理する" in preview["primary_action"]["description"]
+    assert preview["action_source"] == {
+        "source": "action_context",
+        "reason": "culture_translationの行動文脈を相談に基づく説明素材として提案した",
+    }
+    assert preview["source_keys"] == ["recommendation_reason_v4", "culture_translation"]


### PR DESCRIPTION
## Summary

PR #2425で確認したAction SuggestionのFalse GroundingとProvenance Mismatchだけを修正します。

- history_themeが実際にRank Authorityを持つ場合だけcatalog Actionを`consultation_grounded / ranked_history_theme`として扱う
- themeなしの既存「静寂」copyはUX互換のGeneric Safe Actionとして維持し、`generic_safe / fallback`を明示
- previewでcatalog Actionをmeaning_translation由来へ無条件に再ラベルする処理を除去
- culture_translation ActionはReason v4の既存Action本文を維持し、consultation由来の説明素材としてsourceを伝播
- fallback / Knowledge Explanation-only / Context-only / Personalization-onlyはGeneric Safe previewへ固定

## Scope

変更はAction consumption / provenance境界のみです。

変更なし:
- Ranking
- Candidate filtering
- Signal Authority
- Primary Reason priority
- Recommendation Reason v4 Authority
- Knowledge Ranking
- Frontend UI
- DB schema / migration

## Contract compatibility

- `action_suggestion_v4_preview`の既存shapeとsource enumを維持
- legacy Action catalog本文を維持
- `_explanation_payload.action_suggestions`へgrounding metadataを加算
- PR #2417〜#2424 Authority / Context / Explanation contract testsは書き換えずpass

## Verification

- Required 7 scenario integration contract: 7 passed
- Targeted Authority / Action / Reason contracts: 45 passed
- Full backend suite: 1464 passed, 13 skipped
- Frontend contract suite: 815 passed
- OpenAPI lint: passed
- Ruff: passed
- Migration: 0