### PR TITLE
fix: clarify Primary CTA hierarchy and reposition trust metadata

### DIFF
--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -94,17 +94,19 @@ export default function ShrineSaveButton({
     }
   };
 
+  // "subtle" variant: Recommendation Result Hero-only (docs/product/
+  // recommendation-result-information-architecture.md §6/§11/§15 PR3). This must read
+  // as clearly subordinate to the Hero's Primary CTA ("神社の詳細を見る", solid
+  // bg-action-primary) -- a text-link, not a bordered/filled button, so it never
+  // competes with it. Shrine Detail's own Save button uses the "default" variant below,
+  // unaffected by this styling.
   const buttonClass =
     variant === "subtle"
-      ? `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-2.5 text-xs font-semibold transition
+      ? `inline-flex w-full items-center justify-center px-1 py-1.5 text-xs font-semibold underline underline-offset-2 transition
           ${
             fav
-              ? /* border-emerald-200: subtle variant固有の値。default variantの
-                   border-emerald-300とTokenが分裂しているため(MULTI_VARIANT_VALUE_SPLIT)、
-                   --kt-color-saved-border(=emerald-300)を流用せずliteralのまま維持する。
-                   docs/audit/design-token-stage4-mother-ship-decisions.md 参照 */
-                "border-emerald-200 bg-[var(--kt-color-saved-background)] text-[var(--kt-color-saved-text)]"
-              : "border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] text-[var(--kt-color-text-muted)] hover:bg-[var(--kt-color-background-subtle)] hover:text-[var(--kt-color-text-secondary)]"
+              ? "text-[var(--kt-color-saved-text)]"
+              : "text-[var(--kt-color-text-muted)] hover:text-[var(--kt-color-text-secondary)]"
           }
           disabled:opacity-60`
       : `inline-flex w-full items-center justify-center rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold transition

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -120,9 +120,12 @@ function ConciergePremiumEntryCard(props: {
   const href = props.isGuestUser ? buildLoginHref("/billing/upgrade") : "/billing/upgrade";
   const ctaLabel = props.isGuestUser ? "ログインして変化を見返す" : "変化を見返せるようにする";
   return (
-    <section className={conciergePremiumCardClass}>
+    <section className={conciergePremiumCardClass} data-testid="recommendation-premium-preview">
       <div className="space-y-2">
-        <p className="text-sm font-semibold leading-6 text-amber-950">
+        {/* font-medium (not font-semibold): Hero's Primary CTA ("神社の詳細を見る") must stay
+            the only strong visual claim on the screen (docs/product/
+            recommendation-result-information-architecture.md §6/§11/§15 PR3, Finding 7). */}
+        <p className="text-sm font-medium leading-6 text-amber-950">
           {props.isGuestUser
             ? "相談を保存すると、今の状態や選んだ理由をあとから見返せます。"
             : "Premiumでは、前回との違いや状態の変化をあとから見返せます。"}
@@ -968,8 +971,19 @@ export default function ConciergeSectionsRenderer({
                             />
                             <DirectionReferenceCard reference={reasonDisplay.directionReference} recommendationKey={heroItem.shrineId} rank={1} />
 
+                            {/* trustMetadata + historyTheme render adjacently, right after the
+                                Hero (docs/product/recommendation-result-information-architecture.md
+                                §13 v2 "trustMetadata・historyTheme" grouping, Finding 5 follow-up):
+                                both are Shrine-side facts, not a Recommendation reason -- they
+                                never feed into Conclusion/conclusionLines and never re-decide
+                                Primary Reason. Positioned right after the Hero's Primary CTA
+                                because that CTA is Hero's own last element (§6 Desired Contract);
+                                grouping these two together keeps the "神社の事実" thread from
+                                fragmenting further once past that boundary (historyTheme
+                                previously rendered after shrineMeaning, separated from
+                                trustMetadata by a gated section). */}
                             {trustMetadata ? (
-                              <section className={conciergeSoftCardClass}>
+                              <section className={conciergeSoftCardClass} data-testid="recommendation-trust">
                                 <div className="space-y-2">
                                   <div className="flex flex-wrap gap-1">
                                     {trustLabels.slice(0, 4).map((label: string) => (
@@ -990,6 +1004,18 @@ export default function ConciergeSectionsRenderer({
                               </section>
                             ) : null}
 
+                            {historyThemeDisplay ? (
+                              <section className={conciergeSoftCardClass} data-testid="recommendation-history-theme">
+                                <div className="space-y-2">
+                                  <p className="text-xs font-semibold tracking-[0.12em] text-[var(--kt-color-text-muted)]">
+                                    この神社が持つ文脈
+                                  </p>
+
+                                  <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">{historyThemeDisplay.body}</p>
+                                </div>
+                              </section>
+                            ) : null}
+
                             {shrineMeaningVisibility !== "hidden" ? (
                               <section className={conciergeSoftCardClass}>
                                 <div className="space-y-2">
@@ -997,18 +1023,6 @@ export default function ConciergeSectionsRenderer({
                                     相談から見た意味
                                   </p>
                                   <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">{reasonVm.detail.shrineMeaning}</p>
-                                </div>
-                              </section>
-                            ) : null}
-
-                            {historyThemeDisplay ? (
-                              <section className={conciergeSoftCardClass}>
-                                <div className="space-y-2">
-                                  <p className="text-xs font-semibold tracking-[0.12em] text-[var(--kt-color-text-muted)]">
-                                    この神社が持つ文脈
-                                  </p>
-
-                                  <p className="text-sm leading-7 text-[var(--kt-color-text-secondary)]">{historyThemeDisplay.body}</p>
                                 </div>
                               </section>
                             ) : null}

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.ctaHierarchyTrustPlacement.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.ctaHierarchyTrustPlacement.test.tsx
@@ -1,0 +1,237 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/product/recommendation-result-information-architecture.md §6, §11, §13, §15 PR3:
+// Primary CTA("神社の詳細を見る")がHero Result画面で唯一の強いCTAであること、
+// Save / Premium誘導がそれと競合しない従属表現であること、trustMetadataが
+// Ranking理由として再解釈されずShrine Fact/Conclusionと意味的に連続する位置に
+// あることを固定する。Ranking / Authority / Reason生成 / Action Grounding /
+// Analytics semanticsはこのPRの対象外(禁止事項)であり、ここでは検証しない。
+
+const PRIMARY_CTA_CLASS_FRAGMENT = "bg-[var(--kt-color-action-primary)]";
+
+const analyticsMocks = vi.hoisted(() => ({
+  trackSearchEvent: vi.fn(),
+  trackCardEvent: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics/searchEvents", () => ({
+  trackSearchEvent: analyticsMocks.trackSearchEvent,
+}));
+
+vi.mock("@/lib/analytics/cardEvents", () => ({
+  trackCardEvent: analyticsMocks.trackCardEvent,
+}));
+
+vi.mock("@/lib/analytics/track", () => ({
+  track: analyticsMocks.track,
+}));
+
+const authMock = vi.hoisted(() => ({
+  useAuth: vi.fn(() => ({ isLoggedIn: true, loading: false })),
+}));
+
+vi.mock("@/lib/auth/AuthProvider", () => ({
+  useAuth: authMock.useAuth,
+}));
+
+const useFavoriteMock = vi.hoisted(() =>
+  vi.fn((_args: unknown) => ({ fav: false, busy: false, toggle: vi.fn().mockResolvedValue(undefined) })),
+);
+vi.mock("@/hooks/useFavorite", () => ({
+  useFavorite: (args: unknown) => useFavoriteMock(args),
+}));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[], meta: any = {}) {
+  const u: any = { data: { recommendations }, thread: { id: 500 }, meta };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+const trustFixture = {
+  rank_class: "由緒あり",
+  cultural_status: ["重要文化財"],
+  lineage: "式内社",
+  origin_summary: "古くから信仰を集める神社です。",
+};
+
+function heroRec(overrides: Partial<any> = {}) {
+  return {
+    shrine_id: 1,
+    display_name: "根津神社",
+    reason: "仕事運に関わる神社です。",
+    recommendation_reason_v4_detail: {
+      version: "v4",
+      reason_text: "根津神社は仕事運に関わる神社です。",
+      fact: {
+        label: "根津神社",
+        name: "根津神社",
+        history_theme: "再出発",
+        goriyaku: "仕事運",
+        evidence: ["history_theme:再出発"],
+      },
+      interpretation: { theme: "再出発", text: "相談内容から、今扱いたいテーマを読み取っています。" },
+      action: { text: "参拝前に、問いを一つに絞ることを決めておきます。" },
+    },
+    ...overrides,
+  };
+}
+
+function strongCtaElements() {
+  return screen.getAllByRole("link").filter((el) => el.className.includes(PRIMARY_CTA_CLASS_FRAGMENT));
+}
+
+// Hero直下のShrineSaveButton(variant="subtle")は下部のsave_promptボタンと
+// ラベルが同じため、aria-pressedを持つ方(ShrineSaveButton固有)で一意に特定する。
+function heroSaveButton() {
+  return screen.getAllByRole("button").find((el) => el.hasAttribute("aria-pressed"))!;
+}
+
+describe("Recommendation Result CTA Hierarchy & Trust Placement", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    analyticsMocks.track.mockClear();
+    authMock.useAuth.mockReturnValue({ isLoggedIn: true, loading: false });
+    useFavoriteMock.mockReturnValue({ fav: false, busy: false, toggle: vi.fn().mockResolvedValue(undefined) });
+    window.localStorage.clear();
+  });
+
+  it("1. Primary CTA(神社の詳細を見る)だけがstrong CTA class(bg-action-primary)を持つ", () => {
+    const payload = buildTestPayload([heroRec({ trust_metadata: trustFixture })]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    const strongCtas = strongCtaElements();
+    expect(strongCtas).toHaveLength(1);
+    expect(strongCtas[0]).toHaveTextContent("神社の詳細を見る");
+
+    // Save / Premiumはstrong CTAのclassを持たない
+    const saveButton = heroSaveButton();
+    expect(saveButton.className).not.toContain(PRIMARY_CTA_CLASS_FRAGMENT);
+
+    const premiumCta = screen.getByTestId("recommendation-premium-preview").querySelector("a");
+    expect(premiumCta).not.toBeNull();
+    expect(premiumCta!.className).not.toContain(PRIMARY_CTA_CLASS_FRAGMENT);
+  });
+
+  it("2. Saveは削除されずHero下に残る(authenticated/free, Save可能)", () => {
+    const payload = buildTestPayload([heroRec()]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    expect(heroSaveButton()).toHaveTextContent("あとで見返すために保存");
+  });
+
+  it("2b. Save不可(anonymous)ではログイン誘導ラベルへ切り替わるが、要素自体は残る", () => {
+    authMock.useAuth.mockReturnValue({ isLoggedIn: false, loading: false });
+    const payload = buildTestPayload([heroRec()]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    expect(heroSaveButton()).toHaveTextContent("ログインしてあとで見返す");
+  });
+
+  it("3. Premium CTAはanonymous/freeで残る(削除されない)", () => {
+    const payload = buildTestPayload([heroRec()]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    expect(screen.getByTestId("recommendation-premium-preview")).toBeInTheDocument();
+  });
+
+  it("3b. premiumユーザーではpremium_previewポリシーどおりhiddenになる(既存gating、非回帰)", () => {
+    const payload = buildTestPayload([heroRec()]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={true} />);
+
+    expect(screen.queryByTestId("recommendation-premium-preview")).not.toBeInTheDocument();
+  });
+
+  it("4. trustMetadataありでlayoutが成立し、trust直後にhistoryThemeが隣接表示される", () => {
+    const payload = buildTestPayload([heroRec({ trust_metadata: trustFixture, history_theme: "再出発" })]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    const trust = screen.getByTestId("recommendation-trust");
+    const history = screen.getByTestId("recommendation-history-theme");
+    expect(trust).toHaveTextContent("由緒あり");
+    expect(trust).toHaveTextContent("古くから信仰を集める神社です。");
+    expect(history).toBeInTheDocument();
+
+    // DOM順序: trustMetadataがhistoryThemeより先
+    const position = trust.compareDocumentPosition(history);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("4b. trustMetadataなしでもクラッシュせず表示される", () => {
+    const payload = buildTestPayload([heroRec()]);
+
+    expect(() => {
+      render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+    }).not.toThrow();
+
+    expect(screen.queryByTestId("recommendation-trust")).not.toBeInTheDocument();
+    expect(screen.getByText("根津神社")).toBeInTheDocument();
+  });
+
+  it("5. fallbackでもtrustMetadataはConclusionへ含まれず、Ranking reasonとして扱われない", () => {
+    const payload = buildTestPayload(
+      [heroRec({ trust_metadata: trustFixture })],
+      { resultState: { fallback_mode: "nearby_unfiltered" } },
+    );
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).not.toHaveTextContent("由緒あり");
+    expect(conclusion).not.toHaveTextContent("重要文化財");
+    expect(conclusion).not.toHaveTextContent("古くから信仰を集める神社です。");
+
+    // trustMetadata自体は(Shrine Factとして)引き続き表示される
+    expect(screen.getByTestId("recommendation-trust")).toHaveTextContent("由緒あり");
+  });
+
+  it("6. Save analyticsのclick contract(favorite_click / shrine_decision)は変化しない", async () => {
+    const toggle = vi.fn().mockResolvedValue(undefined);
+    useFavoriteMock.mockReturnValue({ fav: false, busy: false, toggle });
+    const payload = buildTestPayload([heroRec()]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    fireEvent.click(heroSaveButton());
+
+    await waitFor(() => expect(toggle).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(analyticsMocks.track).toHaveBeenCalledWith(
+        "favorite_click",
+        expect.objectContaining({ shrineId: 1, ctx: "concierge", nextFav: true }),
+      ),
+    );
+    expect(analyticsMocks.track).toHaveBeenCalledWith(
+      "shrine_decision",
+      expect.objectContaining({ shrineId: 1, action: "save" }),
+    );
+  });
+
+  it("6b. Premium CTA click analytics(premium_preview_click)は変化しない", () => {
+    const payload = buildTestPayload([heroRec()]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={500} isPremiumActive={false} />);
+
+    const premiumCta = screen.getByTestId("recommendation-premium-preview").querySelector("a")!;
+    fireEvent.click(premiumCta);
+
+    expect(analyticsMocks.trackCardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "premium_preview_click", cardId: "premium_preview", shrineId: 1 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Recommendation Result IA v2 PR3 (docs/product/recommendation-result-information-architecture.md Finding 5, Finding 7, §6, §11, §13, §15). After PR2438 (Hero raised into initial viewport) and PR2439 (Hero Reason consolidated into Conclusion + Next Action), this PR resolves the visual/semantic priority conflict between the Primary CTA, Save, Premium entry, and trustMetadata.

**Contract**: the Hero's Primary CTA ("神社の詳細を見る") is the single strongest CTA on the Result screen. Save and Premium are visually subordinate and never compete with it. trustMetadata is treated strictly as Shrine Fact / trust information — never re-interpreted as a Recommendation reason or promoted to Ranking Authority — and is repositioned to sit next to the Shrine Fact content it belongs with instead of being severed from it by the CTA button (Finding 5).

## Changes

- **`ShrineSaveButton`** — the `"subtle"` variant (used only by the Concierge Hero; Shrine Detail's own Save button uses the untouched `"default"` variant) is now a text-link (`underline`, no border/background) instead of a bordered/filled button, so it never visually competes with the Primary CTA. Labels, click handler, and analytics payload (`favorite_click` / `shrine_decision`, including `recommendationInstanceId` / `analyticsProvenance`) are unchanged.
- **`ConciergePremiumEntryCard`** — headline weight reduced from `font-semibold` to `font-medium`. Copy, `href`, and the `premium_preview_click` analytics event are unchanged.
- **`ConciergeSectionsRenderer`** — `trustMetadata` and `historyTheme` now render immediately adjacent to each other right after the Hero (which still ends with its own Primary CTA per the Hero's §6 contract), instead of `historyTheme` being separated from `trustMetadata` by a gated section (`shrineMeaning`). `trustMetadata` is not merged into Conclusion and never feeds `conclusionLines`.

## Out of scope (unchanged, per 禁止事項)

Ranking, candidate filtering, Signal Authority, Primary Reason / Reason v4 generation, Action Grounding, analytics event semantics, filter logic, migrations, backend.

## Test plan

- [x] New test file `ConciergeSectionsRenderer.ctaHierarchyTrustPlacement.test.tsx` — 10 tests covering: Primary CTA is the only strong-CTA-class element; Save renders and remains functional (present + login-prompt variants); Premium CTA renders for anonymous/free and correctly hides for premium (existing gating, non-regression); trustMetadata present/absent layout; adjacency/order of trustMetadata + historyTheme; fallback scenario confirms trustMetadata never leaks into Conclusion; `favorite_click`/`shrine_decision`/`premium_preview_click` analytics contracts unchanged.
- [x] Full web vitest suite: 133 files / 889 tests passed.
- [x] `tsc --noEmit`: clean.
- [x] `next build`: clean.
- [x] Playwright e2e: `05_direction_flow.spec.ts` (12 tests, directly exercises the Hero/trust region this PR touches) — all passed. The other 5 e2e specs (`01_home`, `02_nearby_allow`, `03_concierge`, `03_search_to_detail`, `04_ranking`) fail in this sandbox because they depend on the Django backend on `:8000`, which isn't running here (confirmed via connection-refused); unrelated to this change.
- [x] Browser QA at 375 / 390 / 430px via a temporary debug route (removed before commit): confirmed order Conclusion → Next Action → Primary CTA → trustMetadata → historyTheme → Save (text-link) → Premium, and that no secondary action reads visually stronger than the Primary CTA, at all three widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)