### PR TITLE
feat: distinguish Explanation-only Knowledge facts from Ranking-related facts in Hero

### DIFF
--- a/apps/web/src/features/concierge/__tests__/buildHeroReasonV4Sections.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildHeroReasonV4Sections.test.ts
@@ -36,6 +36,7 @@ describe("buildHeroReasonV4Sections", () => {
 
     expect(result.hasStructured).toBe(true);
     expect(result.factText).toBe("縁結び・厄除け");
+    expect(result.explanationOnlyFactText).toBeNull();
     expect(result.interpretationText).toBe("相談内容から、今扱いたいテーマを読み取っています。");
     expect(result.actionText).toBe("参拝前に、問いを一つに絞ることを決めておきます。");
     expect(result.fallbackText).toBeNull();
@@ -50,10 +51,13 @@ describe("buildHeroReasonV4Sections", () => {
       reason: null,
     });
 
-    expect(result.factText).toBe("武神");
+    // deityが最優先で採用される(採用順位そのものはPR5でも変更しない)が、
+    // deityはExplanation-onlyのためfactTextではなくexplanationOnlyFactTextへ入る(Finding 9)。
+    expect(result.explanationOnlyFactText).toBe("武神");
+    expect(result.factText).toBeNull();
   });
 
-  it("deityが選ばれるケース", () => {
+  it("deityが選ばれるケース(Explanation-only、factTextには入らない)", () => {
     const result = buildHeroReasonV4Sections({
       detail: makeDetail({
         fact: { deity: "武神", shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "武神" },
@@ -62,10 +66,11 @@ describe("buildHeroReasonV4Sections", () => {
       reason: null,
     });
 
-    expect(result.factText).toBe("武神");
+    expect(result.explanationOnlyFactText).toBe("武神");
+    expect(result.factText).toBeNull();
   });
 
-  it("shrine_historyが選ばれるケース(deityが無い場合)", () => {
+  it("shrine_historyが選ばれるケース(deityが無い場合、Explanation-only)", () => {
     const result = buildHeroReasonV4Sections({
       detail: makeDetail({
         fact: { deity: null, shrine_history: "由緒あり", place_context: null, goriyaku: null, history_theme: null, label: "由緒あり" },
@@ -74,10 +79,11 @@ describe("buildHeroReasonV4Sections", () => {
       reason: null,
     });
 
-    expect(result.factText).toBe("由緒あり");
+    expect(result.explanationOnlyFactText).toBe("由緒あり");
+    expect(result.factText).toBeNull();
   });
 
-  it("goriyakuが選ばれるケース(deity/shrine_historyが無い場合)", () => {
+  it("goriyakuが選ばれるケース(deity/shrine_historyが無い場合、Ranking-related)", () => {
     const result = buildHeroReasonV4Sections({
       detail: makeDetail({
         fact: { deity: null, shrine_history: null, place_context: "住所情報", goriyaku: "縁結び", history_theme: "再出発", label: "住所情報" },
@@ -88,9 +94,10 @@ describe("buildHeroReasonV4Sections", () => {
 
     expect(result.factText).toBe("縁結び");
     expect(result.factText).not.toBe("住所情報");
+    expect(result.explanationOnlyFactText).toBeNull();
   });
 
-  it("history_themeが選ばれるケース(deity/shrine_history/goriyakuが無い場合)", () => {
+  it("history_themeが選ばれるケース(deity/shrine_history/goriyakuが無い場合、Ranking-related)", () => {
     const result = buildHeroReasonV4Sections({
       detail: makeDetail({
         fact: { deity: null, shrine_history: null, place_context: "住所情報", goriyaku: null, history_theme: "再出発", label: "住所情報" },
@@ -100,6 +107,7 @@ describe("buildHeroReasonV4Sections", () => {
     });
 
     expect(result.factText).toBe("再出発");
+    expect(result.explanationOnlyFactText).toBeNull();
   });
 
   it("place_contextだけではFactを生成しない(住所を神社の特徴として表示しない)", () => {
@@ -144,7 +152,7 @@ describe("buildHeroReasonV4Sections", () => {
     expect(result.factText).toBeNull();
   });
 
-  it("BackendのFact本文(deity)が独自fallbackより優先される", () => {
+  it("BackendのFact本文(deity)が独自fallbackより優先される(interpretationがhasStructuredを成立させる)", () => {
     const result = buildHeroReasonV4Sections({
       detail: makeDetail({
         fact: { deity: "武神", shrine_history: null, place_context: "住所情報", goriyaku: null, history_theme: null, label: "住所情報" },
@@ -154,8 +162,30 @@ describe("buildHeroReasonV4Sections", () => {
     });
 
     expect(result.hasStructured).toBe(true);
-    expect(result.factText).toBe("武神");
+    expect(result.explanationOnlyFactText).toBe("武神");
+    expect(result.factText).toBeNull();
     expect(result.fallbackText).toBeNull();
+  });
+
+  it("deityのみが構造化要素で、interpretation/actionも空の場合はhasStructured=falseとなりlegacy fallbackへ切り替わる(Fallback Contract、Finding 9)", () => {
+    const result = buildHeroReasonV4Sections({
+      detail: makeDetail({
+        fact: { deity: "武神", shrine_history: null, place_context: null, goriyaku: null, history_theme: null, label: "武神" },
+        interpretation: { text: "" },
+        action: { text: "" },
+        reason_text: "reason_textのfallback文言",
+      }),
+      recommendationReasonV4: "recommendation_reason_v4の内容",
+      reason: "旧型の理由文",
+    });
+
+    // deity単独では「構造化されたRecommendation理由」として扱わない
+    // (=「この神様だから推薦した」という意味一致をConclusionに持たせない)。
+    expect(result.hasStructured).toBe(false);
+    expect(result.factText).toBeNull();
+    expect(result.fallbackText).toBe("reason_textのfallback文言");
+    // deity自体は「参考情報」として引き続き利用可能(hasStructuredの有無に関わらず提供される)。
+    expect(result.explanationOnlyFactText).toBe("武神");
   });
 
   it("detailがまったく無い場合はrecommendation_reason_v4へfallbackする", () => {

--- a/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
+++ b/apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
@@ -1,10 +1,17 @@
 // apps/web/src/features/concierge/buildHeroReasonV4Sections.ts
 import type { RecommendationReasonV4Detail } from "@/lib/api/concierge";
 import { buildRecommendationReasonDisplay } from "../../../../../packages/shared/recommendationReasonDisplay";
-import { pickReasonV4FactText } from "./reasonV4FactPriority";
+import { isExplanationOnlyFactSource, pickReasonV4Fact } from "./reasonV4FactPriority";
 
 export type HeroReasonV4Sections = {
+  // Ranking-related fact only (goriyaku/history_theme won the pick) -- feeds Conclusion,
+  // same meaning/behavior as before PR5.
   factText: string | null;
+  // Explanation-only Knowledge fact only (deity/shrine_history won the pick) --
+  // Signal Authority正本§8: Rank/Eligibilityに一切寄与しないKnowledge fact。Conclusionへは
+  // 混ぜず、呼び出し元で「参考情報」等の従属的な別枠として表示する
+  // (docs/product/recommendation-result-information-architecture.md §13/§15 PR5、Finding 9)。
+  explanationOnlyFactText: string | null;
   interpretationText: string | null;
   actionText: string | null;
   hasStructured: boolean;
@@ -42,6 +49,15 @@ function safeText(value: string | null): string | null {
  * 4. reason(旧文字列)
  *
  * 構造化セクションが1つ以上表示できる場合はfallbackTextを返さない(重複表示防止)。
+ *
+ * Explanation-only Knowledge fact(deity/shrine_history)は「構造化されたRecommendation
+ * 理由」としては数えない -- hasStructuredの判定からexplanationOnlyFactTextを除外している。
+ * これはPriorityの再決定ではなく(採用されるfactは従来どおりreasonV4FactPriority.tsの
+ * deity > shrine_history > goriyaku > history_themeで決まる)、「Explanation-onlyの情報
+ * だけでRecommendationが相談に意味的一致したかのように見せない」というFallback Contract
+ * (今回のPR5要件、Signal Authority正本§7/§10)をFrontend表示層で守るための分岐。
+ * Explanation-only factが唯一の構造化要素だった場合、hasStructured=falseとなり
+ * fallbackText(Backend確定済みのlegacy reason文字列)が代わりにConclusionへ使われる。
  */
 export function buildHeroReasonV4Sections(params: {
   detail?: RecommendationReasonV4Detail | null;
@@ -51,7 +67,10 @@ export function buildHeroReasonV4Sections(params: {
   const detail = params.detail ?? null;
 
   // 優先順位の実体はreasonV4FactPriority.tsに集約する(Hero/Shrine Detailで共通)。
-  const factText = safeText(detail ? pickReasonV4FactText(detail.fact) : null);
+  const pickedFact = detail ? pickReasonV4Fact(detail.fact) : null;
+  const isPickedFactExplanationOnly = pickedFact ? isExplanationOnlyFactSource(pickedFact.source) : false;
+  const factText = safeText(!isPickedFactExplanationOnly ? (pickedFact?.text ?? null) : null);
+  const explanationOnlyFactText = safeText(isPickedFactExplanationOnly ? (pickedFact?.text ?? null) : null);
   const interpretationText = safeText(detail ? clean(detail.interpretation?.text) : null);
   const actionText = safeText(detail ? clean(detail.action?.text) : null);
 
@@ -61,5 +80,5 @@ export function buildHeroReasonV4Sections(params: {
     ? null
     : safeText(pickFirst(detail?.reason_text, params.recommendationReasonV4, params.reason));
 
-  return { factText, interpretationText, actionText, hasStructured, fallbackText };
+  return { factText, explanationOnlyFactText, interpretationText, actionText, hasStructured, fallbackText };
 }

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -930,6 +930,7 @@ export default function ConciergeSectionsRenderer({
                               topReasonLabel={reasonVm.hero.topReasonLabel ?? null}
                               eyebrowLabel={reasonVm.hero.eyebrowLabel ?? null}
                               conclusionLines={conclusionLines}
+                              explanationOnlyFactText={heroReasonV4.explanationOnlyFactText}
                               actionReason={heroReasonV4.actionText}
                               actionSuggestionV4Preview={(heroItem as any).actionSuggestionV4Preview ?? null}
                               analyticsSource="concierge_result"

--- a/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeTopRecommendationHero.tsx
@@ -22,6 +22,15 @@ type Props = {
   // / interpretationReason / legacy fallback). This component never re-decides which
   // line wins -- it only lays the given lines out in the given order.
   conclusionLines?: string[];
+  // Explanation-only Knowledge fact (deity/shrine_history winning the Reason V4 fact
+  // pick) -- docs/product/recommendation-signal-authority.md §8, docs/product/
+  // recommendation-result-information-architecture.md §13/§15 PR5, Finding 9. Never
+  // part of conclusionLines/Conclusion; rendered separately, below it, in a visibly
+  // weaker tone with an explicit "参考情報" label so it can never read as a Ranking
+  // reason. This component does not decide which fact wins or whether it counts as
+  // Explanation-only -- that classification is already made upstream
+  // (reasonV4FactPriority.ts / buildHeroReasonV4Sections.ts).
+  explanationOnlyFactText?: string | null;
   actionReason?: string | null;
   actionSuggestionV4Preview?: ActionSuggestionV4PreviewViewModel | null;
   analyticsSource?: "concierge_result" | "shrine_detail" | "map" | "shrines" | null;
@@ -51,6 +60,7 @@ export default function ConciergeTopRecommendationHero({
   trustLabels = [],
   originSummary = null,
   conclusionLines = [],
+  explanationOnlyFactText = null,
   actionReason = null,
   actionSuggestionV4Preview = null,
   analyticsSource = "concierge_result",
@@ -165,6 +175,19 @@ export default function ConciergeTopRecommendationHero({
               ))}
               {topReasonLabel ? <p className="text-xs leading-5 text-[var(--kt-color-text-muted)]">{topReasonLabel}</p> : null}
             </div>
+          </div>
+        ) : null}
+
+        {explanationOnlyFactText ? (
+          // Deliberately not a bordered/shadowed card like Conclusion/Next Action above --
+          // this must read as a quieter aside, weaker than both Conclusion and the Primary
+          // CTA below (Required UI, §15 PR5). "参考情報" makes explicit that this is
+          // knowledge about the candidate, not a reason it was recommended.
+          <div className="px-1" data-testid="recommendation-explanation-only-fact">
+            <span className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold tracking-[0.08em] text-slate-500">
+              参考情報
+            </span>
+            <p className="mt-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{explanationOnlyFactText}</p>
           </div>
         ) : null}
 

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.explanationOnlyFactDistinction.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.explanationOnlyFactDistinction.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/product/recommendation-result-information-architecture.md §13, §15 PR5, Finding 9
+// docs/product/recommendation-signal-authority.md §8 Knowledge Authority (A: 現状維持)
+//
+// deity/shrine_history(Explanation-only)とgoriyaku/history_theme(Ranking-related)を
+// 視覚的に区別する。Signal Authorityの判断(どちらがPrimaryか、どのfactが採用されるか)は
+// 一切再計算しない -- reasonV4FactPriority.tsの既存優先順位(deity > shrine_history >
+// goriyaku > history_theme)そのままの結果を、どこに・どのトーンで表示するかだけを変える。
+
+const analyticsMocks = vi.hoisted(() => ({ trackSearchEvent: vi.fn(), trackCardEvent: vi.fn() }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: analyticsMocks.trackSearchEvent }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: analyticsMocks.trackCardEvent }));
+vi.mock("@/lib/auth/AuthProvider", () => ({ useAuth: () => ({ isLoggedIn: false, loading: false }) }));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[], meta: any = {}) {
+  const u: any = { data: { recommendations }, thread: { id: 700 }, meta };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+function heroRec(overrides: Partial<any> = {}) {
+  return {
+    shrine_id: 1,
+    display_name: "検証神社",
+    reason: "旧型の理由文",
+    ...overrides,
+  };
+}
+
+function renderHero(rec: any, meta: any = {}) {
+  const payload = buildTestPayload([rec], meta);
+  render(<ConciergeSectionsRenderer payload={payload} threadId={700} isPremiumActive={true} />);
+}
+
+describe("Recommendation Explanation-only Fact Visual Distinction", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    window.localStorage.clear();
+  });
+
+  it("1. deity → Explanation-only表示(参考情報ラベル、Conclusionには入らない)", () => {
+    renderHero(
+      heroRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "検証神社は天照大神が祀られています。",
+          fact: { label: "検証神社", name: "検証神社", deity: "天照大神", shrine_history: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    );
+
+    const explanationOnly = screen.getByTestId("recommendation-explanation-only-fact");
+    expect(explanationOnly).toHaveTextContent("参考情報");
+    expect(explanationOnly).toHaveTextContent("天照大神");
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).not.toHaveTextContent("天照大神");
+  });
+
+  it("2. shrine_history → Explanation-only表示(deityが無い場合)", () => {
+    renderHero(
+      heroRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "検証神社は古い由緒を持ちます。",
+          fact: { label: "検証神社", name: "検証神社", deity: null, shrine_history: "創建は平安時代に遡ります。", goriyaku: null, history_theme: null },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    );
+
+    const explanationOnly = screen.getByTestId("recommendation-explanation-only-fact");
+    expect(explanationOnly).toHaveTextContent("参考情報");
+    expect(explanationOnly).toHaveTextContent("創建は平安時代に遡ります。");
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).not.toHaveTextContent("創建は平安時代に遡ります。");
+  });
+
+  it("3. goriyaku → 通常のsupporting factとしてConclusionへ含まれる(Explanation-only扱いにしない)", () => {
+    renderHero(
+      heroRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "検証神社は仕事運のご利益があります。",
+          fact: { label: "検証神社", name: "検証神社", deity: null, shrine_history: null, goriyaku: "仕事運", history_theme: null },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    );
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).toHaveTextContent("仕事運");
+
+    expect(screen.queryByTestId("recommendation-explanation-only-fact")).not.toBeInTheDocument();
+  });
+
+  it("4. history_theme → 通常のsupporting factとしてConclusionへ含まれる(Explanation-only扱いにしない)", () => {
+    renderHero(
+      heroRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "検証神社は再出発を象徴します。",
+          fact: { label: "検証神社", name: "検証神社", deity: null, shrine_history: null, goriyaku: null, history_theme: "再出発" },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    );
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    expect(conclusion).toHaveTextContent("再出発");
+
+    expect(screen.queryByTestId("recommendation-explanation-only-fact")).not.toBeInTheDocument();
+  });
+
+  it("5. fallback + deity → deityがPrimary理由化せず、Conclusionはlegacy reasonへfallbackする", () => {
+    renderHero(
+      heroRec({
+        reason: "旧型の理由文",
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          // reason_text自体はBackend確定済みのlegacy narrativeであり、deityの単語を含んで
+          // いなくてもよいことを明示するため、ここではdeityと無関係な文言にする(§10
+          // Explanation Contract上、reason_text自体がdeityへ言及すること自体は禁止されて
+          // いないが、この分岐が実際に検証したいのは「構造化fact由来のdeityテキストが
+          // Conclusionの内容として使われないこと」なので、混同を避ける)。
+          reason_text: "近くの神社として候補に入っています。",
+          fact: { label: "検証神社", name: "検証神社", deity: "天照大神", shrine_history: null, goriyaku: null, history_theme: null },
+          // interpretation/actionともに空 -- 構造化されたRecommendation理由が存在しない
+          // (deity単独ではhasStructuredを成立させない、Fallback Contract)。
+          interpretation: { text: "" },
+          action: { text: "" },
+        },
+      }),
+      { resultState: { fallback_mode: "nearby_unfiltered" } },
+    );
+
+    const conclusion = screen.getByTestId("recommendation-conclusion");
+    // "神様が◯◯だから推薦した"と読める形で、構造化fact由来のdeityがConclusionへ現れてはならない。
+    expect(conclusion).not.toHaveTextContent("天照大神");
+    // legacy reason_text(Backend確定済みのfallback文言)がそのまま使われる。
+    expect(conclusion).toHaveTextContent("近くの神社として候補に入っています。");
+
+    // deity自体は「参考情報」として引き続き提示される(消えない、Primary化もしない)。
+    const explanationOnly = screen.getByTestId("recommendation-explanation-only-fact");
+    expect(explanationOnly).toHaveTextContent("天照大神");
+  });
+
+  it("6. Knowledgeなし(deity/shrine_historyともに無い) → 補助UIを一切表示しない", () => {
+    renderHero(
+      heroRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "検証神社は仕事運のご利益があります。",
+          fact: { label: "検証神社", name: "検証神社", deity: null, shrine_history: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    );
+
+    expect(screen.queryByTestId("recommendation-explanation-only-fact")).not.toBeInTheDocument();
+    expect(screen.queryByText("参考情報")).not.toBeInTheDocument();
+  });
+
+  it("7. legacy path(reason_factsのみ、Reason V4 detailなし)でも非回帰でクラッシュせず表示される", () => {
+    renderHero(
+      heroRec({
+        reason_facts: [{ type: "need_tag", label: "縁結び", score: 1, evidence: [], is_primary: true }],
+      }),
+    );
+
+    expect(screen.getAllByTestId("recommendation-conclusion")).toHaveLength(1);
+    expect(screen.queryByTestId("recommendation-explanation-only-fact")).not.toBeInTheDocument();
+  });
+
+  it("deity表示はAuthority/Analyticsに影響しない(card_view analyticsの内容は変化しない)", () => {
+    renderHero(
+      heroRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "検証神社は天照大神が祀られています。",
+          fact: { label: "検証神社", name: "検証神社", deity: "天照大神", shrine_history: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    );
+
+    expect(analyticsMocks.trackCardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "card_view", cardId: "shrine_hero", shrineId: 1, recommendationRank: 1 }),
+    );
+  });
+});

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.heroConsolidation.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.heroConsolidation.test.tsx
@@ -41,7 +41,7 @@ describe("Hero Reason Consolidation - end-to-end", () => {
     window.localStorage.clear();
   });
 
-  it("Knowledge Explanation-only(deity由来fact)はPrimaryへ昇格せず、interpretationの後にそのままConclusionへ含まれる", () => {
+  it("Knowledge Explanation-only(deity由来fact)はPrimaryへ昇格せず、Conclusionには混ざらない(Explanation-only Fact Visual Distinction, PR5, Finding 9)", () => {
     const rec = {
       shrine_id: 1,
       display_name: "武神社",
@@ -68,13 +68,16 @@ describe("Hero Reason Consolidation - end-to-end", () => {
     render(<ConciergeSectionsRenderer payload={payload} threadId={1} isPremiumActive={true} />);
 
     const conclusion = screen.getByTestId("recommendation-conclusion");
-    expect(conclusion).toHaveTextContent("武神");
-    // interpretationが先、Knowledge由来のfactは後(Ranking根拠のように先頭へ出さない)。
-    expect(conclusion.textContent!.indexOf("相談内容から、今のテーマを読み取っています。")).toBeLessThan(
-      conclusion.textContent!.indexOf("武神"),
-    );
-    // 新しい「参考情報」ラベル等は今回のPRでは作らない(PR5の責務)。
-    expect(screen.queryByText("参考情報")).not.toBeInTheDocument();
+    expect(conclusion).toHaveTextContent("相談内容から、今のテーマを読み取っています。");
+    // deity(Explanation-only)はConclusionには一切現れない -- Ranking根拠のように見える形で
+    // 提示しない(Signal Authority正本§10 Explanation Contract)。
+    expect(conclusion).not.toHaveTextContent("武神");
+
+    // 代わりに「参考情報」ラベル付きの別枠(recommendation-explanation-only-fact)で、
+    // Conclusionより弱いトーンで表示される。
+    const explanationOnly = screen.getByTestId("recommendation-explanation-only-fact");
+    expect(explanationOnly).toHaveTextContent("参考情報");
+    expect(explanationOnly).toHaveTextContent("武神");
   });
 
   it("generic_safe Action(actionSource=fallback)のAction SuggestionもNext Actionへ統合表示される", () => {

--- a/apps/web/src/features/concierge/reasonV4FactPriority.ts
+++ b/apps/web/src/features/concierge/reasonV4FactPriority.ts
@@ -7,6 +7,12 @@
 // 優先順位: deity > shrine_history > goriyaku > history_theme
 // place_context(住所)とlabel(place_contextへ落ちうる互換field)はFact本文の候補にしない。
 // 理由は docs/product/recommendation-v4-frontend-adapter-contract.md を参照。
+//
+// この優先順位はどのfieldを「採用するか」の選択ロジックであり、Recommendation Signal
+// Authority(docs/product/recommendation-signal-authority.md §6/§8)を再決定するものでは
+// ない。deity/shrine_historyはExplanation-only、goriyaku/history_themeはRanking-related
+// Signalという正本の分類(§8)は、ここでは変えず、どちらが採用されたかをsourceとして併せて
+// 返すだけに留める(Result IA v2 §15 PR5、Finding 9)。
 
 export type ReasonV4FactLike = {
   deity?: string | null;
@@ -15,18 +21,43 @@ export type ReasonV4FactLike = {
   history_theme?: string | null;
 } | null | undefined;
 
+export type ReasonV4FactSource = "deity" | "shrine_history" | "goriyaku" | "history_theme";
+
+export type ReasonV4Fact = {
+  text: string;
+  source: ReasonV4FactSource;
+};
+
 function clean(value: unknown): string | null {
   if (typeof value !== "string") return null;
   const s = value.trim();
   return s.length ? s : null;
 }
 
-export function pickReasonV4FactText(fact: ReasonV4FactLike): string | null {
+// Signal Authority正本§8: deity/shrine_history(および同§6のknowledge_deities/
+// knowledge_histories)はExplanation-only。Rank/Eligibilityに一切寄与しない。
+export function isExplanationOnlyFactSource(source: ReasonV4FactSource): boolean {
+  return source === "deity" || source === "shrine_history";
+}
+
+export function pickReasonV4Fact(fact: ReasonV4FactLike): ReasonV4Fact | null {
   if (!fact) return null;
-  return (
-    clean(fact.deity) ??
-    clean(fact.shrine_history) ??
-    clean(fact.goriyaku) ??
-    clean(fact.history_theme)
-  );
+
+  const deity = clean(fact.deity);
+  if (deity) return { text: deity, source: "deity" };
+
+  const shrineHistory = clean(fact.shrine_history);
+  if (shrineHistory) return { text: shrineHistory, source: "shrine_history" };
+
+  const goriyaku = clean(fact.goriyaku);
+  if (goriyaku) return { text: goriyaku, source: "goriyaku" };
+
+  const historyTheme = clean(fact.history_theme);
+  if (historyTheme) return { text: historyTheme, source: "history_theme" };
+
+  return null;
+}
+
+export function pickReasonV4FactText(fact: ReasonV4FactLike): string | null {
+  return pickReasonV4Fact(fact)?.text ?? null;
 }


### PR DESCRIPTION
## Summary

Recommendation Result IA v2 PR5 (docs/product/recommendation-result-information-architecture.md §13, §15, Finding 9; docs/product/recommendation-signal-authority.md §8 Knowledge Authority). Presentation-layer visual distinction only — Signal Authority, Ranking, candidate filtering, and Reason generation are unchanged.

## Problem

`reasonV4FactPriority.ts`'s existing fact pick (`deity > shrine_history > goriyaku > history_theme`, unchanged by this PR) fed whichever field won straight into the Hero Conclusion block, with identical visual tone regardless of source. `deity`/`shrine_history` are **Explanation-only** per Signal Authority §8 (zero Rank/Eligibility contribution); `goriyaku`/`history_theme` are real Ranking-related Signals. Presenting them identically under a "相談内容・ご利益との一致" heading risked reading as if Knowledge facts contributed to why a shrine ranked — exactly what the Explanation Contract (§10) prohibits.

## Changes

- **`reasonV4FactPriority.ts`**: added `pickReasonV4Fact()` (text + source) and `isExplanationOnlyFactSource()`, alongside the existing `pickReasonV4FactText()` (kept byte-for-byte behavior-compatible for its other two call sites — `buildShrineDetailReasonV4Sections.ts` and `ConsultationHistoryDetailView.tsx` — which are out of this PR's scope and untouched). The priority order itself is unchanged; only which field won is now also reported.
- **`buildHeroReasonV4Sections.ts`**: split `factText` into two mutually-exclusive fields — `factText` (Ranking-related only, unchanged behavior) and a new `explanationOnlyFactText` (Explanation-only only). `hasStructured` no longer counts an Explanation-only-only fact as "structured Recommendation content" — when `deity`/`shrine_history` is the sole structured element (no interpretation, no action), Conclusion now falls through to the existing legacy `reason_text`/`recommendation_reason_v4`/`reason` fallback chain instead of presenting the Knowledge fact alone as if it mattered to ranking (Fallback Contract).
- **`ConciergeTopRecommendationHero.tsx`**: new `explanationOnlyFactText` prop, rendered as a small "参考情報"-labeled aside between Conclusion and Next Action — plain muted text, no bordered/shadowed card, visibly weaker than both the Conclusion block and the Primary CTA. No new large card, no reversion to the pre-Hero-Reason-Consolidation fact/interpretation/action 3-card split.
- **`ConciergeSectionsRenderer.tsx`**: wires `heroReasonV4.explanationOnlyFactText` through to the new Hero prop.

## Out of scope (unchanged)

Ranking, candidate filtering, Signal Authority, Reason generation, Action Grounding, analytics, DB, migrations, backend.

## Test plan

- [x] `buildHeroReasonV4Sections.test.ts` — updated to assert which of the two new fields the winner lands in; priority order itself unchanged. Added a dedicated case for the Fallback Contract (deity-only → `hasStructured=false` → legacy fallback used, `explanationOnlyFactText` still populated).
- [x] New `ConciergeSectionsRenderer.explanationOnlyFactDistinction.test.tsx` — 8 tests covering the 7 required scenarios: deity → Explanation-only, shrine_history → Explanation-only, goriyaku → normal supporting fact, history_theme → normal supporting fact, fallback+deity → not Primary-ized, no Knowledge → no auxiliary UI, legacy path non-regression, plus an analytics-contract-unchanged check.
- [x] `ConciergeSectionsRenderer.heroConsolidation.test.tsx` — updated the PR2-era test that explicitly deferred this exact behavior ("新しい「参考情報」ラベル等は今回のPRでは作らない（PR5の責務）") to assert the behavior it was written to anticipate.
- [x] Full web vitest suite: 134 files / 897 tests passed.
- [x] `tsc --noEmit`: clean.
- [x] `eslint`: clean.
- [x] `next build`: clean.
- [x] Playwright `05_direction_flow.spec.ts`: all 12 tests passed.
- [x] Browser QA at 375/390/430px via a temporary debug route (removed before commit): confirmed order Conclusion → 参考情報 (Explanation-only reference) → Next Action → Primary CTA at all three widths, with the reference block visibly weaker in tone than both Conclusion and the Primary CTA, and no secondary element outweighing the CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)