### PR TITLE
feat: implement Deep Dive Backend Retrieval Foundation

### DIFF
--- a/backend/temples/services/deep_dive_retrieval.py
+++ b/backend/temples/services/deep_dive_retrieval.py
@@ -1,0 +1,449 @@
+"""Deep Dive Backend Retrieval Foundation.
+
+docs/product/deep-dive-answer-generation-contract.md の実装。同書のPR-B1
+（Question Classification）・PR-B2（Fact Retrieval + Evidence Filtering）・
+PR-B4（Provenance + Output Contract）に相当する。PR-B3（LLMによるanswer
+generation）は本モジュールの対象外であり、本モジュールはLLMを一切呼び出さない。
+
+安全性の核心はLLMの判断に依存しないことである。retrieved usable factが0件の
+場合、grounded answerを生成せずlimitations/unanswered_aspectsを返す
+（Zero-Fact Short Circuit、docs/product/deep-dive-answer-generation-contract.md
+§6・§8）。質問分類（classify_question）もdeterministicなキーワード一致のみで
+行い、LLMを使わない。
+
+Recommendation Authority（Ranking, Candidate filtering, Signal Authority,
+Reason生成）へは一切接続しない。Readiness判定・Evidence Gate判定は既存の
+docs/knowledge/shrine-knowledge-contract.md契約とtemples.services.evidence_gate
+をそのまま再利用し、独自のverification/confidence判定を新設しない。
+confidence→reason_strengthの変換値は、temples.services.recommendation_reason_v4.py
+がすでに確立している変換（high/medium/low → assertive/weakened/suppressed、
+history_type="tradition"のassertive floor）と同一の値を用いる（Recommendation
+Authority領域である同ファイルはimportせず、値のみをここに複製する。
+docs/product/deep-dive-answer-generation-contract.md §5）。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Optional
+
+from django.db.models import Prefetch
+from temples.models import ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services import evidence_gate
+
+# ---------------------------------------------------------------------------
+# Question Taxonomy (docs/product/deep-dive-answer-generation-contract.md §3)
+# ---------------------------------------------------------------------------
+
+QUESTION_TYPE_DEITY_WHO = "deity_who"
+QUESTION_TYPE_DEITY_NATURE = "deity_nature"
+QUESTION_TYPE_FOUNDING = "founding"
+QUESTION_TYPE_HISTORICAL_EVENTS = "historical_events"
+QUESTION_TYPE_TRADITION = "tradition"
+QUESTION_TYPE_SOURCE_BASIS = "source_basis"
+QUESTION_TYPE_OTHER = "other"
+
+# question_type -> ShrineHistory.history_type（founding/historical_events/
+# traditionのみHistoryを取得対象にする。deity_who/deity_nature/source_basis/
+# otherはこの表を使わない、_retrieve_facts_for_question_type参照）。
+_HISTORY_TYPES_BY_QUESTION_TYPE: dict[str, tuple[str, ...]] = {
+    QUESTION_TYPE_FOUNDING: ("founding", "official_origin"),
+    QUESTION_TYPE_HISTORICAL_EVENTS: ("historical_event", "regional_context", "editorial_summary"),
+    QUESTION_TYPE_TRADITION: ("tradition",),
+}
+
+# 分類はdeterministicなキーワード一致のみで行う（LLMを使わない）。複合質問は
+# 複数のquestion_typeを返してよい。いずれにも一致しない場合はOTHERとし、
+# 推測でどれか1つへ寄せない（docs/product/deep-dive-answer-generation-contract.md §3・§12）。
+_KEYWORDS_BY_QUESTION_TYPE: dict[str, tuple[str, ...]] = {
+    QUESTION_TYPE_DEITY_WHO: ("誰を祀", "祭神は誰", "誰が祀られ", "祭神を教え"),
+    QUESTION_TYPE_DEITY_NATURE: ("どんな神", "神様はどんな", "どういう神", "神様について"),
+    QUESTION_TYPE_FOUNDING: ("創建", "なぜ建て", "由来", "起源"),
+    QUESTION_TYPE_HISTORICAL_EVENTS: ("歴史", "出来事", "沿革"),
+    QUESTION_TYPE_TRADITION: ("伝承", "言い伝え", "伝説"),
+    QUESTION_TYPE_SOURCE_BASIS: ("根拠", "出典", "資料は", "情報源", "ソースは"),
+}
+
+_CLASSIFIABLE_QUESTION_TYPES = (
+    QUESTION_TYPE_DEITY_WHO,
+    QUESTION_TYPE_DEITY_NATURE,
+    QUESTION_TYPE_FOUNDING,
+    QUESTION_TYPE_HISTORICAL_EVENTS,
+    QUESTION_TYPE_TRADITION,
+    QUESTION_TYPE_SOURCE_BASIS,
+)
+
+
+def classify_question(question_text: Optional[str]) -> list[str]:
+    """質問文をquestion_typeへ分類する（deterministic、LLMを使わない）。
+
+    複合質問（例:「誰を祀っていて、なぜ創建されたのか」）は複数の
+    question_typeを返す。いずれのキーワードにも一致しない場合は
+    [QUESTION_TYPE_OTHER]を返す（推測でどれかへ寄せない）。
+    """
+    if not question_text:
+        return [QUESTION_TYPE_OTHER]
+
+    matched = [
+        question_type
+        for question_type in _CLASSIFIABLE_QUESTION_TYPES
+        if any(keyword in question_text for keyword in _KEYWORDS_BY_QUESTION_TYPE[question_type])
+    ]
+    return matched if matched else [QUESTION_TYPE_OTHER]
+
+
+# ---------------------------------------------------------------------------
+# Output shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeepDiveFact:
+    """取得されたFact 1件（既にEvidence Gateを通過済み）。"""
+
+    type: str  # "deity" | "history"
+    id: int
+    question_type: str
+    label: str  # deity: display_name / history: title
+    content: str  # deity: canonical_name（無ければdisplay_name） / history: content
+    verification_status: str
+    confidence: str
+    reason_strength: str
+    source_ids: tuple[int, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class DeepDiveSource:
+    """facts内のsource_idsから機械的に導出されたSource 1件。"""
+
+    id: int
+    title: str
+    publisher: str
+    source_type: str
+    url: str
+
+
+@dataclass(frozen=True)
+class DeepDiveContext:
+    """Retrieval Foundationの出力（Output Contract、LLM生成前）。
+
+    "answer"文字列は含まない。LLMによるanswer生成（PR-B3、本書スコープ外）へ
+    そのまま渡すためのcontextである。
+    """
+
+    readiness: str  # "full" | "limited" | "not_ready"
+    question_type: list[str]
+    facts: list[DeepDiveFact]
+    sources: list[DeepDiveSource]
+    limitations: Optional[str]
+    unanswered_aspects: list[str]
+
+
+# ---------------------------------------------------------------------------
+# confidence -> reason_strength（既存recommendation_reason_v4.pyの値を複製、§5）
+# ---------------------------------------------------------------------------
+
+_CONFIDENCE_TO_REASON_STRENGTH: dict[str, str] = {
+    "high": "assertive",
+    "medium": "weakened",
+    "low": "suppressed",
+}
+
+_TRADITION_HISTORY_TYPE = "tradition"
+
+
+def _reason_strength_from_confidence(confidence: str) -> str:
+    return _CONFIDENCE_TO_REASON_STRENGTH.get(confidence, "assertive")
+
+
+def _apply_tradition_hedge_floor(reason_strength: str, history_type: Optional[str]) -> str:
+    """history_type="tradition"のFactはassertiveを許さない（既存Authority契約と同じ規則）。"""
+    if history_type == _TRADITION_HISTORY_TYPE and reason_strength == "assertive":
+        return "weakened"
+    return reason_strength
+
+
+# ---------------------------------------------------------------------------
+# Retrieval + Evidence filtering
+# ---------------------------------------------------------------------------
+
+
+def _fact_ready_sources_prefetch() -> Prefetch:
+    return Prefetch(
+        "sources",
+        queryset=ShrineKnowledgeSource.objects.filter(
+            verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES
+        ),
+    )
+
+
+def _usable_deities(shrine_id: int) -> list[tuple[ShrineDeity, evidence_gate.EvidenceDecision]]:
+    candidates = (
+        ShrineDeity.objects.filter(
+            shrine_id=shrine_id,
+            verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES,
+        )
+        .order_by("sort_order", "id")
+        .prefetch_related(_fact_ready_sources_prefetch())
+    )
+    result: list[tuple[ShrineDeity, evidence_gate.EvidenceDecision]] = []
+    for deity in candidates:
+        decision = evidence_gate.decide_fact_usability(
+            verification_status=deity.verification_status,
+            confidence=deity.confidence,
+            source_verification_statuses=[s.verification_status for s in deity.sources.all()],
+        )
+        if decision.usable:
+            result.append((deity, decision))
+    return result
+
+
+def _usable_histories(
+    shrine_id: int, history_types: Optional[Iterable[str]] = None
+) -> list[tuple[ShrineHistory, evidence_gate.EvidenceDecision]]:
+    qs = ShrineHistory.objects.filter(
+        shrine_id=shrine_id,
+        verification_status__in=evidence_gate.FACT_READY_VERIFICATION_STATUSES,
+    )
+    if history_types is not None:
+        qs = qs.filter(history_type__in=list(history_types))
+    candidates = qs.order_by("sort_order", "id").prefetch_related(_fact_ready_sources_prefetch())
+    result: list[tuple[ShrineHistory, evidence_gate.EvidenceDecision]] = []
+    for history in candidates:
+        decision = evidence_gate.decide_fact_usability(
+            verification_status=history.verification_status,
+            confidence=history.confidence,
+            source_verification_statuses=[s.verification_status for s in history.sources.all()],
+        )
+        if decision.usable:
+            result.append((history, decision))
+    return result
+
+
+def _deity_to_fact(
+    deity: ShrineDeity, decision: evidence_gate.EvidenceDecision, question_type: str
+) -> DeepDiveFact:
+    return DeepDiveFact(
+        type="deity",
+        id=deity.id,
+        question_type=question_type,
+        label=deity.display_name,
+        content=deity.canonical_name or deity.display_name,
+        verification_status=deity.verification_status,
+        confidence=decision.confidence,
+        reason_strength=_reason_strength_from_confidence(decision.confidence),
+        source_ids=tuple(s.id for s in deity.sources.all()),
+    )
+
+
+def _history_to_fact(
+    history: ShrineHistory, decision: evidence_gate.EvidenceDecision, question_type: str
+) -> DeepDiveFact:
+    reason_strength = _apply_tradition_hedge_floor(
+        _reason_strength_from_confidence(decision.confidence), history.history_type
+    )
+    return DeepDiveFact(
+        type="history",
+        id=history.id,
+        question_type=question_type,
+        label=history.title,
+        content=history.content,
+        verification_status=history.verification_status,
+        confidence=decision.confidence,
+        reason_strength=reason_strength,
+        source_ids=tuple(s.id for s in history.sources.all()),
+    )
+
+
+def get_shrine_deep_dive_readiness(shrine_id: int) -> str:
+    """Shrine 1件のDeep Dive Readiness（"full" | "limited" | "not_ready"）。
+
+    docs/audit/deep-dive-readiness-content-sufficiency.md §3.4・
+    evidence_gate.decide_deep_dive_readiness()の実装。Recommendationや
+    Shrine Detailのusable判定と同じEvidence Gate（decide_fact_usability）を
+    再利用し、独自のverification/confidence判定は行わない。
+    """
+    deity_decisions = [decision for _, decision in _usable_deities(shrine_id)]
+    history_decisions = [decision for _, decision in _usable_histories(shrine_id)]
+    return evidence_gate.decide_deep_dive_readiness(
+        deity_decisions=deity_decisions,
+        history_decisions=history_decisions,
+    )
+
+
+def _retrieve_facts_for_question_type(shrine_id: int, question_type: str) -> list[DeepDiveFact]:
+    """1つのquestion_typeに対応するKnowledgeを取得する（Retrieval Contract §4）。
+
+    Frontendはこの判断を一切行わない。question_typeごとの取得対象Modelは
+    固定されており、呼び出し側（build_deep_dive_context）が動的に変更する
+    余地は無い。
+    """
+    if question_type == QUESTION_TYPE_DEITY_WHO:
+        return [
+            _deity_to_fact(deity, decision, question_type)
+            for deity, decision in _usable_deities(shrine_id)
+        ]
+
+    if question_type == QUESTION_TYPE_DEITY_NATURE:
+        # ShrineDeityにはrole/canonical_name以外の性質記述fieldが無いため、
+        # 当該Shrineの全Historyも候補として渡す（Deityへの直接言及が無い
+        # Historyを混ぜない判断はLLM生成側の責務、docs/product/
+        # deep-dive-answer-generation-contract.md §3「deity_nature固有の注意」）。
+        # 本Foundationは候補集合を渡すのみで、関連性の絞り込みは行わない。
+        facts = [
+            _deity_to_fact(deity, decision, question_type)
+            for deity, decision in _usable_deities(shrine_id)
+        ]
+        facts += [
+            _history_to_fact(history, decision, question_type)
+            for history, decision in _usable_histories(shrine_id)
+        ]
+        return facts
+
+    history_types = _HISTORY_TYPES_BY_QUESTION_TYPE.get(question_type)
+    if history_types is not None:
+        return [
+            _history_to_fact(history, decision, question_type)
+            for history, decision in _usable_histories(shrine_id, history_types=history_types)
+        ]
+
+    # QUESTION_TYPE_SOURCE_BASISはbuild_deep_dive_context側でprior_factsから
+    # 導出する（新規Fact取得ではなく既存回答のprovenance参照、§3・§4）。
+    # QUESTION_TYPE_OTHERは意図的に何も取得しない（一致するKnowledge種別が
+    # 不明なまま推測で取得しない、§12）。
+    return []
+
+
+def _sources_from_facts(facts: Iterable[DeepDiveFact]) -> list[DeepDiveSource]:
+    """factsのsource_idsから機械的にSourceを導出する（Provenance Contract §9）。
+
+    LLM出力からfacts_used/sources_usedを逆生成しない。ここで確定した
+    source_idsの集合が、そのままsources_used相当になる。
+    """
+    source_ids: set[int] = set()
+    for fact in facts:
+        source_ids.update(fact.source_ids)
+    if not source_ids:
+        return []
+    sources = ShrineKnowledgeSource.objects.filter(id__in=source_ids).order_by("id")
+    return [
+        DeepDiveSource(
+            id=source.id,
+            title=source.title,
+            publisher=source.publisher,
+            source_type=source.source_type,
+            url=source.url,
+        )
+        for source in sources
+    ]
+
+
+_UNAVAILABLE_MESSAGE = "現在確認できる資料では、詳しい情報を確認できません。"
+_NOT_READY_MESSAGE = "この神社については、根拠付きで詳しくお答えできる情報がまだ十分ではありません。"
+_LIMITED_PREFIX = "この神社について確認できる資料は限られており、確認できる範囲でお答えしています。"
+
+
+def _build_limitations_message(readiness: str, unanswered_aspects: list[str]) -> Optional[str]:
+    parts: list[str] = []
+    if readiness == evidence_gate.DEEP_DIVE_LIMITED:
+        parts.append(_LIMITED_PREFIX)
+    if unanswered_aspects:
+        parts.append(_UNAVAILABLE_MESSAGE)
+    return "".join(parts) if parts else None
+
+
+def build_deep_dive_context(
+    *,
+    shrine_id: int,
+    question_text: Optional[str],
+    prior_facts: Optional[Iterable[DeepDiveFact]] = None,
+) -> DeepDiveContext:
+    """Deep Dive Answer Generationの前段（Retrieval Foundation）を1回で実行する。
+
+    LLM呼び出しは一切行わない（docs/product/deep-dive-answer-generation-contract.md
+    のPR-B3はこの関数の対象外）。ここで返るcontextは、後続のLLM生成ステップへ
+    そのまま渡すための入力であり、"answer"文字列は含まない。
+
+    Zero-Fact Short Circuit: readinessが"not_ready"の場合、または取得された
+    usable factが合計0件の場合、grounded answerを生成せずlimitations/
+    unanswered_aspectsのみを返す。この判定はLLMの判断に依存しない
+    （facts自体がそもそも構築されない、または空のまま返る）。
+    """
+    readiness = get_shrine_deep_dive_readiness(shrine_id)
+
+    if readiness == evidence_gate.DEEP_DIVE_NOT_READY:
+        # Not Readyの神社は、質問分類・Fact取得のいずれも行わない
+        # (Defense in depth、docs/product/deep-dive-answer-generation-contract.md §8ステップ2)。
+        return DeepDiveContext(
+            readiness=readiness,
+            question_type=[],
+            facts=[],
+            sources=[],
+            limitations=_NOT_READY_MESSAGE,
+            unanswered_aspects=[],
+        )
+
+    question_types = classify_question(question_text)
+
+    facts: list[DeepDiveFact] = []
+    seen_fact_keys: set[tuple[str, int]] = set()
+    unanswered_aspects: list[str] = []
+
+    for question_type in question_types:
+        if question_type == QUESTION_TYPE_SOURCE_BASIS:
+            type_facts = list(prior_facts or [])
+        else:
+            type_facts = _retrieve_facts_for_question_type(shrine_id, question_type)
+
+        if not type_facts:
+            unanswered_aspects.append(question_type)
+            continue
+
+        for fact in type_facts:
+            key = (fact.type, fact.id)
+            if key in seen_fact_keys:
+                # 複合質問で複数question_typeが同じFactを指した場合、
+                # 重複させずに1件のみ保持する（最初に一致したquestion_typeの
+                # ラベルを使う）。
+                continue
+            seen_fact_keys.add(key)
+            facts.append(fact)
+
+    if not facts:
+        return DeepDiveContext(
+            readiness=readiness,
+            question_type=question_types,
+            facts=[],
+            sources=[],
+            limitations=_UNAVAILABLE_MESSAGE,
+            unanswered_aspects=question_types,
+        )
+
+    sources = _sources_from_facts(facts)
+    limitations = _build_limitations_message(readiness, unanswered_aspects)
+
+    return DeepDiveContext(
+        readiness=readiness,
+        question_type=question_types,
+        facts=facts,
+        sources=sources,
+        limitations=limitations,
+        unanswered_aspects=unanswered_aspects,
+    )
+
+
+__all__ = [
+    "QUESTION_TYPE_DEITY_WHO",
+    "QUESTION_TYPE_DEITY_NATURE",
+    "QUESTION_TYPE_FOUNDING",
+    "QUESTION_TYPE_HISTORICAL_EVENTS",
+    "QUESTION_TYPE_TRADITION",
+    "QUESTION_TYPE_SOURCE_BASIS",
+    "QUESTION_TYPE_OTHER",
+    "DeepDiveFact",
+    "DeepDiveSource",
+    "DeepDiveContext",
+    "classify_question",
+    "get_shrine_deep_dive_readiness",
+    "build_deep_dive_context",
+]

--- a/backend/temples/services/evidence_gate.py
+++ b/backend/temples/services/evidence_gate.py
@@ -104,6 +104,51 @@ DETAIL_CANDIDATE_VERIFICATION_STATUSES = FACT_READY_VERIFICATION_STATUSES + (
 )
 
 
+DEEP_DIVE_FULL = "full"
+DEEP_DIVE_LIMITED = "limited"
+DEEP_DIVE_NOT_READY = "not_ready"
+
+
+def decide_deep_dive_readiness(
+    *,
+    deity_decisions: Iterable[EvidenceDecision],
+    history_decisions: Iterable[EvidenceDecision],
+) -> str:
+    """Deep Dive Readiness判定（"full" | "limited" | "not_ready"）。
+
+    docs/audit/deep-dive-readiness-content-sufficiency.md §3.4の機械的判定式、
+    docs/product/deep-dive-answer-generation-contract.md §2の実装。
+
+    deity_decisions/history_decisionsには、対象Shrineの各ShrineDeity/
+    ShrineHistoryについて既にdecide_fact_usability()を適用した結果を渡す。
+    本関数自身はDBへ一切アクセスしない（判定ロジックのみに責務を絞る、
+    temples.services.deep_dive_retrievalがDB取得とEvidence Gate適用を担う）。
+
+    - "full": deity/history双方にusable=Trueなfactが1件以上存在し
+      （structural readiness）、かついずれかの軸でconfidence="high"の
+      usable factが1件以上存在する。
+    - "limited": structural readinessは満たすが、どちらの軸でも
+      confidence="high"に到達しない（"medium"止まり）。
+    - "not_ready": deity/historyいずれかでusable factが0件。
+
+    confidenceによる閾値判定はここで新設せず、EvidenceDecision.confidence
+    （Fact自身のverification_status/Source判定を経て既に確定済みの値）を
+    そのまま参照するのみ。usable判定自体の基準（FACT_READY_VERIFICATION_STATUSES）
+    も再定義しない。
+    """
+    deity_usable = [d for d in deity_decisions if d.usable]
+    history_usable = [h for h in history_decisions if h.usable]
+
+    structural_ready = bool(deity_usable) and bool(history_usable)
+    if not structural_ready:
+        return DEEP_DIVE_NOT_READY
+
+    has_high_confidence = any(d.confidence == "high" for d in deity_usable) or any(
+        h.confidence == "high" for h in history_usable
+    )
+    return DEEP_DIVE_FULL if has_high_confidence else DEEP_DIVE_LIMITED
+
+
 def decide_detail_display_state(
     *,
     verification_status: str,
@@ -149,7 +194,11 @@ __all__ = [
     "FACT_READY_VERIFICATION_STATUSES",
     "DETAIL_DISPUTED_VERIFICATION_STATUS",
     "DETAIL_CANDIDATE_VERIFICATION_STATUSES",
+    "DEEP_DIVE_FULL",
+    "DEEP_DIVE_LIMITED",
+    "DEEP_DIVE_NOT_READY",
     "EvidenceDecision",
     "decide_fact_usability",
     "decide_detail_display_state",
+    "decide_deep_dive_readiness",
 ]

--- a/backend/temples/tests/services/test_deep_dive_retrieval.py
+++ b/backend/temples/tests/services/test_deep_dive_retrieval.py
@@ -1,0 +1,404 @@
+"""Deep Dive Backend Retrieval Foundation。
+
+docs/product/deep-dive-answer-generation-contract.md の実装検証。LLM生成
+（PR-B3）は対象外であり、本テストもLLMを一切呼び出さない。安全性の核心
+（Zero-Fact Short Circuit、Evidence Gate再利用、provenance整合）を検証する。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services import evidence_gate
+from temples.services.deep_dive_retrieval import (
+    QUESTION_TYPE_DEITY_NATURE,
+    QUESTION_TYPE_DEITY_WHO,
+    QUESTION_TYPE_FOUNDING,
+    QUESTION_TYPE_HISTORICAL_EVENTS,
+    QUESTION_TYPE_OTHER,
+    QUESTION_TYPE_TRADITION,
+    build_deep_dive_context,
+    classify_question,
+    get_shrine_deep_dive_readiness,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_shrine(name: str) -> Shrine:
+    return Shrine.objects.create(
+        name_jp=name,
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def _create_source(
+    title: str, verification_status: str = "source_confirmed", **kwargs
+) -> ShrineKnowledgeSource:
+    defaults = dict(
+        source_type="shrine_official",
+        title=title,
+        publisher="神社公式",
+        url="https://example.com/",
+        verification_status=verification_status,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineKnowledgeSource.objects.create(**defaults)
+
+
+def _create_deity(shrine: Shrine, display_name: str, sort_order: int = 0, **kwargs) -> ShrineDeity:
+    defaults = dict(
+        display_name=display_name,
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineDeity.objects.create(shrine=shrine, **defaults)
+
+
+def _create_history(shrine: Shrine, title: str, sort_order: int = 0, **kwargs) -> ShrineHistory:
+    defaults = dict(
+        history_type="founding",
+        title=title,
+        content="内容の本文",
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineHistory.objects.create(shrine=shrine, **defaults)
+
+
+# --- 1. 明治神宮 deity ---
+
+
+def test_1_meiji_jingu_deity_who_returns_deity_facts_with_provenance():
+    shrine = _create_shrine("明治神宮相当")
+    source = _create_source("公式サイト「明治神宮とは」")
+    deity1 = _create_deity(shrine, "明治天皇", sort_order=0)
+    deity2 = _create_deity(shrine, "昭憲皇太后", sort_order=1)
+    history = _create_history(shrine, "明治神宮の創建")
+    for fact in (deity1, deity2, history):
+        fact.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="この神社は誰を祀っていますか？")
+
+    assert context.readiness == "full"
+    assert context.question_type == [QUESTION_TYPE_DEITY_WHO]
+    assert {f.id for f in context.facts} == {deity1.id, deity2.id}
+    assert all(f.type == "deity" for f in context.facts)
+    assert all(f.reason_strength == "assertive" for f in context.facts)
+    assert {s.id for s in context.sources} == {source.id}
+    assert context.limitations is None
+    assert context.unanswered_aspects == []
+
+
+# --- 2. 明治神宮 history ---
+
+
+def test_2_meiji_jingu_founding_question_returns_history_facts_only():
+    shrine = _create_shrine("明治神宮相当2")
+    source = _create_source("公式サイト")
+    deity = _create_deity(shrine, "明治天皇")
+    founding = _create_history(shrine, "創建の経緯", history_type="founding")
+    tradition = _create_history(shrine, "言い伝え", history_type="tradition", sort_order=1)
+    for fact in (deity, founding, tradition):
+        fact.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="なぜ創建されたのですか？")
+
+    assert context.question_type == [QUESTION_TYPE_FOUNDING]
+    assert [f.id for f in context.facts] == [founding.id]
+    assert context.facts[0].type == "history"
+    # traditionは対象外（founding/official_originのみ取得、Retrieval Contract §4）
+    assert tradition.id not in [f.id for f in context.facts]
+
+
+# --- 3. Full Ready通常神社 ---
+
+
+def test_3_typical_full_ready_shrine_is_classified_full():
+    shrine = _create_shrine("通常神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "何らかの神", confidence="high")
+    history = _create_history(shrine, "由緒", confidence="medium")
+    deity.sources.add(source)
+    history.sources.add(source)
+
+    assert get_shrine_deep_dive_readiness(shrine.id) == evidence_gate.DEEP_DIVE_FULL
+
+
+# --- 4. 給田六所神社（Limited）相当 ---
+
+
+def test_4_limited_shrine_all_medium_confidence_is_classified_limited_with_weakened_strength():
+    shrine = _create_shrine("給田六所神社相当")
+    source = _create_source("公式")
+    deity1 = _create_deity(shrine, "大国魂大神", confidence="medium", role="primary")
+    deity2 = _create_deity(shrine, "天照皇大神", confidence="medium", role="secondary", sort_order=1)
+    history = _create_history(shrine, "神明社の合祀", confidence="medium", history_type="historical_event")
+    for fact in (deity1, deity2, history):
+        fact.sources.add(source)
+
+    assert get_shrine_deep_dive_readiness(shrine.id) == evidence_gate.DEEP_DIVE_LIMITED
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+    assert context.readiness == "limited"
+    assert all(f.reason_strength == "weakened" for f in context.facts)
+    assert context.limitations is not None
+    assert "限られており" in context.limitations
+
+
+# --- 5. Not Ready ---
+
+
+def test_5_not_ready_shrine_short_circuits_without_classification_or_retrieval():
+    shrine = _create_shrine("由緒未確認神社")
+    # ShrineDeity/ShrineHistoryを一切作らない（Not Ready、structural条件を満たさない）。
+
+    assert get_shrine_deep_dive_readiness(shrine.id) == evidence_gate.DEEP_DIVE_NOT_READY
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+    assert context.readiness == "not_ready"
+    # Not Readyでは質問分類すら行わない(Defense in depth、§8ステップ2)。
+    assert context.question_type == []
+    assert context.facts == []
+    assert context.sources == []
+    assert context.unanswered_aspects == []
+    assert context.limitations is not None
+
+
+def test_5b_not_ready_shrine_partial_knowledge_deity_only_no_history():
+    shrine = _create_shrine("由緒未確認神社2")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "何らかの神")
+    deity.sources.add(source)
+    # historyを作らない → structural readyを満たさない。
+
+    assert get_shrine_deep_dive_readiness(shrine.id) == evidence_gate.DEEP_DIVE_NOT_READY
+
+
+# --- 6. Fact 0 ---
+
+
+def test_6_zero_fact_short_circuit_returns_unavailable_message_without_llm_call():
+    shrine = _create_shrine("伝承なし神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "何らかの神")
+    founding = _create_history(shrine, "創建の経緯", history_type="founding")
+    for fact in (deity, founding):
+        fact.sources.add(source)
+    # tradition種別のHistoryは1件も無い。
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="どんな伝承がありますか？")
+
+    assert context.question_type == [QUESTION_TYPE_TRADITION]
+    assert context.facts == []
+    assert context.sources == []
+    assert context.limitations == "現在確認できる資料では、詳しい情報を確認できません。"
+    assert context.unanswered_aspects == [QUESTION_TYPE_TRADITION]
+
+
+def test_6b_unclassifiable_question_returns_other_without_guessing():
+    shrine = _create_shrine("何でも神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "何らかの神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="今日の天気はどうですか？")
+
+    assert context.question_type == [QUESTION_TYPE_OTHER]
+    assert context.facts == []
+    assert context.limitations is not None
+
+
+# --- 7. Sourceなし ---
+
+
+def test_7_fact_without_fact_ready_source_is_excluded_from_retrieval():
+    shrine = _create_shrine("Source無し神社")
+    deity_with_source = _create_deity(shrine, "Source有りの神")
+    deity_without_source = _create_deity(shrine, "Source無しの神", sort_order=1)
+    source = _create_source("公式")
+    deity_with_source.sources.add(source)
+    # deity_without_sourceにはSourceを一切addしない。
+
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    fact_ids = {f.id for f in context.facts}
+    assert deity_with_source.id in fact_ids
+    assert deity_without_source.id not in fact_ids
+
+
+def test_7b_fact_with_only_draft_source_is_excluded():
+    shrine = _create_shrine("draft Source神社")
+    deity = _create_deity(shrine, "神")
+    draft_source = _create_source("未確認資料", verification_status="draft")
+    deity.sources.add(draft_source)
+    history = _create_history(shrine, "由緒")
+    ready_source = _create_source("公式")
+    history.sources.add(ready_source)
+
+    # deityはfact-ready Sourceを持たないためnot usable → structural readyを満たさない
+    assert get_shrine_deep_dive_readiness(shrine.id) == evidence_gate.DEEP_DIVE_NOT_READY
+
+
+# --- 8. medium confidence ---
+
+
+def test_8_medium_confidence_maps_to_weakened_reason_strength():
+    shrine = _create_shrine("medium confidence神社")
+    source = _create_source("公式")
+    deity_high = _create_deity(shrine, "高確信度の神", confidence="high")
+    deity_medium = _create_deity(shrine, "中確信度の神", confidence="medium", sort_order=1)
+    for fact in (deity_high, deity_medium):
+        fact.sources.add(source)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    strengths_by_id = {f.id: f.reason_strength for f in context.facts}
+    assert strengths_by_id[deity_high.id] == "assertive"
+    assert strengths_by_id[deity_medium.id] == "weakened"
+
+
+def test_8b_tradition_history_type_is_floored_to_weakened_even_with_high_confidence():
+    shrine = _create_shrine("伝承神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source)
+    tradition = _create_history(shrine, "言い伝え", history_type="tradition", confidence="high")
+    tradition.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="どんな伝承がありますか？")
+
+    assert len(context.facts) == 1
+    # confidence=highでもtradition floorによりweakenedへ引き下げられる
+    # (既存recommendation_reason_v4.pyのTRADITION_ALWAYS_HEDGED契約と同一の規則)。
+    assert context.facts[0].reason_strength == "weakened"
+
+
+# --- 9. 複合質問 ---
+
+
+def test_9_compound_question_retrieves_multiple_question_types_without_duplicates():
+    shrine = _create_shrine("複合質問神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    founding = _create_history(shrine, "創建の経緯", history_type="founding")
+    for fact in (deity, founding):
+        fact.sources.add(source)
+
+    question_types = classify_question("誰を祀っていて、なぜ創建されたのですか？")
+    assert question_types == [QUESTION_TYPE_DEITY_WHO, QUESTION_TYPE_FOUNDING]
+
+    context = build_deep_dive_context(
+        shrine_id=shrine.id, question_text="誰を祀っていて、なぜ創建されたのですか？"
+    )
+
+    assert context.question_type == [QUESTION_TYPE_DEITY_WHO, QUESTION_TYPE_FOUNDING]
+    fact_ids = {f.id for f in context.facts}
+    assert fact_ids == {deity.id, founding.id}
+    assert context.unanswered_aspects == []
+
+
+def test_9b_compound_question_deduplicates_overlapping_facts():
+    shrine = _create_shrine("重複質問神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    # deity_who / deity_nature はどちらもShrineDeityを取得するため、同じ質問に
+    # 両方のキーワードが含まれる場合でもfactsへ重複登録しない。
+    context = build_deep_dive_context(
+        shrine_id=shrine.id, question_text="誰を祀っていて、どんな神様ですか？"
+    )
+
+    assert set(context.question_type) == {QUESTION_TYPE_DEITY_WHO, QUESTION_TYPE_DEITY_NATURE}
+    deity_fact_ids = [f.id for f in context.facts if f.type == "deity"]
+    assert deity_fact_ids.count(deity.id) == 1
+
+
+# --- 10. provenance整合 ---
+
+
+def test_10_provenance_round_trips_from_facts_to_sources_exactly():
+    shrine = _create_shrine("Provenance検証神社")
+    source_a = _create_source("Source A")
+    source_b = _create_source("Source B")
+    unrelated_source = _create_source("無関係なSource")
+
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source_a, source_b)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source_a)
+    # unrelated_sourceはどのFactにもRelationしない。
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    deity_fact = next(f for f in context.facts if f.id == deity.id)
+    assert set(deity_fact.source_ids) == {source_a.id, source_b.id}
+
+    returned_source_ids = {s.id for s in context.sources}
+    # sourcesはfacts.source_idsの和集合と厳密に一致する（余分・不足なし）。
+    expected_source_ids = {sid for f in context.facts for sid in f.source_ids}
+    assert returned_source_ids == expected_source_ids
+    assert unrelated_source.id not in returned_source_ids
+
+    source_a_out = next(s for s in context.sources if s.id == source_a.id)
+    assert source_a_out.title == "Source A"
+    assert source_a_out.publisher == "神社公式"
+    assert source_a_out.source_type == "shrine_official"
+
+
+def test_10b_source_basis_question_derives_sources_from_prior_facts_not_new_retrieval():
+    shrine = _create_shrine("根拠質問神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    first_context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+    assert first_context.facts
+
+    followup_context = build_deep_dive_context(
+        shrine_id=shrine.id, question_text="その根拠は何ですか？", prior_facts=first_context.facts
+    )
+
+    assert followup_context.question_type == ["source_basis"]
+    # source_basisは新規Fact取得を行わず、prior_factsをそのまま使う。
+    assert followup_context.facts == first_context.facts
+    assert {s.id for s in followup_context.sources} == {source.id}
+
+
+def test_10c_source_basis_without_prior_facts_short_circuits():
+    shrine = _create_shrine("根拠のみ神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="根拠は何ですか？")
+
+    assert context.question_type == ["source_basis"]
+    assert context.facts == []
+    assert context.limitations is not None


### PR DESCRIPTION
## Summary

Implements the Backend-only retrieval foundation from [docs/product/deep-dive-answer-generation-contract.md](docs/product/deep-dive-answer-generation-contract.md) (PR #2449): readiness, deterministic question classification, Knowledge Fact retrieval, evidence filtering, provenance, and the zero-fact short-circuit. Covers that doc's PR-B1 (Question Classification), PR-B2 (Fact Retrieval + Evidence Filtering), and PR-B4 (Provenance + Output Contract). **LLM answer generation (PR-B3), any API endpoint wiring (PR-B5), and Frontend (PR-B6) are explicitly out of scope for this PR.**

## Safety doesn't depend on an LLM's judgment

Retrieval and evidence filtering are fully deterministic. When zero usable facts are found for a question, no "answer" is ever constructed — callers get `limitations`/`unanswered_aspects` only. There is **no LLM call anywhere in this module**.

## Changes

- **`temples/services/evidence_gate.py`** (additive only, no existing line touched): `decide_deep_dive_readiness()` computing `"full"`/`"limited"`/`"not_ready"` from already-decided `EvidenceDecision` results (per [docs/audit/deep-dive-readiness-content-sufficiency.md](docs/audit/deep-dive-readiness-content-sufficiency.md) §3.4's mechanical formula) — structural readiness (deity + history both usable) plus a high-confidence check on either axis for `full` vs `limited`. No new `verification_status`/`confidence` gate invented; `FACT_READY_VERIFICATION_STATUSES` and `decide_fact_usability()` are reused unchanged.
- **`temples/services/deep_dive_retrieval.py`** (new): deterministic keyword-based `classify_question()` (no LLM) across the 7-type taxonomy from the design doc; per-question-type retrieval mirroring `shrine_knowledge_selector.py`'s existing prefetch-fact-ready-sources pattern; a `confidence → reason_strength` mapping and the tradition-history-type assertive floor, both **reproducing** (not importing, to avoid coupling into Recommendation Authority code) the same values already established in `recommendation_reason_v4.py`; provenance (`facts → sources`) derived mechanically from what was retrieved, never from any generated text; and `build_deep_dive_context()`, the single entry point implementing the Zero-Fact Short Circuit and the Not-Ready defense-in-depth guard.
- **`temples/tests/services/test_deep_dive_retrieval.py`**: the 10 required scenarios (17 tests) — Meiji Jingu deity/history, a typical Full-ready shrine, a Limited-ready shrine (all-medium-confidence, weakened wording), Not Ready (including partial-knowledge), zero-fact short-circuit (including unclassifiable questions), sourceless facts excluded, medium-confidence and tradition-floor wording, compound questions (including fact deduplication), and exact provenance round-tripping (including the `source_basis` question type deriving from `prior_facts` rather than a new retrieval).

## Out of scope (unchanged)

LLM generation, Frontend, Ranking, Recommendation Authority, Knowledge-to-Ranking connections, DB schema, migrations.

## Test plan

- [x] New `test_deep_dive_retrieval.py`: 17/17 passed.
- [x] Existing evidence-gate/knowledge-selector contract tests (`test_evidence_gate.py`, `test_evidence_gate_pilot_regression.py`, `test_evidence_gate_detail_display_state.py`, `test_evidence_gate_recommendation_detail_contract.py`, `test_shrine_knowledge_selector.py`): 73/73 passed, unmodified.
- [x] Full backend suite: **1485 passed**, 13 pre-existing skips (GDAL/PostGIS unavailable locally, unrelated axis gating), 0 failures.
- [x] `python3 manage.py makemigrations --check --dry-run`: "No changes detected" — 0 migrations.
- [x] `ruff check`: clean.
- [x] Pre-push hook (web suite, unaffected by this backend-only change): 136 files / 915 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)