### PR TITLE
fix: consolidate Hero Card reason into Conclusion + Next Action

### DIFF
--- a/apps/web/e2e/05_direction_flow.spec.ts
+++ b/apps/web/e2e/05_direction_flow.spec.ts
@@ -115,14 +115,22 @@ test.describe("方位条件のWeb E2E", () => {
 
     await expect(page.getByText("方位の参考情報")).toBeVisible();
     await expect(page.getByText("現在地から見た方角が、予定日の参考方位と一致しています。")).toBeVisible();
+    // Hero Reason Consolidation (docs/product/recommendation-result-information-
+    // architecture.md §15 PR2): the old fact/interpretation/action 3-card contract
+    // was retired in favor of a single Conclusion block (interpretation before fact)
+    // + a single Next Action block. Direction reference keeps its pre-existing
+    // position, unmoved by that PR: after the whole Hero card (Conclusion, Next
+    // Action, and the primary CTA in between).
     const displayOrder = await page.locator(
-      '[data-testid="recommendation-reason-v4-fact"], [data-testid="recommendation-reason-v4-interpretation"], [data-testid="recommendation-reason-v4-action"], aside:has-text("方位の参考情報")',
+      '[data-testid="recommendation-conclusion"], [data-testid="recommendation-next-action"], aside:has-text("方位の参考情報")',
     ).evaluateAll((nodes) => nodes.map((node) => node.textContent));
-    expect(displayOrder[0]).toContain("この神社について");
-    expect(displayOrder[1]).toContain("今の相談とのつながり");
-    expect(displayOrder[2]).toContain("参拝前にできること");
-    expect(displayOrder[3]).toContain("方位の参考情報");
-    expect(`${displayOrder[0]}${displayOrder[1]}${displayOrder[2]}`).not.toMatch(/方位|方角|吉方位/);
+    expect(displayOrder[0]).toContain("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(displayOrder[0]).toContain("仕事運を整えるご利益");
+    // interpretation(相談理解)がfact(神社の事実)より先(Finding 3の解消を維持する回帰guard)。
+    expect(displayOrder[0]!.indexOf("相談内容から")).toBeLessThan(displayOrder[0]!.indexOf("仕事運を整えるご利益"));
+    expect(displayOrder[1]).toContain("参拝前に、次に確認したいことを一つだけ決めておきます。");
+    expect(displayOrder[2]).toContain("方位の参考情報");
+    expect(`${displayOrder[0]}${displayOrder[1]}`).not.toMatch(/方位|方角|吉方位/);
     await expect.poll(() => captured.analyticsEvents.filter((event) => event.eventName === "direction_match_impression").length).toBe(1);
     await page.waitForTimeout(250);
     expect(captured.analyticsEvents.filter((event) => event.eventName === "direction_match_impression")).toHaveLength(1);
@@ -220,7 +228,7 @@ test.describe("方位条件のWeb E2E", () => {
     await page.goto("/concierge");
     await fillAndSubmit(page);
     await expect(page.getByText("固定レスポンス神社511")).toBeVisible();
-    await expect(page.getByTestId("recommendation-reason-v4-fact")).toBeVisible();
+    await expect(page.getByTestId("recommendation-conclusion")).toBeVisible();
     await expect(page.getByText("方位の参考情報")).toHaveCount(0);
   });
 

--- a/apps/web/src/features/concierge/__tests__/buildHeroConclusion.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildHeroConclusion.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { buildHeroConclusionLines, buildHeroNextActionLines } from "../buildHeroConclusion";
+
+// docs/product/recommendation-result-information-architecture.md §6, §13, §15 PR2:
+// this module only lays out already-Authority-decided strings into two Hero blocks.
+// It must never re-decide which reason wins, never promote Explanation-only Knowledge
+// facts, and never invent connective/causal language for fallback recommendations.
+
+describe("buildHeroConclusionLines", () => {
+  it("1. structured reason -> Conclusionは1つのlines配列(1 block)として返る", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: true,
+      interpretationText: "今の仕事の悩みは、次の一歩を決めきれていない段階にあるようです。",
+      factText: "仕事運・決断力向上のご利益があるとされています。",
+      primaryReason: null,
+      fallbackText: null,
+    });
+
+    expect(lines).toEqual([
+      "今の仕事の悩みは、次の一歩を決めきれていない段階にあるようです。",
+      "仕事運・決断力向上のご利益があるとされています。",
+    ]);
+  });
+
+  it("3. fact-first独立表示なし: interpretationが常にfactより先に来る", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: true,
+      interpretationText: "相談の理解を示す文。",
+      factText: "神社の事実を示す文。",
+      primaryReason: null,
+      fallbackText: null,
+    });
+
+    expect(lines[0]).toBe("相談の理解を示す文。");
+    expect(lines[1]).toBe("神社の事実を示す文。");
+    expect(lines.indexOf("相談の理解を示す文。")).toBeLessThan(lines.indexOf("神社の事実を示す文。"));
+  });
+
+  it("4. need_tag Primary: legacy pathのprimaryReason(need_tag由来)がConclusionに含まれる", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: false,
+      interpretationText: null,
+      factText: null,
+      primaryReason: "今回の相談の中心にある「仕事運」のテーマと重なるため、この神社が候補に入っています。",
+      fallbackText: null,
+    });
+
+    expect(lines).toEqual([
+      "今回の相談の中心にある「仕事運」のテーマと重なるため、この神社が候補に入っています。",
+    ]);
+  });
+
+  it("5. history_theme Primary: legacy pathのprimaryReason(history_theme由来)がConclusionに含まれる", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: false,
+      interpretationText: null,
+      factText: null,
+      primaryReason: "歴史的な文脈が今の相談テーマと重なる神社です。",
+      fallbackText: null,
+    });
+
+    expect(lines).toEqual(["歴史的な文脈が今の相談テーマと重なる神社です。"]);
+  });
+
+  it("6. fallback: Backendが返した文字列をそのまま通し、新しい因果表現を追加しない", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: false,
+      interpretationText: null,
+      factText: null,
+      primaryReason: "近くの神社です。",
+      fallbackText: null,
+    });
+
+    // 入力文字列以外の新しい接続語("だから"/"意味的に一致"等)が追加されていないことを確認する。
+    expect(lines).toEqual(["近くの神社です。"]);
+    expect(lines.join("")).not.toContain("だから");
+    expect(lines.join("")).not.toContain("意味的に一致");
+  });
+
+  it("7. Knowledge Explanation-only: deity由来のfactTextもそのまま(昇格・再ラベルなし)Conclusionへ含まれる", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: true,
+      interpretationText: "相談の理解を示す文。",
+      factText: "武神が祀られています。", // deity-sourced (Explanation-only, per Signal Authority §8)
+      primaryReason: null,
+      fallbackText: null,
+    });
+
+    // 昇格を示す接頭辞("Primary理由:"等)が付与されず、Backendの文字列そのまま。
+    expect(lines).toContain("武神が祀られています。");
+    expect(lines[1]).toBe("武神が祀られています。");
+  });
+
+  it("9. legacy path non-regression: primaryReason + fallbackTextの両方がある場合はこの順で保持される", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: false,
+      interpretationText: null,
+      factText: null,
+      primaryReason: "相談とご利益の一致です。",
+      fallbackText: "静かに過ごせることが通常の推薦理由です。",
+    });
+
+    expect(lines).toEqual(["相談とご利益の一致です。", "静かに過ごせることが通常の推薦理由です。"]);
+  });
+
+  it("空文字/空白のみの値はConclusionへ含めない", () => {
+    const lines = buildHeroConclusionLines({
+      hasStructured: true,
+      interpretationText: "   ",
+      factText: "",
+      primaryReason: null,
+      fallbackText: null,
+    });
+
+    expect(lines).toEqual([]);
+  });
+
+  it("すべて欠落していてもクラッシュせず空配列を返す", () => {
+    expect(() =>
+      buildHeroConclusionLines({
+        hasStructured: false,
+        interpretationText: null,
+        factText: null,
+        primaryReason: null,
+        fallbackText: null,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe("buildHeroNextActionLines", () => {
+  it("2. actionReasonとactionSuggestionが両方ある場合、1つのlines配列(1 block)として返る", () => {
+    const lines = buildHeroNextActionLines({
+      actionText: "参拝前に、今の仕事で「変えたいこと」を1つだけ書き出しておくと、意図が定まりやすくなります。",
+      actionSuggestionSummary: "参拝ルートを確認する",
+    });
+
+    expect(lines).toEqual([
+      "参拝前に、今の仕事で「変えたいこと」を1つだけ書き出しておくと、意図が定まりやすくなります。",
+      "参拝ルートを確認する",
+    ]);
+  });
+
+  it("8. generic_safe Action: actionSourceがfallbackのAction Suggestion要約でもクラッシュせず表示される", () => {
+    // actionSource="fallback"(generic-safe grounding)自体はBackend側で既に決定済みの値であり、
+    // この関数はそのgroundingを再判定しない。ここではpickActionSuggestionV4Summary相当の
+    // 呼び出し元が既に解決した要約文字列を受け取るだけであることを確認する。
+    const lines = buildHeroNextActionLines({
+      actionText: null,
+      actionSuggestionSummary: "まず詳細を見て、行く理由を確認する",
+    });
+
+    expect(lines).toEqual(["まず詳細を見て、行く理由を確認する"]);
+  });
+
+  it("actionTextのみの場合はそのまま1件を返す", () => {
+    const lines = buildHeroNextActionLines({
+      actionText: "参拝前にできることの文。",
+      actionSuggestionSummary: null,
+    });
+
+    expect(lines).toEqual(["参拝前にできることの文。"]);
+  });
+
+  it("完全に同一の文字列は重複させない", () => {
+    const lines = buildHeroNextActionLines({
+      actionText: "同じ文言です。",
+      actionSuggestionSummary: "同じ文言です。",
+    });
+
+    expect(lines).toEqual(["同じ文言です。"]);
+  });
+
+  it("両方欠落していても空配列を返しクラッシュしない", () => {
+    expect(() => buildHeroNextActionLines({ actionText: null, actionSuggestionSummary: null })).not.toThrow();
+    expect(buildHeroNextActionLines({ actionText: null, actionSuggestionSummary: null })).toEqual([]);
+  });
+});

--- a/apps/web/src/features/concierge/buildHeroConclusion.ts
+++ b/apps/web/src/features/concierge/buildHeroConclusion.ts
@@ -1,0 +1,54 @@
+// apps/web/src/features/concierge/buildHeroConclusion.ts
+//
+// Recommendation Result Hero Card consolidation adapter
+// (docs/product/recommendation-result-information-architecture.md §6, §13, §15 PR2).
+//
+// Pure presentation-layer composition ONLY. Every input string here has already been
+// decided by Backend + the existing Reason V4 / reason_facts adapters
+// (buildHeroReasonV4Sections.ts, buildRecommendationReasonViewModel.ts). This module
+// never scores, re-prioritizes, invents a resolver, or promotes Explanation-only
+// Knowledge facts -- it only decides which already-approved strings go into which of
+// the two Hero blocks (Conclusion, Next Action), and in what order. Signal Authority
+// stays entirely with Backend and those existing adapters
+// (docs/product/recommendation-signal-authority.md).
+//
+// Fixed order for the Conclusion block (never derived from score/type):
+//   1. Consultation understanding (interpretationText, when Reason V4 is structured)
+//   2. Shrine-side supporting fact/selection meaning (factText, or primaryReason when
+//      Reason V4 is not structured -- primaryReason already IS Backend's confirmed
+//      "why this shrine" phrase, built from the reason_facts entry Backend itself
+//      marked is_primary)
+// Shrine fact never leads; it always follows the consultation-understanding line when
+// one exists, so it reads as supporting evidence, not the headline claim.
+
+export function buildHeroConclusionLines(params: {
+  hasStructured: boolean;
+  interpretationText: string | null;
+  factText: string | null;
+  primaryReason: string | null;
+  fallbackText: string | null;
+}): string[] {
+  const candidates = params.hasStructured
+    ? [params.interpretationText, params.factText]
+    : [params.primaryReason, params.fallbackText];
+
+  return candidates.filter((line): line is string => Boolean(line && line.trim()));
+}
+
+// Next Action block: merges the Reason V4 action advice (actionText, tied to the same
+// interpretation/fact narrative above) with the Action Suggestion preview summary
+// (actionSuggestionSummary, a separate Backend feature with its own grounding/
+// actionSource -- already resolved and gated by the caller before this function sees
+// it). Both are shown, verbatim, inside a single block instead of two independent
+// cards; neither is dropped, re-worded, or re-attributed to the other's grounding.
+// Exact duplicate strings are shown once.
+export function buildHeroNextActionLines(params: {
+  actionText: string | null;
+  actionSuggestionSummary: string | null;
+}): string[] {
+  const lines = [params.actionText, params.actionSuggestionSummary].filter(
+    (line): line is string => Boolean(line && line.trim()),
+  );
+
+  return Array.from(new Set(lines));
+}

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -9,6 +9,7 @@ import ConciergeFilterPanel from "@/features/concierge/components/ConciergeFilte
 import ModeBadge from "@/features/concierge/components/ModeBadge";
 import { buildRecommendationReasonViewModel } from "@/lib/concierge/buildRecommendationReasonViewModel";
 import { buildHeroReasonV4Sections } from "@/features/concierge/buildHeroReasonV4Sections";
+import { buildHeroConclusionLines } from "@/features/concierge/buildHeroConclusion";
 import ConciergeTopRecommendationHero from "@/features/concierge/components/ConciergeTopRecommendationHero";
 import ShrineCardCompact from "@/components/shrines/ShrineCardCompact";
 
@@ -879,9 +880,19 @@ export default function ConciergeSectionsRenderer({
                           recommendationReasonV4: (heroItem as any).recommendationReasonV4 ?? null,
                           reason: heroItem.description ?? null,
                         });
-                        // 構造化Reason V4がある場合は重複を避ける。無い場合はBackendが指定した
-                        // reason_facts Primaryをadapter経由でVisible UIへ渡す。
-                        const heroSecondaryReason = heroReasonV4.hasStructured ? null : heroReasonV4.fallbackText;
+                        // Hero Reason Consolidation (docs/product/
+                        // recommendation-result-information-architecture.md §6, §13,
+                        // §15 PR2): compose the single Conclusion block from the same
+                        // already-Authority-decided strings the old 4 separate cards
+                        // used (primaryReason / factReason / interpretationReason /
+                        // legacy fallback) -- no new resolver, no re-prioritization.
+                        const conclusionLines = buildHeroConclusionLines({
+                          hasStructured: heroReasonV4.hasStructured,
+                          interpretationText: heroReasonV4.interpretationText,
+                          factText: heroReasonV4.factText,
+                          primaryReason: reasonVm.list.primaryPhrase,
+                          fallbackText: heroReasonV4.fallbackText,
+                        });
                         const trustMetadata = (heroItem as any).trustMetadata ?? null;
                         const trustLabels = [
                           trustMetadata?.rank_class ?? trustMetadata?.rankClass,
@@ -920,10 +931,7 @@ export default function ConciergeSectionsRenderer({
                               subtitle={reasonVm.hero.subtitle ?? null}
                               catchCopy={reasonVm.hero.catchCopy}
                               whyTop={null}
-                              primaryReason={heroReasonV4.hasStructured ? null : reasonVm.list.primaryPhrase}
-                              secondaryReason={heroSecondaryReason}
-                              factReason={heroReasonV4.factText}
-                              interpretationReason={heroReasonV4.interpretationText}
+                              conclusionLines={conclusionLines}
                               actionReason={heroReasonV4.actionText}
                               differenceFromOthers={null}
                               tags={matchedNeedTags.map(labelNeedDisplayTag).slice(0, 3)}

--- a/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect } from "react";
 import type { ReactNode } from "react";
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
+import { buildHeroNextActionLines } from "@/features/concierge/buildHeroConclusion";
 import type {
   ActionSuggestionV4PreviewViewModel,
   ActionSuggestionViewModel,
@@ -21,10 +22,13 @@ type Props = {
   originSummary?: string | null;
   catchCopy: string;
   whyTop?: string | null;
-  primaryReason?: string | null;
-  secondaryReason?: string | null;
-  factReason?: string | null;
-  interpretationReason?: string | null;
+  // Recommendation Result Hero Card consolidation
+  // (docs/product/recommendation-result-information-architecture.md §6, §13, §15
+  // PR2): pre-composed by buildHeroConclusionLines() upstream (ConciergeSectionsRenderer)
+  // from the existing, already-Authority-decided reason text (primaryReason / factReason
+  // / interpretationReason / legacy fallback). This component never re-decides which
+  // line wins -- it only lays the given lines out in the given order.
+  conclusionLines?: string[];
   actionReason?: string | null;
   differenceFromOthers?: string | null;
   nextActionHint?: string | null;
@@ -62,10 +66,7 @@ export default function ConciergeTopRecommendationHero({
   originSummary = null,
   catchCopy: _catchCopy,
   whyTop: _whyTop = null,
-  primaryReason = null,
-  secondaryReason = null,
-  factReason = null,
-  interpretationReason = null,
+  conclusionLines = [],
   actionReason = null,
   differenceFromOthers: _differenceFromOthers = null,
   nextActionHint: _nextActionHint = null,
@@ -97,6 +98,13 @@ export default function ConciergeTopRecommendationHero({
         visibleActionSuggestionV4Preview.actionSource.source,
       ].join("|")
     : "";
+  // Merges Reason V4's action advice with the (already gated/resolved) Action
+  // Suggestion preview summary into one Next Action block -- neither is dropped or
+  // re-attributed, see buildHeroConclusion.ts.
+  const nextActionLines = buildHeroNextActionLines({
+    actionText: actionReason,
+    actionSuggestionSummary: actionSuggestionV4Summary || null,
+  });
   useEffect(() => {
     if (!visibleActionSuggestionV4Preview || !actionSuggestionV4Summary) return;
 
@@ -164,66 +172,36 @@ export default function ConciergeTopRecommendationHero({
           </div>
         </div>
 
-        {primaryReason ? (
+        {conclusionLines.length > 0 ? (
           <div
             className="rounded-[var(--kt-radius-card)] border border-emerald-100 bg-white/70 px-4 py-3 shadow-sm shadow-emerald-900/5"
-            data-testid="recommendation-match-reason"
+            data-testid="recommendation-conclusion"
           >
             <div className="space-y-1.5">
               <p className="text-[11px] font-semibold tracking-[0.14em] text-emerald-700">相談内容・ご利益との一致</p>
-              <p className="text-sm font-semibold leading-6 text-slate-800">{primaryReason}</p>
+              {conclusionLines.map((line, index) => (
+                <p key={index} className="text-sm font-semibold leading-6 text-slate-800">
+                  {line}
+                </p>
+              ))}
               {topReasonLabel ? <p className="text-xs leading-5 text-[var(--kt-color-text-muted)]">{topReasonLabel}</p> : null}
             </div>
           </div>
         ) : null}
 
-        {secondaryReason ? (
-          <div
-            className="rounded-[var(--kt-radius-card)] border border-slate-100 bg-slate-50/70 px-4 py-3"
-            data-testid="recommendation-standard-reason"
-          >
-            <p className="text-[11px] font-semibold tracking-[0.14em] text-slate-600">この神社を選んだ理由</p>
-            <p className="mt-1 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{secondaryReason}</p>
-          </div>
-        ) : null}
-
-        {factReason ? (
-          <div
-            className="rounded-[var(--kt-radius-card)] border border-emerald-100 bg-white/70 px-4 py-3 shadow-sm shadow-emerald-900/5"
-            data-testid="recommendation-reason-v4-fact"
-          >
-            <p className="text-[11px] font-semibold tracking-[0.14em] text-emerald-700">この神社について</p>
-            <p className="mt-1 text-sm leading-6 text-slate-800">{factReason}</p>
-          </div>
-        ) : null}
-
-        {interpretationReason ? (
-          <div
-            className="rounded-[var(--kt-radius-card)] border border-slate-100 bg-slate-50/70 px-4 py-3"
-            data-testid="recommendation-reason-v4-interpretation"
-          >
-            <p className="text-[11px] font-semibold tracking-[0.14em] text-slate-600">今の相談とのつながり</p>
-            <p className="mt-1 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{interpretationReason}</p>
-          </div>
-        ) : null}
-
-        {actionReason ? (
+        {nextActionLines.length > 0 ? (
           <div
             className="rounded-[var(--kt-radius-card)] border border-teal-100 bg-teal-50/70 px-4 py-3 shadow-sm shadow-teal-900/5"
-            data-testid="recommendation-reason-v4-action"
+            data-testid="recommendation-next-action"
           >
-            <p className="text-[11px] font-semibold tracking-[0.14em] text-teal-700">参拝前にできること</p>
-            <p className="mt-1 text-sm leading-6 text-[var(--kt-color-text-secondary)]">{actionReason}</p>
-          </div>
-        ) : null}
-
-        {actionSuggestionV4Summary ? (
-          <div
-            className="rounded-[var(--kt-radius-card)] border border-teal-100 bg-teal-50/70 px-4 py-3 shadow-sm shadow-teal-900/5"
-            data-testid="hero-action-suggestion-v4-preview"
-          >
-            <p className="text-[11px] font-semibold tracking-[0.14em] text-teal-700">次の一歩</p>
-            <p className="mt-1 truncate text-sm leading-6 text-[var(--kt-color-text-secondary)]">{actionSuggestionV4Summary}</p>
+            <div className="space-y-1">
+              <p className="text-[11px] font-semibold tracking-[0.14em] text-teal-700">参拝前にできること</p>
+              {nextActionLines.map((line, index) => (
+                <p key={index} className="text-sm leading-6 text-[var(--kt-color-text-secondary)]">
+                  {line}
+                </p>
+              ))}
+            </div>
           </div>
         ) : null}
 

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.heroConsolidation.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.heroConsolidation.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/product/recommendation-result-information-architecture.md §6, §13, §15 PR2:
+// end-to-end coverage of Hero Reason Consolidation through the real renderer, for the
+// scenarios that are hardest to get right purely at the buildHeroConclusion.ts unit
+// level: Knowledge Explanation-only fact positioning, and a generic_safe Action
+// Suggestion merged into the Next Action block.
+
+const analyticsMocks = vi.hoisted(() => ({ trackSearchEvent: vi.fn(), trackCardEvent: vi.fn() }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: analyticsMocks.trackSearchEvent }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: analyticsMocks.trackCardEvent }));
+vi.mock("@/lib/auth/AuthProvider", () => ({ useAuth: () => ({ isLoggedIn: false, loading: false }) }));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[]) {
+  const u: any = { data: { recommendations }, thread: { id: 1 } };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+describe("Hero Reason Consolidation - end-to-end", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    window.localStorage.clear();
+  });
+
+  it("Knowledge Explanation-only(deity由来fact)はPrimaryへ昇格せず、interpretationの後にそのままConclusionへ含まれる", () => {
+    const rec = {
+      shrine_id: 1,
+      display_name: "武神社",
+      reason: "旧型の理由文",
+      recommendation_reason_v4_detail: {
+        version: "v4",
+        reason_text: "武神社は武神が祀られています。",
+        fact: {
+          label: "武神社",
+          name: "武神社",
+          deity: "武神", // Explanation-only per docs/product/recommendation-signal-authority.md §8
+          shrine_history: null,
+          place_context: null,
+          history_theme: null,
+          goriyaku: null,
+          visit_style_tags: [],
+          evidence: [],
+        },
+        interpretation: { theme: "default", text: "相談内容から、今のテーマを読み取っています。" },
+        action: { text: "" },
+      },
+    };
+    const payload = buildTestPayload([rec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} isPremiumActive={true} />);
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).toHaveTextContent("武神");
+    // interpretationが先、Knowledge由来のfactは後(Ranking根拠のように先頭へ出さない)。
+    expect(conclusion.textContent!.indexOf("相談内容から、今のテーマを読み取っています。")).toBeLessThan(
+      conclusion.textContent!.indexOf("武神"),
+    );
+    // 新しい「参考情報」ラベル等は今回のPRでは作らない(PR5の責務)。
+    expect(screen.queryByText("参考情報")).not.toBeInTheDocument();
+  });
+
+  it("generic_safe Action(actionSource=fallback)のAction SuggestionもNext Actionへ統合表示される", () => {
+    const rec = {
+      shrine_id: 1,
+      display_name: "検証神社",
+      reason: "理由文",
+      reason_facts: [{ type: "need_tag", label: "仕事運", score: 1, evidence: [], is_primary: true }],
+      action_suggestion_v4_preview: {
+        primaryAction: { label: "まず詳細を見て、行く理由を確認する", description: "", actionType: "detail_open", confidence: 0.5 },
+        secondaryAction: { label: "保存する", description: "", actionType: "save", confidence: 0.4 },
+        reflectionPrompt: { question: "行くとしたら何を確認したいですか？", promptType: "before_visit", sourceSeed: "seed" },
+        actionSource: { source: "fallback", reason: "入力不足のため安全な初期提案" },
+        preview: true,
+        version: "v4",
+        sourceKeys: [],
+      },
+    };
+    const payload = buildTestPayload([rec]);
+
+    expect(() => {
+      render(<ConciergeSectionsRenderer payload={payload} threadId={1} isPremiumActive={true} />);
+    }).not.toThrow();
+
+    const nextAction = screen.getByTestId("recommendation-next-action");
+    expect(nextAction).toHaveTextContent("まず詳細を見て、行く理由を確認する");
+    // groundingの値そのもの("fallback")はUIへ表示しない(既存契約を維持)。
+    expect(screen.queryByText("fallback")).not.toBeInTheDocument();
+
+    // 1つのNext Action blockのみ(重複カードなし)。
+    expect(screen.getAllByTestId("recommendation-next-action")).toHaveLength(1);
+  });
+
+  it("legacy path(reason_factsのみ)でもConclusionが1 blockへ統合される(non-regression)", () => {
+    const rec = {
+      shrine_id: 1,
+      display_name: "検証神社",
+      reason: "旧型の理由文",
+      reason_facts: [{ type: "need_tag", label: "縁結び", score: 1, evidence: [], is_primary: true }],
+    };
+    const payload = buildTestPayload([rec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={1} isPremiumActive={true} />);
+
+    expect(screen.getAllByTestId("recommendation-conclusion")).toHaveLength(1);
+    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonFactsContract.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonFactsContract.test.tsx
@@ -48,12 +48,12 @@ describe("Backend reason_facts[] end-to-end consumption", () => {
     expect(Array.isArray(result.unified.data.recommendations[0].reason_facts)).toBe(true);
     const recommendationSection = result.payload.sections.find((section) => section.type === "recommendations");
     expect(recommendationSection && Array.isArray(recommendationSection.items[0].reasonFacts)).toBe(true);
-    expect(screen.getByTestId("recommendation-match-reason")).toHaveTextContent("火");
+    expect(screen.getByTestId("recommendation-conclusion")).toHaveTextContent("火");
   });
 
   it("history_theme PrimaryをHeroと詳細meaning文言へ通す", () => {
     renderBackendResponse([{ shrine_id: 1, name: "再出発神社", reason_facts: [fact("history_theme", "再出発")] }]);
-    expect(screen.getByTestId("recommendation-match-reason")).toHaveTextContent("再出発");
+    expect(screen.getByTestId("recommendation-conclusion")).toHaveTextContent("再出発");
     expect(screen.getAllByText(/再出発/).length).toBeGreaterThan(0);
   });
 

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonV4Detail.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.reasonV4Detail.test.tsx
@@ -93,17 +93,28 @@ describe("ConciergeSectionsRenderer - Reason V4構造化表示", () => {
     window.localStorage.clear();
   });
 
-  it("Heroでfact/interpretation/actionの3セクションが表示される", () => {
+  it("Hero Reason ConsolidationによりConclusion(fact+interpretation)とNext Action(action)の2blockへ集約される", () => {
     const payload = buildTestPayload([heroRecWithDetail]);
     render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
 
-    expect(screen.getByTestId("recommendation-reason-v4-fact")).toHaveTextContent("仕事運");
-    expect(screen.getByTestId("recommendation-reason-v4-interpretation")).toHaveTextContent(
-      "相談内容から、今扱いたいテーマを読み取っています。",
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).toHaveTextContent("相談内容から、今扱いたいテーマを読み取っています。");
+    expect(conclusion).toHaveTextContent("仕事運");
+
+    // interpretation(相談理解)がfact(神社の事実)より先に表示される
+    // (docs/product/recommendation-result-information-architecture.md §3 Finding 3)。
+    expect(conclusion.textContent!.indexOf("相談内容から、今扱いたいテーマを読み取っています。")).toBeLessThan(
+      conclusion.textContent!.indexOf("仕事運"),
     );
-    expect(screen.getByTestId("recommendation-reason-v4-action")).toHaveTextContent(
+
+    expect(screen.getByTestId("recommendation-next-action")).toHaveTextContent(
       "参拝前に、問いを一つに絞ることを決めておきます。",
     );
+
+    // 旧5枚独立カードのtestidはもう存在しない(1つのConclusion + 1つのNext Actionへ統合)。
+    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-reason-v4-interpretation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-reason-v4-action")).not.toBeInTheDocument();
   });
 
   it("action.sourceは表示されない", () => {
@@ -117,7 +128,6 @@ describe("ConciergeSectionsRenderer - Reason V4構造化表示", () => {
     const payload = buildTestPayload([heroRecWithDetail]);
     render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
 
-    expect(screen.queryByTestId("recommendation-standard-reason")).not.toBeInTheDocument();
     expect(screen.queryByText("根津神社は仕事運に関わる神社です。")).not.toBeInTheDocument();
   });
 
@@ -134,10 +144,8 @@ describe("ConciergeSectionsRenderer - Reason V4構造化表示", () => {
     const payload = buildTestPayload([rec]);
     render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
 
-    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("recommendation-reason-v4-interpretation")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("recommendation-reason-v4-action")).not.toBeInTheDocument();
-    expect(screen.getByTestId("recommendation-standard-reason")).toHaveTextContent("reason_textのfallback文言");
+    expect(screen.queryByTestId("recommendation-next-action")).not.toBeInTheDocument();
+    expect(screen.getByTestId("recommendation-conclusion")).toHaveTextContent("reason_textのfallback文言");
   });
 
   it("recommendation_reason_v4_detailが無くてもクラッシュせず表示される", () => {
@@ -150,8 +158,8 @@ describe("ConciergeSectionsRenderer - Reason V4構造化表示", () => {
     render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={true} />);
 
     expect(screen.getByText("小網神社")).toBeInTheDocument();
-    expect(screen.getByTestId("recommendation-standard-reason")).toHaveTextContent("旧型の理由文のみの候補");
-    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
+    expect(screen.getByTestId("recommendation-conclusion")).toHaveTextContent("旧型の理由文のみの候補");
+    expect(screen.queryByTestId("recommendation-next-action")).not.toBeInTheDocument();
   });
 
   it("Heroのcard_view analyticsイベントの内容は変化しない", () => {

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeTopRecommendationHero.test.tsx
@@ -21,7 +21,7 @@ describe("ConciergeTopRecommendationHero", () => {
         name="検証神社"
         href="/shrines/17?ctx=concierge"
         catchCopy="今の相談に合う候補です。"
-        primaryReason="今回の相談の中心にある「金運」のテーマと重なるため、この神社が候補に入っています。"
+        conclusionLines={["今回の相談の中心にある「金運」のテーマと重なるため、この神社が候補に入っています。"]}
         routeLabel="詳しく見る"
       />,
     );
@@ -39,52 +39,75 @@ describe("ConciergeTopRecommendationHero", () => {
     expect(screen.queryByTestId("hero-secondary-actions")).not.toBeInTheDocument();
   });
 
-  it("主理由の後に通常の推薦理由を表示する", () => {
+  it("Conclusion内の複数lineは渡された順序のまま1つのblockに表示される（Hero Reason Consolidation）", () => {
     render(
       <ConciergeTopRecommendationHero
         name="検証神社"
         catchCopy="入口コピー"
-        primaryReason="相談とご利益の一致です。"
-        secondaryReason="静かに過ごせることが通常の推薦理由です。"
+        conclusionLines={["相談の理解を示す文。", "神社の事実・選定理由を示す文。"]}
       />,
     );
 
-    const match = screen.getByTestId("recommendation-match-reason");
-    const reason = screen.getByTestId("recommendation-standard-reason");
-    expect(match.compareDocumentPosition(reason) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // 1つのConclusion blockのみが存在する（旧primaryReason/secondaryReasonの2枚には分かれない）。
+    expect(screen.getAllByTestId("recommendation-conclusion")).toHaveLength(1);
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    const first = screen.getByText("相談の理解を示す文。");
+    const second = screen.getByText("神社の事実・選定理由を示す文。");
+    expect(conclusion).toContainElement(first);
+    expect(conclusion).toContainElement(second);
+    expect(first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  it("fact/interpretation/actionをこの順序で表示し、action.sourceは表示しない", () => {
+  it("actionReasonとactionSuggestionV4Previewが両方あっても1つのNext Action blockに統合される（重複カードなし）", () => {
     render(
       <ConciergeTopRecommendationHero
         name="検証神社"
         catchCopy="入口コピー"
-        factReason="仕事運に関わる神社です。"
-        interpretationReason="相談内容から、今扱いたいテーマを読み取っています。"
         actionReason="参拝前に、問いを一つに絞ることを決めておきます。"
+        actionSuggestionV4Preview={{
+          primaryAction: {
+            label: "参拝ルートを確認する",
+            description: "",
+            actionType: "route_open",
+            confidence: 0.7,
+          },
+          secondaryAction: {
+            label: "保存する",
+            description: "",
+            actionType: "save",
+            confidence: 0.5,
+          },
+          reflectionPrompt: {
+            question: "参拝後、何が変わったか一言で残しますか？",
+            promptType: "after_visit",
+            sourceSeed: "seed",
+          },
+          actionSource: { source: "action_context", reason: "ranked_history_theme" },
+          preview: true,
+          version: "v4",
+          sourceKeys: ["ranked_history_theme"],
+        }}
       />,
     );
 
-    const fact = screen.getByTestId("recommendation-reason-v4-fact");
-    const interpretation = screen.getByTestId("recommendation-reason-v4-interpretation");
-    const action = screen.getByTestId("recommendation-reason-v4-action");
+    // 1つのNext Action blockのみが存在する（旧actionReason/次の一歩カードの2枚には分かれない）。
+    expect(screen.getAllByTestId("recommendation-next-action")).toHaveLength(1);
 
-    expect(fact).toHaveTextContent("仕事運に関わる神社です。");
-    expect(interpretation).toHaveTextContent("相談内容から、今扱いたいテーマを読み取っています。");
-    expect(action).toHaveTextContent("参拝前に、問いを一つに絞ることを決めておきます。");
+    const nextAction = screen.getByTestId("recommendation-next-action");
+    expect(nextAction).toHaveTextContent("参拝前に、問いを一つに絞ることを決めておきます。");
+    expect(nextAction).toHaveTextContent("参拝ルートを確認する");
 
-    expect(fact.compareDocumentPosition(interpretation) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(interpretation.compareDocumentPosition(action) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-
-    expect(screen.queryByText("meaning_translation.action_context")).not.toBeInTheDocument();
+    // action.sourceそのものはUIに表示しない(既存契約を維持)。
+    expect(screen.queryByText("ranked_history_theme")).not.toBeInTheDocument();
+    expect(screen.queryByText("action_context")).not.toBeInTheDocument();
   });
 
-  it("factReason等が無い場合は各セクションを表示しない", () => {
+  it("conclusionLines/actionReason/actionSuggestionが無い場合はConclusion/Next Actionどちらも表示しない", () => {
     render(<ConciergeTopRecommendationHero name="検証神社" catchCopy="入口コピー" />);
 
-    expect(screen.queryByTestId("recommendation-reason-v4-fact")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("recommendation-reason-v4-interpretation")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("recommendation-reason-v4-action")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-conclusion")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-next-action")).not.toBeInTheDocument();
   });
 
 
@@ -168,8 +191,8 @@ describe("ConciergeTopRecommendationHero", () => {
       />,
     );
 
-    expect(screen.getByTestId("hero-action-suggestion-v4-preview")).toBeInTheDocument();
-    expect(screen.getByText("次の一歩")).toBeInTheDocument();
+    expect(screen.getByTestId("recommendation-next-action")).toBeInTheDocument();
+    expect(screen.getByText("参拝前にできること")).toBeInTheDocument();
     expect(screen.getByText("まず詳細を見て、行く理由を確認する")).toBeInTheDocument();
     expect(screen.queryByText("候補として保存して、あとで見返す")).not.toBeInTheDocument();
     expect(screen.queryByText("後から相談内容と一緒に見返せます。")).not.toBeInTheDocument();
@@ -259,7 +282,7 @@ describe("ConciergeTopRecommendationHero", () => {
           originSummary="由緒の要約"
           address="東京都千代田区1-1-1"
           topReasonLabel="選ばれた理由"
-          primaryReason="相談とご利益の一致"
+          conclusionLines={["相談とご利益の一致"]}
           routeLabel="詳しく見る"
         />,
       );


### PR DESCRIPTION
## Summary

`docs/product/recommendation-result-information-architecture.md` §3 Finding 2/3/4, implementing §15 PR2. The Hero Card's structured Reason V4 path stacked 4 independent cards — fact → interpretation → action → action-suggestion — with **fact rendering before interpretation**, inverting the desired flow:

```
相談を理解した → だからこの神社を選んだ → この神社にはこういう事実がある → だから次にこうするとよい
```

`actionReason` and the Action Suggestion preview summary also duplicated each other as two separate "what to do next" cards.

## Change

Hero now shows exactly two blocks:

- **Conclusion**: interpretation before fact (structured Reason V4 path), or `primaryReason` before legacy `fallbackText` (non-structured path) — same order rule both ways. Shrine fact never leads.
- **Next Action**: `actionReason` and the Action Suggestion summary merged into one block instead of two, de-duping only exact-identical strings.

```diff
- factReason card ("この神社について")
- interpretationReason card ("今の相談とのつながり")
- actionReason card ("参拝前にできること")
- actionSuggestionV4Summary card ("次の一歩")
+ Conclusion card (interpretation, then fact)
+ Next Action card (actionReason + actionSuggestion summary, merged)
```

## Authority safety

Added `buildHeroConclusion.ts` — a **pure presentation-layer composition adapter** (`buildHeroConclusionLines` / `buildHeroNextActionLines`) that only lays out strings `buildHeroReasonV4Sections.ts` and `buildRecommendationReasonViewModel.ts` **already decided**. Neither of those existing Authority adapters was touched — `git diff` shows zero changes to either file. The new module never scores, re-prioritizes, invents a resolver, or promotes Explanation-only Knowledge facts (`deity`/`shrine_history` stay exactly as classified in `docs/product/recommendation-signal-authority.md` §8 — no new "参考情報" visual distinction added, that's explicitly PR5's job).

## Verified impact (375/390/430px, temporary debug route, deleted before this commit)

Against the PR #2438 baseline: Hero card count drops from 4 to 2, interpretation now precedes fact, the duplicate action card is gone, and the primary CTA shifts modestly higher from the removed card chrome. The larger win here is **information order correctness and duplicate elimination**, not raw height — that was PR1's job.

## Scope

No Backend/Ranking/Candidate filtering/Signal Authority/Reason generation/Action Grounding/Analytics change. migration: 0.

## Test plan
- [x] `buildHeroConclusion.test.ts` (14 tests): structured → 1 Conclusion block, action → 1 Next Action block, no fact-first ordering, need_tag Primary, history_theme Primary, fallback (no invented causal language), Knowledge Explanation-only (no promotion), generic_safe Action, legacy path, empty/malformed inputs
- [x] `ConciergeSectionsRenderer.heroConsolidation.test.tsx` (3 tests): end-to-end through the real renderer for Knowledge Explanation-only positioning, generic_safe Action merging, and legacy-path non-regression
- [x] `ConciergeTopRecommendationHero.test.tsx` and `ConciergeSectionsRenderer.reasonV4Detail.test.tsx`/`reasonFactsContract.test.tsx` updated for the new 2-block contract (old 5-testid layout intentionally retired, not spuriously broken); Action Suggestion analytics tracking assertions (`action_suggestion_preview_view` etc.) left untouched and still pass
- [x] Web full suite: 879 passed
- [x] Web typecheck: passed
- [x] Production build: passed
- [x] Browser QA at 375/390/430px vs PR #2438 baseline: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)