### PR TITLE
fix: propagate recommendation instance identity

### DIFF
--- a/apps/mobile/app/concierge/index.tsx
+++ b/apps/mobile/app/concierge/index.tsx
@@ -38,6 +38,7 @@ import { trackMobileDirection } from "../../lib/directionEvents";
 import { track } from "../../lib/analytics";
 import {
   buildRecommendationResultSetId,
+  normalizeRecommendationInstanceId,
   recommendationAnalyticsProperties,
   recommendationAnalyticsProvenance,
   type RecommendationAnalyticsProvenance,
@@ -91,6 +92,9 @@ type RecommendationCard = {
   actionSuggestionV4Preview?: ActionSuggestionV4Preview | null;
   directionReference?: DirectionReference | null;
   analyticsProvenance: RecommendationAnalyticsProvenance;
+  // docs/audit/recommendation-instance-identity-propagation.md: Backend-issued rid,
+  // reused as-is. Never generated/derived on Mobile.
+  recommendationInstanceId: string | null;
 };
 
 type ActionSuggestionV4Action = {
@@ -158,6 +162,8 @@ type RecommendationApiCard = {
   direction_reference?: DirectionReference | null;
   primary_reason_source?: string | null;
   _primary_reason_source?: string | null;
+  recommendation_instance_id?: string | null;
+  recommendationInstanceId?: string | null;
 };
 function normalizeRecommendationReasonDetail(raw: unknown): RecommendationReasonDetail | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
@@ -356,6 +362,9 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
     reasonFacts,
     actionSuggestionPreview: item.action_suggestion_v4_preview ?? item.actionSuggestionV4Preview,
   });
+  const recommendationInstanceId = normalizeRecommendationInstanceId(
+    item.recommendation_instance_id ?? item.recommendationInstanceId,
+  );
   const reason = resolveRecommendationReason({
     recommendationReasonV4,
     reasonFacts,
@@ -378,6 +387,7 @@ function toRecommendationCard(item: RecommendationApiCard, index: number): Recom
     actionSuggestionV4Preview,
     directionReference: validDirectionReferenceOrNull(item.direction_reference),
     analyticsProvenance,
+    recommendationInstanceId,
   };
 }
 
@@ -690,6 +700,7 @@ export default function ConciergeScreen() {
         resultSetId,
         shrineId: card.shrineId ?? card.id,
         recommendationRank: index + 1,
+        recommendationInstanceId: card.recommendationInstanceId,
         ...recommendationAnalyticsProperties(card.analyticsProvenance),
       });
     });
@@ -823,6 +834,7 @@ export default function ConciergeScreen() {
         source_keys: card.actionSuggestionV4Preview?.sourceKeys ?? [],
         primary_reason_source: card.analyticsProvenance.primaryReasonSource,
         is_fallback_recommendation: card.analyticsProvenance.isFallbackRecommendation,
+        recommendation_instance_id: card.recommendationInstanceId,
       },
     });
   };
@@ -840,6 +852,7 @@ export default function ConciergeScreen() {
       resultSetId,
       shrineId: card.shrineId,
       recommendationRank: rank,
+      recommendationInstanceId: card.recommendationInstanceId,
       ...recommendationAnalyticsProperties(card.analyticsProvenance),
     });
     router.push({
@@ -855,6 +868,7 @@ export default function ConciergeScreen() {
         recommendationReasonV4Detail: serializeReasonV4Detail(card.reasonV4Detail),
         recommendationRank: String(rank),
         resultSetId,
+        recommendationInstanceId: card.recommendationInstanceId ?? "",
       },
     });
   };

--- a/apps/mobile/app/shrines/[id].tsx
+++ b/apps/mobile/app/shrines/[id].tsx
@@ -39,6 +39,7 @@ import {
   type ConciergeReasonFacts,
 } from "../../lib/recommendationReasonFacts";
 import {
+  normalizeRecommendationInstanceId,
   recommendationAnalyticsProperties,
   recommendationAnalyticsProvenance,
 } from "../../../../packages/shared/recommendationAnalyticsProvenance";
@@ -216,12 +217,22 @@ export default function ShrineDetail() {
     recommendationReasonV4Detail?: string | string[];
     recommendationRank?: string | string[];
     resultSetId?: string | string[];
+    recommendationInstanceId?: string | string[];
   }>();
   const shrineId = React.useMemo(() => {
     const raw = params.id;
     if (!raw) return undefined;
     return Array.isArray(raw) ? raw[0] : raw;
   }, [params.id]);
+
+  // docs/audit/recommendation-instance-identity-propagation.md: carried only from a
+  // Concierge-origin navigation's route params (Backend rid). Direct detail access
+  // has no such params, so this stays null -- never generated on Mobile.
+  const contextRecommendationInstanceId = React.useMemo(() => {
+    const raw = params.recommendationInstanceId;
+    const value = Array.isArray(raw) ? raw[0] : raw;
+    return normalizeRecommendationInstanceId(value);
+  }, [params.recommendationInstanceId]);
 
   const contextRecommendationReasonV4 = React.useMemo(() => {
     const raw = params.recommendationReasonV4;
@@ -408,6 +419,7 @@ export default function ShrineDetail() {
             ctx: "mobile_shrine_detail",
             recommendation_rank: Number(Array.isArray(params.recommendationRank) ? params.recommendationRank[0] : params.recommendationRank) || null,
             result_set_id: Array.isArray(params.resultSetId) ? params.resultSetId[0] : params.resultSetId,
+            recommendation_instance_id: contextRecommendationInstanceId,
             ...analyticsProperties,
           },
         });
@@ -465,6 +477,7 @@ export default function ShrineDetail() {
       platform: "mobile",
       shrineId: apiShrineId ?? shrineId,
       nextFav: now,
+      recommendationInstanceId: contextRecommendationInstanceId,
       ...analyticsProperties,
     });
 
@@ -499,6 +512,7 @@ export default function ShrineDetail() {
         shrineId: targetShrineId,
         historyTheme: primaryHistoryTheme,
         provenance: analyticsProvenance,
+        recommendationInstanceId: contextRecommendationInstanceId,
       });
     } catch (error) {
       if (isUnauthenticatedError(error)) {
@@ -520,6 +534,7 @@ export default function ShrineDetail() {
       reflectionFormType: "one_line",
       reflectionContext: "visit_done",
       provenance: analyticsProvenance,
+      recommendationInstanceId: contextRecommendationInstanceId,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visited]);
@@ -549,6 +564,7 @@ export default function ShrineDetail() {
           reflectionContext: "visit_done",
           answerLength: answer.length,
           provenance: analyticsProvenance,
+          recommendationInstanceId: contextRecommendationInstanceId,
         });
       }
     } catch (error) {
@@ -577,6 +593,7 @@ export default function ShrineDetail() {
       shrineId: targetShrineId ?? "",
       historyTheme: primaryHistoryTheme,
       provenance: analyticsProvenance,
+      recommendationInstanceId: contextRecommendationInstanceId,
     });
 
     // Reflection本文・相談文等の自由入力は一切引き継がず、Conciergeを通常状態で開く
@@ -595,12 +612,17 @@ export default function ShrineDetail() {
           ctx: "mobile_shrine_detail",
           recommendation_rank: Number(Array.isArray(params.recommendationRank) ? params.recommendationRank[0] : params.recommendationRank) || null,
           result_set_id: Array.isArray(params.resultSetId) ? params.resultSetId[0] : params.resultSetId,
+          recommendation_instance_id: contextRecommendationInstanceId,
           ...analyticsProperties,
         },
       });
       // Backend保存用(trackShrineRouteOpen)とは別に、PostHog等で可視化するための
       // track()イベントをWeb版のroute_openと同じ名前・意味で送る。
-      trackRouteOpen({ shrineId: shrineIdNumber, provenance: analyticsProvenance });
+      trackRouteOpen({
+        shrineId: shrineIdNumber,
+        provenance: analyticsProvenance,
+        recommendationInstanceId: contextRecommendationInstanceId,
+      });
     }
     const hasLatLng = typeof shrine.latitude === "number" && typeof shrine.longitude === "number";
     const destination = hasLatLng ? `${shrine.latitude},${shrine.longitude}` : encodeURIComponent(shrine.name);

--- a/apps/mobile/lib/__tests__/recommendationAnalyticsProvenance.test.ts
+++ b/apps/mobile/lib/__tests__/recommendationAnalyticsProvenance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  normalizeRecommendationInstanceId,
   recommendationAnalyticsProperties,
   recommendationAnalyticsProvenance,
 } from "../../../../packages/shared/recommendationAnalyticsProvenance";
@@ -25,5 +26,17 @@ describe("Mobile recommendation provenance parity", () => {
     }));
     expect(properties.actionSource).toBe(source);
     expect(properties.actionSourceKeys).toBe(sourceKeys.length > 0 ? sourceKeys.join(",") : undefined);
+  });
+});
+
+// docs/audit/recommendation-instance-identity-propagation.md: Mobile must read the same
+// Backend-issued rid as Web, via the same shared normalizer -- never generate its own.
+describe("normalizeRecommendationInstanceId parity", () => {
+  it("WebとMobileが同じBackend値を同じ結果へ正規化する", () => {
+    expect(normalizeRecommendationInstanceId("a1b2c3d4")).toBe("a1b2c3d4");
+  });
+
+  it.each([undefined, null, "", "   "])("欠損値(%p)はnullのまま、合成しない", (raw) => {
+    expect(normalizeRecommendationInstanceId(raw)).toBeNull();
   });
 });

--- a/apps/mobile/lib/searchAnalytics.ts
+++ b/apps/mobile/lib/searchAnalytics.ts
@@ -52,12 +52,14 @@ export function trackMapMarkerSelect(params: { shrineId: string }): void {
 export function trackRouteOpen(params: {
   shrineId: string | number;
   provenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
 }): void {
   track("route_open", {
     source: SOURCE_SHRINE_DETAIL,
     shrineId: params.shrineId,
     routeTarget: "google_maps",
     platform: "mobile",
+    recommendationInstanceId: params.recommendationInstanceId || undefined,
     ...(params.provenance ? recommendationAnalyticsProperties(params.provenance) : {}),
   });
 }

--- a/apps/mobile/lib/visitReflectionAnalytics.ts
+++ b/apps/mobile/lib/visitReflectionAnalytics.ts
@@ -19,15 +19,25 @@ type BasePayloadParams = {
   threadId?: number | string | null;
   historyTheme?: string | null;
   provenance?: RecommendationAnalyticsProvenance;
+  // docs/audit/recommendation-instance-identity-propagation.md: Backend-issued rid,
+  // reused as-is. Never generated/derived on Mobile.
+  recommendationInstanceId?: string | null;
 };
 
-function buildBasePayload({ shrineId, threadId, historyTheme, provenance }: BasePayloadParams): Record<string, unknown> {
+function buildBasePayload({
+  shrineId,
+  threadId,
+  historyTheme,
+  provenance,
+  recommendationInstanceId,
+}: BasePayloadParams): Record<string, unknown> {
   return {
     source: SOURCE,
     platform: "mobile",
     shrineId,
     threadId: threadId || undefined,
     historyTheme: historyTheme || undefined,
+    recommendationInstanceId: recommendationInstanceId || undefined,
     ...(provenance ? recommendationAnalyticsProperties(provenance) : {}),
   };
 }

--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -47,7 +47,10 @@ import { compareState } from "@/lib/concierge/compareState";
 import type { StateDelta } from "@/lib/concierge/stateComparison";
 import { parseDirectionRouteContext } from "@/lib/analytics/directionRouteContext";
 import { normalizeRecommendationReasonV4Detail } from "@/lib/shrine/buildShrineDetailReasonV4Sections";
-import { recommendationAnalyticsProvenance } from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
+import {
+  normalizeRecommendationInstanceId,
+  recommendationAnalyticsProvenance,
+} from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
 
 function normalizeCtx(v?: string | null): "map" | "concierge" | null {
   return v === "map" || v === "concierge" ? v : null;
@@ -422,6 +425,13 @@ export default async function Page({ params, searchParams }: Props) {
     reasonFacts: selectedRecommendation?.reason_facts,
     actionSuggestionPreview: selectedRecommendation?.action_suggestion_v4_preview,
   });
+  // Recommendation Instance Identity Contract
+  // (docs/audit/recommendation-instance-identity-propagation.md): read-only, Backend
+  // rid persisted on the thread snapshot. Direct detail access (no ctx=concierge && tid,
+  // i.e. selectedRecommendation stays null) yields null here -- never synthesized.
+  const recommendationInstanceId = normalizeRecommendationInstanceId(
+    selectedRecommendation?.recommendation_instance_id,
+  );
 
   const model = buildShrineDetailModel({
     shrine: s,
@@ -444,7 +454,13 @@ export default async function Page({ params, searchParams }: Props) {
   return (
     <>
       <ScrollToTopOnMount />
-      <ShrineDetailViewTracker shrineId={numericId} ctx={ctx} tid={tid} analyticsProvenance={analyticsProvenance} />
+      <ShrineDetailViewTracker
+        shrineId={numericId}
+        ctx={ctx}
+        tid={tid}
+        analyticsProvenance={analyticsProvenance}
+        recommendationInstanceId={recommendationInstanceId}
+      />
       <ShrineDetailToast shrineId={numericId} />
       <ShrineDetailShell
         title={pageTitle}
@@ -455,6 +471,7 @@ export default async function Page({ params, searchParams }: Props) {
         tid={tid}
         historyTheme={historyThemeForAnalytics}
         analyticsProvenance={analyticsProvenance}
+        recommendationInstanceId={recommendationInstanceId}
         directionRouteContext={directionRouteContext}
         addGoshuinHref={null}
         googleDirHref={googleDirHref}
@@ -468,6 +485,7 @@ export default async function Page({ params, searchParams }: Props) {
           isPremiumActive={isPremiumActive}
           historyTheme={historyThemeForAnalytics}
           analyticsProvenance={analyticsProvenance}
+          recommendationInstanceId={recommendationInstanceId}
           addGoshuinHref={addGoshuinHref}
           saveActionNode={
             <ShrineSaveButton
@@ -478,6 +496,7 @@ export default async function Page({ params, searchParams }: Props) {
               nextPath={nextPath}
               guestMode={guestMode}
               analyticsProvenance={analyticsProvenance}
+              recommendationInstanceId={recommendationInstanceId}
               initial={initialFavorite}
             />
           }

--- a/apps/web/src/components/shrine/GoogleMapRouteLink.tsx
+++ b/apps/web/src/components/shrine/GoogleMapRouteLink.tsx
@@ -19,6 +19,7 @@ type Props = {
   className?: string;
   directionRouteContext?: DirectionRouteContext | null;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
 };
 
 export default function GoogleMapRouteLink({
@@ -31,6 +32,7 @@ export default function GoogleMapRouteLink({
   className,
   directionRouteContext = null,
   analyticsProvenance,
+  recommendationInstanceId = null,
 }: Props) {
   let routeUrl: URL | null = null;
   try {
@@ -67,6 +69,7 @@ export default function GoogleMapRouteLink({
             threadId: tid != null ? String(tid) : undefined,
             historyTheme: historyTheme ?? undefined,
             ctx,
+            recommendationInstanceId,
             ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
           });
         } catch {
@@ -86,6 +89,7 @@ export default function GoogleMapRouteLink({
                 routeTarget: "google_maps",
                 historyTheme,
                 ctx,
+                recommendation_instance_id: recommendationInstanceId,
                 ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
               },
             }).catch(() => console.warn("route_interaction_delivery_failed"));

--- a/apps/web/src/components/shrine/ShrineDetailShell.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailShell.tsx
@@ -39,6 +39,7 @@ type Props = {
   historyTheme?: string | null;
   directionRouteContext?: DirectionRouteContext | null;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
 };
 
 export default function ShrineDetailShell({
@@ -59,6 +60,7 @@ export default function ShrineDetailShell({
   historyTheme = null,
   directionRouteContext = null,
   analyticsProvenance,
+  recommendationInstanceId = null,
 }: Props) {
   const shouldShowActions = !hideActions && Boolean(googleDirHref || saveAction?.node || addGoshuinHref);
 
@@ -94,6 +96,7 @@ export default function ShrineDetailShell({
                 historyTheme={historyTheme}
                 directionRouteContext={directionRouteContext}
                 analyticsProvenance={analyticsProvenance}
+                recommendationInstanceId={recommendationInstanceId}
                 className="inline-flex min-h-[44px] w-full items-center justify-center rounded-[var(--kt-radius-panel)] bg-slate-900 px-4 py-3 text-sm font-semibold text-[var(--kt-color-text-inverse)] hover:bg-slate-800"
               />
             ) : null}

--- a/apps/web/src/components/shrine/ShrineDetailViewTracker.tsx
+++ b/apps/web/src/components/shrine/ShrineDetailViewTracker.tsx
@@ -13,9 +13,16 @@ type Props = {
   ctx?: "map" | "concierge" | null;
   tid?: string | null;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
 };
 
-export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null, analyticsProvenance }: Props) {
+export function ShrineDetailViewTracker({
+  shrineId,
+  ctx = null,
+  tid = null,
+  analyticsProvenance,
+  recommendationInstanceId = null,
+}: Props) {
   const trackedRef = useRef(false);
 
   useEffect(() => {
@@ -28,6 +35,7 @@ export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null, anal
       source,
       shrineId,
       threadId: tid ?? undefined,
+      recommendationInstanceId,
       ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
     });
 
@@ -39,10 +47,11 @@ export function ShrineDetailViewTracker({ shrineId, ctx = null, tid = null, anal
       metadata: {
         event: "shrine_detail_view",
         ctx,
+        recommendation_instance_id: recommendationInstanceId,
         ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
       },
     });
-  }, [shrineId, ctx, tid, analyticsProvenance]);
+  }, [shrineId, ctx, tid, analyticsProvenance, recommendationInstanceId]);
 
   return null;
 }

--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -25,6 +25,7 @@ type Props = {
   };
   onToggleSuccess?: (nextFav: boolean) => void;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
 };
 
 export default function ShrineSaveButton({
@@ -37,6 +38,7 @@ export default function ShrineSaveButton({
   initial,
   onToggleSuccess,
   analyticsProvenance,
+  recommendationInstanceId = null,
 }: Props) {
   const router = useRouter();
   const { isLoggedIn, loading } = useAuth();
@@ -65,6 +67,7 @@ export default function ShrineSaveButton({
         source: "shrine_detail",
         cardId: "saved_record",
         accessLevel,
+        recommendationInstanceId,
         ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
       });
 
@@ -74,6 +77,7 @@ export default function ShrineSaveButton({
           action: "save",
           ctx,
           tid,
+          recommendationInstanceId,
           ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
         });
       }

--- a/apps/web/src/components/shrine/__tests__/ShrineSaveButton.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/ShrineSaveButton.test.tsx
@@ -73,6 +73,7 @@ describe("ShrineSaveButton", () => {
         source: "shrine_detail",
         cardId: "saved_record",
         accessLevel: "free",
+        recommendationInstanceId: null,
       });
     });
 

--- a/apps/web/src/components/shrine/__tests__/recommendationInstanceIdPropagation.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/recommendationInstanceIdPropagation.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/audit/recommendation-instance-identity-propagation.md:
+// detail -> route/save/visit/reflection must carry the identical recommendationInstanceId
+// that was resolved server-side from the thread snapshot (page.tsx). Direct detail access
+// (no recommendationInstanceId prop) must never synthesize one.
+
+const { trackSearchEvent, trackShrineInteraction } = vi.hoisted(() => ({
+  trackSearchEvent: vi.fn(),
+  trackShrineInteraction: vi.fn(),
+}));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent }));
+vi.mock("@/lib/api/shrineInteractions", () => ({ trackShrineInteraction }));
+
+import { ShrineDetailViewTracker } from "../ShrineDetailViewTracker";
+import GoogleMapRouteLink from "../GoogleMapRouteLink";
+
+const routeHref = "https://www.google.com/maps/dir/?api=1&destination=35,139";
+
+describe("Recommendation Instance Identity: detail -> route", () => {
+  beforeEach(() => {
+    trackSearchEvent.mockClear();
+    trackShrineInteraction.mockClear();
+  });
+
+  it("ShrineDetailViewTrackerとGoogleMapRouteLinkが同じrecommendationInstanceIdを送る", () => {
+    const recommendationInstanceId = "a1b2c3d4";
+
+    render(
+      <ShrineDetailViewTracker
+        shrineId={42}
+        ctx="concierge"
+        tid="768"
+        recommendationInstanceId={recommendationInstanceId}
+      />,
+    );
+
+    expect(trackSearchEvent).toHaveBeenCalledWith(
+      "shrine_detail_view",
+      expect.objectContaining({ shrineId: 42, recommendationInstanceId }),
+    );
+    expect(trackShrineInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shrineId: 42,
+        actionType: "detail_view",
+        metadata: expect.objectContaining({ recommendation_instance_id: recommendationInstanceId }),
+      }),
+    );
+
+    const { getByRole } = render(
+      <GoogleMapRouteLink
+        href={routeHref}
+        label="Googleマップで経路案内"
+        shrineId={42}
+        ctx="concierge"
+        tid="768"
+        recommendationInstanceId={recommendationInstanceId}
+      />,
+    );
+    fireEvent.click(getByRole("link", { name: "Googleマップで経路案内" }));
+
+    const routeOpenCall = trackSearchEvent.mock.calls.find(([name]) => name === "route_open");
+    expect(routeOpenCall?.[1]).toMatchObject({ shrineId: 42, recommendationInstanceId });
+  });
+
+  it("Direct detail access(recommendationInstanceId無し)ではidentityを合成せずnullのまま送る", () => {
+    render(<ShrineDetailViewTracker shrineId={7} ctx={null} tid={null} />);
+
+    expect(trackSearchEvent).toHaveBeenCalledWith(
+      "shrine_detail_view",
+      expect.objectContaining({ recommendationInstanceId: null }),
+    );
+    expect(trackShrineInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({ recommendation_instance_id: null }),
+      }),
+    );
+  });
+});

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -391,6 +391,7 @@ export default function ShrineDetailArticle({
   tid = null,
   historyTheme = null,
   analyticsProvenance,
+  recommendationInstanceId = null,
   meaningPayloadSource = "fallback",
   saveActionNode,
   actionState,
@@ -423,6 +424,7 @@ export default function ShrineDetailArticle({
   tid?: string | number | null;
   historyTheme?: string | null;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
   meaningPayloadSource?: "v2" | "fallback";
   saveActionNode?: React.ReactNode;
   actionState?: "none" | "detail_viewed" | "saved" | "route_opened" | "visited" | "reflected" | null;
@@ -716,6 +718,7 @@ export default function ShrineDetailArticle({
                     ctx={ctx}
                     accessLevel={accessLevel}
                     analyticsProvenance={analyticsProvenance}
+                    recommendationInstanceId={recommendationInstanceId}
                   />
                 ) : null}
 
@@ -743,6 +746,7 @@ export default function ShrineDetailArticle({
                           historyTheme: historyTheme ?? undefined,
                           accessLevel,
                           mode: ctx === "concierge" ? "need" : undefined,
+                          recommendationInstanceId,
                           ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
                         });
                         const now = new Date().toISOString();

--- a/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
@@ -19,6 +19,7 @@ type Props = {
   accessLevel?: "anonymous" | "free" | "premium" | null;
   onSaved?: () => void;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  recommendationInstanceId?: string | null;
 };
 
 const PROMPT_TEXT = "参拝して、今どんな変化がありましたか？";
@@ -31,6 +32,7 @@ export function ShrineReflectionPrompt({
   accessLevel = null,
   onSaved,
   analyticsProvenance,
+  recommendationInstanceId = null,
 }: Props) {
   const mode = ctx === "concierge" ? "need" : undefined;
   const [answer, setAnswer] = useState("");
@@ -53,9 +55,10 @@ export function ShrineReflectionPrompt({
       reflectionContext: "visit_done",
       mode,
       accessLevel,
+      recommendationInstanceId,
       ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
     });
-  }, [accessLevel, analyticsProvenance, historyTheme, mode, shrineId, threadId]);
+  }, [accessLevel, analyticsProvenance, historyTheme, mode, recommendationInstanceId, shrineId, threadId]);
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -87,6 +90,7 @@ export function ShrineReflectionPrompt({
         moodAfter: moodAfter || undefined,
         mode,
         accessLevel,
+        recommendationInstanceId,
         ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
       });
 

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
@@ -43,6 +43,7 @@ describe("ShrineReflectionPrompt", () => {
       reflectionContext: "visit_done",
       mode: "need",
       accessLevel: "free",
+      recommendationInstanceId: null,
     });
   });
 
@@ -105,6 +106,7 @@ describe("ShrineReflectionPrompt", () => {
       moodAfter: "calm",
       mode: "need",
       accessLevel: "free",
+      recommendationInstanceId: null,
     });
     expect(onSaved).toHaveBeenCalled();
   });

--- a/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.recommendationInstanceId.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.recommendationInstanceId.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildPayloadFromUnified } from "../buildPayloadFromUnified";
+
+// docs/audit/recommendation-instance-identity-propagation.md:
+// Backend rid (embedded as recommendation_instance_id on each item) must reach the
+// normalized item unchanged -- this is the single source both the impression/click
+// events (via ConciergeSectionsRenderer) and the detail page (via the thread snapshot
+// that persists this same normalized-equivalent raw item) read from.
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+describe("buildPayloadFromUnified - recommendationInstanceId", () => {
+  it("registered item(shrine_idあり)へBackendのrecommendation_instance_idをそのまま複製する", () => {
+    const u: any = {
+      data: {
+        recommendations: [
+          { shrine_id: 10, display_name: "S1", reason: "R1", recommendation_instance_id: "a1b2c3d4" },
+        ],
+      },
+      thread: { id: 1 },
+    };
+
+    const p = buildPayloadFromUnified(u, baseFilterState);
+    const items = (p?.sections.find((s: any) => s.type === "recommendations") as any)?.items;
+    expect(items[0].recommendationInstanceId).toBe("a1b2c3d4");
+  });
+
+  it("place item(place_idのみ)へも同じ値を複製する", () => {
+    const u: any = {
+      data: {
+        recommendations: [
+          { place_id: "P10", display_name: "S1", reason: "R1", recommendation_instance_id: "a1b2c3d4" },
+        ],
+      },
+      thread: { id: 1 },
+    };
+
+    const p = buildPayloadFromUnified(u, baseFilterState);
+    const items = (p?.sections.find((s: any) => s.type === "recommendations") as any)?.items;
+    expect(items[0].recommendationInstanceId).toBe("a1b2c3d4");
+  });
+
+  it("値が無ければnullのまま、Frontendで合成しない", () => {
+    const u: any = {
+      data: {
+        recommendations: [{ shrine_id: 11, display_name: "S2", reason: "R2" }],
+      },
+      thread: { id: 1 },
+    };
+
+    const p = buildPayloadFromUnified(u, baseFilterState);
+    const items = (p?.sections.find((s: any) => s.type === "recommendations") as any)?.items;
+    expect(items[0].recommendationInstanceId).toBeNull();
+  });
+
+  it("同一raw入力を複数回正規化しても同じ値になる(再render相当で不変)", () => {
+    const rec = { shrine_id: 12, display_name: "S3", reason: "R3", recommendation_instance_id: "stable-id" };
+    const u: any = { data: { recommendations: [rec] }, thread: { id: 1 } };
+
+    const first = buildPayloadFromUnified(u, baseFilterState);
+    const second = buildPayloadFromUnified(u, baseFilterState);
+
+    const firstId = (first?.sections.find((s: any) => s.type === "recommendations") as any)?.items[0]
+      .recommendationInstanceId;
+    const secondId = (second?.sections.find((s: any) => s.type === "recommendations") as any)?.items[0]
+      .recommendationInstanceId;
+
+    expect(firstId).toBe("stable-id");
+    expect(secondId).toBe("stable-id");
+  });
+});

--- a/apps/web/src/features/concierge/buildPayloadFromUnified.ts
+++ b/apps/web/src/features/concierge/buildPayloadFromUnified.ts
@@ -8,6 +8,7 @@ import type {
 import type { ConciergeReasonFacts, RecommendationReasonV4Detail } from "@/lib/api/concierge";
 import { validDirectionReferenceOrNull, type DirectionReference } from "../../../../../packages/shared/directionReference";
 import {
+  normalizeRecommendationInstanceId,
   recommendationAnalyticsProvenance,
   type RecommendationAnalyticsProvenance,
 } from "../../../../../packages/shared/recommendationAnalyticsProvenance";
@@ -25,6 +26,7 @@ type NormalizedItemBase = {
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
   analyticsProvenance: RecommendationAnalyticsProvenance;
+  recommendationInstanceId: string | null;
   reasonV4Detail?: RecommendationReasonV4Detail | null;
   recommendationReasonV4?: string | null;
   trustMetadata?: any | null;
@@ -167,6 +169,9 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
     reasonFacts,
     actionSuggestionPreview: actionSuggestionV4Preview,
   });
+  const recommendationInstanceId = normalizeRecommendationInstanceId(
+    r?.recommendation_instance_id ?? r?.recommendationInstanceId,
+  );
   const directionReference = validDirectionReferenceOrNull(r?.direction_reference);
 
   if (shrineId) {
@@ -182,6 +187,7 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
       breakdown_detail: breakdownDetail,
       reasonFacts,
       analyticsProvenance,
+      recommendationInstanceId,
       actionSuggestionV4Preview,
       reasonV4Detail,
       recommendationReasonV4,
@@ -210,6 +216,7 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
       breakdown_detail: breakdownDetail,
       reasonFacts,
       analyticsProvenance,
+      recommendationInstanceId,
       actionSuggestionV4Preview,
       reasonV4Detail,
       recommendationReasonV4,
@@ -301,6 +308,9 @@ function dedupeItems(items: NormalizedItem[]): NormalizedItem[] {
         }
         if (reg?.kind === "registered" && !reg.consultationAxis && item.consultationAxis) {
           out[idx] = { ...out[idx], consultationAxis: item.consultationAxis };
+        }
+        if (reg?.kind === "registered" && !reg.recommendationInstanceId && item.recommendationInstanceId) {
+          out[idx] = { ...out[idx], recommendationInstanceId: item.recommendationInstanceId };
         }
         if (reg?.kind === "registered" && !reg.reasonV4Detail && item.reasonV4Detail) {
           out[idx] = { ...out[idx], reasonV4Detail: item.reasonV4Detail };

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -368,6 +368,7 @@ export default function ConciergeSectionsRenderer({
           payload.meta?.consultationAxis,
         ),
         analyticsProvenance: item.analyticsProvenance,
+        recommendationInstanceId: item.recommendationInstanceId ?? null,
       }));
     });
   }, [payload, normalizedModeForTracking]);
@@ -391,6 +392,7 @@ export default function ConciergeSectionsRenderer({
         recommendationRank: item.rank,
         mode: item.mode,
         historyTheme: item.historyTheme ?? analyticsContext?.historyTheme,
+        recommendationInstanceId: item.recommendationInstanceId,
         ...consultationAxisAnalytics(item.consultationAxis ?? analyticsContext?.consultationAxis),
         ...(item.analyticsProvenance
           ? recommendationAnalyticsProperties(item.analyticsProvenance)
@@ -936,6 +938,7 @@ export default function ConciergeSectionsRenderer({
                                   historyTheme: historyTheme ?? analyticsContext?.historyTheme,
                                   ...consultationAxisAnalytics(heroItem.consultationAxis ?? analyticsContext?.consultationAxis),
                                   firstClick: resolveFirstResultClick(resultSetId),
+                                  recommendationInstanceId: heroItem.recommendationInstanceId ?? null,
                                   ...(heroItem.analyticsProvenance
                                     ? recommendationAnalyticsProperties(heroItem.analyticsProvenance)
                                     : {}),
@@ -1114,6 +1117,7 @@ export default function ConciergeSectionsRenderer({
                                           (item as any).consultationAxis ?? analyticsContext?.consultationAxis,
                                         ),
                                         firstClick: resolveFirstResultClick(resultSetId),
+                                        recommendationInstanceId: item.recommendationInstanceId ?? null,
                                         ...(item.analyticsProvenance
                                           ? recommendationAnalyticsProperties(item.analyticsProvenance)
                                           : {}),

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.recommendationInstanceId.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.recommendationInstanceId.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/audit/recommendation-instance-identity-propagation.md:
+// impression -> click must carry the identical Backend-issued recommendationInstanceId
+// for the same recommendation, and it must stay stable across re-normalization
+// (simulating a re-render).
+
+const analyticsMocks = vi.hoisted(() => ({
+  trackSearchEvent: vi.fn(),
+  trackCardEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/searchEvents", () => ({
+  trackSearchEvent: analyticsMocks.trackSearchEvent,
+}));
+
+vi.mock("@/lib/analytics/cardEvents", () => ({
+  trackCardEvent: analyticsMocks.trackCardEvent,
+}));
+
+const authMock = vi.hoisted(() => ({
+  useAuth: vi.fn(() => ({ isLoggedIn: false, loading: false })),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: authMock.useAuth,
+}));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[]) {
+  const u: any = { data: { recommendations }, thread: { id: 768 } };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+describe("Recommendation Instance Identity: impression -> click", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    authMock.useAuth.mockReturnValue({ isLoggedIn: false, loading: false });
+    window.localStorage.clear();
+  });
+
+  it("concierge_result_impressionとshrine_detail_transitionが同じrecommendationInstanceIdを送る", () => {
+    const heroRec = {
+      shrine_id: 1,
+      display_name: "第一候補神社",
+      reason: "第一候補の理由文です。",
+      recommendation_instance_id: "a1b2c3d4",
+    };
+    const payload = buildTestPayload([heroRec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    const impressionCall = analyticsMocks.trackSearchEvent.mock.calls.find(
+      ([name]) => name === "concierge_result_impression",
+    );
+    expect(impressionCall?.[1]).toMatchObject({ shrineId: 1, recommendationInstanceId: "a1b2c3d4" });
+
+    fireEvent.click(screen.getByRole("link", { name: "神社の詳細を見る" }));
+
+    const clickCall = analyticsMocks.trackSearchEvent.mock.calls.find(
+      ([name]) => name === "shrine_detail_transition",
+    );
+    expect(clickCall?.[1]).toMatchObject({ shrineId: 1, recommendationInstanceId: "a1b2c3d4" });
+    expect(clickCall?.[1].recommendationInstanceId).toBe(impressionCall?.[1].recommendationInstanceId);
+  });
+
+  it("recommendation_instance_idが無いDirectアクセス相当の候補ではidentityを合成しない", () => {
+    const heroRec = { shrine_id: 2, display_name: "識別子なし神社", reason: "理由" };
+    const payload = buildTestPayload([heroRec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    const impressionCall = analyticsMocks.trackSearchEvent.mock.calls.find(
+      ([name]) => name === "concierge_result_impression",
+    );
+    expect(impressionCall?.[1].recommendationInstanceId).toBeNull();
+  });
+
+  it("再normalizeしてもrecommendationInstanceIdは不変(rerender相当)", () => {
+    const heroRec = {
+      shrine_id: 5,
+      display_name: "再検証神社",
+      reason: "理由",
+      recommendation_instance_id: "stable-9f8e",
+    };
+    const payload = buildTestPayload([heroRec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+    const first = analyticsMocks.trackSearchEvent.mock.calls.find(
+      ([name]) => name === "concierge_result_impression",
+    )?.[1].recommendationInstanceId;
+
+    const rebuiltPayload = buildTestPayload([heroRec]);
+    const rebuiltHero = (rebuiltPayload.sections.find((s: any) => s.type === "recommendations") as any).items[0];
+
+    expect(rebuiltHero.recommendationInstanceId).toBe(first);
+    expect(first).toBe("stable-9f8e");
+  });
+});

--- a/apps/web/src/features/concierge/hooks.ts
+++ b/apps/web/src/features/concierge/hooks.ts
@@ -20,6 +20,7 @@ import { normalizeBirthdateInput } from "@/lib/date/normalizeBirthdateInput";
 import { trackRecommendationQuality } from "@/lib/analytics/searchEvents";
 import {
   buildRecommendationResultSetId,
+  normalizeRecommendationInstanceId,
   recommendationAnalyticsProperties,
   recommendationAnalyticsProvenance,
 } from "../../../../../packages/shared/recommendationAnalyticsProvenance";
@@ -163,6 +164,9 @@ export function trackRecommendationQualityFromRecommendations(args: {
       knowledge_backing_class: quality.knowledge_backing_class ?? null,
       deity_knowledge_used: quality.deity_knowledge_used ?? null,
       history_knowledge_used: quality.history_knowledge_used ?? null,
+      recommendationInstanceId: normalizeRecommendationInstanceId(
+        (rec as any).recommendation_instance_id ?? (rec as any).recommendationInstanceId,
+      ),
       ...recommendationAnalyticsProperties(recommendationAnalyticsProvenance({
         primaryReasonSource: (rec as any).primary_reason_source ?? (rec as any)._primary_reason_source,
         reasonFacts: rec.reason_facts,

--- a/apps/web/src/features/concierge/sections/types.ts
+++ b/apps/web/src/features/concierge/sections/types.ts
@@ -37,6 +37,8 @@ export type RegisteredShrineItem = {
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  /** Backend rid, reused as-is (docs/audit/recommendation-instance-identity-propagation.md). Never generated on Frontend. */
+  recommendationInstanceId?: string | null;
   consultationAxis?: string | null;
   explanation?: {
     version?: number | null;
@@ -66,6 +68,8 @@ export type PlaceShrineItem = {
   breakdown_detail?: any | null;
   reasonFacts?: ConciergeReasonFacts | null;
   analyticsProvenance?: RecommendationAnalyticsProvenance;
+  /** Backend rid, reused as-is (docs/audit/recommendation-instance-identity-propagation.md). Never generated on Frontend. */
+  recommendationInstanceId?: string | null;
   consultationAxis?: string | null;
   isDummy?: boolean;
   directionReference?: DirectionReference | null;

--- a/apps/web/src/lib/analytics/__tests__/recommendationProvenance.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/recommendationProvenance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  normalizeRecommendationInstanceId,
   recommendationAnalyticsProperties,
   recommendationAnalyticsProvenance,
 } from "../../../../../../packages/shared/recommendationAnalyticsProvenance";
@@ -37,5 +38,30 @@ describe("Web recommendation provenance", () => {
     });
     expect(provenance.actionSource).toBe(source);
     expect(provenance.actionSourceKeys).toEqual(sourceKeys);
+  });
+});
+
+// docs/audit/recommendation-instance-identity-propagation.md: this only normalizes a
+// Backend-issued value (rid). It must never generate/guess/reconstruct an id.
+describe("normalizeRecommendationInstanceId", () => {
+  it("Backendのrecommendation_instance_idをそのまま通す", () => {
+    expect(normalizeRecommendationInstanceId("a1b2c3d4")).toBe("a1b2c3d4");
+  });
+
+  it("前後の空白を取り除く", () => {
+    expect(normalizeRecommendationInstanceId("  a1b2c3d4  ")).toBe("a1b2c3d4");
+  });
+
+  it.each([undefined, null, "", "   ", 123, {}, []])(
+    "存在しない値(%p)はnullへfallbackし、合成しない",
+    (raw) => {
+      expect(normalizeRecommendationInstanceId(raw)).toBeNull();
+    },
+  );
+
+  it("同一入力に対して常に同じ値を返す(再renderで不変)", () => {
+    const first = normalizeRecommendationInstanceId("a1b2c3d4");
+    const second = normalizeRecommendationInstanceId("a1b2c3d4");
+    expect(first).toBe(second);
   });
 });

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -50,6 +50,7 @@ export type SearchAnalyticsPayload = {
   isFallbackRecommendation?: boolean | null;
   actionSource?: string | null;
   actionSourceKeys?: string | null;
+  recommendationInstanceId?: string | null;
   position?: "hero_primary" | "compact" | "map" | "list" | null;
   firstClick?: boolean | null;
   query?: string | null;
@@ -135,6 +136,7 @@ export type RecommendationQualityAnalyticsPayload = {
   isFallbackRecommendation?: boolean | null;
   actionSource?: string | null;
   actionSourceKeys?: string | null;
+  recommendationInstanceId?: string | null;
   // docs/audit/knowledge-recommendation-analytics-contract.md 提案の最小Contract。
   // Backend recommendation_reason_quality（PR2382のbuild_shrine_reason_provenance()を
   // 再利用して算出）から受け取るのみで、Web側では再計算しない。

--- a/apps/web/src/lib/api/concierge/types.ts
+++ b/apps/web/src/lib/api/concierge/types.ts
@@ -150,6 +150,8 @@ export type ConciergeRecommendation = {
   id?: number | null;
   shrine_id?: number | null;
   place_id?: string | null;
+  /** Backend-issued per-request rid, reused as-is. Never generated/derived on Frontend. */
+  recommendation_instance_id?: string | null;
 
   name: string;
   display_name?: string;

--- a/backend/temples/api_views_concierge.py
+++ b/backend/temples/api_views_concierge.py
@@ -849,6 +849,19 @@ class ConciergeChatView(APIView):
                         if isinstance(recommendation, dict):
                             recommendation.pop("direction_reference", None)
 
+            # Recommendation Instance Identity Contract
+            # (docs/audit/recommendation-instance-identity-propagation.md, Option C):
+            # reuse the existing per-request rid as the immutable recommendation_instance_id.
+            # No new ID generator -- same embed-into-item pattern already used for
+            # primary_reason_source (concierge_chat_ranking.py).
+            for recommendation_key in ("recommendations", "recommendations_v2"):
+                recommendation_list = recs.get(recommendation_key)
+                if not isinstance(recommendation_list, list):
+                    continue
+                for recommendation in recommendation_list:
+                    if isinstance(recommendation, dict):
+                        recommendation["recommendation_instance_id"] = rid
+
             after_n = len(recs.get("recommendations") or [])
             rec_count = after_n
 

--- a/backend/temples/tests/api/test_recommendation_instance_identity_contract.py
+++ b/backend/temples/tests/api/test_recommendation_instance_identity_contract.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+"""
+Recommendation Instance Identity Contract
+(docs/audit/recommendation-instance-identity-propagation.md, Option C).
+
+Backend must reuse the existing per-request `rid` as `recommendation_instance_id` on
+every recommendation item -- no new ID generator, no derivation from content.
+"""
+import json
+
+import pytest
+
+URL = "/api/concierge/chat/"
+
+
+def _stub_candidates(monkeypatch):
+    monkeypatch.setattr("temples.api_views_concierge.build_chat_candidates", lambda **kwargs: [])
+
+
+def _stub_recommendations(monkeypatch, payload):
+    if isinstance(payload, list):
+        payload = {"recommendations": payload}
+
+    monkeypatch.setattr(
+        "temples.api_views_concierge.build_chat_recommendations",
+        lambda **kwargs: payload,
+    )
+
+
+@pytest.mark.django_db
+def test_recommendation_instance_id_equals_request_rid(client, monkeypatch):
+    _stub_candidates(monkeypatch)
+    _stub_recommendations(
+        monkeypatch,
+        [
+            {"name": "神社A", "shrine_id": 1, "reason": "ok"},
+            {"name": "神社B", "shrine_id": 2, "reason": "ok"},
+        ],
+    )
+
+    r = client.post(
+        URL,
+        data=json.dumps({"query": "近場で参拝したい", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+
+    body = r.json()
+    rid = body["_debug"]["rid"]
+    assert rid
+
+    recs = body["data"]["recommendations"]
+    assert len(recs) == 2
+    for rec in recs:
+        assert rec["recommendation_instance_id"] == rid
+
+
+@pytest.mark.django_db
+def test_recommendation_instance_id_propagates_to_recommendations_v2(client, monkeypatch):
+    _stub_candidates(monkeypatch)
+    _stub_recommendations(
+        monkeypatch,
+        {
+            "recommendations": [{"name": "神社A", "shrine_id": 1, "reason": "ok"}],
+            "recommendations_v2": [{"name": "神社A", "shrine_id": 1, "reason": "ok"}],
+        },
+    )
+
+    r = client.post(
+        URL,
+        data=json.dumps({"query": "近場で参拝したい", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+
+    body = r.json()
+    rid = body["_debug"]["rid"]
+    assert body["data"]["recommendations"][0]["recommendation_instance_id"] == rid
+    assert body["data"]["recommendations_v2"][0]["recommendation_instance_id"] == rid
+
+
+@pytest.mark.django_db
+def test_recommendation_instance_id_differs_across_requests_with_identical_content(client, monkeypatch):
+    """
+    Same stubbed recommendation content across two independent requests must still
+    get two different recommendation_instance_id values -- proving the id tracks the
+    request/generation (rid), not the recommendation content (no derivation/hash of
+    the payload, no reuse of a previous id).
+    """
+    _stub_candidates(monkeypatch)
+    _stub_recommendations(monkeypatch, [{"name": "神社A", "shrine_id": 1, "reason": "ok"}])
+
+    r1 = client.post(
+        URL,
+        data=json.dumps({"query": "近場で参拝したい", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+    r2 = client.post(
+        URL,
+        data=json.dumps({"query": "近場で参拝したい", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+
+    id1 = r1.json()["data"]["recommendations"][0]["recommendation_instance_id"]
+    id2 = r2.json()["data"]["recommendations"][0]["recommendation_instance_id"]
+    assert id1 != id2
+
+
+@pytest.mark.django_db
+def test_recommendation_instance_id_absent_when_no_recommendations(client, monkeypatch):
+    """Quota-reached early return: recs={"recommendations": []} has nothing to embed."""
+    _stub_candidates(monkeypatch)
+    _stub_recommendations(monkeypatch, [])
+
+    r = client.post(
+        URL,
+        data=json.dumps({"query": "近場で参拝したい", "lat": 35.0, "lng": 139.0}),
+        content_type="application/json",
+    )
+    assert r.status_code == 200
+    assert r.json()["data"]["recommendations"] == []

--- a/packages/shared/recommendationAnalyticsProvenance.ts
+++ b/packages/shared/recommendationAnalyticsProvenance.ts
@@ -86,3 +86,14 @@ export function buildRecommendationResultSetId(
     .join("|");
   return `${threadId ?? "unknown"}:${signature || "empty"}`;
 }
+
+// Recommendation Instance Identity Contract
+// (docs/audit/recommendation-instance-identity-propagation.md, Option C):
+// this only normalizes a value the Backend already produced (`rid`, embedded
+// as `recommendation_instance_id` on each recommendation item). Frontend/
+// Mobile must never generate, guess, or reconstruct this id -- an absent
+// value (e.g. direct detail access with no recommendation origin) stays
+// `null`, it is never synthesized.
+export function normalizeRecommendationInstanceId(raw: unknown): string | null {
+  return trimmedString(raw);
+}


### PR DESCRIPTION
## Summary

Implements the Minimal Contract from #2431 (`docs/audit/recommendation-instance-identity-propagation.md`): **Option B + Option C only**.

- **Option C**: reuse the existing per-request Backend `rid` as `recommendationInstanceId`. No new ID generator — `rid` is embedded into each recommendation item (`recommendation_instance_id`) right after `build_chat_recommendations()` returns, the same place/pattern already used for `primary_reason_source`. This value flows for free into the `ConciergeThread.recommendations` JSONField snapshot (no writer change), so `shrines/[id]/page.tsx` can recover it from the thread on Detail without any new query param.
- **Option B**: propagate that id into existing analytics events (PostHog `concierge_result_impression` / `shrine_detail_transition` / `shrine_detail_view` / `route_open` / `favorite_click` / `shrine_decision` / `visit_done` / `reflection_*`) and into existing `metadata` JSONFields (`ShrineInteractionLog`, `ActionEvent`) — no backend schema change, those already accept a free-form `metadata` dict.

Frontend/Mobile never generate, guess, or reconstruct this id — `packages/shared/recommendationAnalyticsProvenance.ts` gains `normalizeRecommendationInstanceId`, a pure passthrough/trim-only normalizer. Direct detail access (no `ctx=concierge && tid` on Web, no Concierge-origin route params on Mobile) yields `null`, never a synthesized value.

### Web
`ConciergeSectionsRenderer` (impression/click), `shrines/[id]/page.tsx` (reads only from the thread snapshot), `ShrineDetailViewTracker`, `GoogleMapRouteLink`, `ShrineSaveButton`, `ShrineDetailArticle` (`visit_done`), `ShrineReflectionPrompt`.

### Mobile
`concierge/index.tsx` (impression/click + `ActionEvent` metadata), `shrines/[id].tsx` (id only present when carried by Concierge-origin route params), `searchAnalytics.ts`, `visitReflectionAnalytics.ts`.

## Prohibited/out of scope (per contract)
- No new ID generator, no DB migration.
- `Favorite` / `Visit` / `ShrineReflection` get **no new field** (Option D not implemented).
- `ConciergeRecommendationLog` / `ConciergeRecommendationClickLog` get **no new writer**.
- No Ranking / candidate filtering / Signal Authority / Reason / Action Grounding / UI / learning-weight change.

## Test plan
- [x] Backend: `rid` → `recommendation_instance_id` on every item, propagates to `recommendations_v2`, differs across independent requests with identical content, absent when there are no recommendations (`backend/temples/tests/api/test_recommendation_instance_identity_contract.py`)
- [x] Web: impression → click identity match (`ConciergeSectionsRenderer.recommendationInstanceId.test.tsx`)
- [x] Web: click-side normalization contract for registered/place items (`buildPayloadFromUnified.recommendationInstanceId.test.ts`)
- [x] Web: detail → route identity match, direct-detail-no-identity (`recommendationInstanceIdPropagation.test.tsx`)
- [x] Web/Mobile: shared normalizer parity + no-synthesis (`recommendationProvenance.test.ts`, `recommendationAnalyticsProvenance.test.ts`)
- [x] Rerender stability: pure-function re-normalization yields the identical value
- [x] Backend full API/service suite: 201 passed, no regressions in Favorite/Visit/Reflection/ActionEvent endpoints
- [x] Web full suite: 840 passed · Mobile full suite: 285 passed
- [x] Web/Mobile typecheck: passed
- migration: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)