### PR TITLE
feat: implement Deep Dive Answer Generation (LLM closed-book generation)

### DIFF
--- a/backend/temples/services/deep_dive_answer.py
+++ b/backend/temples/services/deep_dive_answer.py
@@ -1,0 +1,265 @@
+"""Deep Dive Answer Generation (PR-B3 + PR-B4)。
+
+docs/product/deep-dive-answer-generation-contract.md の実装。
+temples.services.deep_dive_retrieval（PR-B1・PR-B2・#2450でmerge済み）を
+唯一のFact取得経路とし、そのretrieval結果のみを根拠にLLMへ回答文を生成させる
+（closed-book、§6・§8ステップ6-7）。
+
+**LLMはKnowledge Retrieverではない**: LLMへ渡すShrine固有情報は
+build_deep_dive_context()が返したusable factsのみであり、LLMにDB再検索・
+Fact選択・Source選択・readiness判定・一般知識によるFact補完のいずれも
+させない。質問分類・Fact取得・Evidence filtering・readiness判定は
+deep_dive_retrieval.py側で既にdeterministicに確定済みであり、本モジュールは
+それを変更しない。
+
+**Call Gate（最重要のsafety layer、§6・§8ステップ6）**: 以下の場合、LLMを
+一切呼び出さない。
+  - readiness == "not_ready"
+  - usable factsが0件（confidence="low"→"suppressed"によりgeneration対象外に
+    なった結果0件になる場合を含む）
+呼び出し自体をしないことで、grounded answerを構成できない状態でLLMが
+何かを生成してしまうリスクを構造的に排除する
+（temples.services.deep_dive_retrievalのZero-Fact Short Circuitと同じ設計思想）。
+
+**Provenance（§9）**: facts_used/sources_usedは、LLMのテキスト出力から抽出
+しない。build_deep_dive_context()がretrieval時に確定したFact/Sourceの集合
+から機械的に導出する。LLMへ渡したFactの集合＝facts_usedであり、closed-book
+promptなので後から集合が変化することもない。
+
+**LLM統合方式**: 既存のtemples.llm.client.LLMClient / settings.CONCIERGE_USE_LLM
+feature-flagパターン（temples/services/concierge_chat_llm_route.pyが確立した
+パターン）をそのまま再利用する。新規のLLM統合方式・新規feature flagは発明しない。
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+from temples.llm.client import PLACEHOLDER, LLMClient
+from temples.services import evidence_gate
+from temples.services.deep_dive_retrieval import (
+    DeepDiveFact,
+    DeepDiveSource,
+    build_deep_dive_context,
+)
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Output Contract (docs/product/deep-dive-answer-generation-contract.md §10)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DeepDiveFactUsed:
+    """Output Contractの facts_used 1件。
+
+    LLM出力からではなく、retrieval時に確定したFact集合(DeepDiveFact)から
+    機械的に導出する(§9)。verification_status/confidence/content等の内部
+    fieldはOutput Contractの対象外のため保持しない。
+    """
+
+    type: str
+    id: int
+    label: str
+
+
+@dataclass(frozen=True)
+class DeepDiveAnswer:
+    """docs/product/deep-dive-answer-generation-contract.md §10 Output Contract。"""
+
+    answer: str
+    readiness: str
+    facts_used: list[DeepDiveFactUsed]
+    sources_used: list[DeepDiveSource]
+    limitations: Optional[str]
+    unanswered_aspects: list[str]
+    # Output Contract §10の「最低限」フィールドには含まれない、observability専用の値。
+    # LLMが実際に呼ばれ、その出力がそのままanswerに使われたかどうかを示す
+    # (呼ばれなかった/失敗した場合はFalse。テストでのCall Gate検証に使う)。
+    llm_used: bool
+
+
+# ---------------------------------------------------------------------------
+# No-Hallucination Contract (§6): confidence="low"→reason_strength="suppressed"の
+# Factはgeneration対象から除外する。deep_dive_retrieval.py自体はconfidenceで
+# フィルタしない設計(usable判定はverification_statusのみ、§5)であり、
+# suppressed除外はAnswer Generation層の責務としてここで行う。
+# ---------------------------------------------------------------------------
+
+_SUPPRESSED_REASON_STRENGTH = "suppressed"
+
+
+def _usable_for_generation(facts: Iterable[DeepDiveFact]) -> list[DeepDiveFact]:
+    return [f for f in facts if f.reason_strength != _SUPPRESSED_REASON_STRENGTH]
+
+
+# ---------------------------------------------------------------------------
+# Closed-book prompt (§6・§8ステップ7)
+# ---------------------------------------------------------------------------
+
+_SYSTEM_PROMPT = (
+    "あなたは神社の詳細情報について、与えられたFactのみを根拠に回答するアシスタントです。"
+    "以下を厳密に守ってください。\n"
+    "- 与えられたFact以外の情報を、神社固有の事実として述べない。\n"
+    "- Fact間に明示されていない因果関係を推測して繋げない。\n"
+    "- 一般的な神道知識・他の神社との比較・あなたが妥当と判断した推測を、"
+    "この神社のFactとして混ぜない。\n"
+    "- reason_strengthが「weakened」のFactは、断定調ではなく「〜と伝わる」"
+    "「〜とされる」のように弱めた表現で述べる。\n"
+    "- reason_strengthが「assertive」のFactは断定調で述べてよい。\n"
+    "- 尋ねられた内容に対応するFactが無い場合、無理に埋めず、確認できない旨を述べる。\n"
+    "- 出力は回答本文の自然文のみとし、前置き・見出し・断り書きを含めない。"
+)
+
+
+def _build_user_prompt(question_text: str, facts: list[DeepDiveFact]) -> str:
+    fact_lines = "\n".join(
+        f"- [{fact.label}] {fact.content}（reason_strength: {fact.reason_strength}）"
+        for fact in facts
+    )
+    return f"質問: {question_text}\n\n利用できるFact（これ以外の情報は使わない）:\n{fact_lines}"
+
+
+def _call_llm(question_text: str, facts: list[DeepDiveFact]) -> Optional[str]:
+    """Closed-book生成を1回呼び出す。使えない/失敗した場合はNoneを返す(fabricateしない)。"""
+    client = LLMClient()
+    if getattr(client, "_client", None) is None or getattr(client, "_mode", None) is None:
+        return None
+
+    messages = [
+        {"role": "system", "content": _SYSTEM_PROMPT},
+        {"role": "user", "content": _build_user_prompt(question_text, facts)},
+    ]
+
+    try:
+        msg = client.chat(messages)
+    except Exception as exc:
+        log.warning(
+            "[deep_dive_answer] LLM call raised error_class=%s", type(exc).__name__
+        )
+        return None
+
+    content = msg.get("content") if isinstance(msg, dict) else None
+    if not content or content == PLACEHOLDER["content"]:
+        return None
+    return content.strip() or None
+
+
+# ---------------------------------------------------------------------------
+# Failure Modes (§12)
+# ---------------------------------------------------------------------------
+
+_LLM_FAILURE_MESSAGE = (
+    "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
+)
+
+
+def _facts_used_from(facts: Iterable[DeepDiveFact]) -> list[DeepDiveFactUsed]:
+    return [DeepDiveFactUsed(type=f.type, id=f.id, label=f.label) for f in facts]
+
+
+def _sources_used_for(
+    facts: list[DeepDiveFact], all_sources: list[DeepDiveSource]
+) -> list[DeepDiveSource]:
+    """facts(generation対象に絞り込み済み)のsource_idsに限定してsourcesを絞る(§9)。"""
+    source_ids: set[int] = set()
+    for fact in facts:
+        source_ids.update(fact.source_ids)
+    return [source for source in all_sources if source.id in source_ids]
+
+
+def _empty_answer(readiness: str, limitations: Optional[str]) -> DeepDiveAnswer:
+    return DeepDiveAnswer(
+        answer="",
+        readiness=readiness,
+        facts_used=[],
+        sources_used=[],
+        limitations=limitations,
+        unanswered_aspects=[],
+        llm_used=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point (§8)
+# ---------------------------------------------------------------------------
+
+
+def generate_deep_dive_answer(
+    *,
+    shrine_id: int,
+    question_text: Optional[str],
+    prior_facts: Optional[Iterable[DeepDiveFact]] = None,
+) -> DeepDiveAnswer:
+    """Deep Dive Answer Generationの全体pipeline(§8ステップ1-9)を1回実行する。
+
+    Guard(§8ステップ2)・質問分類・Fact取得・Evidence filtering・provenanceは
+    build_deep_dive_context()(既存Retrieval Foundation、PR #2450)にそのまま
+    委譲し、本関数はLLM呼び出しの要否判定(Call Gate)とclosed-book生成のみを
+    追加する。readiness判定・Fact取得ロジック自体はここで再実装しない。
+    """
+    context = build_deep_dive_context(
+        shrine_id=shrine_id, question_text=question_text, prior_facts=prior_facts
+    )
+
+    if context.readiness == evidence_gate.DEEP_DIVE_NOT_READY:
+        # Not Ready: Retrieval Foundation側で既にfacts取得を行っていない
+        # (defense in depth)。ここでもLLMは呼び出さない。
+        return _empty_answer(context.readiness, context.limitations)
+
+    generation_facts = _usable_for_generation(context.facts)
+
+    if not generation_facts:
+        # Zero-Fact Short Circuit(§6・§8ステップ6a)。context.factsが0件の場合と、
+        # confidence="low"(suppressed)のみで実質使えるFactが無い場合の両方を含む。
+        unanswered = context.unanswered_aspects or context.question_type
+        limitations = context.limitations
+        return DeepDiveAnswer(
+            answer="",
+            readiness=context.readiness,
+            facts_used=[],
+            sources_used=[],
+            limitations=limitations,
+            unanswered_aspects=unanswered,
+            llm_used=False,
+        )
+
+    answer_text = _call_llm(question_text or "", generation_facts)
+
+    facts_used = _facts_used_from(generation_facts)
+    sources_used = _sources_used_for(generation_facts, context.sources)
+
+    if answer_text is None:
+        # LLM未使用/失敗: Factを捏造したfallback文章は作らない。retrieval済みの
+        # facts_used/sources_used(mechanicalに確定済み、safeな情報)はそのまま返し、
+        # answerのみ固定のdeterministicな失敗文言にする(§12)。
+        return DeepDiveAnswer(
+            answer=_LLM_FAILURE_MESSAGE,
+            readiness=context.readiness,
+            facts_used=facts_used,
+            sources_used=sources_used,
+            limitations=context.limitations,
+            unanswered_aspects=context.unanswered_aspects,
+            llm_used=False,
+        )
+
+    return DeepDiveAnswer(
+        answer=answer_text,
+        readiness=context.readiness,
+        facts_used=facts_used,
+        sources_used=sources_used,
+        limitations=context.limitations,
+        unanswered_aspects=context.unanswered_aspects,
+        llm_used=True,
+    )
+
+
+__all__ = [
+    "DeepDiveFactUsed",
+    "DeepDiveAnswer",
+    "generate_deep_dive_answer",
+]

--- a/backend/temples/tests/services/test_deep_dive_answer.py
+++ b/backend/temples/tests/services/test_deep_dive_answer.py
@@ -1,0 +1,338 @@
+"""Deep Dive Answer Generation(PR-B3 + PR-B4)のテスト。
+
+docs/product/deep-dive-answer-generation-contract.md の実装検証。
+Call Gate(readiness=not_ready/usable facts=0でLLM未呼び出し)、provenanceの
+機械的導出、Limitedでの非推測、LLM失敗時の安全なfallbackを検証する。
+実LLM(openai SDK)は一切呼び出さない — LLMClientをテストダブルで差し替える。
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services import deep_dive_answer
+from temples.services.deep_dive_answer import generate_deep_dive_answer
+
+pytestmark = pytest.mark.django_db
+
+
+def _create_shrine(name: str) -> Shrine:
+    return Shrine.objects.create(
+        name_jp=name,
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def _create_source(
+    title: str, verification_status: str = "source_confirmed", **kwargs
+) -> ShrineKnowledgeSource:
+    defaults = dict(
+        source_type="shrine_official",
+        title=title,
+        publisher="神社公式",
+        url="https://example.com/",
+        verification_status=verification_status,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineKnowledgeSource.objects.create(**defaults)
+
+
+def _create_deity(shrine: Shrine, display_name: str, sort_order: int = 0, **kwargs) -> ShrineDeity:
+    defaults = dict(
+        display_name=display_name,
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineDeity.objects.create(shrine=shrine, **defaults)
+
+
+def _create_history(shrine: Shrine, title: str, sort_order: int = 0, **kwargs) -> ShrineHistory:
+    defaults = dict(
+        history_type="founding",
+        title=title,
+        content="内容の本文",
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineHistory.objects.create(shrine=shrine, **defaults)
+
+
+def _boom(*args, **kwargs):
+    raise AssertionError("LLM must not be constructed/called in this path")
+
+
+class _FakeLLMClient:
+    """テストダブル。実openai SDKは一切importしない。"""
+
+    def __init__(self, content=None, raise_exc: Exception | None = None):
+        self._client = object()
+        self._mode = "chat"
+        self._content = content
+        self._raise_exc = raise_exc
+        self.calls: list[list[dict]] = []
+
+    def chat(self, messages):
+        self.calls.append(messages)
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return {"role": "assistant", "content": self._content}
+
+
+# --- Call Gate: not_ready / zero-fact ではLLMを一切呼び出さない ---
+
+
+def test_not_ready_shrine_never_constructs_llm_client(monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("由緒未確認神社")
+    # ShrineDeity/ShrineHistoryを作らない → not_ready。
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.readiness == "not_ready"
+    assert result.answer == ""
+    assert result.facts_used == []
+    assert result.sources_used == []
+    assert result.limitations is not None
+    assert result.llm_used is False
+
+
+def test_zero_fact_short_circuit_never_constructs_llm_client(monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("伝承なし神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "何らかの神")
+    founding = _create_history(shrine, "創建の経緯", history_type="founding")
+    for fact in (deity, founding):
+        fact.sources.add(source)
+    # tradition種別のHistoryが無い → 該当質問はfacts=0件。
+
+    result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="どんな伝承がありますか？"
+    )
+
+    assert result.answer == ""
+    assert result.facts_used == []
+    assert result.sources_used == []
+    assert result.unanswered_aspects == ["tradition"]
+    assert result.limitations is not None
+    assert result.llm_used is False
+
+
+def test_unclassifiable_question_never_constructs_llm_client(monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("何でも神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="今日の天気はどうですか？"
+    )
+
+    assert result.facts_used == []
+    assert result.llm_used is False
+
+
+def test_suppressed_low_confidence_facts_short_circuit_without_llm_call(monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("低確信度のみ神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "低確信度の神", confidence="low")
+    history = _create_history(shrine, "由緒", confidence="high")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    # confidence="low"(reason_strength="suppressed")のFactはgeneration対象外。
+    assert result.facts_used == []
+    assert result.sources_used == []
+    assert result.llm_used is False
+
+
+# --- Full Ready: LLMが1回だけ呼ばれ、provenanceはmechanicalに導出される ---
+
+
+def test_full_ready_calls_llm_once_and_derives_provenance_mechanically(monkeypatch):
+    fake_client = _FakeLLMClient(content="明治天皇と昭憲皇太后をお祀りしています。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("明治神宮相当")
+    source = _create_source("公式サイト「明治神宮とは」")
+    deity1 = _create_deity(shrine, "明治天皇", sort_order=0)
+    deity2 = _create_deity(shrine, "昭憲皇太后", sort_order=1)
+    history = _create_history(shrine, "明治神宮の創建")
+    for fact in (deity1, deity2, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="この神社は誰を祀っていますか？"
+    )
+
+    assert len(fake_client.calls) == 1
+    assert result.llm_used is True
+    assert result.answer == "明治天皇と昭憲皇太后をお祀りしています。"
+    assert result.readiness == "full"
+    assert {f.id for f in result.facts_used} == {deity1.id, deity2.id}
+    assert all(f.type == "deity" for f in result.facts_used)
+    assert {s.id for s in result.sources_used} == {source.id}
+    assert result.limitations is None
+    assert result.unanswered_aspects == []
+
+
+def test_llm_output_is_not_parsed_for_provenance(monkeypatch):
+    """factsに言及していないLLM出力でも、facts_usedはretrieval結果のまま変わらない。"""
+    fake_client = _FakeLLMClient(content="（何も言及しない適当な文章）")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("provenance非依存神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.answer == "（何も言及しない適当な文章）"
+    assert {f.id for f in result.facts_used} == {deity.id}
+    assert {s.id for s in result.sources_used} == {source.id}
+
+
+# --- Limited: 取得できたFactのみ回答し、推測で埋めない ---
+
+
+def test_limited_shrine_prompt_marks_weakened_and_does_not_guess_missing_parts(monkeypatch):
+    fake_client = _FakeLLMClient(content="確認できる範囲でお答えします。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("給田六所神社相当")
+    source = _create_source("公式")
+    deity1 = _create_deity(shrine, "大国魂大神", confidence="medium")
+    deity2 = _create_deity(shrine, "天照皇大神", confidence="medium", sort_order=1)
+    history = _create_history(shrine, "神明社の合祀", confidence="medium", history_type="historical_event")
+    for fact in (deity1, deity2, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.readiness == "limited"
+    assert len(fake_client.calls) == 1
+    user_message = fake_client.calls[0][1]["content"]
+    # medium confidence → reason_strength="weakened"であることをpromptに明示する。
+    assert "weakened" in user_message
+    assert "assertive" not in user_message
+    assert {f.id for f in result.facts_used} == {deity1.id, deity2.id}
+    assert result.limitations is not None
+    assert "限られており" in result.limitations
+
+
+def test_full_ready_shrine_with_partial_facts_reports_unanswered_aspects(monkeypatch):
+    """Full Ready神社でも、対応するFactが無い質問typeはunanswered_aspectsへ残る。"""
+    fake_client = _FakeLLMClient(content="創建の経緯についてお答えします。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("複合質問神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    founding = _create_history(shrine, "創建の経緯", history_type="founding")
+    for fact in (deity, founding):
+        fact.sources.add(source)
+    # tradition種別のHistoryは無い。
+
+    result = generate_deep_dive_answer(
+        shrine_id=shrine.id,
+        question_text="なぜ創建されたのですか？また、どんな伝承がありますか？",
+    )
+
+    assert result.llm_used is True
+    assert {f.id for f in result.facts_used} == {founding.id}
+    assert result.unanswered_aspects == ["tradition"]
+
+
+# --- LLM Failure: Factを捏造せず、retrieval済み情報とfailure stateを安全に返す ---
+
+
+def test_llm_call_raises_returns_fixed_failure_message_with_retrieved_facts_preserved(
+    monkeypatch,
+):
+    fake_client = _FakeLLMClient(raise_exc=RuntimeError("network down"))
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("LLM失敗神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.llm_used is False
+    assert result.answer == "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
+    # facts_used/sources_usedはretrieval済みの安全な情報としてそのまま返す(捏造しない)。
+    assert {f.id for f in result.facts_used} == {deity.id}
+    assert {s.id for s in result.sources_used} == {source.id}
+
+
+def test_llm_disabled_by_feature_flag_returns_safe_fixed_message(settings):
+    settings.CONCIERGE_USE_LLM = False
+    shrine = _create_shrine("LLM無効神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.llm_used is False
+    assert result.answer == "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
+    assert {f.id for f in result.facts_used} == {deity.id}
+
+
+# --- Regression: PR #2450のRetrieval Foundationは変更しない ---
+
+
+def test_source_basis_followup_reuses_prior_facts_without_new_retrieval(monkeypatch):
+    fake_client = _FakeLLMClient(content="公式サイトの記載を根拠にしています。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("根拠質問神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    first = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+    assert first.facts_used
+
+    from temples.services.deep_dive_retrieval import build_deep_dive_context
+
+    first_context = build_deep_dive_context(
+        shrine_id=shrine.id, question_text="誰を祀っていますか？"
+    )
+    followup = generate_deep_dive_answer(
+        shrine_id=shrine.id,
+        question_text="その根拠は何ですか？",
+        prior_facts=first_context.facts,
+    )
+
+    assert followup.llm_used is True
+    assert {f.id for f in followup.facts_used} == {f.id for f in first_context.facts}
+    assert {s.id for s in followup.sources_used} == {source.id}


### PR DESCRIPTION
## Summary

Implements Backend-only LLM Answer Generation from [docs/product/deep-dive-answer-generation-contract.md](docs/product/deep-dive-answer-generation-contract.md) (PR #2449), building directly on [PR #2450](https://github.com/etsu33/jinja_app/pull/2450) (Retrieval Foundation, merged). Covers that doc's PR-B3 (LLM Payload + Closed-book generation, §6/§8 steps 6-7) and PR-B4 (Provenance + Output Contract, §9/§10).

## LLM is not a Knowledge Retriever

The only shrine-specific information ever passed to the LLM is the usable facts that `deep_dive_retrieval.build_deep_dive_context()` already retrieved and evidence-gated. The LLM never does DB lookup, fact/source selection, or readiness judgment — all of that remains exactly as PR #2450 left it, unmodified.

## Call Gate (safety-critical)

LLM is never constructed/called when:
- `readiness == "not_ready"`
- usable facts == 0 (including `confidence="low"` → `reason_strength="suppressed"` facts, which this layer filters out per §5 — retrieval intentionally does not filter by confidence)

Tests assert this with a stub that raises if the LLM client is ever constructed on these paths — not just "the LLM wasn't called," but "the LLM machinery was never touched."

## Changes

- **`temples/services/deep_dive_answer.py`** (new): `generate_deep_dive_answer()`, the single entry point.
  - Closed-book prompt: only evidence-gated facts (with `reason_strength`) are included; system prompt forbids fact fabrication, causal inference beyond what's stated, and general Shinto-knowledge mixing.
  - Provenance: `facts_used`/`sources_used` are derived mechanically from the retrieval context's fact/source sets — never parsed from LLM text output.
  - Failure handling: LLM disabled or erroring returns a fixed deterministic message with no fabricated fallback narrative, while still surfacing the real (mechanically-derived) `facts_used`/`sources_used` — retrieval info and failure state are both returned safely, never silently dropped.
  - Reuses the existing `temples.llm.client.LLMClient` / `settings.CONCIERGE_USE_LLM` feature-flag pattern (`concierge_chat_llm_route.py`) verbatim — no new LLM integration method or feature flag invented.
- **`temples/tests/services/test_deep_dive_answer.py`**: 11 tests — Call Gate (not_ready / zero-fact / unclassifiable / suppressed-confidence, all assert zero LLM construction), Full Ready generation with mechanical provenance, LLM output never parsed for `facts_used`, Limited wording constraints (weakened-only prompt, no guessing on missing facts), partial-fact `unanswered_aspects` on Full Ready shrines, LLM failure-safe fallback, LLM-disabled fallback, and `source_basis` follow-up reusing `prior_facts`.

## Out of scope (unchanged)

Frontend, Ranking, Recommendation Authority, Knowledge-to-Ranking connections, readiness spec, DB schema, migrations. PR #2450's Retrieval Foundation code and tests are untouched.

## Test plan

- [x] New `test_deep_dive_answer.py`: 11/11 passed.
- [x] PR #2450 regression (`test_deep_dive_retrieval.py`, `test_evidence_gate*.py`, `test_shrine_knowledge_selector.py`): 85/85 passed, unmodified.
- [x] Full backend suite: **1496 passed**, 13 pre-existing skips (GDAL/PostGIS unavailable locally, unrelated axis gating), 0 failures.
- [x] `python3 manage.py makemigrations --check --dry-run`: "No changes detected" — 0 migrations.
- [x] `ruff check`: clean.
- [x] Pre-push hook (web contract suite, unaffected by this backend-only change): 136 files / 915 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)