### PR TITLE
fix: align mobile reason facts contract

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -41,36 +41,17 @@ import {
   serializeReasonV4Detail,
   type RecommendationReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
+import {
+  buildReasonFactItems,
+  findPrimaryReasonFact,
+  normalizeRecommendationReasonFacts,
+  resolveActionEventHistoryTheme,
+  type ConciergeReasonFacts,
+} from "../../lib/recommendationReasonFacts";
 
 // ────────────────────────────────────────────
 // 型
 // ────────────────────────────────────────────
-type RecommendationReasonFactAxis =
-  | "need"
-  | "benefit"
-  | "feature"
-  | "element"
-  | "distance"
-  | "popularity"
-  | "fallback";
-
-type RecommendationReasonFacts = {
-  version?: 1;
-  primary_axis?: RecommendationReasonFactAxis | null;
-  secondary_axis?: RecommendationReasonFactAxis | null;
-  matched_need_tags?: string[];
-  matched_benefits?: string[];
-  shrine_feature?: string | null;
-  shrine_benefit?: string | null;
-  visit_fit?: string | null;
-  matched_element?: string | null;
-  matched_sign?: string | null;
-  distance_label?: string | null;
-  popularity_label?: string | null;
-  fallback_reason?: string | null;
-  confidence?: "high" | "mid" | "low" | null;
-};
-
 type RecommendationReasonQuality = {
   shrine_data_rate?: number | null;
   consultation_reflection_rate?: number | null;
@@ -94,7 +75,7 @@ type RecommendationCard = {
   connection: string;
   reason: string;
   recommendationReasonV4?: string | null;
-  reasonFacts?: RecommendationReasonFacts | null;
+  reasonFacts: ConciergeReasonFacts;
   recommendationReasonQuality?: RecommendationReasonQuality | null;
   recommendationReasonDetail?: RecommendationReasonDetail | null;
   reasonV4Detail?: RecommendationReasonV4Detail | null;
@@ -150,8 +131,8 @@ type RecommendationApiCard = {
   reason?: string;
   recommendation_reason_v4?: string | null;
   recommendationReasonV4?: string | null;
-  reason_facts?: RecommendationReasonFacts | null;
-  reasonFacts?: RecommendationReasonFacts | null;
+  reason_facts?: unknown;
+  reasonFacts?: unknown;
   recommendation_reason_quality?: RecommendationReasonQuality | null;
   recommendationReasonQuality?: RecommendationReasonQuality | null;
   recommendation_reason_detail?: RecommendationReasonDetail | null;
@@ -329,17 +310,13 @@ function resolveRecommendationReason({
   fallbackReason,
 }: {
   recommendationReasonV4?: string | null;
-  reasonFacts?: RecommendationReasonFacts | null;
+  reasonFacts?: ConciergeReasonFacts | null;
   fallbackReason?: string | null;
 }) {
   const v4Reason = asTrimmedString(recommendationReasonV4);
   if (v4Reason) return v4Reason;
 
-  const factBasedReason =
-    asTrimmedString(reasonFacts?.shrine_feature) ??
-    asTrimmedString(reasonFacts?.shrine_benefit) ??
-    asTrimmedString(reasonFacts?.visit_fit) ??
-    asTrimmedString(reasonFacts?.fallback_reason);
+  const factBasedReason = asTrimmedString(findPrimaryReasonFact(reasonFacts)?.label);
 
   if (factBasedReason) return factBasedReason;
 
@@ -347,28 +324,6 @@ function resolveRecommendationReason({
   if (legacyReason) return legacyReason;
 
   return "相談内容と神社情報をもとに選ばれた神社です。";
-}
-
-function buildReasonFactItems(reasonFacts?: RecommendationReasonFacts | null) {
-  if (!reasonFacts) return [];
-
-  return [
-    reasonFacts.shrine_feature
-      ? { label: "神社固有の文脈", value: reasonFacts.shrine_feature }
-      : null,
-    reasonFacts.shrine_benefit
-      ? { label: "ご利益・意味", value: reasonFacts.shrine_benefit }
-      : null,
-    reasonFacts.visit_fit
-      ? { label: "参拝との相性", value: reasonFacts.visit_fit }
-      : null,
-    reasonFacts.distance_label
-      ? { label: "行きやすさ", value: reasonFacts.distance_label }
-      : null,
-    reasonFacts.popularity_label
-      ? { label: "参考情報", value: reasonFacts.popularity_label }
-      : null,
-  ].filter((item): item is { label: string; value: string } => Boolean(item?.value?.trim()));
 }
 
 function toRecommendationCard(item: RecommendationApiCard, index: number): RecommendationCard {
@@ -385,8 +340,7 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
   const reasonV4Detail = normalizeRecommendationReasonV4Detail(
     item.recommendation_reason_v4_detail ?? item.recommendationReasonV4Detail,
   );
-  const reasonFactsRaw = item.reason_facts ?? item.reasonFacts ?? null;
-  const reasonFacts = Array.isArray(reasonFactsRaw) ? (reasonFactsRaw[0] ?? null) : reasonFactsRaw;
+  const reasonFacts = normalizeRecommendationReasonFacts(item.reason_facts ?? item.reasonFacts);
   const reason = resolveRecommendationReason({
     recommendationReasonV4,
     reasonFacts,
@@ -815,7 +769,10 @@ export default function ConciergeScreen() {
       source: "mobile_concierge_result",
       shrineId: card.shrineId ?? null,
       threadId: null,
-      historyTheme: card.reasonFacts?.primary_axis ?? "",
+      historyTheme: resolveActionEventHistoryTheme({
+        facts: card.reasonFacts,
+        actionSourceKeys: card.actionSuggestionV4Preview?.sourceKeys,
+      }),
       actionCategory: action.actionType,
       metadata: {
         platform: "mobile",

--- a/apps/mobile/lib/__tests__/recommendationReasonFacts.test.ts
+++ b/apps/mobile/lib/__tests__/recommendationReasonFacts.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReasonFactItems,
+  findPrimaryReasonFact,
+  normalizeRecommendationReasonFacts,
+  resolveActionEventHistoryTheme,
+} from "../recommendationReasonFacts";
+
+const fact = (type: string, label: string, isPrimary = true) => ({
+  type,
+  label,
+  evidence: [`${type}_evidence`],
+  score: 3.5,
+  is_primary: isPrimary,
+});
+
+describe("Mobile Recommendation Reason Facts contract", () => {
+  it.each([
+    ["need_tag Primary", "need_tag", "仕事", "相談との一致"],
+    ["history_theme Primary", "history_theme", "再出発", "神社固有の文脈"],
+    ["goriyaku Primary", "goriyaku_tag", "厄除け", "ご利益・意味"],
+    ["Explicit Constraint", "user_selected_tag", "駅から近い", "明示した条件"],
+    ["Personalization", "element", "火", "生年月日との相性"],
+    ["visit_style", "visit_style", "静かに参拝", "参拝との相性"],
+    ["fallback", "fallback", "条件に近い候補", "参考情報"],
+  ])("%sをBackend指定のPrimaryとして保持する", (_case, type, label, displayLabel) => {
+    const raw = [fact("need_tag", "先頭だが非Primary", false), fact(type, label)];
+
+    const normalized = normalizeRecommendationReasonFacts(raw);
+
+    expect(normalized).toEqual(raw);
+    expect(findPrimaryReasonFact(normalized)).toEqual(fact(type, label));
+    expect(buildReasonFactItems(normalized)).toContainEqual({ label: displayLabel, value: label });
+  });
+
+  it("malformed Factとunknown typeを安全に扱う", () => {
+    const normalized = normalizeRecommendationReasonFacts([
+      null,
+      "invalid",
+      { type: "", label: "missing type" },
+      { type: "need_tag", label: "" },
+      { type: "unknown", label: "未知", evidence: [" ok ", 1], score: "bad", is_primary: true },
+    ]);
+
+    expect(normalized).toEqual([
+      { type: "unknown", label: "未知", evidence: ["ok"], score: 0, is_primary: true },
+    ]);
+    expect(buildReasonFactItems(normalized)).toEqual([]);
+    expect(normalizeRecommendationReasonFacts({ primary_axis: "history_theme" })).toEqual([]);
+  });
+
+  it("no-primary Fact[]でPrimaryを推測しない", () => {
+    const normalized = normalizeRecommendationReasonFacts([
+      fact("history_theme", "勝負", false),
+      { type: "need_tag", label: "仕事", evidence: [], score: 99 },
+    ]);
+
+    expect(findPrimaryReasonFact(normalized)).toBeNull();
+    expect(resolveActionEventHistoryTheme({
+      facts: normalized,
+      actionSourceKeys: ["ranked_history_theme", "action_catalog"],
+    })).toBe("");
+  });
+
+  it("ActionEventにはgrounded history Primaryだけを記録する", () => {
+    expect(resolveActionEventHistoryTheme({
+      facts: [fact("history_theme", "縁")],
+      actionSourceKeys: ["ranked_history_theme", "action_catalog"],
+    })).toBe("縁");
+
+    for (const primary of [
+      fact("need_tag", "仕事"),
+      fact("goriyaku_tag", "厄除け"),
+      fact("user_selected_tag", "駅から近い"),
+      fact("element", "火"),
+      fact("visit_style", "静かに参拝"),
+      fact("fallback", "条件に近い候補"),
+    ]) {
+      expect(resolveActionEventHistoryTheme({
+        facts: [primary],
+        actionSourceKeys: ["ranked_history_theme", "action_catalog"],
+      })).toBe("");
+    }
+
+    expect(resolveActionEventHistoryTheme({
+      facts: [fact("history_theme", "縁")],
+      actionSourceKeys: ["recommendation_reason_v4", "culture_translation"],
+    })).toBe("");
+  });
+});

--- a/apps/mobile/lib/recommendationReasonFacts.ts
+++ b/apps/mobile/lib/recommendationReasonFacts.ts
@@ -1,0 +1,82 @@
+export type ConciergeReasonFact = {
+  type: string;
+  label: string;
+  evidence: string[];
+  score: number;
+  is_primary?: boolean;
+};
+
+export type ConciergeReasonFacts = ConciergeReasonFact[];
+
+function trimmedString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function normalizeRecommendationReasonFacts(raw: unknown): ConciergeReasonFacts {
+  if (!Array.isArray(raw)) return [];
+
+  return raw.flatMap((item): ConciergeReasonFact[] => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+
+    const value = item as Record<string, unknown>;
+    const type = trimmedString(value.type);
+    const label = trimmedString(value.label);
+    if (!type || !label) return [];
+
+    const evidence = Array.isArray(value.evidence)
+      ? value.evidence
+          .map(trimmedString)
+          .filter((entry): entry is string => entry !== null)
+      : [];
+    const score =
+      typeof value.score === "number" && Number.isFinite(value.score)
+        ? value.score
+        : 0;
+
+    return [{
+      type,
+      label,
+      evidence,
+      score,
+      ...(typeof value.is_primary === "boolean"
+        ? { is_primary: value.is_primary }
+        : {}),
+    }];
+  });
+}
+
+export function findPrimaryReasonFact(
+  facts: ConciergeReasonFacts | null | undefined,
+): ConciergeReasonFact | null {
+  return facts?.find((fact) => fact.is_primary === true) ?? null;
+}
+
+const DISPLAY_LABEL_BY_TYPE: Record<string, string> = {
+  element: "生年月日との相性",
+  need_tag: "相談との一致",
+  user_selected_tag: "明示した条件",
+  goriyaku_tag: "ご利益・意味",
+  history_theme: "神社固有の文脈",
+  text_hint: "ご利益・意味",
+  visit_style: "参拝との相性",
+  fallback: "参考情報",
+};
+
+export function buildReasonFactItems(facts: ConciergeReasonFacts | null | undefined) {
+  return (facts ?? []).flatMap((fact) => {
+    const displayLabel = DISPLAY_LABEL_BY_TYPE[fact.type];
+    return displayLabel ? [{ label: displayLabel, value: fact.label }] : [];
+  });
+}
+
+export function resolveActionEventHistoryTheme(args: {
+  facts: ConciergeReasonFacts | null | undefined;
+  actionSourceKeys: string[] | null | undefined;
+}): string {
+  if (!args.actionSourceKeys?.includes("ranked_history_theme")) return "";
+
+  const primary = findPrimaryReasonFact(args.facts);
+  return primary?.type === "history_theme" ? primary.label : "";
+}


### PR DESCRIPTION
## Summary

- align Mobile `reason_facts` with the Backend wire contract (`ConciergeReasonFact[]`)
- validate non-array and malformed facts while preserving valid fact order and fields
- consume only Backend `is_primary === true`; no score/order/type-priority or fallback inference
- record ActionEvent `historyTheme` only when the Backend primary fact is `history_theme` and the selected action is grounded by `ranked_history_theme`
- add Mobile contract coverage for primary authorities, fallback, malformed arrays, and no-primary arrays

## Scope

Production changes are limited to the Mobile consumption boundary. No Backend, Web, ranking, candidate filtering, authority, reason generation, action grounding, analytics schema, DB schema, or migration changes.

## Tests

- Mobile targeted contract: 10 passed
- Mobile full suite: 25 files / 275 passed
- Mobile typecheck: passed
- Backend Authority/Reason/Action contracts: 35 passed
- Web contract suite: 123 files / 815 passed
- pre-push OpenAPI lint: passed
- pre-push Web contract suite: 123 files / 815 passed

## Base

PR #2427 merged while this work was in progress. The branch now has a clean three-file Mobile-only diff against the updated `develop`.