### PR TITLE
fix: downgrade fallback escape-hatch CTA from filled to outline style

### DIFF
--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -815,11 +815,16 @@ export default function ConciergeSectionsRenderer({
                     </button>
                     <button
                       type="button"
-                      /* bg-neutral-900: Dark Surface Contract Group A候補だが、
-                         --kt-color-surface-emphasis(slate-800/900)とcomputed colorが
-                         一致しないため今回は適用しない(Blocked by Contract)。
-                         詳細は docs/audit/design-token-stage3-dark-surface-decision.md */
-                      className="rounded-[var(--kt-radius-panel)] bg-neutral-900 px-4 py-3 text-sm font-semibold text-white"
+                      /* Fallback escape-hatch CTA Visual Weight Polish (docs/audit/
+                         recommendation-result-ia-v2-final.md Should item, docs/product/
+                         recommendation-result-information-architecture.md §11): this used to be
+                         a solid bg-neutral-900 fill, which read as visually on par with Hero's
+                         Primary CTA (docs/product/recommendation-result-information-architecture.md
+                         §6/§11/§15 PR3 contract: "神社の詳細を見る" must stay the only strong CTA).
+                         Downgraded from filled to the same plain-border/no-fill style already used
+                         by its sibling button above and by "もう少し詳しく添える"/"入口に戻る"
+                         elsewhere in this file -- an existing pattern, not a new one. */
+                      className="rounded-[var(--kt-radius-panel)] border px-4 py-3 text-sm font-semibold"
                       onClick={() => onAction?.({ type: "filter_clear" })}
                     >
                       条件を広げて見直す

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.fallbackEscapeHatchWeight.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.fallbackEscapeHatchWeight.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/audit/recommendation-result-ia-v2-final.md (Should item) +
+// docs/product/recommendation-result-information-architecture.md §6/§11/§15 PR3:
+// the fallback escape-hatch ("近くの神社を静かに見る" / "条件を広げて見直す") must stay
+// available under the same conditions and dispatch the same actions as before -- only its
+// visual weight changes, so it never reads as visually on par with Hero's Primary CTA
+// ("神社の詳細を見る", the only strong CTA on the Result screen).
+
+const PRIMARY_CTA_CLASS_FRAGMENT = "bg-[var(--kt-color-action-primary)]";
+
+const analyticsMocks = vi.hoisted(() => ({ trackSearchEvent: vi.fn(), trackCardEvent: vi.fn() }));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent: analyticsMocks.trackSearchEvent }));
+vi.mock("@/lib/analytics/cardEvents", () => ({ trackCardEvent: analyticsMocks.trackCardEvent }));
+vi.mock("@/lib/auth/AuthProvider", () => ({ useAuth: () => ({ isLoggedIn: false, loading: false }) }));
+
+import ConciergeSectionsRenderer from "../ConciergeSectionsRenderer";
+import { buildPayloadFromUnified } from "@/features/concierge/buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function buildTestPayload(recommendations: any[], signals: any = {}) {
+  const u: any = { data: { recommendations, _signals: signals }, thread: { id: 900 } };
+  const payload = buildPayloadFromUnified(u, baseFilterState);
+  if (!payload) throw new Error("payload should not be null in this fixture");
+  return payload;
+}
+
+const semanticHeroRec = {
+  shrine_id: 1,
+  display_name: "根津神社",
+  reason: "仕事運に関わる神社です。",
+  reason_facts: [{ type: "need_tag", label: "仕事運", score: 1, evidence: [], is_primary: true }],
+};
+
+describe("Fallback Escape-hatch CTA Visual Weight Polish", () => {
+  beforeEach(() => {
+    analyticsMocks.trackSearchEvent.mockClear();
+    analyticsMocks.trackCardEvent.mockClear();
+    window.localStorage.clear();
+  });
+
+  it("1. fallback(_signals.result_state.fallback_mode=nearby_unfiltered) → escape-hatchが表示される", () => {
+    const payload = buildTestPayload([semanticHeroRec], { result_state: { fallback_mode: "nearby_unfiltered" } });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} />);
+
+    expect(screen.getByRole("button", { name: "近くの神社を静かに見る" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "条件を広げて見直す" })).toBeInTheDocument();
+  });
+
+  it("1b. fallback(is_dummy候補) → escape-hatchが表示される", () => {
+    const payload = buildTestPayload([{ ...semanticHeroRec, is_dummy: true }]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} />);
+
+    expect(screen.getByRole("button", { name: "近くの神社を静かに見る" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "条件を広げて見直す" })).toBeInTheDocument();
+  });
+
+  it("2. semantic Primary(fallbackでもdummyでもない) → escape-hatchは表示されない", () => {
+    const payload = buildTestPayload([semanticHeroRec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} />);
+
+    expect(screen.queryByRole("button", { name: "近くの神社を静かに見る" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "条件を広げて見直す" })).not.toBeInTheDocument();
+  });
+
+  it("3. Primary CTAはfallback時もstrongのまま(bg-action-primaryの塗りを維持)", () => {
+    const payload = buildTestPayload([semanticHeroRec], { result_state: { fallback_mode: "nearby_unfiltered" } });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} />);
+
+    const primaryCta = screen.getByRole("link", { name: "神社の詳細を見る" });
+    expect(primaryCta.className).toContain(PRIMARY_CTA_CLASS_FRAGMENT);
+  });
+
+  it("4. escape-hatchはPrimary CTAと同等のstrong styleではない(bg-action-primaryを持たず、塗りボタンでもない)", () => {
+    const payload = buildTestPayload([semanticHeroRec], { result_state: { fallback_mode: "nearby_unfiltered" } });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} />);
+
+    const openMap = screen.getByRole("button", { name: "近くの神社を静かに見る" });
+    const widen = screen.getByRole("button", { name: "条件を広げて見直す" });
+
+    for (const btn of [openMap, widen]) {
+      expect(btn.className).not.toContain(PRIMARY_CTA_CLASS_FRAGMENT);
+      // 塗り(solid fill)スタイルへ後退していないこと -- 旧bg-neutral-900のような
+      // 単色塗りボタンは、Primary CTAと並んだ時に同格の強さに見えてしまう。
+      expect(btn.className).not.toMatch(/bg-neutral-900|bg-black|text-white/);
+      // outline/枠のみスタイルへ格下げされていること。
+      expect(btn.className).toContain("border");
+    }
+  });
+
+  it("5. clickで既存のonAction(open_map / filter_clear)が維持される(navigation先変更0)", () => {
+    const onAction = vi.fn();
+    const payload = buildTestPayload([semanticHeroRec], { result_state: { fallback_mode: "nearby_unfiltered" } });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} onAction={onAction} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "近くの神社を静かに見る" }));
+    expect(onAction).toHaveBeenCalledWith({ type: "open_map" });
+
+    fireEvent.click(screen.getByRole("button", { name: "条件を広げて見直す" }));
+    expect(onAction).toHaveBeenCalledWith({ type: "filter_clear" });
+  });
+
+  it("6. fallback表示中もHero側のanalytics(card_view/shrine_detail_transition)は変化しない", () => {
+    const payload = buildTestPayload([semanticHeroRec], { result_state: { fallback_mode: "nearby_unfiltered" } });
+    render(<ConciergeSectionsRenderer payload={payload} threadId={900} isPremiumActive={false} />);
+
+    expect(analyticsMocks.trackCardEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "card_view", cardId: "shrine_hero", shrineId: 1, recommendationRank: 1 }),
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "神社の詳細を見る" }));
+    expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+      "shrine_detail_transition",
+      expect.objectContaining({ source: "concierge_result", position: "hero_primary", shrineId: 1 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Resolves the last remaining Should item from [docs/audit/recommendation-result-ia-v2-final.md](docs/audit/recommendation-result-ia-v2-final.md) ([PR #2443](https://github.com/etsu33/jinja_app/pull/2443)): the fallback escape-hatch's "条件を広げて見直す" button used a solid `bg-neutral-900` fill, which read as visually on par with Hero's Primary CTA ("神社の詳細を見る") — the [PR #2440](https://github.com/etsu33/jinja_app/pull/2440) contract requires exactly one strong CTA on the Result screen. PR #2438–#2444's Result IA v2 contract is otherwise unchanged.

## Investigation (Phase 1)

- **Render location**: `ConciergeSectionsRenderer.tsx`, the `(isFallback || hasDummy)` block inside the `"recommendations"` section case.
- **Fallback display condition**: `isFallback = rs?.fallback_mode === "nearby_unfiltered"` (from `payload.meta.resultState`, itself derived from Backend's `_signals.result_state`) OR `hasDummy = items.some(x => x.isDummy === true)` — both untouched by this PR.
- **Component/variant**: plain inline `<button>` elements (not a shared component) — no other screen imports this exact code path. A separate, unrelated `bg-neutral-900` usage exists in `ConciergeCard.tsx` (used by `PrimaryRecommendationCard`/`PlaceShrineCard`, a different card family) — left untouched, out of scope.
- **Style diff vs Primary CTA**: Primary CTA (`ConciergeTopRecommendationHero.tsx`) is a solid `bg-[var(--kt-color-action-primary)]` fill with `font-bold` and a shadow. The flagged button was also a solid fill (`bg-neutral-900`, `font-semibold`, `text-white`) — both solid/high-contrast, reading as similarly "primary" in weight despite being in a 2-column grid before Hero.
- **Click handler / navigation**: `onClick={() => onAction?.({ type: "filter_clear" })}` — dispatches the same existing app action used elsewhere in this file (e.g. the "クリア" chip), not a direct navigation. Untouched.
- **Analytics**: neither escape-hatch button fires an analytics event directly; Hero's own `card_view`/`shrine_detail_transition` events are unaffected by this fallback banner rendering.

## Change

Downgraded the button's class from a solid fill to the same plain `border`/no-fill style already used by:
- its own sibling button ("近くの神社を静かに見る"), and
- "もう少し詳しく添える" / "入口に戻る" elsewhere in this same file.

Reusing an existing pattern already present in the file, not introducing a new component or token.

## Out of scope (unchanged)

Fallback detection conditions, fallback reason text, Recommendation candidates, Ranking, navigation destinations, Backend, Signal Authority, Action Grounding, analytics semantics, migrations.

## Test plan

- [x] New `ConciergeSectionsRenderer.fallbackEscapeHatchWeight.test.tsx` — 7 tests covering: fallback (both `fallback_mode` and `is_dummy` triggers) shows the escape-hatch; semantic-Primary results show neither button; Primary CTA keeps its strong class; both escape-hatch buttons no longer carry the Primary CTA class or any solid-fill/white-text styling and are back to outline/border; `onAction` payloads (`open_map`/`filter_clear`) unchanged; Hero's own analytics unaffected.
- [x] `ConciergeSectionsRenderer.ctaHierarchyTrustPlacement.test.tsx`, `.coverage.test.tsx` — pass unmodified (existing CTA hierarchy and fallback-button-clickability contracts untouched).
- [x] Full web vitest suite: 136 files / 915 tests passed.
- [x] `tsc --noEmit`: clean.
- [x] `eslint`: clean.
- [x] `next build`: clean.
- [x] Playwright `05_direction_flow.spec.ts`: all 12 tests passed.
- [x] Browser QA at 375/390/430px via a temporary debug route (removed before commit, never staged): Conclusion → Next Action → Primary CTA → fallback escape-hatch → Save → Premium all shown together — Primary CTA is now the only solid-filled, high-contrast element on screen; the escape-hatch remains clearly visible and clickable as a matched pair of outline buttons; no horizontal overflow at any width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)