### PR TITLE
feat: implement Deep Dive API Contract (Thin API Boundary)

### DIFF
--- a/backend/shrine_project/settings.py
+++ b/backend/shrine_project/settings.py
@@ -293,6 +293,7 @@ REST_FRAMEWORK = {
 
         # feature scopes
         "concierge": "8/min",          # ← 仕様として固定
+        "deep_dive": "8/min",          # concierge同様、LLM呼び出しを伴うため保守的に固定
         "places": "30/min",
         "places-nearby": "30/min",
         "shrines": "60/min",

--- a/backend/temples/api/serializers/deep_dive.py
+++ b/backend/temples/api/serializers/deep_dive.py
@@ -1,0 +1,70 @@
+"""Deep Dive Ask API(PR-B5)のrequest/response serializer。
+
+docs/product/deep-dive-answer-generation-contract.md §11 API Responsibility。
+readiness判定・question classification・Fact取得・Evidence filtering・LLM
+payload構築・provenance決定はすべてBackend Authority
+(temples.services.deep_dive_answer.generate_deep_dive_answer())が行う。
+ここでは入力のvalidationと、既に確定した出力のstable public shapeへの
+変換のみを行う(Thin Boundary)。
+
+Clientからreadiness/facts/sources/confidence/verification_statusを受け取らない
+(これらはBackend Authorityであり、Clientが指定できるパラメータではない)。
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class DeepDiveAskRequestSerializer(serializers.Serializer):
+    """POST /api/deep-dive/ask/ のrequest body。shrine_id + questionのみを受け取る。"""
+
+    shrine_id = serializers.IntegerField(min_value=1)
+    # 空文字は許容する(classify_question()が"other"へ分類し、通常のunanswered
+    # 応答として処理される。分類できない入力を400にはしない、§12)。
+    question = serializers.CharField(
+        required=True, allow_blank=True, trim_whitespace=False, max_length=2000
+    )
+
+
+class DeepDiveFactUsedSerializer(serializers.Serializer):
+    """facts_used 1件。docs §9 Provenance Contract通り、mechanicalに導出済みの値のみ。"""
+
+    type = serializers.CharField()
+    id = serializers.IntegerField()
+    label = serializers.CharField()
+
+
+class DeepDiveSourceUsedSerializer(serializers.Serializer):
+    """sources_used 1件。stable public shapeのみ(内部note/管理用fieldは含まない)。"""
+
+    id = serializers.IntegerField()
+    title = serializers.CharField()
+    publisher = serializers.CharField()
+    source_type = serializers.CharField()
+    url = serializers.CharField()
+
+
+class DeepDiveAskResponseSerializer(serializers.Serializer):
+    """docs §10 Output Contract + question_type(§3の分類結果、そのままpass through)。
+
+    ドキュメンテーション用途(drf-spectacular schema)。Viewは
+    generate_deep_dive_answer()の戻り値からdictを直接組み立ててResponse()へ渡し、
+    このserializerでの再シリアライズは行わない(値の再解釈をしないため)。
+    """
+
+    answer = serializers.CharField()
+    readiness = serializers.ChoiceField(choices=["full", "limited", "not_ready"])
+    question_type = serializers.ListField(child=serializers.CharField())
+    facts_used = DeepDiveFactUsedSerializer(many=True)
+    sources_used = DeepDiveSourceUsedSerializer(many=True)
+    limitations = serializers.CharField(allow_null=True)
+    unanswered_aspects = serializers.ListField(child=serializers.CharField())
+
+
+__all__ = [
+    "DeepDiveAskRequestSerializer",
+    "DeepDiveFactUsedSerializer",
+    "DeepDiveSourceUsedSerializer",
+    "DeepDiveAskResponseSerializer",
+]

--- a/backend/temples/api/urls.py
+++ b/backend/temples/api/urls.py
@@ -48,6 +48,7 @@ from temples.api.views.reflection import ShrineReflectionCreateView, ShrineRefle
 from temples.api.views.shrine_interaction import ShrineInteractionLogCreateView
 from temples.api.views.action_event import ActionEventCreateView
 from temples.api.views.debug_behavior_funnel import DebugBehaviorFunnelView
+from temples.api.views.deep_dive import DeepDiveAskView
 from temples.api.views.score_v3_dashboard import ScoreV3DashboardView
 from temples.api_views import FavoriteViewSet
 
@@ -118,6 +119,7 @@ urlpatterns = [
     path("shrines/<int:pk>/", shrine_detail_view, name="shrine_detail"),
     path("shrines/<int:pk>/data/", shrine_detail_view, name="shrine_detail_data"),
     path("shrines/<int:pk>/meaning/", ShrineMeaningView.as_view(), name="shrine_meaning"),
+    path("deep-dive/ask/", DeepDiveAskView.as_view(), name="deep-dive-ask"),
     path("shrines/nearby/", NearestShrinesAPIView.as_view(), name="nearby"),
     path("shrines/<int:id>/visit/", VisitCreateView.as_view(), name="shrine-visit"),
     path("shrines/<int:pk>/reflection/", ShrineReflectionCreateView.as_view(), name="shrine-reflection-create"),

--- a/backend/temples/api/views/deep_dive.py
+++ b/backend/temples/api/views/deep_dive.py
@@ -1,0 +1,111 @@
+"""Deep Dive Ask API(PR-B5): Thin API Boundary。
+
+docs/product/deep-dive-answer-generation-contract.md §11 API Responsibilityの
+実装。readiness判定・question classification・Fact取得・Evidence filtering・
+LLM payload構築・provenance決定は一切ここで再実装しない。すべて
+temples.services.deep_dive_answer.generate_deep_dive_answer()に委譲し、この
+Viewはinput validationとHTTP status/shape変換のみを行う。
+
+HTTP Contract:
+  - shrine_idが未存在の神社 -> 404("shrine not found"、既存
+    ShrineMeaningView/ShrineReflectionCreateViewの規約と同一)。
+  - readiness="not_ready" -> 200(Knowledge不足という正常なProduct State。
+    エラーではない。既存ConciergeChatViewのquota超過時と同じ、200+status
+    fieldパターン)。
+  - Fact 0件(zero-fact short circuit) -> 200(同上、Product State)。
+  - LLM呼び出し失敗/未有効化 -> 200(generate_deep_dive_answer()が既に
+    fixed messageへdeterministicに縮退させている。API層で追加のerror
+    statusを割り当てない -- provider failureはこの機能の設計上、常に
+    安全なanswer状態として現れ、HTTP例外にならない)。
+  - request validation error(shrine_id欠如/型不正、question欠如、不正な
+    JSON body) -> 400(DRFの標準serializer validation / parser挙動)。
+  - 上記以外の予期しない例外 -> 500("detail"のみ、ShrineMeaningViewと同一
+    パターン)。
+"""
+
+from __future__ import annotations
+
+import logging
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from temples.api.serializers.deep_dive import (
+    DeepDiveAskRequestSerializer,
+    DeepDiveAskResponseSerializer,
+)
+from temples.models import Shrine
+from temples.services.deep_dive_answer import DeepDiveAnswer, generate_deep_dive_answer
+
+log = logging.getLogger(__name__)
+
+
+def _serialize_answer(result: DeepDiveAnswer) -> dict:
+    """generate_deep_dive_answer()の戻り値をstable public JSON shapeへ変換する。
+
+    値そのものの再解釈は行わない(型変換のみ): readiness/answer/question_type/
+    limitations/unanswered_aspectsはそのまま、facts_used/sources_usedは
+    frozen dataclassをdictへ変換するのみで、フィールドの追加・削除・意味変更は
+    行わない(facts_used/sources_usedは元々、内部専用field(verification_status/
+    confidence/content等)を持たないOutput Contract専用の型)。
+    """
+    return {
+        "answer": result.answer,
+        "readiness": result.readiness,
+        "question_type": list(result.question_type),
+        "facts_used": [
+            {"type": f.type, "id": f.id, "label": f.label} for f in result.facts_used
+        ],
+        "sources_used": [
+            {
+                "id": s.id,
+                "title": s.title,
+                "publisher": s.publisher,
+                "source_type": s.source_type,
+                "url": s.url,
+            }
+            for s in result.sources_used
+        ],
+        "limitations": result.limitations,
+        "unanswered_aspects": list(result.unanswered_aspects),
+    }
+
+
+class DeepDiveAskView(APIView):
+    """POST /api/deep-dive/ask/ -- shrine_id + question -> Deep Dive answer。"""
+
+    permission_classes = [AllowAny]
+    throttle_scope = "deep_dive"
+
+    @extend_schema(
+        request=DeepDiveAskRequestSerializer,
+        responses={200: DeepDiveAskResponseSerializer},
+        tags=["DeepDive"],
+        summary="Deep Dive answer generation",
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = DeepDiveAskRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        shrine_id = serializer.validated_data["shrine_id"]
+        question = serializer.validated_data["question"]
+
+        try:
+            shrine = Shrine.objects.get(pk=shrine_id)
+        except Shrine.DoesNotExist:
+            return Response({"detail": "shrine not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        try:
+            result = generate_deep_dive_answer(shrine_id=shrine.id, question_text=question)
+        except Exception:
+            log.exception("[deep_dive_ask] generate_deep_dive_answer raised unexpectedly")
+            return Response(
+                {"detail": "deep dive answer generation failed"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        return Response(_serialize_answer(result), status=status.HTTP_200_OK)
+
+
+__all__ = ["DeepDiveAskView"]

--- a/backend/temples/services/deep_dive_answer.py
+++ b/backend/temples/services/deep_dive_answer.py
@@ -69,10 +69,17 @@ class DeepDiveFactUsed:
 
 @dataclass(frozen=True)
 class DeepDiveAnswer:
-    """docs/product/deep-dive-answer-generation-contract.md §10 Output Contract。"""
+    """docs/product/deep-dive-answer-generation-contract.md §10 Output Contract。
+
+    question_typeは§10の元表には無いが、build_deep_dive_context()が既に
+    確定させているclassification結果であり、API層(PR-B5)がこれを再分類せずに
+    そのまま公開できるよう、ここでpass throughする(§3の分類結果そのもの、
+    複合質問の場合は複数要素を持つlist)。
+    """
 
     answer: str
     readiness: str
+    question_type: list[str]
     facts_used: list[DeepDiveFactUsed]
     sources_used: list[DeepDiveSource]
     limitations: Optional[str]
@@ -176,6 +183,7 @@ def _empty_answer(readiness: str, limitations: Optional[str]) -> DeepDiveAnswer:
     return DeepDiveAnswer(
         answer="",
         readiness=readiness,
+        question_type=[],
         facts_used=[],
         sources_used=[],
         limitations=limitations,
@@ -221,6 +229,7 @@ def generate_deep_dive_answer(
         return DeepDiveAnswer(
             answer="",
             readiness=context.readiness,
+            question_type=context.question_type,
             facts_used=[],
             sources_used=[],
             limitations=limitations,
@@ -240,6 +249,7 @@ def generate_deep_dive_answer(
         return DeepDiveAnswer(
             answer=_LLM_FAILURE_MESSAGE,
             readiness=context.readiness,
+            question_type=context.question_type,
             facts_used=facts_used,
             sources_used=sources_used,
             limitations=context.limitations,
@@ -250,6 +260,7 @@ def generate_deep_dive_answer(
     return DeepDiveAnswer(
         answer=answer_text,
         readiness=context.readiness,
+        question_type=context.question_type,
         facts_used=facts_used,
         sources_used=sources_used,
         limitations=context.limitations,

--- a/backend/temples/tests/api/test_deep_dive_ask_api.py
+++ b/backend/temples/tests/api/test_deep_dive_ask_api.py
@@ -1,0 +1,334 @@
+"""Deep Dive Ask API(PR-B5、Thin API Boundary)のcontract test。
+
+docs/product/deep-dive-answer-generation-contract.md §11 API Responsibility。
+Backend Authority(readiness判定・question classification・Fact取得・Evidence
+filtering・LLM payload構築・provenance決定)がView内で再実装されていないこと、
+Not Ready/Fact 0件でLLMが呼ばれないこと、internal field(verification_status/
+confidence/reason_strength/content)が公開されないことを検証する。
+実LLM(openai SDK)は一切呼び出さない。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from django.utils import timezone
+
+from temples.models import Shrine, ShrineDeity, ShrineHistory, ShrineKnowledgeSource
+from temples.services import deep_dive_answer
+
+pytestmark = pytest.mark.django_db
+
+URL = "/api/deep-dive/ask/"
+
+
+def _create_shrine(name: str) -> Shrine:
+    return Shrine.objects.create(
+        name_jp=name,
+        address="東京都千代田区1-2-3",
+        latitude=35.6812,
+        longitude=139.7671,
+    )
+
+
+def _create_source(
+    title: str, verification_status: str = "source_confirmed", **kwargs
+) -> ShrineKnowledgeSource:
+    defaults = dict(
+        source_type="shrine_official",
+        title=title,
+        publisher="神社公式",
+        url="https://example.com/",
+        verification_status=verification_status,
+    )
+    if verification_status in ("source_confirmed", "reviewed"):
+        defaults["verified_at"] = timezone.now()
+    defaults.update(kwargs)
+    return ShrineKnowledgeSource.objects.create(**defaults)
+
+
+def _create_deity(shrine: Shrine, display_name: str, sort_order: int = 0, **kwargs) -> ShrineDeity:
+    defaults = dict(
+        display_name=display_name,
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineDeity.objects.create(shrine=shrine, **defaults)
+
+
+def _create_history(shrine: Shrine, title: str, sort_order: int = 0, **kwargs) -> ShrineHistory:
+    defaults = dict(
+        history_type="founding",
+        title=title,
+        content="内容の本文",
+        verification_status="source_confirmed",
+        confidence="high",
+        sort_order=sort_order,
+        verified_at=timezone.now(),
+    )
+    defaults.update(kwargs)
+    return ShrineHistory.objects.create(shrine=shrine, **defaults)
+
+
+def _make_full_ready_shrine(name: str = "フルレディ神社") -> Shrine:
+    shrine = _create_shrine(name)
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+    return shrine
+
+
+def _boom(*args, **kwargs):
+    raise AssertionError("LLM must not be constructed/called on this path")
+
+
+class _FakeLLMClient:
+    def __init__(self, content=None, raise_exc: Exception | None = None):
+        self._client = object()
+        self._mode = "chat"
+        self._content = content
+        self._raise_exc = raise_exc
+        self.calls: list[list[dict]] = []
+
+    def chat(self, messages):
+        self.calls.append(messages)
+        if self._raise_exc is not None:
+            raise self._raise_exc
+        return {"role": "assistant", "content": self._content}
+
+
+def _post(client, body):
+    return client.post(URL, data=json.dumps(body), content_type="application/json")
+
+
+# --- 1. Full Ready ---
+
+
+def test_1_full_ready_returns_200_with_answer_and_provenance(client, monkeypatch):
+    fake_client = _FakeLLMClient(content="この神社の神様についてお答えします。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _make_full_ready_shrine("明治神宮相当")
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["readiness"] == "full"
+    assert body["answer"] == "この神社の神様についてお答えします。"
+    assert body["question_type"] == ["deity_who"]
+    assert len(body["facts_used"]) == 1
+    assert body["facts_used"][0]["type"] == "deity"
+    assert len(body["sources_used"]) == 1
+    assert body["limitations"] is None
+    assert body["unanswered_aspects"] == []
+
+
+# --- 2. Limited ---
+
+
+def test_2_limited_shrine_returns_200_with_limited_readiness(client, monkeypatch):
+    fake_client = _FakeLLMClient(content="確認できる範囲でお答えします。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("給田六所神社相当")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "大国魂大神", confidence="medium")
+    history = _create_history(shrine, "由緒", confidence="medium")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["readiness"] == "limited"
+    assert body["limitations"] is not None
+    assert len(body["facts_used"]) == 1
+
+
+# --- 3. Not Ready ---
+
+
+def test_3_not_ready_shrine_returns_200_not_an_error(client, monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("由緒未確認神社")
+    # ShrineDeity/ShrineHistoryを一切作らない → not_ready。
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    # Not Readyはエラーではなく正常なProduct State(Knowledge不足) -> 200。
+    assert res.status_code == 200
+    body = res.json()
+    assert body["readiness"] == "not_ready"
+    assert body["answer"] == ""
+    assert body["facts_used"] == []
+    assert body["sources_used"] == []
+    assert body["limitations"] is not None
+
+
+# --- 4. Zero Fact ---
+
+
+def test_4_zero_fact_short_circuit_returns_200_with_unanswered_aspects(client, monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("伝承なし神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    founding = _create_history(shrine, "創建の経緯", history_type="founding")
+    for fact in (deity, founding):
+        fact.sources.add(source)
+    # tradition種別のHistoryは無い。
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "どんな伝承がありますか？"})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["facts_used"] == []
+    assert body["unanswered_aspects"] == ["tradition"]
+    assert body["limitations"] is not None
+
+
+# --- 5. Invalid Shrine ---
+
+
+def test_5_invalid_shrine_id_returns_404(client):
+    res = _post(client, {"shrine_id": 999999, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 404
+    assert "detail" in res.json()
+
+
+# --- 6. Empty Question ---
+
+
+def test_6_empty_question_is_not_a_validation_error(client, monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _make_full_ready_shrine("空質問神社")
+
+    res = _post(client, {"shrine_id": shrine.id, "question": ""})
+
+    # 空文字は分類不能("other")として正常に処理される。バリデーションエラーにしない。
+    assert res.status_code == 200
+    body = res.json()
+    assert body["question_type"] == ["other"]
+    assert body["facts_used"] == []
+
+
+# --- 7. Malformed Request ---
+
+
+def test_7_missing_required_fields_returns_400(client):
+    res = client.post(URL, data=json.dumps({}), content_type="application/json")
+
+    assert res.status_code == 400
+    body = res.json()
+    assert "shrine_id" in body
+    assert "question" in body
+
+
+def test_7b_wrong_type_shrine_id_returns_400(client):
+    res = _post(client, {"shrine_id": "not-a-number", "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 400
+    assert "shrine_id" in res.json()
+
+
+def test_7c_malformed_json_body_returns_400(client):
+    res = client.post(URL, data="{not valid json", content_type="application/json")
+
+    assert res.status_code == 400
+
+
+# --- 8. LLM Failure ---
+
+
+def test_8_llm_failure_returns_200_with_fixed_message_and_retrieved_facts(client, monkeypatch):
+    fake_client = _FakeLLMClient(raise_exc=RuntimeError("network down"))
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _make_full_ready_shrine("LLM失敗神社")
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 200
+    body = res.json()
+    assert body["answer"] == "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
+    # LLMが失敗しても、retrieval済みの安全なfacts_used/sources_usedはそのまま返る。
+    assert len(body["facts_used"]) == 1
+    assert len(body["sources_used"]) == 1
+
+
+# --- 9. Provenance一致 ---
+
+
+def test_9_provenance_matches_service_output_exactly(client, monkeypatch):
+    fake_client = _FakeLLMClient(content="回答本文。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("Provenance検証神社")
+    source_a = _create_source("Source A")
+    source_b = _create_source("Source B")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source_a, source_b)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source_a)
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 200
+    body = res.json()
+
+    expected = deep_dive_answer.generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="誰を祀っていますか？"
+    )
+    assert {f["id"] for f in body["facts_used"]} == {f.id for f in expected.facts_used}
+    assert {f["type"] for f in body["facts_used"]} == {f.type for f in expected.facts_used}
+    assert {s["id"] for s in body["sources_used"]} == {s.id for s in expected.sources_used}
+    assert {s["id"] for s in body["sources_used"]} == {source_a.id, source_b.id}
+
+
+# --- 10. Internal Fields非公開 ---
+
+
+def test_10_internal_fields_are_never_exposed(client, monkeypatch):
+    fake_client = _FakeLLMClient(content="回答本文。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _make_full_ready_shrine("内部field検証神社")
+
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 200
+    raw_text = res.content.decode("utf-8")
+    for internal_field in (
+        "verification_status",
+        "confidence",
+        "reason_strength",
+        "content",
+        "source_ids",
+        "llm_used",
+    ):
+        assert internal_field not in raw_text, f"{internal_field} leaked into API response"
+
+
+# --- 11. Not Ready LLM Call 0 (API経由でのCall Gate検証) ---
+
+
+def test_11_not_ready_never_constructs_llm_client_via_api(client, monkeypatch):
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", _boom)
+    shrine = _create_shrine("Not Ready LLM検証神社")
+    # ShrineDeity/ShrineHistoryを一切作らない → not_ready。
+
+    # _boomはLLMClient()が呼ばれた瞬間にAssertionErrorを送出する。例外なく
+    # 200が返ることが、API経由でもLLMが一切構築されないことの証明になる。
+    res = _post(client, {"shrine_id": shrine.id, "question": "誰を祀っていますか？"})
+
+    assert res.status_code == 200
+    assert res.json()["readiness"] == "not_ready"

--- a/backend/temples/tests/test_api_style.py
+++ b/backend/temples/tests/test_api_style.py
@@ -54,6 +54,7 @@ def test_openapi_conventions(client: APIClient):
             "/api/public/shrines/{id}/",
             "/api/debug/behavior-funnel/",
             "/api/concierge/score-v3/dashboard/",
+            "/api/deep-dive/ask/",
         }
         if p not in exceptions and not pluralish.search(p):
             violations.append(f"[plural] {p}")

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -19,6 +19,8 @@ tags:
     description: 経路検索（距離・時間・ポリライン）
   - name: ScoreV3Admin
     description: Score v3 観測・判定ダッシュボード（IsAdminUser 専用）
+  - name: DeepDive
+    description: Deep Dive 回答生成（Verified Knowledge Factのみを根拠にしたLLM回答）
 
 paths:
   /api/populars/:
@@ -239,6 +241,37 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DirectionsResponse"
+
+  /api/deep-dive/ask/:
+    post:
+      summary: Deep Dive 回答生成
+      description: >
+        shrine_id + question を受け取り、Verified Knowledge Factのみを根拠にした
+        回答を返す。readiness判定・Fact取得・Evidence filtering・LLM呼び出しは
+        すべてBackendが行う（Client側はreadiness/facts/sources/confidence/
+        verification_statusのいずれも指定できない）。readiness="not_ready"や
+        該当Factが0件の場合もHTTP 200で返る（Knowledge不足という正常な
+        Product Stateであり、エラーではない）。
+      tags: [DeepDive]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeepDiveAskRequest"
+      responses:
+        "200":
+          description: OK（readiness="not_ready"／Fact 0件の場合も200で返る）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeepDiveAskResponse"
+        "400":
+          description: Validation Error — shrine_id/questionが不正
+        "404":
+          description: Not Found — 指定されたshrine_idの神社が存在しない
+        "500":
+          description: Internal Server Error — 予期しない内部エラー
 
 
 components:
@@ -886,3 +919,83 @@ components:
             $ref: "#/components/schemas/ConciergePlanStop"
         data:
           $ref: "#/components/schemas/ConciergePlanData"
+
+    DeepDiveAskRequest:
+      type: object
+      required: [shrine_id, question]
+      properties:
+        shrine_id:
+          type: integer
+          minimum: 1
+          description: "対象神社のID"
+        question:
+          type: string
+          maxLength: 2000
+          description: >
+            自由文の質問。空文字も許容する（分類できない入力として
+            unanswered_aspects で正常に返る。エラーにはならない）。
+
+    DeepDiveFactUsed:
+      type: object
+      required: [type, id, label]
+      properties:
+        type:
+          type: string
+          enum: [deity, history]
+        id:
+          type: integer
+        label:
+          type: string
+
+    DeepDiveSourceUsed:
+      type: object
+      required: [id, title, publisher, source_type, url]
+      properties:
+        id:
+          type: integer
+        title:
+          type: string
+        publisher:
+          type: string
+        source_type:
+          type: string
+        url:
+          type: string
+
+    DeepDiveAskResponse:
+      type: object
+      required:
+        [
+          answer,
+          readiness,
+          question_type,
+          facts_used,
+          sources_used,
+          limitations,
+          unanswered_aspects,
+        ]
+      properties:
+        answer:
+          type: string
+        readiness:
+          type: string
+          enum: [full, limited, not_ready]
+        question_type:
+          type: array
+          items:
+            type: string
+        facts_used:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeepDiveFactUsed"
+        sources_used:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeepDiveSourceUsed"
+        limitations:
+          type: string
+          nullable: true
+        unanswered_aspects:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## Summary

Implements the Thin API Boundary from [docs/product/deep-dive-answer-generation-contract.md](docs/product/deep-dive-answer-generation-contract.md) §11 API Responsibility, connecting [PR #2450](https://github.com/etsu33/jinja_app/pull/2450) (Retrieval Foundation) / [PR #2451](https://github.com/etsu33/jinja_app/pull/2451) (Answer Generation) to a Frontend-safe endpoint. Covers PR-B5 (API endpoint integration) from that doc's PR split. **Frontend is unchanged.**

## API View is not an Authority Layer

Readiness judgment, question classification, fact retrieval, evidence filtering, LLM payload construction, and provenance decision are never reimplemented in the view. The view is a thin wrapper around `generate_deep_dive_answer()` — input validation in, HTTP status/shape mapping out, nothing else.

## Changes

- **`temples/services/deep_dive_answer.py`**: added `question_type` to `DeepDiveAnswer` — a pass-through of `build_deep_dive_context()`'s already-computed classification, needed so the API can expose it without a second retrieval call or re-classifying in the view. Purely additive; all four construction sites updated; no existing test in this file touched.
- **`temples/api/serializers/deep_dive.py`** (new): `DeepDiveAskRequestSerializer` (`shrine_id`, `question` only — rejects `readiness`/`facts`/`sources`/`confidence`/`verification_status`, since those are Backend Authority) and response serializers used for drf-spectacular documentation only (the view builds the response dict by hand from the service's dataclasses, so service output is never reinterpreted).
- **`temples/api/views/deep_dive.py`** (new): `DeepDiveAskView`, `POST /api/deep-dive/ask/`. HTTP contract, researched against existing view conventions (`ShrineMeaningView`, `ShrineReflectionCreateView`, `ConciergeChatView`) before deciding:
  - **404** on nonexistent `shrine_id`.
  - **`readiness="not_ready"` and Fact=0 both return 200** — Knowledge insufficiency is a normal product state, not an error, matching `ConciergeChatView`'s existing quota-exceeded 200+status-field precedent.
  - **LLM failure/disabled also returns 200**: `generate_deep_dive_answer()` already degrades this to a fixed deterministic message internally, so it never surfaces as an HTTP-level error.
  - **400** on validation errors (missing/malformed `shrine_id`/`question`, unparseable JSON) via DRF's standard behavior.
  - **500** only for genuinely unexpected exceptions (`ShrineMeaningView` pattern).
  - `facts_used`/`sources_used` are serialized straight from `DeepDiveFactUsed`/`DeepDiveSource`, which already carry only the stable public shape (no `verification_status`/`confidence`/`content`/`reason_strength`).
- **`temples/api/urls.py`**: registers the new endpoint.
- **`shrine_project/settings.py`**: adds `"deep_dive": "8/min"` throttle scope (same conservative rate as `"concierge"`, since both trigger LLM calls).
- **`temples/tests/test_api_style.py`**: adds `/api/deep-dive/ask/` to the existing non-plural-endpoint exceptions list (same precedent as `/api/concierge/plan/`, `/api/concierge/chat/`).
- **`docs/openapi.yaml`**: hand-written entry plus `DeepDiveAskRequest`/`DeepDiveAskResponse`/`DeepDiveFactUsed`/`DeepDiveSourceUsed` schemas, matching this repo's existing hand-maintained-doc convention.
- **`temples/tests/api/test_deep_dive_ask_api.py`** (new): the 11 required scenarios (13 tests) — Full Ready, Limited, Not Ready (200, not an error), zero-fact, invalid shrine (404), empty question (200, not a validation error), malformed request (missing fields / wrong type / broken JSON, all 400), LLM failure (200 with fixed message, retrieved facts preserved), provenance exactly matching a direct `generate_deep_dive_answer()` call, internal fields never appearing in the response body, and Not Ready never constructing an LLM client end-to-end through the API (a raising stub proves zero LLM construction, not just zero calls).

## Out of scope (unchanged)

Frontend, Ranking, Recommendation Authority, Knowledge-to-Ranking connections, readiness spec, DB schema, migrations. PR #2450/#2451's existing tests are untouched.

## Test plan

- [x] New `test_deep_dive_ask_api.py`: 13/13 passed (11 required scenarios).
- [x] Full backend suite: **1509 passed**, 13 pre-existing skips, 0 failures.
- [x] `python3 manage.py makemigrations --check --dry-run`: "No changes detected" — 0 migrations.
- [x] `pnpm lint:openapi` (Spectral): clean.
- [x] Pre-push hook (web contract suite, unaffected by this backend-only change): 136 files / 915 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)