### PR TITLE
fix: propagate recommendation analytics provenance

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -35,6 +35,13 @@ import { toOriginPayload, type UserOrigin } from "../../../../packages/shared/us
 import { buildRecommendationReasonDisplay } from "../../../../packages/shared/recommendationReasonDisplay";
 import { getOriginSession } from "../../lib/originSession";
 import { trackMobileDirection } from "../../lib/directionEvents";
+import { track } from "../../lib/analytics";
+import {
+  buildRecommendationResultSetId,
+  recommendationAnalyticsProperties,
+  recommendationAnalyticsProvenance,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../packages/shared/recommendationAnalyticsProvenance";
 import {
   buildReasonV4Sections,
   normalizeRecommendationReasonV4Detail,
@@ -83,6 +90,7 @@ type RecommendationCard = {
   shrineId?: string;
   actionSuggestionV4Preview?: ActionSuggestionV4Preview | null;
   directionReference?: DirectionReference | null;
+  analyticsProvenance: RecommendationAnalyticsProvenance;
 };
 
 type ActionSuggestionV4Action = {
@@ -148,6 +156,8 @@ type RecommendationApiCard = {
   action_suggestion_v4_preview?: unknown;
   actionSuggestionV4Preview?: unknown;
   direction_reference?: DirectionReference | null;
+  primary_reason_source?: string | null;
+  _primary_reason_source?: string | null;
 };
 function normalizeRecommendationReasonDetail(raw: unknown): RecommendationReasonDetail | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
@@ -341,6 +351,11 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
     item.recommendation_reason_v4_detail ?? item.recommendationReasonV4Detail,
   );
   const reasonFacts = normalizeRecommendationReasonFacts(item.reason_facts ?? item.reasonFacts);
+  const analyticsProvenance = recommendationAnalyticsProvenance({
+    primaryReasonSource: item.primary_reason_source ?? item._primary_reason_source,
+    reasonFacts,
+    actionSuggestionPreview: item.action_suggestion_v4_preview ?? item.actionSuggestionV4Preview,
+  });
   const reason = resolveRecommendationReason({
     recommendationReasonV4,
     reasonFacts,
@@ -362,6 +377,7 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
     shrineId: shrineId !== undefined && shrineId !== null ? String(shrineId) : undefined,
     actionSuggestionV4Preview,
     directionReference: validDirectionReferenceOrNull(item.direction_reference),
+    analyticsProvenance,
   };
 }
 
@@ -646,6 +662,7 @@ export default function ConciergeScreen() {
   const [loading, setLoading] = React.useState(false);
   const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
   const [results, setResults] = React.useState<RecommendationCard[]>([]);
+  const trackedResultSetRef = React.useRef<string | null>(null);
   const [selectedVisitStyle, setSelectedVisitStyle] = React.useState<string | undefined>(params.visitStyle || undefined);
   const [birthdate, setBirthdate] = React.useState(params.birthdate ?? "");
   const [plannedVisitDate, setPlannedVisitDate] = React.useState(params.plannedVisitDate ?? "");
@@ -656,6 +673,27 @@ export default function ConciergeScreen() {
   const [supportText, setSupportText] = React.useState(params.support ?? "");
   const hasAnyCondition = Boolean(selectedVisitStyle || birthdate.trim() || plannedVisitDate.trim() || selectedGoriyaku || supportText.trim());
   const isSendDisabled = loading || (!input.trim() && !hasAnyCondition);
+
+  React.useEffect(() => {
+    if (results.length === 0) return;
+    const resultSetId = buildRecommendationResultSetId(
+      null,
+      results.map((card) => ({ shrineId: card.shrineId ?? card.id })),
+    );
+    if (trackedResultSetRef.current === resultSetId) return;
+    trackedResultSetRef.current = resultSetId;
+
+    results.forEach((card, index) => {
+      track("concierge_result_impression", {
+        source: "concierge_result",
+        platform: "mobile",
+        resultSetId,
+        shrineId: card.shrineId ?? card.id,
+        recommendationRank: index + 1,
+        ...recommendationAnalyticsProperties(card.analyticsProvenance),
+      });
+    });
+  }, [results]);
   const lastInitialQueryRef = React.useRef<string | null>(null);
 
   // Homeからの相談内容・条件が変わったら自動送信する
@@ -783,6 +821,8 @@ export default function ConciergeScreen() {
         action_description: action.description,
         action_source: card.actionSuggestionV4Preview?.actionSource.source ?? null,
         source_keys: card.actionSuggestionV4Preview?.sourceKeys ?? [],
+        primary_reason_source: card.analyticsProvenance.primaryReasonSource,
+        is_fallback_recommendation: card.analyticsProvenance.isFallbackRecommendation,
       },
     });
   };
@@ -790,6 +830,18 @@ export default function ConciergeScreen() {
   const handleDetail = (card: RecommendationCard, rank: number) => {
     if (card.directionReference?.matched) trackMobileDirection("direction_match_detail_opened", { matched: true, recommendation_rank: rank });
     if (!card.shrineId) return;
+    const resultSetId = buildRecommendationResultSetId(
+      null,
+      results.map((result) => ({ shrineId: result.shrineId ?? result.id })),
+    );
+    track("shrine_detail_transition", {
+      source: "concierge_result",
+      platform: "mobile",
+      resultSetId,
+      shrineId: card.shrineId,
+      recommendationRank: rank,
+      ...recommendationAnalyticsProperties(card.analyticsProvenance),
+    });
     router.push({
       pathname: "/shrines/[id]",
       params: {
@@ -801,6 +853,8 @@ export default function ConciergeScreen() {
           : "",
         actionSuggestionV4Preview: card.actionSuggestionV4Preview ? JSON.stringify(card.actionSuggestionV4Preview) : "",
         recommendationReasonV4Detail: serializeReasonV4Detail(card.reasonV4Detail),
+        recommendationRank: String(rank),
+        resultSetId,
       },
     });
   };

--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -31,36 +31,17 @@ import {
   type RecommendationReasonV4Detail,
 } from "../../lib/recommendationReasonV4";
 import { buildShrineFactViewModel, type ShrineDeity, type ShrineHistory } from "../../lib/shrineKnowledgeFact";
-
-type RecommendationReasonFactAxis =
-  | "need"
-  | "benefit"
-  | "feature"
-  | "element"
-  | "distance"
-  | "popularity"
-  | "fallback";
-
-type RecommendationReasonFacts = {
-  version?: 1;
-  primary_axis?: RecommendationReasonFactAxis | null;
-  secondary_axis?: RecommendationReasonFactAxis | null;
-  matched_need_tags?: string[];
-  matched_benefits?: string[];
-  shrine_feature?: string | null;
-  shrine_benefit?: string | null;
-  visit_fit?: string | null;
-  matched_element?: string | null;
-  matched_sign?: string | null;
-  distance_label?: string | null;
-  popularity_label?: string | null;
-  fallback_reason?: string | null;
-  confidence?: "high" | "mid" | "low" | null;
-  type?: string | null;
-  label?: string | null;
-  label_ja?: string | null;
-  evidence?: Array<string | { label?: string | null; value?: string | null; text?: string | null }>;
-};
+import { track } from "../../lib/analytics";
+import {
+  buildReasonFactItems,
+  findPrimaryReasonFact,
+  normalizeRecommendationReasonFacts,
+  type ConciergeReasonFacts,
+} from "../../lib/recommendationReasonFacts";
+import {
+  recommendationAnalyticsProperties,
+  recommendationAnalyticsProvenance,
+} from "../../../../packages/shared/recommendationAnalyticsProvenance";
 
 
 
@@ -88,6 +69,10 @@ type ActionSuggestionV4Preview = {
   secondary_action?: ActionSuggestionV4Action | null;
   reflectionPrompt?: ActionSuggestionV4ReflectionPrompt | null;
   reflection_prompt?: ActionSuggestionV4ReflectionPrompt | null;
+  actionSource?: { source?: string | null } | null;
+  action_source?: { source?: string | null } | null;
+  sourceKeys?: string[];
+  source_keys?: string[];
 };
 
 type RecommendationExplanation =
@@ -108,7 +93,7 @@ type Shrine = {
   description?: string;
   recommendationReason?: string;
   recommendationReasonV4?: string;
-  reasonFacts?: RecommendationReasonFacts | null;
+  reasonFacts?: ConciergeReasonFacts | null;
   explanation?: RecommendationExplanation;
   actionSuggestion?: string;
   actionSuggestionV4Preview?: ActionSuggestionV4Preview | null;
@@ -133,8 +118,8 @@ type ShrineApiResponse = {
   recommendationReason?: string | null;
   recommendation_reason_v4?: string | null;
   recommendationReasonV4?: string | null;
-  reason_facts?: RecommendationReasonFacts | null;
-  reasonFacts?: RecommendationReasonFacts | null;
+  reason_facts?: unknown;
+  reasonFacts?: unknown;
   explanation?: RecommendationExplanation;
   action_suggestion?: string | null;
   actionSuggestion?: string | null;
@@ -189,11 +174,7 @@ function resolveRecommendationReason(shrine: Shrine) {
   const v4Reason = asTrimmedString(shrine.recommendationReasonV4);
   if (v4Reason) return v4Reason;
 
-  const factBasedReason =
-    asTrimmedString(shrine.reasonFacts?.shrine_feature) ??
-    asTrimmedString(shrine.reasonFacts?.shrine_benefit) ??
-    asTrimmedString(shrine.reasonFacts?.visit_fit) ??
-    asTrimmedString(shrine.reasonFacts?.fallback_reason);
+  const factBasedReason = asTrimmedString(findPrimaryReasonFact(shrine.reasonFacts)?.label);
 
   if (factBasedReason) return factBasedReason;
 
@@ -201,43 +182,6 @@ function resolveRecommendationReason(shrine: Shrine) {
   if (legacyReason) return legacyReason;
 
   return "相談内容と神社情報をもとに選ばれた神社です。";
-}
-
-function buildReasonFactItems(reasonFacts?: RecommendationReasonFacts | RecommendationReasonFacts[] | null) {
-  if (!reasonFacts) return [];
-
-  const facts = Array.isArray(reasonFacts) ? reasonFacts : [reasonFacts];
-  const technicalValues = new Set(["history_theme", "matched_need_tags", "fallback"]);
-
-  return facts
-    .flatMap((fact) => {
-      const structuredItems = [
-        fact.shrine_feature ? { label: "神社固有の文脈", value: fact.shrine_feature } : null,
-        fact.shrine_benefit ? { label: "ご利益・意味", value: fact.shrine_benefit } : null,
-        fact.visit_fit ? { label: "参拝との相性", value: fact.visit_fit } : null,
-        fact.distance_label ? { label: "行きやすさ", value: fact.distance_label } : null,
-        fact.popularity_label ? { label: "参考情報", value: fact.popularity_label } : null,
-      ];
-
-      const labelValue = asTrimmedString(fact.label_ja ?? fact.label);
-      const labelItem = labelValue ? { label: "推薦の文脈", value: labelValue } : null;
-
-      const evidenceItems = Array.isArray(fact.evidence)
-        ? fact.evidence.map((evidence) => {
-            const rawValue =
-              typeof evidence === "string"
-                ? evidence
-                : evidence.value ?? evidence.text ?? null;
-            const value = asTrimmedString(rawValue);
-            if (!value || technicalValues.has(value) || value === labelValue) return null;
-
-            return { label: "判断材料", value };
-          })
-        : [];
-
-      return [labelItem, ...structuredItems, ...evidenceItems];
-    })
-    .filter((item): item is { label: string; value: string } => Boolean(item?.value?.trim()));
 }
 
 function toShrine(api: ShrineApiResponse): Shrine {
@@ -248,7 +192,7 @@ function toShrine(api: ShrineApiResponse): Shrine {
     description: api.description ?? api.goriyaku ?? undefined,
     recommendationReason: api.recommendationReason ?? api.recommendation_reason ?? undefined,
     recommendationReasonV4: api.recommendationReasonV4 ?? api.recommendation_reason_v4 ?? undefined,
-    reasonFacts: api.reasonFacts ?? api.reason_facts ?? null,
+    reasonFacts: normalizeRecommendationReasonFacts(api.reasonFacts ?? api.reason_facts),
     explanation: api.explanation ?? undefined,
     actionSuggestion: api.actionSuggestion ?? api.action_suggestion ?? undefined,
     actionSuggestionV4Preview: api.actionSuggestionV4Preview ?? api.action_suggestion_v4_preview ?? null,
@@ -270,6 +214,8 @@ export default function ShrineDetail() {
     recommendationReasonDetail?: string | string[];
     actionSuggestionV4Preview?: string | string[];
     recommendationReasonV4Detail?: string | string[];
+    recommendationRank?: string | string[];
+    resultSetId?: string | string[];
   }>();
   const shrineId = React.useMemo(() => {
     const raw = params.id;
@@ -283,18 +229,16 @@ export default function ShrineDetail() {
     return asTrimmedString(value) ?? undefined;
   }, [params.recommendationReasonV4]);
 
-  const contextReasonFacts = React.useMemo<RecommendationReasonFacts | null>(() => {
+  const contextReasonFacts = React.useMemo<ConciergeReasonFacts>(() => {
     const raw = params.reasonFacts;
     const value = Array.isArray(raw) ? raw[0] : raw;
-    if (!value) return null;
+    if (!value) return [];
 
     try {
       const parsed = JSON.parse(value);
-      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-        ? (parsed as RecommendationReasonFacts)
-        : null;
+      return normalizeRecommendationReasonFacts(parsed);
     } catch {
-      return null;
+      return [];
     }
   }, [params.reasonFacts]);
 
@@ -380,7 +324,8 @@ export default function ShrineDetail() {
     [shrine],
   );
 
-  const reasonFactItems = buildReasonFactItems(contextReasonFacts ?? shrine?.reasonFacts).slice(0, 3);
+  const effectiveReasonFacts = contextReasonFacts.length > 0 ? contextReasonFacts : shrine?.reasonFacts;
+  const reasonFactItems = buildReasonFactItems(effectiveReasonFacts).slice(0, 3);
 
   const hasConsultationSummary = Boolean(contextRecommendationReasonDetail?.consultationSummary);
   const hasShrineMeaning = Boolean(contextRecommendationReasonDetail?.shrineMeaning);
@@ -391,9 +336,9 @@ export default function ShrineDetail() {
     return resolveRecommendationReason({
       ...shrine,
       recommendationReasonV4: contextRecommendationReasonV4 ?? shrine.recommendationReasonV4,
-      reasonFacts: contextReasonFacts ?? shrine.reasonFacts,
+      reasonFacts: effectiveReasonFacts,
     });
-  }, [contextReasonFacts, contextRecommendationReasonV4, shrine]);
+  }, [contextRecommendationReasonV4, effectiveReasonFacts, shrine]);
 
   // Concierge以外の遷移ではcontextReasonV4Detailがnullのため常にhasStructured=falseとなり、
   // 神社APIの値から相談文脈を推測することはない(v4 detailはroute params専用でShrine型に持たせていない)
@@ -418,6 +363,15 @@ export default function ShrineDetail() {
   }, [shrine]);
 
   const actionSuggestionV4Preview = contextActionSuggestionV4Preview ?? shrine?.actionSuggestionV4Preview ?? null;
+  const analyticsProvenance = recommendationAnalyticsProvenance({
+    reasonFacts: contextReasonFacts.length > 0 ? contextReasonFacts : shrine?.reasonFacts,
+    actionSuggestionPreview: actionSuggestionV4Preview,
+  });
+  const analyticsProperties = recommendationAnalyticsProperties(analyticsProvenance);
+  const primaryHistoryTheme = (() => {
+    const primary = findPrimaryReasonFact(contextReasonFacts.length > 0 ? contextReasonFacts : shrine?.reasonFacts);
+    return primary?.type === "history_theme" ? primary.label : "";
+  })();
   const primaryAction = actionSuggestionV4Preview?.primaryAction ?? actionSuggestionV4Preview?.primary_action ?? null;
   const secondaryAction = actionSuggestionV4Preview?.secondaryAction ?? actionSuggestionV4Preview?.secondary_action ?? null;
   const reflectionPrompt = actionSuggestionV4Preview?.reflectionPrompt ?? actionSuggestionV4Preview?.reflection_prompt ?? null;
@@ -452,6 +406,9 @@ export default function ShrineDetail() {
           source: "mobile_shrine_detail",
           metadata: {
             ctx: "mobile_shrine_detail",
+            recommendation_rank: Number(Array.isArray(params.recommendationRank) ? params.recommendationRank[0] : params.recommendationRank) || null,
+            result_set_id: Array.isArray(params.resultSetId) ? params.resultSetId[0] : params.resultSetId,
+            ...analyticsProperties,
           },
         });
       }
@@ -503,6 +460,13 @@ export default function ShrineDetail() {
 
     const now = await toggleFavorite(String(shrineId));
     setFav(now);
+    track("favorite_click", {
+      source: "shrine_detail",
+      platform: "mobile",
+      shrineId: apiShrineId ?? shrineId,
+      nextFav: now,
+      ...analyticsProperties,
+    });
 
     if (now) {
       try {
@@ -533,7 +497,8 @@ export default function ShrineDetail() {
       setVisited(true);
       trackVisitDone({
         shrineId: targetShrineId,
-        historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+        historyTheme: primaryHistoryTheme,
+        provenance: analyticsProvenance,
       });
     } catch (error) {
       if (isUnauthenticatedError(error)) {
@@ -551,9 +516,10 @@ export default function ShrineDetail() {
 
     trackReflectionPromptView({
       shrineId: targetShrineId,
-      historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+      historyTheme: primaryHistoryTheme,
       reflectionFormType: "one_line",
       reflectionContext: "visit_done",
+      provenance: analyticsProvenance,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visited]);
@@ -569,7 +535,7 @@ export default function ShrineDetail() {
         shrineId: targetShrineId,
         answer,
         prompt: asTrimmedString(reflectionPrompt?.question) ?? "参拝後に何を感じましたか？",
-        historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis ?? "",
+        historyTheme: primaryHistoryTheme,
         moodBefore: "",
         moodAfter: "",
       });
@@ -578,10 +544,11 @@ export default function ShrineDetail() {
         setReflectionSaved(true);
         trackReflectionSaved({
           shrineId: targetShrineId,
-          historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+          historyTheme: primaryHistoryTheme,
           reflectionFormType: "one_line",
           reflectionContext: "visit_done",
           answerLength: answer.length,
+          provenance: analyticsProvenance,
         });
       }
     } catch (error) {
@@ -608,7 +575,8 @@ export default function ShrineDetail() {
     const targetShrineId = apiShrineId ?? shrineId;
     trackReflectionToConsultationClick({
       shrineId: targetShrineId ?? "",
-      historyTheme: contextReasonFacts?.primary_axis ?? shrine?.reasonFacts?.primary_axis,
+      historyTheme: primaryHistoryTheme,
+      provenance: analyticsProvenance,
     });
 
     // Reflection本文・相談文等の自由入力は一切引き継がず、Conciergeを通常状態で開く
@@ -625,11 +593,14 @@ export default function ShrineDetail() {
         source: "mobile_shrine_detail",
         metadata: {
           ctx: "mobile_shrine_detail",
+          recommendation_rank: Number(Array.isArray(params.recommendationRank) ? params.recommendationRank[0] : params.recommendationRank) || null,
+          result_set_id: Array.isArray(params.resultSetId) ? params.resultSetId[0] : params.resultSetId,
+          ...analyticsProperties,
         },
       });
       // Backend保存用(trackShrineRouteOpen)とは別に、PostHog等で可視化するための
       // track()イベントをWeb版のroute_openと同じ名前・意味で送る。
-      trackRouteOpen({ shrineId: shrineIdNumber });
+      trackRouteOpen({ shrineId: shrineIdNumber, provenance: analyticsProvenance });
     }
     const hasLatLng = typeof shrine.latitude === "number" && typeof shrine.longitude === "number";
     const destination = hasLatLng ? `${shrine.latitude},${shrine.longitude}` : encodeURIComponent(shrine.name);

--- a/apps/mobile/lib/__tests__/recommendationAnalyticsProvenance.test.ts
+++ b/apps/mobile/lib/__tests__/recommendationAnalyticsProvenance.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  recommendationAnalyticsProperties,
+  recommendationAnalyticsProvenance,
+} from "../../../../packages/shared/recommendationAnalyticsProvenance";
+
+describe("Mobile recommendation provenance parity", () => {
+  it.each(["need_tag", "history_theme", "fallback"])("Primary %sをWebと同じfieldで送る", (type) => {
+    const properties = recommendationAnalyticsProperties(recommendationAnalyticsProvenance({
+      reasonFacts: [{ type, label: type, score: 1, evidence: [], is_primary: true }],
+    }));
+    expect(properties).toMatchObject({
+      primaryReasonSource: type,
+      isFallbackRecommendation: type === "fallback",
+    });
+  });
+
+  it.each([
+    ["fallback", []],
+    ["action_context", ["ranked_history_theme", "action_catalog"]],
+  ])("Action grounding %sをWebと同じfieldで送る", (source, sourceKeys) => {
+    const properties = recommendationAnalyticsProperties(recommendationAnalyticsProvenance({
+      actionSuggestionPreview: { actionSource: { source }, sourceKeys },
+    }));
+    expect(properties.actionSource).toBe(source);
+    expect(properties.actionSourceKeys).toBe(sourceKeys.length > 0 ? sourceKeys.join(",") : undefined);
+  });
+});

--- a/apps/mobile/lib/searchAnalytics.ts
+++ b/apps/mobile/lib/searchAnalytics.ts
@@ -5,6 +5,10 @@
 // track()自体がnull/undefined除去・primitive型への制限・送信失敗の握り潰しを担うため、
 // ここではEvent名とPayloadの型・組み立てのみに責務を絞る(UIからPostHog providerを直接呼ばない)。
 import { track } from "./analytics";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../packages/shared/recommendationAnalyticsProvenance";
 
 const SOURCE_HOME = "home";
 const SOURCE_SEARCH = "mobile_search";
@@ -45,11 +49,15 @@ export function trackMapMarkerSelect(params: { shrineId: string }): void {
 
 // 神社詳細画面の外部経路CTA(Googleマップ起動)。Web版のroute_openと同一Event名・
 // 同一の意味で送る(source/routeTargetの値も揃える)。
-export function trackRouteOpen(params: { shrineId: string | number }): void {
+export function trackRouteOpen(params: {
+  shrineId: string | number;
+  provenance?: RecommendationAnalyticsProvenance;
+}): void {
   track("route_open", {
     source: SOURCE_SHRINE_DETAIL,
     shrineId: params.shrineId,
     routeTarget: "google_maps",
     platform: "mobile",
+    ...(params.provenance ? recommendationAnalyticsProperties(params.provenance) : {}),
   });
 }

--- a/apps/mobile/lib/shrineInteractions.ts
+++ b/apps/mobile/lib/shrineInteractions.ts
@@ -1,6 +1,7 @@
 
 
 import { postAuth } from "./http";
+import { track } from "./analytics";
 
 export type ShrineInteractionActionType = "detail_view" | "route_open" | "shrine_card_click";
 
@@ -62,6 +63,12 @@ export async function trackShrineInteraction({
 }
 
 export async function trackShrineDetailView(params: Omit<TrackShrineInteractionParams, "actionType">) {
+  track("shrine_detail_view", {
+    source: params.source ?? "mobile_shrine_detail",
+    shrineId: params.shrineId,
+    platform: "mobile",
+    ...(params.metadata ?? {}),
+  });
   return trackShrineInteraction({
     ...params,
     actionType: "detail_view",

--- a/apps/mobile/lib/visitReflectionAnalytics.ts
+++ b/apps/mobile/lib/visitReflectionAnalytics.ts
@@ -4,6 +4,10 @@
 // 型そのものをWeb/Mobileで共有する基盤がまだ無いため、契約(イベント名・フィールドの意味)のみを揃え、
 // 型定義はこのファイルに個別で持つ。
 import { track } from "./analytics";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../packages/shared/recommendationAnalyticsProvenance";
 
 const SOURCE = "shrine_detail";
 
@@ -14,15 +18,17 @@ type BasePayloadParams = {
   shrineId: number | string;
   threadId?: number | string | null;
   historyTheme?: string | null;
+  provenance?: RecommendationAnalyticsProvenance;
 };
 
-function buildBasePayload({ shrineId, threadId, historyTheme }: BasePayloadParams): Record<string, unknown> {
+function buildBasePayload({ shrineId, threadId, historyTheme, provenance }: BasePayloadParams): Record<string, unknown> {
   return {
     source: SOURCE,
     platform: "mobile",
     shrineId,
     threadId: threadId || undefined,
     historyTheme: historyTheme || undefined,
+    ...(provenance ? recommendationAnalyticsProperties(provenance) : {}),
   };
 }
 

--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -47,6 +47,7 @@ import { compareState } from "@/lib/concierge/compareState";
 import type { StateDelta } from "@/lib/concierge/stateComparison";
 import { parseDirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 import { normalizeRecommendationReasonV4Detail } from "@/lib/shrine/buildShrineDetailReasonV4Sections";
+import { recommendationAnalyticsProvenance } from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 function normalizeCtx(v?: string | null): "map" | "concierge" | null {
   return v === "map" || v === "concierge" ? v : null;
@@ -415,6 +416,12 @@ export default async function Page({ params, searchParams }: Props) {
   const recommendationReasonV4Detail = normalizeRecommendationReasonV4Detail(
     selectedRecommendation?.recommendation_reason_v4_detail ?? null,
   );
+  const analyticsProvenance = recommendationAnalyticsProvenance({
+    primaryReasonSource:
+      selectedRecommendation?.primary_reason_source ?? selectedRecommendation?._primary_reason_source,
+    reasonFacts: selectedRecommendation?.reason_facts,
+    actionSuggestionPreview: selectedRecommendation?.action_suggestion_v4_preview,
+  });
 
   const model = buildShrineDetailModel({
     shrine: s,
@@ -437,7 +444,7 @@ export default async function Page({ params, searchParams }: Props) {
   return (
     <>
       <ScrollToTopOnMount />
-      <ShrineDetailViewTracker shrineId={numericId} ctx={ctx} tid={tid} />
+      <ShrineDetailViewTracker shrineId={numericId} ctx={ctx} tid={tid} analyticsProvenance={analyticsProvenance} />
       <ShrineDetailToast shrineId={numericId} />
       <ShrineDetailShell
         title={pageTitle}
@@ -447,6 +454,7 @@ export default async function Page({ params, searchParams }: Props) {
         ctx={ctx}
         tid={tid}
         historyTheme={historyThemeForAnalytics}
+        analyticsProvenance={analyticsProvenance}
         directionRouteContext={directionRouteContext}
         addGoshuinHref={null}
         googleDirHref={googleDirHref}
@@ -459,6 +467,7 @@ export default async function Page({ params, searchParams }: Props) {
           stateDelta={stateDelta}
           isPremiumActive={isPremiumActive}
           historyTheme={historyThemeForAnalytics}
+          analyticsProvenance={analyticsProvenance}
           addGoshuinHref={addGoshuinHref}
           saveActionNode={
             <ShrineSaveButton
@@ -468,6 +477,7 @@ export default async function Page({ params, searchParams }: Props) {
               tid={tid}
               nextPath={nextPath}
               guestMode={guestMode}
+              analyticsProvenance={analyticsProvenance}
               initial={initialFavorite}
             />
           }

--- a/apps/web/src/components/shrine/GoogleMapRouteLink.tsx
+++ b/apps/web/src/components/shrine/GoogleMapRouteLink.tsx
@@ -4,6 +4,10 @@ import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { trackShrineInteraction } from "@/lib/api/shrineInteractions";
 import { trackWebDirection } from "@/lib/analytics/directionEvents";
 import type { DirectionRouteContext } from "@/lib/analytics/directionRouteContext";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 type Props = {
   href: string;
@@ -14,6 +18,7 @@ type Props = {
   historyTheme?: string | null;
   className?: string;
   directionRouteContext?: DirectionRouteContext | null;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
 };
 
 export default function GoogleMapRouteLink({
@@ -25,6 +30,7 @@ export default function GoogleMapRouteLink({
   historyTheme = null,
   className,
   directionRouteContext = null,
+  analyticsProvenance,
 }: Props) {
   let routeUrl: URL | null = null;
   try {
@@ -61,6 +67,7 @@ export default function GoogleMapRouteLink({
             threadId: tid != null ? String(tid) : undefined,
             historyTheme: historyTheme ?? undefined,
             ctx,
+            ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
           });
         } catch {
           console.warn("route_analytics_delivery_failed");
@@ -79,6 +86,7 @@ export default function GoogleMapRouteLink({
                 routeTarget: "google_maps",
                 historyTheme,
                 ctx,
+                ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
               },
             }).catch(() => console.warn("route_interaction_delivery_failed"));
           } catch {

--- a/apps/web/src/components/shrine/ShrineDetailShell.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailShell.tsx
@@ -7,6 +7,7 @@ import { LABELS } from "@/lib/ui/labels";
 import DetailSection from "@/components/shrine/DetailSection";
 import GoogleMapRouteLink from "@/components/shrine/GoogleMapRouteLink";
 import type { DirectionRouteContext } from "@/lib/analytics/directionRouteContext";
+import type { RecommendationAnalyticsProvenance } from "../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 type SaveAction = {
   shrineId: number;
@@ -37,6 +38,7 @@ type Props = {
   tid?: string | number | null;
   historyTheme?: string | null;
   directionRouteContext?: DirectionRouteContext | null;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
 };
 
 export default function ShrineDetailShell({
@@ -56,6 +58,7 @@ export default function ShrineDetailShell({
   tid = null,
   historyTheme = null,
   directionRouteContext = null,
+  analyticsProvenance,
 }: Props) {
   const shouldShowActions = !hideActions && Boolean(googleDirHref || saveAction?.node || addGoshuinHref);
 
@@ -90,6 +93,7 @@ export default function ShrineDetailShell({
                 tid={tid}
                 historyTheme={historyTheme}
                 directionRouteContext={directionRouteContext}
+                analyticsProvenance={analyticsProvenance}
                 className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] bg-slate-900 px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-inverse)] hover:bg-slate-800"
               />
             ) : null}

--- a/apps/web/src/components/shrine/ShrineDetailViewTracker.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailViewTracker.tsx
@@ -3,14 +3,19 @@
 import { useEffect, useRef } from "react";
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { trackShrineInteraction } from "@/lib/api/shrineInteractions";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 type Props = {
   shrineId: number;
   ctx?: "map" | "concierge" | null;
   tid?: string | null;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
 };
 
-export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null }: Props) {
+export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null, analyticsProvenance }: Props) {
   const trackedRef = useRef(false);
 
   useEffect(() => {
@@ -23,6 +28,7 @@ export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null }: Pr
       source,
       shrineId,
       threadId: tid ?? undefined,
+      ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
     });
 
     void trackShrineInteraction({
@@ -33,9 +39,10 @@ export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null }: Pr
       metadata: {
         event: "shrine_detail_view",
         ctx,
+        ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
       },
     });
-  }, [shrineId, ctx, tid]);
+  }, [shrineId, ctx, tid, analyticsProvenance]);
 
   return null;
 }

--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -7,6 +7,10 @@ import { buildShrineHref } from "@/lib/nav/buildShrineHref";
 import { buildLoginHref } from "@/lib/nav/login";
 import { useAuth } from "@/lib/auth/AuthProvider";
 import { track } from "@/lib/analytics/track";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 type Props = {
   shrineId: number;
@@ -20,6 +24,7 @@ type Props = {
     favorite_id: number | null;
   };
   onToggleSuccess?: (nextFav: boolean) => void;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
 };
 
 export default function ShrineSaveButton({
@@ -31,6 +36,7 @@ export default function ShrineSaveButton({
   variant = "default",
   initial,
   onToggleSuccess,
+  analyticsProvenance,
 }: Props) {
   const router = useRouter();
   const { isLoggedIn, loading } = useAuth();
@@ -59,6 +65,7 @@ export default function ShrineSaveButton({
         source: "shrine_detail",
         cardId: "saved_record",
         accessLevel,
+        ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
       });
 
       if (nextFav) {
@@ -67,6 +74,7 @@ export default function ShrineSaveButton({
           action: "save",
           ctx,
           tid,
+          ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
         });
       }
 

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -69,6 +69,10 @@ import { addVisit, getVisits, type Visit } from "@/lib/api/visits";
 
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { ShrineReflectionPrompt } from "@/components/shrine/detail/ShrineReflectionPrompt";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 
 function ShrineDetailSections({ sections }: { sections: ShrineDetailSectionModel[] }) {
@@ -386,6 +390,7 @@ export default function ShrineDetailArticle({
   ctx = null,
   tid = null,
   historyTheme = null,
+  analyticsProvenance,
   meaningPayloadSource = "fallback",
   saveActionNode,
   actionState,
@@ -417,6 +422,7 @@ export default function ShrineDetailArticle({
   ctx?: string | null;
   tid?: string | number | null;
   historyTheme?: string | null;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
   meaningPayloadSource?: "v2" | "fallback";
   saveActionNode?: React.ReactNode;
   actionState?: "none" | "detail_viewed" | "saved" | "route_opened" | "visited" | "reflected" | null;
@@ -709,6 +715,7 @@ export default function ShrineDetailArticle({
                     threadId={tid != null ? String(tid) : null}
                     ctx={ctx}
                     accessLevel={accessLevel}
+                    analyticsProvenance={analyticsProvenance}
                   />
                 ) : null}
 
@@ -736,6 +743,7 @@ export default function ShrineDetailArticle({
                           historyTheme: historyTheme ?? undefined,
                           accessLevel,
                           mode: ctx === "concierge" ? "need" : undefined,
+                          ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
                         });
                         const now = new Date().toISOString();
                         setVisitSummary((current) => ({

--- a/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
@@ -6,6 +6,10 @@ import { useEffect, useMemo, useState } from "react";
 
 import { createShrineReflection } from "@/lib/api/reflections";
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
+import {
+  recommendationAnalyticsProperties,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 type Props = {
   shrineId: number | string;
@@ -14,6 +18,7 @@ type Props = {
   ctx?: string | null;
   accessLevel?: "anonymous" | "free" | "premium" | null;
   onSaved?: () => void;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
 };
 
 const PROMPT_TEXT = "参拝して、今どんな変化がありましたか？";
@@ -25,6 +30,7 @@ export function ShrineReflectionPrompt({
   ctx = null,
   accessLevel = null,
   onSaved,
+  analyticsProvenance,
 }: Props) {
   const mode = ctx === "concierge" ? "need" : undefined;
   const [answer, setAnswer] = useState("");
@@ -47,8 +53,9 @@ export function ShrineReflectionPrompt({
       reflectionContext: "visit_done",
       mode,
       accessLevel,
+      ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
     });
-  }, [accessLevel, historyTheme, mode, shrineId, threadId]);
+  }, [accessLevel, analyticsProvenance, historyTheme, mode, shrineId, threadId]);
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -80,6 +87,7 @@ export function ShrineReflectionPrompt({
         moodAfter: moodAfter || undefined,
         mode,
         accessLevel,
+        ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
       });
 
       setStatus("saved");

--- a/apps/web/src/features/concierge/buildPayloadFromUnified.ts
+++ b/apps/web/src/features/concierge/buildPayloadFromUnified.ts
@@ -7,6 +7,10 @@ import type {
 } from "@/features/concierge/sections/types";
 import type { ConciergeReasonFacts, RecommendationReasonV4Detail } from "@/lib/api/concierge";
 import { validDirectionReferenceOrNull, type DirectionReference } from "../../../../../packages/shared/directionReference";
+import {
+  recommendationAnalyticsProvenance,
+  type RecommendationAnalyticsProvenance,
+} from "../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 
 import { detailHrefFromRecommendation } from "@/features/concierge/detailHref";
@@ -20,6 +24,7 @@ type NormalizedItemBase = {
   breakdown: any | null;
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
+  analyticsProvenance: RecommendationAnalyticsProvenance;
   reasonV4Detail?: RecommendationReasonV4Detail | null;
   recommendationReasonV4?: string | null;
   trustMetadata?: any | null;
@@ -37,6 +42,7 @@ type NormalizedItemBase = {
     timeEstimate: string;
     measurementKey: string;
   }>;
+  actionSuggestionV4Preview?: unknown;
   detailHref?: string;
   isDummy?: boolean;
   directionReference?: DirectionReference | null;
@@ -155,6 +161,12 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
     analyticsContext.consultationAxis,
   );
   const actionSuggestions = normalizeActionSuggestions(r);
+  const actionSuggestionV4Preview = r?.action_suggestion_v4_preview ?? r?.actionSuggestionV4Preview ?? null;
+  const analyticsProvenance = recommendationAnalyticsProvenance({
+    primaryReasonSource: r?.primary_reason_source ?? r?._primary_reason_source,
+    reasonFacts,
+    actionSuggestionPreview: actionSuggestionV4Preview,
+  });
   const directionReference = validDirectionReferenceOrNull(r?.direction_reference);
 
   if (shrineId) {
@@ -169,6 +181,8 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
       breakdown,
       breakdown_detail: breakdownDetail,
       reasonFacts,
+      analyticsProvenance,
+      actionSuggestionV4Preview,
       reasonV4Detail,
       recommendationReasonV4,
       trustMetadata,
@@ -195,6 +209,8 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
       breakdown,
       breakdown_detail: breakdownDetail,
       reasonFacts,
+      analyticsProvenance,
+      actionSuggestionV4Preview,
       reasonV4Detail,
       recommendationReasonV4,
       trustMetadata,

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -24,6 +24,10 @@ import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { trackWebDirection } from "@/lib/analytics/directionEvents";
 import { withDirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 import { buildRecommendationReasonDisplay } from "../../../../../../packages/shared/recommendationReasonDisplay";
+import {
+  buildRecommendationResultSetId,
+  recommendationAnalyticsProperties,
+} from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 import type {
   ConciergeSectionsPayload,
@@ -363,13 +367,13 @@ export default function ConciergeSectionsRenderer({
           (item as any).consultationAxis,
           payload.meta?.consultationAxis,
         ),
+        analyticsProvenance: item.analyticsProvenance,
       }));
     });
   }, [payload, normalizedModeForTracking]);
 
   const resultSetId = useMemo(() => {
-    const signature = resultImpressions.map((item) => `${item.rank}:${item.position}:${item.shrineId}`).join("|");
-    return `${tid ?? "unknown"}:${signature || "empty"}`;
+    return buildRecommendationResultSetId(tid, resultImpressions);
   }, [resultImpressions, tid]);
 
   useEffect(() => {
@@ -388,6 +392,9 @@ export default function ConciergeSectionsRenderer({
         mode: item.mode,
         historyTheme: item.historyTheme ?? analyticsContext?.historyTheme,
         ...consultationAxisAnalytics(item.consultationAxis ?? analyticsContext?.consultationAxis),
+        ...(item.analyticsProvenance
+          ? recommendationAnalyticsProperties(item.analyticsProvenance)
+          : {}),
       });
     });
   }, [analyticsContext?.consultationAxis, analyticsContext?.historyTheme, resultImpressions, resultSetId, tid]);
@@ -929,6 +936,9 @@ export default function ConciergeSectionsRenderer({
                                   historyTheme: historyTheme ?? analyticsContext?.historyTheme,
                                   ...consultationAxisAnalytics(heroItem.consultationAxis ?? analyticsContext?.consultationAxis),
                                   firstClick: resolveFirstResultClick(resultSetId),
+                                  ...(heroItem.analyticsProvenance
+                                    ? recommendationAnalyticsProperties(heroItem.analyticsProvenance)
+                                    : {}),
                                 }); }
                               }
                             />
@@ -1104,6 +1114,9 @@ export default function ConciergeSectionsRenderer({
                                           (item as any).consultationAxis ?? analyticsContext?.consultationAxis,
                                         ),
                                         firstClick: resolveFirstResultClick(resultSetId),
+                                        ...(item.analyticsProvenance
+                                          ? recommendationAnalyticsProperties(item.analyticsProvenance)
+                                          : {}),
                                       }); }
                                     }
                                   />

--- a/apps/web/src/features/concierge/hooks.ts
+++ b/apps/web/src/features/concierge/hooks.ts
@@ -18,6 +18,11 @@ import {
 import type { ConciergeChatRequestV1, ConciergeChatFilters } from "@/features/concierge/types/chatRequest";
 import { normalizeBirthdateInput } from "@/lib/date/normalizeBirthdateInput";
 import { trackRecommendationQuality } from "@/lib/analytics/searchEvents";
+import {
+  buildRecommendationResultSetId,
+  recommendationAnalyticsProperties,
+  recommendationAnalyticsProvenance,
+} from "../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 /* ====== スレッド一覧 ====== */
 
@@ -133,6 +138,10 @@ export function trackRecommendationQualityFromRecommendations(args: {
   threadId: string | null;
   accessLevel: ConciergeAccessLevel;
 }) {
+  const resultSetId = buildRecommendationResultSetId(
+    args.threadId,
+    args.recommendations.map((rec) => ({ shrineId: rec.shrine_id ?? rec.id })),
+  );
   args.recommendations.forEach((rec, index) => {
     const quality = rec.recommendation_reason_quality;
     if (!quality || typeof quality !== "object") return;
@@ -142,6 +151,7 @@ export function trackRecommendationQualityFromRecommendations(args: {
       threadId: args.threadId,
       shrineId: rec.shrine_id ?? rec.id ?? null,
       recommendationRank: index + 1,
+      resultSetId,
       accessLevel: args.accessLevel,
       shrine_data_rate: quality.shrine_data_rate ?? null,
       consultation_reflection_rate: quality.consultation_reflection_rate ?? null,
@@ -153,6 +163,11 @@ export function trackRecommendationQualityFromRecommendations(args: {
       knowledge_backing_class: quality.knowledge_backing_class ?? null,
       deity_knowledge_used: quality.deity_knowledge_used ?? null,
       history_knowledge_used: quality.history_knowledge_used ?? null,
+      ...recommendationAnalyticsProperties(recommendationAnalyticsProvenance({
+        primaryReasonSource: (rec as any).primary_reason_source ?? (rec as any)._primary_reason_source,
+        reasonFacts: rec.reason_facts,
+        actionSuggestionPreview: (rec as any).action_suggestion_v4_preview,
+      })),
     });
   });
 }

--- a/apps/web/src/features/concierge/sections/types.ts
+++ b/apps/web/src/features/concierge/sections/types.ts
@@ -1,6 +1,7 @@
 import type { ConciergeBreakdown, ConciergeReasonFacts } from "@/lib/api/concierge";
 import type { ConciergeModeSignal } from "@/features/concierge/types/unified";
 import type { DirectionReference } from "../../../../../../packages/shared/directionReference";
+import type { RecommendationAnalyticsProvenance } from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 /* =========================
  * filter state
@@ -35,6 +36,7 @@ export type RegisteredShrineItem = {
   breakdown?: ConciergeBreakdown | null;
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
   consultationAxis?: string | null;
   explanation?: {
     version?: number | null;
@@ -63,6 +65,7 @@ export type PlaceShrineItem = {
   breakdown?: ConciergeBreakdown | null;
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
+  analyticsProvenance?: RecommendationAnalyticsProvenance;
   consultationAxis?: string | null;
   isDummy?: boolean;
   directionReference?: DirectionReference | null;

--- a/apps/web/src/lib/analytics/__tests__/recommendationProvenance.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/recommendationProvenance.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  recommendationAnalyticsProperties,
+  recommendationAnalyticsProvenance,
+} from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
+
+describe("Web recommendation provenance", () => {
+  it.each(["need_tag", "history_theme", "fallback"])("Primary %sをそのまま送る", (type) => {
+    const provenance = recommendationAnalyticsProvenance({
+      reasonFacts: [{ type, label: type, score: 1, evidence: [], is_primary: true }],
+    });
+    expect(recommendationAnalyticsProperties(provenance)).toMatchObject({
+      primaryReasonSource: type,
+      isFallbackRecommendation: type === "fallback",
+    });
+  });
+
+  it("culture_translationをPrimary化せずAction sourceだけ保持する", () => {
+    const provenance = recommendationAnalyticsProvenance({
+      reasonFacts: [{ type: "culture_translation", is_primary: false }],
+      actionSuggestionPreview: {
+        action_source: { source: "action_context" },
+        source_keys: ["recommendation_reason_v4", "culture_translation"],
+      },
+    });
+    expect(provenance.primaryReasonSource).toBeNull();
+    expect(provenance.actionSourceKeys).toContain("culture_translation");
+  });
+
+  it.each([
+    ["fallback", []],
+    ["action_context", ["ranked_history_theme", "action_catalog"]],
+  ])("Action grounding %sを再ラベルしない", (source, sourceKeys) => {
+    const provenance = recommendationAnalyticsProvenance({
+      actionSuggestionPreview: { action_source: { source }, source_keys: sourceKeys },
+    });
+    expect(provenance.actionSource).toBe(source);
+    expect(provenance.actionSourceKeys).toEqual(sourceKeys);
+  });
+});

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -46,6 +46,10 @@ export type SearchAnalyticsPayload = {
   action_grounding_rate?: number | null;
   is_ai_inference_only?: boolean | null;
   fallback_source?: string | null;
+  primaryReasonSource?: string | null;
+  isFallbackRecommendation?: boolean | null;
+  actionSource?: string | null;
+  actionSourceKeys?: string | null;
   position?: "hero_primary" | "compact" | "map" | "list" | null;
   firstClick?: boolean | null;
   query?: string | null;
@@ -127,6 +131,10 @@ export type RecommendationQualityAnalyticsPayload = {
   action_grounding_rate?: number | null;
   is_ai_inference_only?: boolean | null;
   fallback_source?: string | null;
+  primaryReasonSource?: string | null;
+  isFallbackRecommendation?: boolean | null;
+  actionSource?: string | null;
+  actionSourceKeys?: string | null;
   // docs/audit/knowledge-recommendation-analytics-contract.md 提案の最小Contract。
   // Backend recommendation_reason_quality（PR2382のbuild_shrine_reason_provenance()を
   // 再利用して算出）から受け取るのみで、Web側では再計算しない。

--- a/packages/shared/recommendationAnalyticsProvenance.ts
+++ b/packages/shared/recommendationAnalyticsProvenance.ts
@@ -1,0 +1,88 @@
+export type RecommendationAnalyticsProvenance = {
+  primaryReasonSource: string | null;
+  isFallbackRecommendation: boolean | null;
+  actionSource: string | null;
+  actionSourceKeys: string[];
+};
+
+function trimmedString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function backendPrimaryFactType(reasonFacts: unknown): string | null {
+  if (!Array.isArray(reasonFacts)) return null;
+
+  for (const fact of reasonFacts) {
+    if (!fact || typeof fact !== "object" || Array.isArray(fact)) continue;
+    const candidate = fact as Record<string, unknown>;
+    if (candidate.is_primary !== true) continue;
+    return trimmedString(candidate.type);
+  }
+
+  return null;
+}
+
+export function recommendationAnalyticsProvenance(input: {
+  primaryReasonSource?: unknown;
+  reasonFacts?: unknown;
+  actionSuggestionPreview?: unknown;
+}): RecommendationAnalyticsProvenance {
+  const primaryReasonSource =
+    trimmedString(input.primaryReasonSource) ?? backendPrimaryFactType(input.reasonFacts);
+
+  const preview =
+    input.actionSuggestionPreview &&
+    typeof input.actionSuggestionPreview === "object" &&
+    !Array.isArray(input.actionSuggestionPreview)
+      ? (input.actionSuggestionPreview as Record<string, unknown>)
+      : null;
+  const sourceRaw = preview?.action_source ?? preview?.actionSource;
+  const source =
+    sourceRaw && typeof sourceRaw === "object" && !Array.isArray(sourceRaw)
+      ? trimmedString((sourceRaw as Record<string, unknown>).source)
+      : null;
+  const sourceKeysRaw = preview?.source_keys ?? preview?.sourceKeys;
+  const actionSourceKeys = Array.isArray(sourceKeysRaw)
+    ? sourceKeysRaw.flatMap((value) => {
+        const key = trimmedString(value);
+        return key ? [key] : [];
+      })
+    : [];
+
+  return {
+    primaryReasonSource,
+    isFallbackRecommendation:
+      primaryReasonSource === null ? null : primaryReasonSource === "fallback",
+    actionSource: source,
+    actionSourceKeys,
+  };
+}
+
+export function recommendationAnalyticsProperties(
+  provenance: RecommendationAnalyticsProvenance,
+): Record<string, string | boolean> {
+  return {
+    ...(provenance.primaryReasonSource
+      ? { primaryReasonSource: provenance.primaryReasonSource }
+      : {}),
+    ...(provenance.isFallbackRecommendation !== null
+      ? { isFallbackRecommendation: provenance.isFallbackRecommendation }
+      : {}),
+    ...(provenance.actionSource ? { actionSource: provenance.actionSource } : {}),
+    ...(provenance.actionSourceKeys.length > 0
+      ? { actionSourceKeys: provenance.actionSourceKeys.join(",") }
+      : {}),
+  };
+}
+
+export function buildRecommendationResultSetId(
+  threadId: string | number | null | undefined,
+  recommendations: Array<{ shrineId: string | number | null | undefined }>,
+): string {
+  const signature = recommendations
+    .map((item, index) => `${index + 1}:${item.shrineId ?? "unknown"}`)
+    .join("|");
+  return `${threadId ?? "unknown"}:${signature || "empty"}`;
+}


### PR DESCRIPTION
## Summary

- add one shared Web/Mobile adapter that copies Backend-confirmed primary authority and Action preview provenance without re-ranking or re-labeling
- attach `primaryReasonSource`, `isFallbackRecommendation`, `actionSource`, and `actionSourceKeys` to recommendation impression/click/quality events
- propagate the same values through detail view, route, save, visit, reflection, and Mobile ActionEvent paths
- use the existing PostHog payloads and Backend JSON `metadata`; no DB field or API schema expansion
- align Mobile shrine-detail consumption with the Backend `reason_facts: Fact[]` contract so downstream provenance cannot fall back to the legacy aggregate object

## Metrics enabled

- Primary Authority CTR and detail-view rate
- fallback CTR
- Action source/source-key grouped route/save/visit rate
- generic-safe (`actionSource=fallback`) vs grounded (`sourceKeys` such as `ranked_history_theme`) behavior rate

Analytics does not infer a Primary from score/order/type priority. It accepts an explicit `primary_reason_source`, or the Backend-marked `is_primary === true` fact only. Culture translation and Knowledge facts are never promoted.

## Click writer decision

`ConciergeRecommendationClickLog` still has no production writer. Existing click measurement is `shrine_detail_transition`, so this PR does not activate the legacy DB model or add a duplicate writer.

## Scope

No Backend production, ranking, candidate filtering, signal authority, Reason, Action Grounding, learning weight, UI, DB model, or migration changes.

## Validation

- Web/Mobile provenance targeted tests: 51 passed
- Mobile full suite: 26 files / 280 passed
- Web contract suite: 124 files / 821 passed
- Backend Authority/Reason/Action contracts: 42 passed
- Web typecheck: passed
- Mobile typecheck: passed
- OpenAPI lint: passed
- Web production build with webpack: passed
- Standard Turbopack build is blocked in this execution environment because its CSS worker attempts a prohibited local port bind; the same source compiles and prerenders successfully with Next's webpack builder
- migration: 0