### PR TITLE
feat: implement Deep Dive Frontend MVP

### DIFF
--- a/apps/web/src/app/api/deep-dive/ask/__tests__/route.test.ts
+++ b/apps/web/src/app/api/deep-dive/ask/__tests__/route.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const djFetchMock = vi.fn();
+
+vi.mock("@/lib/server/backend", () => ({
+  djFetch: (...args: unknown[]) => djFetchMock(...args),
+}));
+
+import { POST } from "../route";
+
+function makeReq(body: unknown) {
+  return new NextRequest("http://localhost/api/deep-dive/ask/", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("/api/deep-dive/ask BFF contract", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upstream 200(Full)をそのまま透過する", async () => {
+    const upstreamBody = {
+      answer: "回答本文。",
+      readiness: "full",
+      question_type: ["deity_who"],
+      facts_used: [],
+      sources_used: [],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+    djFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(upstreamBody), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await POST(makeReq({ shrine_id: 1, question: "誰を祀っていますか？" }));
+
+    expect(djFetchMock).toHaveBeenCalledTimes(1);
+    const [, path, init] = djFetchMock.mock.calls[0];
+    expect(path).toBe("/api/deep-dive/ask/");
+    expect(init).toMatchObject({ method: "POST", forwardAuth: false });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(upstreamBody);
+  });
+
+  it("upstream 200(not_ready)もそのまま200として透過する(errorに変換しない)", async () => {
+    const upstreamBody = {
+      answer: "",
+      readiness: "not_ready",
+      question_type: [],
+      facts_used: [],
+      sources_used: [],
+      limitations: "この神社については、根拠付きで詳しくお答えできる情報がまだ十分ではありません。",
+      unanswered_aspects: [],
+    };
+    djFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(upstreamBody), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await POST(makeReq({ shrine_id: 58, question: "誰を祀っていますか？" }));
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual(upstreamBody);
+  });
+
+  it("upstream 400はstatusをそのまま透過する", async () => {
+    djFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ question: ["This field is required."] }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await POST(makeReq({ shrine_id: 1 }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it("upstream 404はstatusをそのまま透過する", async () => {
+    djFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "shrine not found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await POST(makeReq({ shrine_id: 999999, question: "質問" }));
+
+    expect(res.status).toBe(404);
+  });
+
+  it("upstream 500はstatusをそのまま透過する", async () => {
+    djFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: "internal error" }), {
+        status: 500,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const res = await POST(makeReq({ shrine_id: 1, question: "質問" }));
+
+    expect(res.status).toBe(500);
+  });
+
+  it("djFetch自体が例外を投げた場合(network失敗)は502を返す", async () => {
+    djFetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const res = await POST(makeReq({ shrine_id: 1, question: "質問" }));
+
+    expect(res.status).toBe(502);
+  });
+});

--- a/apps/web/src/app/api/deep-dive/ask/route.ts
+++ b/apps/web/src/app/api/deep-dive/ask/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from "next/server";
+import { djFetch } from "@/lib/server/backend";
+
+// POST /api/deep-dive/ask/ -> Django POST /api/deep-dive/ask/ (AllowAny, no auth to forward).
+//
+// Thin proxy: upstream's HTTP status is passed through unchanged (400/404/200/500),
+// so the Frontend can distinguish input error / shrine not found / normal product
+// state (readiness="not_ready" is still HTTP 200) from an actual system failure.
+// No response body reinterpretation happens here.
+
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const payload = await req.text();
+  const contentType = req.headers.get("content-type") ?? "application/json";
+
+  let upstream: Response;
+  try {
+    upstream = await djFetch(req, "/api/deep-dive/ask/", {
+      method: "POST",
+      forwardAuth: false,
+      headers: { "content-type": contentType },
+      body: payload,
+    });
+  } catch {
+    return NextResponse.json({ detail: "upstream unreachable" }, { status: 502 });
+  }
+
+  const body = await upstream.text();
+  const ct = upstream.headers.get("content-type") || "application/json";
+
+  return new NextResponse(body, {
+    status: upstream.status,
+    headers: { "content-type": ct },
+  });
+}

--- a/apps/web/src/components/shrine/detail/ShrineDeepDivePrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDeepDivePrompt.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+
+import { askDeepDive, type DeepDiveAnswer, type DeepDiveAskError } from "@/lib/api/deepDive";
+
+type Props = {
+  shrineId: number;
+};
+
+type ErrorKind = "validation" | "not_found" | "system";
+
+const QUESTION_MAX_LENGTH = 2000;
+
+// docs/product/deep-dive-answer-generation-contract.md §11 API Responsibility:
+// Frontendはreadiness/question_type/Fact選択/Source選択/confidence/verificationの
+// いずれも判断しない。ここではBackend response(DeepDiveAnswer)をそのまま表示するのみ。
+
+function DeepDiveSourceList({ sources }: { sources: DeepDiveAnswer["sources_used"] }) {
+  if (sources.length === 0) return null;
+
+  return (
+    <div className="mt-3">
+      <p className="text-xs font-semibold text-[var(--kt-color-text-muted)]">出典</p>
+      <ul className="mt-1 space-y-2">
+        {sources.map((source) => (
+          <li
+            key={source.id}
+            className="rounded-[var(--kt-radius-panel)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-background-subtle)] p-2"
+          >
+            <p className="text-sm font-semibold text-[var(--kt-color-text-primary)] break-words">{source.title}</p>
+            <p className="mt-0.5 text-xs text-[var(--kt-color-text-muted)] break-words">
+              {[source.publisher, source.source_type].filter(Boolean).join(" ・ ")}
+            </p>
+            {source.url ? (
+              <a
+                href={source.url}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="mt-0.5 block break-all text-xs text-sky-700 underline"
+              >
+                {source.url}
+              </a>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function DeepDiveUnansweredAspects({ aspects }: { aspects: string[] }) {
+  if (aspects.length === 0) return null;
+
+  return (
+    <p className="mt-2 text-xs leading-5 text-[var(--kt-color-text-muted)]">
+      回答できなかった内容: {aspects.join(" / ")}
+    </p>
+  );
+}
+
+function DeepDiveResultView({ result }: { result: DeepDiveAnswer }) {
+  if (result.readiness === "not_ready") {
+    // Not Readyは正常なProduct State(Knowledge不足)。errorではないため、
+    // 赤/枠付きにせず、控えめなslateテキストで理由を表示するのみ。
+    return <p className="mt-3 text-xs leading-5 text-slate-400">{result.limitations}</p>;
+  }
+
+  return (
+    <div className="mt-3 rounded-[var(--kt-radius-panel)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-3">
+      <p className="whitespace-pre-wrap break-words text-sm leading-6 text-[var(--kt-color-text-primary)]">
+        {result.answer}
+      </p>
+
+      {result.readiness === "limited" && result.limitations ? (
+        <p className="mt-2 text-xs leading-5 text-slate-500">{result.limitations}</p>
+      ) : null}
+
+      <DeepDiveUnansweredAspects aspects={result.unanswered_aspects} />
+      <DeepDiveSourceList sources={result.sources_used} />
+    </div>
+  );
+}
+
+const ERROR_MESSAGES: Record<ErrorKind, string> = {
+  validation: "質問の内容を確認してください。",
+  not_found: "神社情報を取得できませんでした。",
+  system: "通信に失敗しました。時間をおいて再度お試しください。",
+};
+
+export function ShrineDeepDivePrompt({ shrineId }: Props) {
+  const [question, setQuestion] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<DeepDiveAnswer | null>(null);
+  const [errorKind, setErrorKind] = useState<ErrorKind | null>(null);
+
+  const trimmedQuestion = question.trim();
+  // 空質問はAPI自体は正常に処理できるが(unclassifiable -> unanswered応答)、
+  // 不要なnetwork requestを避けるためFrontend側でのみ送信を止める
+  // (Backend Authority変更ではない、UX上のvalidationのみ)。
+  const canSubmit = trimmedQuestion.length > 0 && !submitting;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+
+    setSubmitting(true);
+    setErrorKind(null);
+
+    try {
+      const response = await askDeepDive(shrineId, trimmedQuestion);
+      setResult(response);
+    } catch (err) {
+      const status = (err as DeepDiveAskError)?.status;
+      if (status === 400) {
+        setErrorKind("validation");
+      } else if (status === 404) {
+        setErrorKind("not_found");
+      } else {
+        setErrorKind("system");
+      }
+      setResult(null);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-[var(--kt-radius-card)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] p-4">
+      <h2 className="text-base font-semibold text-[var(--kt-color-text-primary)]">この神社について質問する</h2>
+      <p className="mt-1 text-xs leading-5 text-[var(--kt-color-text-muted)]">
+        確認できている情報の範囲でお答えします。
+      </p>
+
+      <input
+        type="text"
+        value={question}
+        onChange={(event) => setQuestion(event.target.value)}
+        maxLength={QUESTION_MAX_LENGTH}
+        placeholder="例：誰を祀っていますか？ / なぜ創建されたのですか？"
+        className="mt-3 w-full rounded-[var(--kt-radius-panel)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-400 focus:border-[var(--kt-color-border-focus)]"
+      />
+
+      <button
+        type="button"
+        disabled={!canSubmit}
+        onClick={handleSubmit}
+        className="mt-3 w-full rounded-2xl bg-[var(--kt-color-text-primary)] px-4 py-2 text-sm font-semibold text-white disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {submitting ? "回答を生成中..." : "質問する"}
+      </button>
+
+      {errorKind ? <p className="mt-3 text-xs font-semibold text-rose-700">{ERROR_MESSAGES[errorKind]}</p> : null}
+
+      {!errorKind && result ? <DeepDiveResultView result={result} /> : null}
+    </section>
+  );
+}
+
+export default ShrineDeepDivePrompt;

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -69,6 +69,7 @@ import { addVisit, getVisits, type Visit } from "@/lib/api/visits";
 
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { ShrineReflectionPrompt } from "@/components/shrine/detail/ShrineReflectionPrompt";
+import { ShrineDeepDivePrompt } from "@/components/shrine/detail/ShrineDeepDivePrompt";
 import {
   recommendationAnalyticsProperties,
   type RecommendationAnalyticsProvenance,
@@ -676,6 +677,12 @@ export default function ShrineDetailArticle({
       {/* 神社Fact（祭神・由緒・歴史）。Interpretation/Recommendation/Actionとは独立した表示責務。
           Premium gatingの対象にせず、Knowledge未登録（deities/historiesとも空）ならnullで非表示。 */}
       {factSection ? <ShrineFactSection section={factSection} /> : null}
+
+      {/* Deep Dive Q&A。readiness/Fact選択/Source選択はすべてBackend Authority
+          (POST /api/deep-dive/ask/)。Frontend側でreadinessを先読みして表示可否を
+          判断しない(質問してみるまでnot_readyかどうかは分からない扱いにする)ため、
+          factSectionの有無に関わらず常に表示する。 */}
+      <ShrineDeepDivePrompt shrineId={cardProps.shrineId} />
 
       {resolvedSaveActionNode ? (
         <section className="pt-4">

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDeepDivePrompt.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDeepDivePrompt.test.tsx
@@ -1,0 +1,288 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ShrineDeepDivePrompt } from "../ShrineDeepDivePrompt";
+import { askDeepDive, type DeepDiveAnswer, type DeepDiveAskError } from "@/lib/api/deepDive";
+
+vi.mock("@/lib/api/deepDive", () => ({
+  askDeepDive: vi.fn(),
+}));
+
+const mockedAskDeepDive = vi.mocked(askDeepDive);
+
+function ask(text: string) {
+  fireEvent.change(screen.getByPlaceholderText(/誰を祀っていますか/), { target: { value: text } });
+  fireEvent.click(screen.getByRole("button", { name: /質問する/ }));
+}
+
+function makeError(status: number): DeepDiveAskError {
+  const error = new Error("deep_dive_ask_failed") as DeepDiveAskError;
+  error.status = status;
+  return error;
+}
+
+describe("ShrineDeepDivePrompt", () => {
+  beforeEach(() => {
+    mockedAskDeepDive.mockReset();
+  });
+
+  // --- 1. 明治神宮 deity ---
+  it("1. Full readiness(deity_who)でanswer/sourcesを表示する", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "明治天皇と昭憲皇太后をお祀りしています。",
+      readiness: "full",
+      question_type: ["deity_who"],
+      facts_used: [{ type: "deity", id: 1, label: "明治天皇" }],
+      sources_used: [
+        {
+          id: 1,
+          title: "公式サイト「明治神宮とは」",
+          publisher: "明治神宮",
+          source_type: "shrine_official",
+          url: "https://example.com/about",
+        },
+      ],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("誰を祀っていますか？");
+
+    expect(await screen.findByText("明治天皇と昭憲皇太后をお祀りしています。")).toBeInTheDocument();
+    expect(screen.getByText("公式サイト「明治神宮とは」")).toBeInTheDocument();
+    expect(mockedAskDeepDive).toHaveBeenCalledWith(1, "誰を祀っていますか？");
+  });
+
+  // --- 2. Full history ---
+  it("2. Full readiness(founding)でanswer/sourcesを表示する", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "創建の経緯についてお答えします。",
+      readiness: "full",
+      question_type: ["founding"],
+      facts_used: [{ type: "history", id: 2, label: "創建の経緯" }],
+      sources_used: [
+        { id: 2, title: "由緒書", publisher: "神社本庁", source_type: "official_record", url: "https://example.com/history" },
+      ],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={4} />);
+    ask("なぜ創建されたのですか？");
+
+    expect(await screen.findByText("創建の経緯についてお答えします。")).toBeInTheDocument();
+    expect(screen.getByText("由緒書")).toBeInTheDocument();
+  });
+
+  // --- 3. Full tradition ---
+  it("3. Full readiness(tradition)でanswer/sourcesを表示する", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "こう伝わっています。",
+      readiness: "full",
+      question_type: ["tradition"],
+      facts_used: [{ type: "history", id: 3, label: "言い伝え" }],
+      sources_used: [
+        { id: 3, title: "地域史料", publisher: "郷土資料館", source_type: "local_record", url: "https://example.com/tradition" },
+      ],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={7} />);
+    ask("どんな伝承がありますか？");
+
+    expect(await screen.findByText("こう伝わっています。")).toBeInTheDocument();
+    expect(screen.getByText("地域史料")).toBeInTheDocument();
+  });
+
+  // --- 4. Limited ---
+  it("4. Limited readinessはerror扱いにせず、answer + limitationsを表示する", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "確認できる範囲でお答えします。",
+      readiness: "limited",
+      question_type: ["deity_who"],
+      facts_used: [{ type: "deity", id: 5, label: "大国魂大神" }],
+      sources_used: [{ id: 5, title: "公式", publisher: "神社", source_type: "shrine_official", url: "https://example.com" }],
+      limitations: "この神社について確認できる資料は限られており、確認できる範囲でお答えしています。",
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={22} />);
+    ask("誰を祀っていますか？");
+
+    expect(await screen.findByText("確認できる範囲でお答えします。")).toBeInTheDocument();
+    const limitationsNode = await screen.findByText(
+      "この神社について確認できる資料は限られており、確認できる範囲でお答えしています。",
+    );
+    expect(limitationsNode.className).not.toContain("rose");
+  });
+
+  // --- 5. Not Ready ---
+  it("5. Not Readyはerror alertにせず、静かなslate文言で理由を表示する", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "",
+      readiness: "not_ready",
+      question_type: [],
+      facts_used: [],
+      sources_used: [],
+      limitations: "この神社については、根拠付きで詳しくお答えできる情報がまだ十分ではありません。",
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={58} />);
+    ask("誰を祀っていますか？");
+
+    const message = await screen.findByText(
+      "この神社については、根拠付きで詳しくお答えできる情報がまだ十分ではありません。",
+    );
+    expect(message.className).toContain("slate-400");
+    expect(message.className).not.toContain("rose");
+    expect(message.className).not.toContain("border");
+  });
+
+  // --- 6. Source複数 ---
+  it("6. 複数Sourceを表示し、internal fieldは表示しない", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "回答本文。",
+      readiness: "full",
+      question_type: ["deity_who"],
+      facts_used: [],
+      sources_used: [
+        { id: 1, title: "Source A", publisher: "publisher A", source_type: "shrine_official", url: "https://a.example.com" },
+        { id: 2, title: "Source B", publisher: "publisher B", source_type: "academic", url: "https://b.example.com" },
+      ],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("誰を祀っていますか？");
+
+    expect(await screen.findByText("Source A")).toBeInTheDocument();
+    expect(screen.getByText("Source B")).toBeInTheDocument();
+    expect(screen.getByText("https://a.example.com")).toBeInTheDocument();
+    expect(screen.getByText("https://b.example.com")).toBeInTheDocument();
+
+    const container = screen.getByText("回答本文。").closest("div");
+    expect(container?.textContent).not.toMatch(/verification_status|confidence|reason_strength/);
+  });
+
+  // --- 7. unanswered_aspects ---
+  it("7. unanswered_aspectsがある場合はその内容を表示する", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "創建の経緯についてお答えします。",
+      readiness: "full",
+      question_type: ["founding", "tradition"],
+      facts_used: [{ type: "history", id: 1, label: "創建の経緯" }],
+      sources_used: [],
+      limitations: null,
+      unanswered_aspects: ["tradition"],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("なぜ創建されたのですか？また、どんな伝承がありますか？");
+
+    expect(await screen.findByText(/tradition/)).toBeInTheDocument();
+  });
+
+  // --- 8. LLM failure(200) ---
+  it("8. LLM失敗時の固定文言(200)を通常のanswerとして表示する(独自fallbackを作らない)", async () => {
+    const response: DeepDiveAnswer = {
+      answer: "現在、回答の生成に失敗しました。時間をおいて再度お試しください。",
+      readiness: "full",
+      question_type: ["deity_who"],
+      facts_used: [{ type: "deity", id: 1, label: "神" }],
+      sources_used: [{ id: 1, title: "公式", publisher: "神社", source_type: "shrine_official", url: "https://example.com" }],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+    mockedAskDeepDive.mockResolvedValueOnce(response);
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("誰を祀っていますか？");
+
+    const message = await screen.findByText("現在、回答の生成に失敗しました。時間をおいて再度お試しください。");
+    // Backendのdeterministic responseをそのまま表示するだけであり、
+    // Frontend独自のerror styling(rose)を追加しない。
+    expect(message.className).not.toContain("rose");
+  });
+
+  // --- 9. network failure ---
+  it("9. network failureはsystem errorとしてrose表示する", async () => {
+    mockedAskDeepDive.mockRejectedValueOnce(new Error("network down"));
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("誰を祀っていますか？");
+
+    const message = await screen.findByText("通信に失敗しました。時間をおいて再度お試しください。");
+    expect(message.className).toContain("rose");
+  });
+
+  it("400 validation errorは入力エラーとして表示する", async () => {
+    mockedAskDeepDive.mockRejectedValueOnce(makeError(400));
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("誰を祀っていますか？");
+
+    expect(await screen.findByText("質問の内容を確認してください。")).toBeInTheDocument();
+  });
+
+  it("404 shrine not foundはその旨を表示する", async () => {
+    mockedAskDeepDive.mockRejectedValueOnce(makeError(404));
+
+    render(<ShrineDeepDivePrompt shrineId={999999} />);
+    ask("誰を祀っていますか？");
+
+    expect(await screen.findByText("神社情報を取得できませんでした。")).toBeInTheDocument();
+  });
+
+  // --- 10. empty question ---
+  it("10. 空質問(空白のみ含む)は送信ボタンを無効化し、APIを呼ばない", () => {
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+
+    const button = screen.getByRole("button", { name: "質問する" });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText(/誰を祀っていますか/), { target: { value: "   " } });
+    expect(button).toBeDisabled();
+
+    fireEvent.click(button);
+    expect(mockedAskDeepDive).not.toHaveBeenCalled();
+  });
+
+  it("送信中はボタンを無効化しラベルを変える", async () => {
+    let resolvePromise: (value: DeepDiveAnswer) => void = () => {};
+    mockedAskDeepDive.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePromise = resolve;
+      }),
+    );
+
+    render(<ShrineDeepDivePrompt shrineId={1} />);
+    ask("誰を祀っていますか？");
+
+    expect(screen.getByRole("button", { name: "回答を生成中..." })).toBeDisabled();
+
+    resolvePromise({
+      answer: "回答",
+      readiness: "full",
+      question_type: ["deity_who"],
+      facts_used: [],
+      sources_used: [],
+      limitations: null,
+      unanswered_aspects: [],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "質問する" })).not.toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/lib/api/__tests__/deepDive.test.ts
+++ b/apps/web/src/lib/api/__tests__/deepDive.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { askDeepDive } from "../deepDive";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+describe("deepDive api", () => {
+  it("askDeepDive は成功時にresponseをそのまま返す(値の再解釈をしない)", async () => {
+    const body = {
+      answer: "明治天皇と昭憲皇太后をお祀りしています。",
+      readiness: "full",
+      question_type: ["deity_who"],
+      facts_used: [{ type: "deity", id: 1, label: "明治天皇" }],
+      sources_used: [
+        { id: 1, title: "公式サイト", publisher: "明治神宮", source_type: "shrine_official", url: "https://example.com" },
+      ],
+      limitations: null,
+      unanswered_aspects: [],
+    };
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body,
+    });
+
+    await expect(askDeepDive(1, "誰を祀っていますか？")).resolves.toEqual(body);
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/deep-dive/ask/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ shrine_id: 1, question: "誰を祀っていますか？" }),
+    });
+  });
+
+  it("shrine_idを常に数値へ変換して送信する", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({}),
+    });
+
+    await askDeepDive("42", "質問");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/deep-dive/ask/",
+      expect.objectContaining({ body: JSON.stringify({ shrine_id: 42, question: "質問" }) }),
+    );
+  });
+
+  it("400 validation errorはstatus/bodyを持つerrorとしてrejectする", async () => {
+    const body = { shrine_id: ["A valid integer is required."] };
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body,
+    });
+
+    await expect(askDeepDive(1, "")).rejects.toMatchObject({
+      message: "deep_dive_ask_failed",
+      status: 400,
+      body,
+    });
+  });
+
+  it("404 shrine not foundはstatus 404のerrorとしてrejectする", async () => {
+    const body = { detail: "shrine not found" };
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => body,
+    });
+
+    await expect(askDeepDive(999999, "誰を祀っていますか？")).rejects.toMatchObject({
+      status: 404,
+      body,
+    });
+  });
+
+  it("500はstatus 500のerrorとしてrejectする", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers({ "content-type": "application/json" }),
+      json: async () => ({ detail: "internal error" }),
+    });
+
+    await expect(askDeepDive(1, "質問")).rejects.toMatchObject({ status: 500 });
+  });
+
+  it("APIエラーは握りつぶさずrejectする(networkエラー)", async () => {
+    fetchMock.mockRejectedValue(new Error("network down"));
+
+    await expect(askDeepDive(1, "質問")).rejects.toThrow("network down");
+  });
+});

--- a/apps/web/src/lib/api/deepDive.ts
+++ b/apps/web/src/lib/api/deepDive.ts
@@ -1,0 +1,59 @@
+// docs/product/deep-dive-answer-generation-contract.md / POST /api/deep-dive/ask/
+//
+// Backend Authority契約: readiness/question_type/facts_used/sources_used/
+// limitations/unanswered_aspectsはすべてBackendが確定した値をそのまま扱う。
+// このクライアントは型を付けてBFF routeを呼ぶだけで、値の再解釈・再判定は行わない。
+
+export type DeepDiveReadiness = "full" | "limited" | "not_ready";
+
+export type DeepDiveFactUsed = {
+  type: string;
+  id: number;
+  label: string;
+};
+
+export type DeepDiveSourceUsed = {
+  id: number;
+  title: string;
+  publisher: string;
+  source_type: string;
+  url: string;
+};
+
+export type DeepDiveAnswer = {
+  answer: string;
+  readiness: DeepDiveReadiness;
+  question_type: string[];
+  facts_used: DeepDiveFactUsed[];
+  sources_used: DeepDiveSourceUsed[];
+  limitations: string | null;
+  unanswered_aspects: string[];
+};
+
+export type DeepDiveAskError = Error & {
+  status?: number;
+  body?: unknown;
+};
+
+export async function askDeepDive(shrineId: number | string, question: string): Promise<DeepDiveAnswer> {
+  const res = await fetch("/api/deep-dive/ask/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify({ shrine_id: Number(shrineId), question }),
+  });
+
+  const contentType = res.headers.get("content-type") || "";
+  const body = contentType.includes("application/json") ? await res.json() : null;
+
+  if (!res.ok) {
+    const error = new Error("deep_dive_ask_failed") as DeepDiveAskError;
+    error.status = res.status;
+    error.body = body;
+    throw error;
+  }
+
+  return body as DeepDiveAnswer;
+}


### PR DESCRIPTION
## Summary

Connects [docs/product/deep-dive-answer-generation-contract.md](docs/product/deep-dive-answer-generation-contract.md) to a minimal Shrine Detail UI, built on `POST /api/deep-dive/ask/` ([#2450](https://github.com/etsu33/jinja_app/pull/2450)–[#2452](https://github.com/etsu33/jinja_app/pull/2452)). **Single question → single answer only** — no chat history, thread, or memory.

## Frontend is not an Authority Layer

Readiness, `question_type`, fact selection, source selection, confidence, and verification are never judged here — only the Backend response is rendered. The question input renders **unconditionally** on every shrine detail page (not gated on whether `ShrineFactSection` has data), specifically to avoid the Frontend pre-guessing readiness from Knowledge presence — readiness is only known after a real question round-trips through the Backend.

## Changes

- **`apps/web/src/lib/api/deepDive.ts`** (new): `askDeepDive(shrineId, question)`, following the existing raw-fetch client pattern (`shrineSubmissions.ts`) — same-origin BFF call, duck-typed `Error & {status, body}` on non-OK responses, no reinterpretation of the response shape.
- **`apps/web/src/app/api/deep-dive/ask/route.ts`** (new): thin BFF proxy to Django's `AllowAny` endpoint (`forwardAuth: false`, no JWT refresh dance needed). Upstream HTTP status passes through unchanged (400/404/200/500) so the Frontend can tell input error / shrine not found / normal product state (`readiness="not_ready"` is still 200) apart from an actual system failure — modeled on `concierge/chat`'s status-passthrough pattern, not `public/shrines`' collapse-everything-to-502 pattern, since collapsing would erase exactly the distinction this feature needs.
- **`apps/web/src/components/shrine/detail/ShrineDeepDivePrompt.tsx`** (new): question input + submit CTA, mounted right after `ShrineFactSection`. Raw `useState` (matching this repo's existing convention — no SWR/react-query anywhere).
  - **Full/Limited**: `answer` + `sources_used` (title/publisher/source_type/url only) + `unanswered_aspects` when present. Limited's `limitations` renders in calm slate, not error styling.
  - **Not Ready**: `limitations` in plain `slate-400`, no border, no red — matching the existing "not enough data yet" precedent elsewhere in `ShrineDetailArticle.tsx`, explicitly not the rose/bordered style used for real errors.
  - **LLM failure (200 with fixed message)**: rendered as a completely normal answer — the Backend already reduced this to a safe deterministic string, so the Frontend adds no fallback UI of its own.
  - **HTTP 400/404/network+500**: classified from the thrown error's `status` into validation/not_found/system, rendered inline in rose, matching `ShrineReflectionPrompt`'s existing inline-error convention.
  - Empty/whitespace-only question disables the submit button client-side — a pure UX guard against a wasted request, not a Backend Authority change (the Backend already treats a blank question as normal "other"-classified input).
- **`ShrineDetailArticle.tsx`**: mounts `ShrineDeepDivePrompt` unconditionally, independent of `factSection`/`hasVisitHistory` gating.
- **Tests**: `deepDive.test.ts`, `route.test.ts`, `ShrineDeepDivePrompt.test.tsx` — cover all 10 required scenarios (Meiji-Jingu-style deity/history/tradition Full answers, Limited, Not Ready, multiple sources, unanswered aspects, LLM failure, network failure, empty question) plus 400/404 HTTP contract coverage.

## Browser QA (375 / 390 / 430px)

Verified with a temporary local harness (not committed): long answer text, an unbreakable long token, a long source title, and a long URL all wrap via `break-words`/`break-all` without horizontal overflow at any of the three widths; Not Ready (slate, no border) is visually distinct from System Error (rose) at every width.

## Out of scope (unchanged)

Backend, Ranking, Recommendation Authority, Knowledge-to-Ranking connections, DB schema, migrations, multi-turn chat.

## Test plan

- [x] New tests: `deepDive.test.ts` (6), `route.test.ts` (6), `ShrineDeepDivePrompt.test.tsx` (13) — all passing.
- [x] Full web suite: **940 passed** (139 files, +3 new), 0 failures.
- [x] `tsc --noEmit`: clean.
- [x] `eslint`: 0 errors (2 pre-existing warnings in an unrelated file, `MyPageView.tsx`).
- [x] `next build`: succeeds, `/api/deep-dive/ask` registered.
- [x] Browser QA at 375/390/430px: no layout breakage on long answer/source title/URL/Limited limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)