### PR TITLE
fix: reduce collapsed filter density on Recommendation Result

### DIFF
--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -612,98 +612,53 @@ export default function ConciergeSectionsRenderer({
             const canApplyCompatFilter =
               !!state.birthdate?.trim() || (state.selectedTagIds?.length ?? 0) > 0 || !!state.extraCondition?.trim();
 
-            // 閉じ状態（プリセット選択 + 即絞り）
-            if (!state.isOpen) {
-              const presets = ["静か", "駅近", "ひとり", "階段少なめ"] as const;
+            // Quick preset state is shared between the collapsed summary (selectedPresets
+            // count/label only) and the open panel (interactive chips, moved there --
+            // see the isOpen branch below and docs/product/
+            // recommendation-result-information-architecture.md §15 PR1 follow-up).
+            const presets = ["静か", "駅近", "ひとり", "階段少なめ"] as const;
+            const parts = parseExtraTokens(state.extraCondition);
+            const set = new Set(parts);
 
-              const parts = parseExtraTokens(state.extraCondition);
-              const set = new Set(parts);
+            const togglePreset = (p: string) => {
+              const next = new Set(parts);
+              const turningOn = !next.has(p);
+              if (next.has(p)) next.delete(p);
+              else next.add(p);
+              onAction?.({ type: "filter_set_extra", extraCondition: Array.from(next).join(" ") });
 
-              const togglePreset = (p: string) => {
-                const next = new Set(parts);
-                const turningOn = !next.has(p);
-                if (next.has(p)) next.delete(p);
-                else next.add(p);
-                onAction?.({ type: "filter_set_extra", extraCondition: Array.from(next).join(" ") });
-
-                // Structured Visit Preference is union/append-only here (like
-                // mergeExtra() in ConciergeFilterPanel.tsx) -- toggling a
-                // preset off never removes a tag, since it may also have
-                // been set via the open ConciergeFilterPanel.
-                if (turningOn) {
-                  const addedTags = visitPreferencesForClosedPresets([p]);
-                  if (addedTags.length) {
-                    const merged = new Set([...(state.visitPreferences ?? []), ...addedTags]);
-                    onAction?.({
-                      type: "filter_set_visit_preferences",
-                      visitPreferences: Array.from(merged),
-                    });
-                  }
+              // Structured Visit Preference is union/append-only here (like
+              // mergeExtra() in ConciergeFilterPanel.tsx) -- toggling a
+              // preset off never removes a tag, since it may also have
+              // been set via the open ConciergeFilterPanel.
+              if (turningOn) {
+                const addedTags = visitPreferencesForClosedPresets([p]);
+                if (addedTags.length) {
+                  const merged = new Set([...(state.visitPreferences ?? []), ...addedTags]);
+                  onAction?.({
+                    type: "filter_set_visit_preferences",
+                    visitPreferences: Array.from(merged),
+                  });
                 }
-              };
+              }
+            };
 
-              const selectedPresets = presets.filter((p) => set.has(p));
+            const selectedPresets = presets.filter((p) => set.has(p));
 
+            // Collapsed state is an entry point only (docs/product/
+            // recommendation-result-information-architecture.md §3 Finding 1 follow-up,
+            // §15 PR1): a single way to open the full editor. The current condition (if
+            // any) is already surfaced by the existing appliedLabel chip near the results
+            // below (with its own "クリア" control) -- not repeated here. Actual input
+            // controls (preset chips, apply, back-to-entry) live in the open
+            // ConciergeFilterPanel branch below -- moved there, not removed.
+            if (!state.isOpen) {
               return (
                 <div key={`filter-${i}-closed`}>
                   <DetailSection title="補助条件を添える">
-                    <p className="mb-2 text-xs text-[var(--kt-color-text-muted)]">必要なものだけ選んでください</p>
-
-                    <div className="mb-3 flex flex-wrap gap-2">
-                      {presets.map((p) => {
-                        const active = set.has(p);
-                        return (
-                          <button
-                            key={p}
-                            type="button"
-                            className={[
-                              "rounded-full border px-3 py-1 text-xs font-semibold transition",
-                              active
-                                ? "bg-[var(--kt-color-action-primary)] text-[var(--kt-color-action-primary-text)] border-[var(--kt-color-action-primary)]"
-                                : "bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-secondary)] hover:bg-[var(--kt-color-background-subtle)]",
-                            ].join(" ")}
-                            onClick={() => togglePreset(p)}
-                          >
-                            {p}
-                          </button>
-                        );
-                      })}
-                    </div>
-
-                    {selectedPresets.length > 0 && (
-                      <div className={`mb-3 ${conciergeSoftCardClass} text-xs leading-6 text-slate-600`}>
-                        追加済み: {selectedPresets.join(" / ")}
-                      </div>
-                    )}
-
-                    {!isEntryRoute ? (
-                      <button
-                        type="button"
-                        className="mt-2 w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
-                        onClick={() => {
-                          onAction?.({ type: "back_to_entry" });
-                          scrollToConciergeInput();
-                        }}
-                        disabled={sending}
-                      >
-                        入口に戻る
-                      </button>
-                    ) : null}
-
                     <button
                       type="button"
-                      className="w-full rounded-[var(--kt-radius-panel)] bg-[var(--kt-color-action-primary)] px-4 py-3 text-sm font-semibold text-[var(--kt-color-action-primary-text)] disabled:opacity-60"
-                      disabled={!canApplyCompatFilter || sending}
-                      onClick={() => {
-                        onAction?.({ type: "filter_apply" });
-                      }}
-                    >
-                      {sending ? "絞り込み中…" : "この内容で反映する"}
-                    </button>
-
-                    <button
-                      type="button"
-                      className="mt-2 w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
+                      className="w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
                       onClick={() => onAction?.({ type: "add_condition" })}
                     >
                       もう少し詳しく添える
@@ -748,6 +703,57 @@ export default function ConciergeSectionsRenderer({
                     onAction?.({ type: "filter_set_visit_preferences", visitPreferences: tags })
                   }
                 />
+
+                {/* Quick presets, moved here from the collapsed state (docs/product/
+                    recommendation-result-information-architecture.md §15 PR1
+                    follow-up) -- same tokens/tag mapping as before, just no longer
+                    interactive while collapsed. Distinct from ConciergeFilterPanel's
+                    own longer-label presets above: "ひとり"/"階段少なめ" have no
+                    equivalent there and would otherwise become unreachable. */}
+                <div className="mt-2 rounded-[var(--kt-radius-panel)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-3">
+                  <p className="mb-2 text-xs text-[var(--kt-color-text-muted)]">必要なものだけ選んでください</p>
+
+                  <div className="flex flex-wrap gap-2">
+                    {presets.map((p) => {
+                      const active = set.has(p);
+                      return (
+                        <button
+                          key={p}
+                          type="button"
+                          className={[
+                            "rounded-full border px-3 py-1 text-xs font-semibold transition",
+                            active
+                              ? "bg-[var(--kt-color-action-primary)] text-[var(--kt-color-action-primary-text)] border-[var(--kt-color-action-primary)]"
+                              : "bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-secondary)] hover:bg-[var(--kt-color-background-subtle)]",
+                          ].join(" ")}
+                          onClick={() => togglePreset(p)}
+                        >
+                          {p}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {selectedPresets.length > 0 && (
+                    <div className={`mt-2 ${conciergeSoftCardClass} text-xs leading-6 text-slate-600`}>
+                      追加済み: {selectedPresets.join(" / ")}
+                    </div>
+                  )}
+                </div>
+
+                {!isEntryRoute ? (
+                  <button
+                    type="button"
+                    className="mt-2 w-full rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
+                    onClick={() => {
+                      onAction?.({ type: "back_to_entry" });
+                      scrollToConciergeInput();
+                    }}
+                    disabled={sending}
+                  >
+                    入口に戻る
+                  </button>
+                ) : null}
               </div>
             );
           }

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx
@@ -1,6 +1,9 @@
-// Regression test: does the closed-card preset toggle ("静か"/"駅近")
+// Regression test: does the quick preset toggle ("静か"/"駅近")
 // actually dispatch filter_set_visit_preferences alongside filter_set_extra?
 // (ConciergeSectionsRenderer.tsx togglePreset(), added in PR #2405.)
+// These chips moved from the collapsed state into the open ConciergeFilterPanel
+// state (docs/product/recommendation-result-information-architecture.md §15 PR1);
+// the toggle logic itself, and its assertions here, are unchanged.
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -19,7 +22,7 @@ import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
 import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
 
 const baseFilterState: any = {
-  isOpen: false,
+  isOpen: true,
   birthdate: "",
   element4: null,
   goriyakuTags: [],
@@ -44,7 +47,7 @@ const heroRec = {
   },
 };
 
-describe("closed-card preset toggle -> filter_set_visit_preferences", () => {
+describe("quick preset toggle (open state) -> filter_set_visit_preferences", () => {
   it("clicking 静か dispatches filter_set_visit_preferences with ['quiet']", () => {
     const onAction = vi.fn();
     const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.coverage.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.coverage.test.tsx
@@ -94,32 +94,27 @@ describe("ConciergeSectionsRenderer - 既存経路のCoverage補完", () => {
     expect(onAction).toHaveBeenCalledWith({ type: "filter_clear" });
   });
 
-  it("補助条件(閉じた状態)のプリセット切替・入口に戻る・反映する・詳しく添えるが動作する", () => {
+  it("補助条件(閉じた状態)は入口のみで、詳しく添えるボタンでadd_conditionが発火する（docs/product/recommendation-result-information-architecture.md §15 PR1）", () => {
     const onAction = vi.fn();
     const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
     const payload = buildTestPayload(u, { ...baseFilterState, extraCondition: "駅近" });
     render(<ConciergeSectionsRenderer payload={payload} threadId={1} onAction={onAction} isEntryRoute={false} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "静か" }));
-    expect(onAction).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "filter_set_extra" }),
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: "入口に戻る" }));
-    expect(onAction).toHaveBeenCalledWith({ type: "back_to_entry" });
-
-    fireEvent.click(screen.getByRole("button", { name: "この内容で反映する" }));
-    expect(onAction).toHaveBeenCalledWith({ type: "filter_apply" });
+    // Quick preset chips / apply / back-to-entry now live only in the open state --
+    // moved there, not removed (see the next test).
+    expect(screen.queryByRole("button", { name: "静か" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "入口に戻る" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "この内容で反映する" })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "もう少し詳しく添える" }));
     expect(onAction).toHaveBeenCalledWith({ type: "add_condition" });
   });
 
-  it("補助条件(開いた状態)のConciergeFilterPanel操作がonActionを発火する", () => {
+  it("補助条件(開いた状態)のConciergeFilterPanel操作・クイックプリセット・入口に戻るがonActionを発火する", () => {
     const onAction = vi.fn();
     const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
     const payload = buildTestPayload(u, { ...baseFilterState, isOpen: true, extraCondition: "静か" });
-    render(<ConciergeSectionsRenderer payload={payload} threadId={1} onAction={onAction} />);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} onAction={onAction} isEntryRoute={false} />);
 
     fireEvent.click(screen.getByRole("button", { name: "健康" }));
     expect(onAction).toHaveBeenCalledWith({ type: "filter_toggle_tag", tagId: 1 });
@@ -139,6 +134,16 @@ describe("ConciergeSectionsRenderer - 既存経路のCoverage補完", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "この内容に反映する" }));
     expect(onAction).toHaveBeenCalledWith({ type: "filter_apply" });
+
+    // Quick presets moved here from the collapsed state (docs/product/
+    // recommendation-result-information-architecture.md §15 PR1).
+    fireEvent.click(screen.getByRole("button", { name: "駅近" }));
+    expect(onAction).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "filter_set_visit_preferences", visitPreferences: ["nearby"] }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "入口に戻る" }));
+    expect(onAction).toHaveBeenCalledWith({ type: "back_to_entry" });
   });
 
   it("補助条件(開いた状態)ではConciergeFilterPanelのタイトルが重複表示されない(Concierge Entry Responsive/Density Polish)", () => {

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.filterCollapsedDensity.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.filterCollapsedDensity.test.tsx
@@ -1,0 +1,142 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// docs/product/recommendation-result-information-architecture.md §3 Finding 1
+// follow-up, §15 PR1: the collapsed filter state must act as an entry point only
+// (a single "add/change condition" affordance), not an inline input UI. Real input
+// controls (quick preset chips, apply, back-to-entry) live in the open
+// ConciergeFilterPanel state -- moved there, not removed. This file locks that
+// contract down, separately from the pre-existing behavior tests in
+// ConciergeSectionsRenderer.coverage.test.tsx.
+
+const authMock = vi.hoisted(() => ({
+  useAuth: vi.fn(() => ({ isLoggedIn: false, loading: false })),
+}));
+vi.mock("@/lib/auth/AuthProvider", () => ({ useAuth: authMock.useAuth }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: vi.fn() }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: vi.fn() }));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+  visitPreferences: [],
+};
+
+const heroRec = {
+  shrine_id: 1,
+  display_name: "第一候補神社",
+  reason: "理由文",
+};
+
+function buildTestPayload(filterState: any) {
+  const u: any = { data: { recommendations: [heroRec] }, thread: { id: 1 } };
+  const payload = buildPayloadFromUnified(u, filterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+describe("Collapsed filter density (default collapsed contract)", () => {
+  it("1. filter未指定 + initial result: collapsedはtitle + 単一の入口ボタンのみ", () => {
+    const payload = buildTestPayload(baseFilterState);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} isEntryRoute={false} />);
+
+    expect(screen.getByText("補助条件を添える")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "もう少し詳しく添える" })).toBeInTheDocument();
+
+    // Real input controls must not be reachable while collapsed.
+    expect(screen.queryByRole("button", { name: "静か" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "駅近" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "ひとり" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "階段少なめ" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "入口に戻る" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "この内容で反映する" })).not.toBeInTheDocument();
+    expect(document.querySelector('input[type="date"]')).toBeNull();
+  });
+
+  it("2. filter指定済み + result: collapsedでも同じ最小構成のまま（appliedLabelは既存の別blockが担う、重複表示しない）", () => {
+    const payload = buildTestPayload({ ...baseFilterState, extraCondition: "静か" });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} isEntryRoute={false} />);
+
+    // "条件: 静か" appears exactly once (the pre-existing appliedLabel chip near the
+    // results section), not duplicated inside the collapsed filter entry point.
+    expect(screen.getAllByText("条件: 静か")).toHaveLength(1);
+    expect(screen.getByRole("button", { name: "もう少し詳しく添える" })).toBeInTheDocument();
+  });
+
+  it("3. collapsed -> open: 「もう少し詳しく添える」がadd_conditionを発火する", () => {
+    const onAction = vi.fn();
+    const payload = buildTestPayload(baseFilterState);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} onAction={onAction} isEntryRoute={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "もう少し詳しく添える" }));
+    expect(onAction).toHaveBeenCalledWith({ type: "add_condition" });
+  });
+
+  it("4. open -> collapsed: 「閉じる」がfilter_closeを発火する", () => {
+    const onAction = vi.fn();
+    const payload = buildTestPayload({ ...baseFilterState, isOpen: true });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} onAction={onAction} isEntryRoute={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+    expect(onAction).toHaveBeenCalledWith({ type: "filter_close" });
+  });
+
+  it("5. close/reopenでinput値が保持される（親stateのpayload再構築を模した再render）", () => {
+    const onAction = vi.fn();
+    const openState = {
+      ...baseFilterState,
+      isOpen: true,
+      birthdate: "1990-05-20",
+      extraCondition: "駅近",
+    };
+
+    const { rerender } = render(
+      <ConciergeSectionsRenderer payload={buildTestPayload(openState)} threadId={1} onAction={onAction} isEntryRoute={false} />,
+    );
+    expect((document.querySelector('input[type="date"]') as HTMLInputElement).value).toBe("1990-05-20");
+    expect(screen.getByRole("button", { name: "駅近" }).className).toContain("action-primary");
+
+    // Close: only the parent's isOpen flag flips, the rest of filterState is untouched
+    // (mirrors how ConciergeClientFull's filter_close handler only calls
+    // setIsFilterOpen(false), never resets extraCondition/birthdate/etc).
+    const closedState = { ...openState, isOpen: false };
+    rerender(<ConciergeSectionsRenderer payload={buildTestPayload(closedState)} threadId={1} onAction={onAction} isEntryRoute={false} />);
+    expect(screen.queryByRole("button", { name: "駅近" })).not.toBeInTheDocument();
+
+    // Reopen: the same values must still be there, not reset.
+    rerender(<ConciergeSectionsRenderer payload={buildTestPayload(openState)} threadId={1} onAction={onAction} isEntryRoute={false} />);
+    expect((document.querySelector('input[type="date"]') as HTMLInputElement).value).toBe("1990-05-20");
+    expect(screen.getByRole("button", { name: "駅近" }).className).toContain("action-primary");
+  });
+
+  it("6. 再Recommendation後(fallback候補)でもcollapsed contractを維持する", () => {
+    const u: any = {
+      data: { recommendations: [{ ...heroRec, is_dummy: true }] },
+      thread: { id: 1 },
+    };
+    const payload = buildPayloadFromUnified(u, baseFilterState)!;
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} isEntryRoute={false} />);
+
+    expect(screen.getByRole("button", { name: "もう少し詳しく添える" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "静か" })).not.toBeInTheDocument();
+  });
+
+  it("7. authenticated/anonymousどちらでもcollapsed contractは崩れない", () => {
+    authMock.useAuth.mockReturnValueOnce({ isLoggedIn: true, loading: false });
+    const payload = buildTestPayload(baseFilterState);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} isEntryRoute={false} />);
+
+    expect(screen.getByRole("button", { name: "もう少し詳しく添える" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "静か" })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to `docs/product/recommendation-result-information-architecture.md` §3 Finding 1, after an earlier attempt (PR request for "default collapse") turned out to be based on a mistaken premise: `isFilterOpen` **already defaults to `false`** in `ConciergeClientFull.tsx:487` — there's no expanded-by-default state to fix. The real problem was that the *collapsed* variant itself was a dense inline input UI (title, helper text, 4 preset chips, and 3 buttons), pushing the Hero recommendation below the fold regardless of open/closed state.

## Change

The collapsed filter state (`!state.isOpen` branch in `ConciergeSectionsRenderer.tsx`) is now an entry point only:

```diff
- 補助条件を添える
- 必要なものだけ選んでください
- [静か] [駅近] [ひとり] [階段少なめ]
- (追加済み: ... )
- [入口に戻る]
- [この内容で反映する]
- [もう少し詳しく添える]
+ 補助条件を添える
+ [もう少し詳しく添える]
```

The current condition (if set) isn't duplicated here — the existing `appliedLabel` chip near the results section already shows it, with its own "クリア" control.

**Nothing was deleted.** The quick preset chips and "入口に戻る" move into the open `ConciergeFilterPanel` branch — same tokens, same `CLOSED_PRESET_VISIT_PREFERENCE_TAGS` mapping, same action types (`filter_set_extra` / `filter_set_visit_preferences` / `back_to_entry`). Apply already existed there ("この内容に反映する").

## Verified impact (375/390/430px, temporary debug route, deleted before this commit)

The collapsed block shrinks from ~500px to ~200px, and the Hero shrine name now renders within the first viewport instead of requiring a scroll — confirmed by direct before/after screenshot comparison at all three widths.

## Scope

No new UI component, no filter item deleted (moved, not removed), no payload/action-type change, no backend/Ranking/Signal Authority/Reason/Action Grounding/Analytics change. migration: 0.

## Test plan
- [x] Collapsed state: only title + entry button, no input controls (new `ConciergeSectionsRenderer.filterCollapsedDensity.test.tsx`, 7 scenarios: empty/with-condition, toggle open, toggle close, close→reopen state persistence, fallback recommendations, authenticated/anonymous)
- [x] Open state: `ConciergeFilterPanel` interactions + relocated quick presets + back-to-entry all still dispatch correctly (updated `ConciergeSectionsRenderer.coverage.test.tsx`)
- [x] Quick preset → `filter_set_visit_preferences` mapping unchanged (updated `ConciergeSectionsRenderer.closedCardVisitPreference.test.tsx`, now exercised in the open state)
- [x] Web full suite: 862 passed
- [x] Web typecheck: passed
- [x] Production build: passed
- [x] Browser QA at 375/390/430px: passed, before/after comparison confirms the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)