### PR TITLE
fix: give Compact Cards Hero's Explanation-only distinction, merge duplicate reason headings

### DIFF
--- a/apps/web/src/components/shrines/ShrineCardCompact.tsx
+++ b/apps/web/src/components/shrines/ShrineCardCompact.tsx
@@ -19,8 +19,18 @@ export type ShrineCardCompactProps = {
   href?: string | null;
   imageUrl?: string | null;
   address?: string | null;
-  summary?: string | null;
-  primaryReason?: string | null;
+  // Single, already-resolved "why this candidate" text (docs/product/
+  // recommendation-result-information-architecture.md §15 Compact Recommendation Reason /
+  // Explanation Consistency): the caller picks one already-Authority-decided source
+  // (primary reason phrase, or legacy reason text as fallback) -- this component never
+  // chooses between multiple reason sources itself, and never re-decides which one wins.
+  reason?: string | null;
+  // Explanation-only Knowledge fact (deity/shrine_history) -- docs/product/
+  // recommendation-signal-authority.md §8. Same Explanation-only classification Hero uses
+  // (reasonV4FactPriority.ts / buildHeroReasonV4Sections.ts via the caller), rendered here
+  // as a single small muted line -- deliberately lighter than Hero's own "参考情報" block,
+  // since Compact's responsibility is a short candidate summary, not a Hero-sized Conclusion.
+  explanationOnlyFactText?: string | null;
   trustMetadata?: ShrineCardCompactTrustMetadata | null;
   tags?: string[];
   distanceM?: number | null;
@@ -32,8 +42,8 @@ export default function ShrineCardCompact({
   href = null,
   imageUrl = null,
   address = null,
-  summary = null,
-  primaryReason = null,
+  reason = null,
+  explanationOnlyFactText = null,
   trustMetadata = null,
   tags: _tags = [],
   distanceM = null,
@@ -73,17 +83,20 @@ export default function ShrineCardCompact({
               </div>
             ) : null}
             {originSummary ? <p className="line-clamp-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{originSummary}</p> : null}
-            {primaryReason ? (
+            {reason ? (
               <div data-testid="recommendation-match-reason">
                 <p className="text-[10px] font-semibold text-emerald-700">相談内容・ご利益との一致</p>
-                <p className="line-clamp-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{primaryReason}</p>
+                <p className="line-clamp-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{reason}</p>
               </div>
             ) : null}
-            {summary ? (
-              <div data-testid="recommendation-standard-reason">
-                <p className="text-[10px] font-semibold text-slate-600">この神社を選んだ理由</p>
-                <p className="line-clamp-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">{summary}</p>
-              </div>
+            {explanationOnlyFactText ? (
+              <p
+                className="line-clamp-1 text-[10px] leading-4 text-[var(--kt-color-text-muted)]"
+                data-testid="recommendation-compact-explanation-only-fact"
+              >
+                <span className="font-semibold text-slate-500">参考情報: </span>
+                {explanationOnlyFactText}
+              </p>
             ) : null}
           </div>
 

--- a/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
+++ b/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
@@ -31,31 +31,55 @@ describe("ShrineCardCompact", () => {
     expect(screen.queryByText(/km$/)).not.toBeInTheDocument();
   });
 
-  it("renders match reason before the standard reason, but not tags", () => {
+  it("renders a single reason block, not tags", () => {
     render(
       <ShrineCardCompact
         name="検証神社"
         href="/shrines/1?ctx=concierge"
-        summary="長いMeaning文のサマリー"
-        primaryReason="短い理由"
+        reason="短い理由"
         tags={["mental", "rest"]}
       />,
     );
 
     expect(screen.getByText("短い理由")).toBeInTheDocument();
-    expect(screen.getByText("長いMeaning文のサマリー")).toBeInTheDocument();
     expect(screen.queryByText("mental")).not.toBeInTheDocument();
-    const match = screen.getByTestId("recommendation-match-reason");
-    const reason = screen.getByTestId("recommendation-standard-reason");
-    expect(match.compareDocumentPosition(reason) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getByTestId("recommendation-match-reason")).toBeInTheDocument();
+    expect(screen.queryByTestId("recommendation-standard-reason")).not.toBeInTheDocument();
   });
 
-  it("does not render primaryReason when it is null", () => {
+  it("does not render reason when it is null", () => {
     const { container } = render(
-      <ShrineCardCompact name="検証神社" href="/shrines/1?ctx=concierge" primaryReason={null} />,
+      <ShrineCardCompact name="検証神社" href="/shrines/1?ctx=concierge" reason={null} />,
     );
 
     expect(container.querySelectorAll("p")).toHaveLength(0);
+  });
+
+  it("renders explanationOnlyFactText as a small separate line, distinct from the reason block", () => {
+    render(
+      <ShrineCardCompact
+        name="検証神社"
+        href="/shrines/1?ctx=concierge"
+        reason="仕事運のご利益と一致するため、この神社が候補に入っています。"
+        explanationOnlyFactText="須佐之男命"
+      />,
+    );
+
+    const reasonBlock = screen.getByTestId("recommendation-match-reason");
+    expect(reasonBlock).not.toHaveTextContent("須佐之男命");
+
+    const explanationOnly = screen.getByTestId("recommendation-compact-explanation-only-fact");
+    expect(explanationOnly).toHaveTextContent("参考情報");
+    expect(explanationOnly).toHaveTextContent("須佐之男命");
+  });
+
+  it("does not render explanationOnlyFactText when absent", () => {
+    render(
+      <ShrineCardCompact name="検証神社" href="/shrines/1?ctx=concierge" reason="短い理由" explanationOnlyFactText={null} />,
+    );
+
+    expect(screen.queryByTestId("recommendation-compact-explanation-only-fact")).not.toBeInTheDocument();
+    expect(screen.queryByText("参考情報")).not.toBeInTheDocument();
   });
 
   describe("Design Token参照 (Semantic Token契約、CSS文字列全体の比較はしない)", () => {
@@ -65,7 +89,7 @@ describe("ShrineCardCompact", () => {
           name="検証神社"
           href="/shrines/1?ctx=concierge"
           address="東京都千代田区1-1-1"
-          primaryReason="短い理由"
+          reason="短い理由"
         />,
       );
 

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -1113,6 +1113,25 @@ export default function ConciergeSectionsRenderer({
                                 reason: item.description,
                                 directionReference: item.directionReference,
                               });
+                              // Compact Recommendation Reason / Explanation Consistency
+                              // (docs/product/recommendation-result-information-architecture.md
+                              // §15): reuse the exact same Hero adapter to classify the same
+                              // Reason V4 fact -- no new Explanation-only decision, no Compact-local
+                              // priority logic. Only explanationOnlyFactText is consumed here;
+                              // Compact's "why" text stays driven by the existing reason_facts-based
+                              // primaryPhrase (below), never by this adapter's factText/interpretationText
+                              // (that composition is Hero's Conclusion, not ported to Compact).
+                              const compactReasonV4 = buildHeroReasonV4Sections({
+                                detail: (item as any).reasonV4Detail ?? null,
+                                recommendationReasonV4: (item as any).recommendationReasonV4 ?? null,
+                                reason: item.description ?? null,
+                              });
+                              // Single reason source, not two: matchReason (reason_facts-derived,
+                              // already Authority-decided) wins when present; the legacy free-text
+                              // reason field is only shown as a fallback when matchReason is
+                              // unavailable (Finding: Compact previously showed both under separate
+                              // headings, reading as a repeated explanation of the same "why").
+                              const compactReason = compactReasonDisplay.matchReason ?? compactReasonDisplay.reason;
 
                               return (
                                 <div key={`rec-${i}-compact-${item.shrineId}`} className="space-y-2">
@@ -1121,8 +1140,8 @@ export default function ConciergeSectionsRenderer({
                                     href={withDirectionRouteContext(item.detailHref, item.directionReference, "other")}
                                     imageUrl={item.imageUrl}
                                     address={item.address ?? null}
-                                    summary={compactReasonDisplay.reason}
-                                    primaryReason={compactReasonDisplay.matchReason}
+                                    reason={compactReason}
+                                    explanationOnlyFactText={compactReasonV4.explanationOnlyFactText}
                                     tags={[]}
                                     distanceM={(item as any).distance_m ?? null}
                                     onDetailClick={() =>

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.compactExplanationOnlyFactDistinction.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.compactExplanationOnlyFactDistinction.test.tsx
@@ -1,0 +1,240 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/product/recommendation-result-information-architecture.md §15
+// Compact Recommendation Reason / Explanation Consistency
+// docs/product/recommendation-signal-authority.md §8 Knowledge Authority (A: 現状維持)
+//
+// PR #2442 (Explanation-only Fact Visual Distinction) はHeroにのみ適用され、Compact Card
+// (2位以降候補)はdeity/shrine_historyの区別を継承していなかった(docs/audit/
+// recommendation-result-ia-v2-final.md Should item)。ここではCompact CardでもHeroと同じ
+// reasonV4FactPriority.ts / buildHeroReasonV4Sections.tsのExplanation-only分類をそのまま
+// 再利用し(Compact独自のAuthority再実装はしない)、旧2見出し(「相談内容・ご利益との一致」+
+// 「この神社を選んだ理由」)の反復を1つのreason blockへ整理したことを検証する。
+
+const analyticsMocks = vi.hoisted(() => ({ trackSearchEvent: vi.fn(), trackCardEvent: vi.fn() }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: analyticsMocks.trackSearchEvent }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: analyticsMocks.trackCardEvent }));
+vi.mock("@/lib/auth/AuthProvider", () => ({ useAuth: () => ({ isLoggedIn: false, loading: false }) }));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[], meta: any = {}) {
+  const u: any = { data: { recommendations }, thread: { id: 800 }, meta };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+const heroRec = {
+  shrine_id: 1,
+  display_name: "第一候補神社",
+  reason: "第一候補の理由文です。",
+};
+
+function compactRec(overrides: Partial<any> = {}) {
+  return {
+    shrine_id: 2,
+    display_name: "第二候補神社",
+    reason: "第二候補の理由文です。",
+    ...overrides,
+  };
+}
+
+function openOthers() {
+  fireEvent.click(screen.getByRole("button", { name: "迷った時だけ、ほかの神社を見る" }));
+}
+
+function compactCardOf(name: string) {
+  const card = screen.getByText(name).closest("article");
+  if (!card) throw new Error(`compact card not found: ${name}`);
+  return card;
+}
+
+describe("Compact Recommendation Reason / Explanation Consistency", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    window.localStorage.clear();
+  });
+
+  it("1. need_tag → Compactのreason blockへPrimaryとして表示される", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({ reason_facts: [{ type: "need_tag", label: "仕事運", score: 1, evidence: [], is_primary: true }] }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    expect(card.querySelector('[data-testid="recommendation-match-reason"]')).toHaveTextContent("仕事運");
+  });
+
+  it("2. history_theme → Compactのreason blockへPrimaryとして表示される", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({ reason_facts: [{ type: "history_theme", label: "再出発", score: 1, evidence: [], is_primary: true }] }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    expect(card.querySelector('[data-testid="recommendation-match-reason"]')).toHaveTextContent("再出発");
+  });
+
+  it("3. deity → Compactでも「参考情報」ラベル付きでExplanation-only表示され、reason blockには混ざらない", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({
+        reason_facts: [{ type: "need_tag", label: "仕事運", score: 1, evidence: [], is_primary: true }],
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "第二候補神社は天照大神が祀られています。",
+          fact: { label: "第二候補神社", name: "第二候補神社", deity: "天照大神", shrine_history: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "" },
+          action: { text: "" },
+        },
+      }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    const reasonBlock = card.querySelector('[data-testid="recommendation-match-reason"]');
+    expect(reasonBlock).not.toHaveTextContent("天照大神");
+
+    const explanationOnly = card.querySelector('[data-testid="recommendation-compact-explanation-only-fact"]');
+    expect(explanationOnly).toHaveTextContent("参考情報");
+    expect(explanationOnly).toHaveTextContent("天照大神");
+  });
+
+  it("4. shrine_history → Compactでも「参考情報」ラベル付きでExplanation-only表示される(deityが無い場合)", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({
+        reason_facts: [{ type: "need_tag", label: "仕事運", score: 1, evidence: [], is_primary: true }],
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "第二候補神社は古い由緒を持ちます。",
+          fact: { label: "第二候補神社", name: "第二候補神社", deity: null, shrine_history: "創建は平安時代に遡ります。", goriyaku: null, history_theme: null },
+          interpretation: { text: "" },
+          action: { text: "" },
+        },
+      }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    const explanationOnly = card.querySelector('[data-testid="recommendation-compact-explanation-only-fact"]');
+    expect(explanationOnly).toHaveTextContent("創建は平安時代に遡ります。");
+  });
+
+  it("5. fallback + deity → deityがreason blockのPrimary理由として扱われない(false attributionなし)", () => {
+    const payload = buildTestPayload(
+      [
+        heroRec,
+        compactRec({
+          // reason_facts無し・reasonV4のstructuredもdeityのみ -- 構造化されたRecommendation
+          // 理由が存在しないfallbackケース。
+          recommendation_reason_v4_detail: {
+            version: "v4",
+            reason_text: "近くの神社として候補に入っています。",
+            fact: { label: "第二候補神社", name: "第二候補神社", deity: "天照大神", shrine_history: null, goriyaku: null, history_theme: null },
+            interpretation: { text: "" },
+            action: { text: "" },
+          },
+        }),
+      ],
+      { resultState: { fallback_mode: "nearby_unfiltered" } },
+    );
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    const reasonBlock = card.querySelector('[data-testid="recommendation-match-reason"]');
+    expect(reasonBlock).not.toHaveTextContent("天照大神");
+
+    // deity自体は参考情報として引き続き提示される。
+    expect(card.querySelector('[data-testid="recommendation-compact-explanation-only-fact"]')).toHaveTextContent("天照大神");
+  });
+
+  it("6. Knowledgeなし(deity/shrine_historyともに無い) → 参考情報UIを一切表示しない", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({ reason_facts: [{ type: "need_tag", label: "仕事運", score: 1, evidence: [], is_primary: true }] }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    expect(card.querySelector('[data-testid="recommendation-compact-explanation-only-fact"]')).toBeNull();
+    expect(card).not.toHaveTextContent("参考情報");
+  });
+
+  it("7. heading重複なし: reason blockは1つだけで、旧「この神社を選んだ理由」見出しは存在しない", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({
+        reason:
+          "この長い理由文は44文字を大きく超える想定で書かれており、compactTextによって句点や記号の位置で自然に切り詰められることを検証するためのテキストです。",
+      }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    const card = compactCardOf("第二候補神社");
+    expect(card.querySelectorAll('[data-testid="recommendation-match-reason"]')).toHaveLength(1);
+    expect(card.querySelector('[data-testid="recommendation-standard-reason"]')).toBeNull();
+    expect(screen.queryByText("この神社を選んだ理由")).not.toBeInTheDocument();
+  });
+
+  it("8. legacy path(reason_facts/reasonV4Detailどちらも無し)でもクラッシュせず表示される(non-regression)", () => {
+    const payload = buildTestPayload([heroRec, compactRec()]);
+
+    expect(() => {
+      render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+      openOthers();
+    }).not.toThrow();
+
+    const card = compactCardOf("第二候補神社");
+    expect(card.querySelector('[data-testid="recommendation-match-reason"]')).not.toBeNull();
+  });
+
+  it("既存のDetailクリックanalytics(shrine_detail_transition)は変化しない", () => {
+    const payload = buildTestPayload([
+      heroRec,
+      compactRec({
+        recommendation_reason_v4_detail: {
+          version: "v4",
+          reason_text: "第二候補神社は天照大神が祀られています。",
+          fact: { label: "第二候補神社", name: "第二候補神社", deity: "天照大神", shrine_history: null, goriyaku: null, history_theme: null },
+          interpretation: { text: "相談内容から、今扱いたいテーマを読み取っています。" },
+          action: { text: "" },
+        },
+      }),
+    ]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={800} isPremiumActive={true} />);
+    openOthers();
+
+    fireEvent.click(screen.getByText("詳細だけ見る"));
+
+    expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+      "shrine_detail_transition",
+      expect.objectContaining({ source: "concierge_result", position: "compact", shrineId: 2, recommendationRank: 2 }),
+    );
+  });
+});

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.otherRecommendations.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.otherRecommendations.test.tsx
@@ -145,7 +145,7 @@ describe("ConciergeSectionsRenderer - 他候補の開閉UI", () => {
     expect(screen.getByText("東京都中央区2-2-2")).toBeInTheDocument();
   });
 
-  it("他候補カードも一致理由の後に通常理由を表示する", () => {
+  it("他候補カードは単一のreason blockのみを表示する(旧2見出しの反復を解消、Compact Recommendation Reason / Explanation Consistency)", () => {
     const payload = buildTestPayload([heroRec, otherRecWithAddress]);
     render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
 
@@ -153,11 +153,9 @@ describe("ConciergeSectionsRenderer - 他候補の開閉UI", () => {
 
     const compactCard = screen.getByText("他候補神社A").closest("article");
     expect(compactCard).not.toBeNull();
-    const match = compactCard?.querySelector('[data-testid="recommendation-match-reason"]');
-    const reason = compactCard?.querySelector('[data-testid="recommendation-standard-reason"]');
-    expect(match).not.toBeNull();
-    expect(reason).not.toBeNull();
-    expect(match!.compareDocumentPosition(reason!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // 旧「相談内容・ご利益との一致」+「この神社を選んだ理由」の2見出しはもう存在しない。
+    expect(compactCard?.querySelectorAll('[data-testid="recommendation-match-reason"]')).toHaveLength(1);
+    expect(compactCard?.querySelector('[data-testid="recommendation-standard-reason"]')).toBeNull();
   });
 
   it("addressがない他候補カードでもエラーにならず表示される", () => {


### PR DESCRIPTION
## Summary

Follow-up to [docs/audit/recommendation-result-ia-v2-final.md](docs/audit/recommendation-result-ia-v2-final.md) ([PR #2443](https://github.com/etsu33/jinja_app/pull/2443)), which judged Result IA v2 **GO** with zero Must items and recorded two Should items specific to Compact Cards (2nd/3rd candidates). This PR resolves both, Compact-only:

1. **Compact never inherited PR #2442's Explanation-only Fact Visual Distinction.** `deity`/`shrine_history` (Explanation-only per `docs/product/recommendation-signal-authority.md` §8) could appear under Compact's "why this shrine" text with no visual/semantic distinction from a real Ranking-related reason — unlike Hero, which got this fix in #2442.
2. **Compact showed two reason headings** ("相談内容・ご利益との一致" + 「この神社を選んだ理由」) that read as repeating the same explanation from two different sources.

## Changes

- **`ShrineCardCompact.tsx`**: replaced the two props (`summary`/`primaryReason`, two headings) with a single `reason` prop/heading, plus a new `explanationOnlyFactText` prop rendered as one small muted line — no card, no pill, deliberately lighter than Hero's own "参考情報" block, since Compact's job is a short summary, not a Hero-sized Conclusion.
- **`ConciergeSectionsRenderer.tsx`** (Compact call site only, Hero call site untouched): reuses `buildHeroReasonV4Sections` — the exact same adapter Hero uses — against the Compact item's own `reasonV4Detail`, consuming only its `explanationOnlyFactText` field. No new Explanation-only classification logic, no re-derivation of Primary Authority. The single reason text prefers the existing reason_facts-derived `matchReason` (already Authority-decided) and falls back to the legacy free-text reason only when `matchReason` is unavailable — previously both were shown simultaneously under separate headings.

## Out of scope (unchanged)

Hero (`ConciergeTopRecommendationHero.tsx`, `buildHeroReasonV4Sections.ts`, `reasonV4FactPriority.ts` are not touched by this diff), backend, ranking, candidate filtering, Signal Authority, reason generation, Action Grounding, analytics, migrations.

## Test plan

- [x] `ShrineCardCompact.test.tsx` — updated for the new prop contract, plus two new tests for `explanationOnlyFactText` rendering/absence.
- [x] New `ConciergeSectionsRenderer.compactExplanationOnlyFactDistinction.test.tsx` — 9 tests covering the 8 required scenarios (need_tag Primary, history_theme Primary, deity Explanation-only, shrine_history Explanation-only, fallback+deity non-attribution, no-Knowledge, no heading duplication, legacy non-regression) plus an analytics-contract-unchanged check.
- [x] `ConciergeSectionsRenderer.otherRecommendations.test.tsx` — the old two-heading-order assertion replaced with a single-block assertion; all other cases in the file pass unmodified.
- [x] `ConciergeSectionsRenderer.reasonFactsContract.test.tsx`, `ConciergeSectionsRenderer.resultSaveProvenance.test.tsx` — pass unmodified.
- [x] Full web vitest suite: 135 files / 908 tests passed.
- [x] `tsc --noEmit`: clean.
- [x] `eslint`: clean.
- [x] `next build`: clean.
- [x] Playwright `05_direction_flow.spec.ts`: all 12 tests passed.
- [x] Browser QA at 375/390/430px via a temporary debug route (removed before commit, never staged): Hero + 2nd + 3rd candidate shown together — Compact cards render clearly lighter-density than Hero (single-line reason, no card chrome, small inline "参考情報: 菅原道真公" note distinct from the reason text), no horizontal overflow at any width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)