### PR TITLE
feat: implement Deep Dive Deterministic Answer Builder Foundation (PR-ND1)

### DIFF
--- a/backend/temples/services/deep_dive_deterministic_answer.py
+++ b/backend/temples/services/deep_dive_deterministic_answer.py
@@ -1,0 +1,174 @@
+"""Deep Dive Deterministic Answer Builder Foundation (PR-ND1)。
+
+docs/audit/deep-dive-non-llm-runtime-alignment.md §5 Non-LLM Answer
+Contractの実装。Evidence-gated済みの`DeepDiveFact`（temples.services.
+deep_dive_retrieval）から、LLMを一切使わずにユーザー向け回答文字列を
+構築するpure functionを提供する。
+
+**本モジュールはFoundationのみである。** 既存の
+`temples.services.deep_dive_answer.generate_deep_dive_answer()`の
+production behaviorには接続しない（呼び出し元を持たない、PR-ND2の
+スコープ）。API・Frontend・DB schemaのいずれにも影響しない。
+
+Absolute Safety Rules（docs/audit/deep-dive-non-llm-runtime-alignment.md
+§5・§6 No-Hallucination Contractをそのまま継承）:
+  - Factに無い固有情報を追加しない -- `build_deterministic_answer()`は
+    `DeepDiveFact.label`/`.content`の引用・連結のみで構成し、新しい
+    文を生成しない。
+  - 一般知識で補完しない -- テンプレート自体が固定文言のみを追加する
+    （Fact本文を書き換えない）。
+  - deity/history間の意味推論をしない -- `deity_nature`はdeity_who相当
+    まで安全に縮退する（§5.3、本モジュール内コメント参照）。History
+    からdeityの性質を推論する経路はコード上存在しない。
+  - Sourceをanswer textから生成しない -- 本モジュールはSource/
+    provenanceを一切扱わない（既存のfacts_used/sources_used機械導出
+    ロジック、deep_dive_answer.pyの責務のまま）。
+  - zero usable factsでは回答を捏造しない -- 該当factが無い場合は
+    `None`を返す（空文字列や説明文を生成しない）。
+  - suppressed factを使用しない -- `reason_strength == "suppressed"`
+    のFactは入力から除外してから組み立てる。
+  - LLMを呼ばない -- 本モジュールはtemples.llm以下のいかなるモジュール
+    もimportしない。
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+from temples.services.deep_dive_retrieval import (
+    QUESTION_TYPE_DEITY_NATURE,
+    QUESTION_TYPE_DEITY_WHO,
+    QUESTION_TYPE_FOUNDING,
+    QUESTION_TYPE_HISTORICAL_EVENTS,
+    QUESTION_TYPE_TRADITION,
+    DeepDiveFact,
+)
+
+# ---------------------------------------------------------------------------
+# reason_strength定数（deep_dive_retrieval.pyの値と同一。Recommendation
+# Authority領域のファイルをimportせず値のみ複製する既存パターン
+# (deep_dive_retrieval.py自身のdocstring参照)をここでも踏襲する）。
+# ---------------------------------------------------------------------------
+
+_SUPPRESSED = "suppressed"
+_ASSERTIVE = "assertive"
+_WEAKENED = "weakened"
+
+_DEITY_FACT_TYPE = "deity"
+_HISTORY_FACT_TYPE = "history"
+
+# この対応表に無いquestion_type（source_basis/other等）はPR-ND1の対象外。
+# build_deterministic_answer()は未対応のquestion_typeに対して常にNoneを返す
+# （推測でどれかのtemplateへ寄せない）。
+_HISTORY_QUESTION_TYPES = (
+    QUESTION_TYPE_FOUNDING,
+    QUESTION_TYPE_HISTORICAL_EVENTS,
+    QUESTION_TYPE_TRADITION,
+)
+
+
+def _scoped_usable_facts(question_type: str, facts: Iterable[DeepDiveFact]) -> list[DeepDiveFact]:
+    """指定question_typeに属し、かつsuppressedでないfactのみへ絞り込む。
+
+    facts自体は呼び出し側がbuild_deep_dive_context()から取得した
+    evidence-gated済みの集合を渡す想定だが、本関数はfact.question_typeの
+    一致とreason_strength != suppressedの両方を自前で再確認する
+    （呼び出し側の絞り込みに依存しない、defense in depth）。
+    """
+    return [
+        fact
+        for fact in facts
+        if fact.question_type == question_type and fact.reason_strength != _SUPPRESSED
+    ]
+
+
+def _build_deity_segment(facts: list[DeepDiveFact]) -> Optional[str]:
+    """deity Factからの回答segment（§5.2）。deity_who・deity_nature共通。
+
+    同一reason_strengthのdeity Factは1文にまとめ、labelを「・」で連結する。
+    assertiveとweakenedが混在する場合は2文に分け、1文で断定調と伝聞調を
+    混ぜない。
+    """
+    deity_facts = [f for f in facts if f.type == _DEITY_FACT_TYPE]
+    if not deity_facts:
+        return None
+
+    assertive_labels = [f.label for f in deity_facts if f.reason_strength == _ASSERTIVE]
+    weakened_labels = [f.label for f in deity_facts if f.reason_strength == _WEAKENED]
+
+    sentences: list[str] = []
+    if assertive_labels:
+        sentences.append(f"{'・'.join(assertive_labels)}をお祀りしています。")
+    if weakened_labels:
+        sentences.append(f"{'・'.join(weakened_labels)}をお祀りしていると伝わっています。")
+
+    return "\n".join(sentences) if sentences else None
+
+
+def _hedge_history_content(content: str) -> str:
+    """weakenedなhistory Factへ伝聞表現を付与する。content自体は書き換えない。"""
+    trimmed = content[:-1] if content.endswith("。") else content
+    return f"{trimmed}と伝わっています。"
+
+
+def _build_history_segment(facts: list[DeepDiveFact]) -> Optional[str]:
+    """history Factからの回答segment（§5.2）。founding/historical_events/
+    tradition共通。tradition種別のFactはretrieval層
+    （_apply_tradition_hedge_floor）が既にreason_strength="weakened"へ
+    floorしているため、本関数はhistory_typeを個別に判定しない
+    （reason_strengthのみを見れば十分、値の二重管理をしない）。
+    """
+    history_facts = [f for f in facts if f.type == _HISTORY_FACT_TYPE]
+    if not history_facts:
+        return None
+
+    sentences: list[str] = []
+    for fact in history_facts:
+        if fact.reason_strength == _ASSERTIVE:
+            sentences.append(fact.content)
+        else:
+            sentences.append(_hedge_history_content(fact.content))
+
+    return "\n".join(sentences) if sentences else None
+
+
+def build_deterministic_answer(
+    *, question_type: str, facts: Iterable[DeepDiveFact]
+) -> Optional[str]:
+    """1つのquestion_typeに対する回答segmentを、Factの引用・連結のみで構築する。
+
+    docs/audit/deep-dive-non-llm-runtime-alignment.md §5 Non-LLM Answer
+    Contractの実装。呼び出し側で複数question_type（複合質問）を扱う場合は、
+    question_typeごとに本関数を呼び出しsegmentを連結する（本関数自体は
+    1 question_type分のみを扱うpure function、Architecture要件どおり）。
+
+    Returns:
+        構築できた回答文字列。該当するusable factが1件も無い場合は
+        `None`（空文字列や説明文を生成しない、捏造しない）。
+
+    Safety:
+        - suppressed（confidence="low"相当）なFactは`_scoped_usable_facts()`
+          で除外済みのため、生成に使われない。
+        - `question_type == QUESTION_TYPE_DEITY_NATURE`の場合、facts引数に
+          history Factが含まれていても、`_build_deity_segment()`は
+          `fact.type == "deity"`のみを見るため、history Factの内容が
+          deityの性質説明として混入することはない（PR #2456 §5.3の
+          安全な縮退。role fieldも現行DeepDiveFactに存在しないため使わない
+          -- deity_whoと出力が一致する）。
+    """
+    scoped_facts = _scoped_usable_facts(question_type, facts)
+    if not scoped_facts:
+        return None
+
+    if question_type in (QUESTION_TYPE_DEITY_WHO, QUESTION_TYPE_DEITY_NATURE):
+        return _build_deity_segment(scoped_facts)
+
+    if question_type in _HISTORY_QUESTION_TYPES:
+        return _build_history_segment(scoped_facts)
+
+    # source_basis/other/未知のquestion_typeはPR-ND1の対象外。推測で
+    # deity/historyいずれかのtemplateへ寄せない。
+    return None
+
+
+__all__ = ["build_deterministic_answer"]

--- a/backend/temples/tests/services/test_deep_dive_deterministic_answer.py
+++ b/backend/temples/tests/services/test_deep_dive_deterministic_answer.py
@@ -1,0 +1,315 @@
+"""Deep Dive Deterministic Answer Builder Foundation(PR-ND1)のテスト。
+
+docs/audit/deep-dive-non-llm-runtime-alignment.md §5 Non-LLM Answer
+Contractの実装検証。build_deterministic_answer()はpure function
+（DeepDiveFactの引用・連結のみ）であり、DBもLLMも一切使わない
+——このテストファイルはdjango_db markerを持たない。
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from temples.services.deep_dive_deterministic_answer import build_deterministic_answer
+from temples.services.deep_dive_retrieval import (
+    QUESTION_TYPE_DEITY_NATURE,
+    QUESTION_TYPE_DEITY_WHO,
+    QUESTION_TYPE_FOUNDING,
+    QUESTION_TYPE_HISTORICAL_EVENTS,
+    QUESTION_TYPE_OTHER,
+    QUESTION_TYPE_TRADITION,
+    DeepDiveFact,
+)
+
+
+def _deity_fact(
+    label: str,
+    *,
+    question_type: str = QUESTION_TYPE_DEITY_WHO,
+    reason_strength: str = "assertive",
+    id: int = 1,
+) -> DeepDiveFact:
+    return DeepDiveFact(
+        type="deity",
+        id=id,
+        question_type=question_type,
+        label=label,
+        content=label,
+        verification_status="source_confirmed",
+        confidence="high" if reason_strength == "assertive" else "medium",
+        reason_strength=reason_strength,
+        source_ids=(1,),
+    )
+
+
+def _history_fact(
+    content: str,
+    *,
+    question_type: str = QUESTION_TYPE_FOUNDING,
+    reason_strength: str = "assertive",
+    id: int = 1,
+    label: str = "由緒",
+) -> DeepDiveFact:
+    return DeepDiveFact(
+        type="history",
+        id=id,
+        question_type=question_type,
+        label=label,
+        content=content,
+        verification_status="source_confirmed",
+        confidence="high" if reason_strength == "assertive" else "medium",
+        reason_strength=reason_strength,
+        source_ids=(1,),
+    )
+
+
+# --- 1. deity_who ---
+
+
+def test_1_deity_who_assertive_builds_sentence_from_labels():
+    facts = [_deity_fact("明治天皇"), _deity_fact("昭憲皇太后", id=2)]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer == "明治天皇・昭憲皇太后をお祀りしています。"
+
+
+# --- 2. deity_nature safe degradation ---
+
+
+def test_2_deity_nature_ignores_history_facts_and_degrades_to_deity_who_output():
+    deity_facts = [_deity_fact("大国魂大神", question_type=QUESTION_TYPE_DEITY_NATURE)]
+    history_facts = [
+        _history_fact(
+            "この神は不安を鎮める神として知られる。",
+            question_type=QUESTION_TYPE_DEITY_NATURE,
+        )
+    ]
+
+    answer = build_deterministic_answer(
+        question_type=QUESTION_TYPE_DEITY_NATURE, facts=deity_facts + history_facts
+    )
+
+    # deity_whoと同一の出力になる(安全な縮退、PR #2456 §5.3)。
+    deity_who_equivalent = build_deterministic_answer(
+        question_type=QUESTION_TYPE_DEITY_WHO,
+        facts=[replace(deity_facts[0], question_type=QUESTION_TYPE_DEITY_WHO)],
+    )
+    assert answer == deity_who_equivalent
+    assert answer == "大国魂大神をお祀りしています。"
+    # history Factの内容(性質の説明)がどこにも混入していないことを明示的に確認する。
+    assert "不安を鎮める" not in answer
+
+
+# --- 3. history (historical_events) ---
+
+
+def test_3_historical_events_assertive_uses_content_verbatim():
+    facts = [
+        _history_fact(
+            "村社に列格した。",
+            question_type=QUESTION_TYPE_HISTORICAL_EVENTS,
+        )
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_HISTORICAL_EVENTS, facts=facts)
+
+    assert answer == "村社に列格した。"
+
+
+# --- 4. founding ---
+
+
+def test_4_founding_assertive_uses_content_verbatim():
+    facts = [
+        _history_fact(
+            "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。",
+            question_type=QUESTION_TYPE_FOUNDING,
+        )
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_FOUNDING, facts=facts)
+
+    assert answer == "明治神宮は、東京都渋谷区代々木に大正9年（1920）に創建された。"
+
+
+# --- 5. tradition ---
+
+
+def test_5_tradition_weakened_appends_hedge_and_preserves_content():
+    # retrieval層(_apply_tradition_hedge_floor)がtraditionを常にweakenedへ
+    # floorするため、ここでもweakenedとして渡す。
+    facts = [
+        _history_fact(
+            "武蔵国府中の武蔵総社六所宮の分霊を勧請して創建した",
+            question_type=QUESTION_TYPE_TRADITION,
+            reason_strength="weakened",
+        )
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_TRADITION, facts=facts)
+
+    assert answer == "武蔵国府中の武蔵総社六所宮の分霊を勧請して創建したと伝わっています。"
+
+
+def test_5b_tradition_content_ending_with_period_is_trimmed_before_hedge():
+    facts = [
+        _history_fact(
+            "分霊を勧請して創建した。",
+            question_type=QUESTION_TYPE_TRADITION,
+            reason_strength="weakened",
+        )
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_TRADITION, facts=facts)
+
+    assert answer == "分霊を勧請して創建したと伝わっています。"
+    assert "。と伝わっています" not in answer
+
+
+# --- 6. Limited / weakened wording ---
+
+
+def test_6_deity_weakened_wording_differs_from_assertive():
+    facts = [_deity_fact("大国魂大神", reason_strength="weakened")]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer == "大国魂大神をお祀りしていると伝わっています。"
+
+
+def test_6b_mixed_assertive_and_weakened_deities_produce_two_sentences_not_blended():
+    facts = [
+        _deity_fact("明治天皇", reason_strength="assertive", id=1),
+        _deity_fact("昭憲皇太后", reason_strength="weakened", id=2),
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer == "明治天皇をお祀りしています。\n昭憲皇太后をお祀りしていると伝わっています。"
+
+
+# --- 7. zero facts ---
+
+
+def test_7_empty_facts_returns_none():
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=[])
+    assert answer is None
+
+
+def test_7b_facts_present_but_none_match_question_type_returns_none():
+    facts = [_deity_fact("明治天皇", question_type=QUESTION_TYPE_FOUNDING)]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer is None
+
+
+def test_7c_unsupported_question_type_returns_none_without_guessing():
+    facts = [_deity_fact("明治天皇", question_type=QUESTION_TYPE_OTHER)]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_OTHER, facts=facts)
+
+    assert answer is None
+
+
+# --- 8. multiple facts ---
+
+
+def test_8_multiple_deity_facts_joined_with_nakaguro():
+    facts = [
+        _deity_fact("大国魂大神", id=1),
+        _deity_fact("天照皇大神", id=2),
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer == "大国魂大神・天照皇大神をお祀りしています。"
+
+
+def test_8b_multiple_history_facts_joined_with_newline_each_content_preserved():
+    facts = [
+        _history_fact("村社に列格した。", id=1, question_type=QUESTION_TYPE_HISTORICAL_EVENTS),
+        _history_fact("社殿を改築した。", id=2, question_type=QUESTION_TYPE_HISTORICAL_EVENTS),
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_HISTORICAL_EVENTS, facts=facts)
+
+    assert answer == "村社に列格した。\n社殿を改築した。"
+
+
+# --- 9. suppressed facts exclusion ---
+
+
+def test_9_suppressed_fact_is_excluded_from_output():
+    facts = [
+        _deity_fact("明治天皇", reason_strength="assertive", id=1),
+        _deity_fact("除外されるべき神", reason_strength="suppressed", id=2),
+    ]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer == "明治天皇をお祀りしています。"
+    assert "除外されるべき神" not in answer
+
+
+def test_9b_all_facts_suppressed_returns_none_not_empty_string():
+    facts = [_deity_fact("神", reason_strength="suppressed")]
+
+    answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert answer is None
+
+
+# --- 10. deterministic output ---
+
+
+def test_10_same_input_produces_identical_output_across_calls():
+    facts = [
+        _deity_fact("明治天皇", id=1),
+        _deity_fact("昭憲皇太后", reason_strength="weakened", id=2),
+    ]
+
+    first = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+    second = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+
+    assert first == second
+    assert first is not None
+
+
+# --- 11. no LLM construction/call ---
+
+
+def test_11_never_constructs_or_calls_llm_client(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise AssertionError("LLM must not be constructed by a deterministic answer builder")
+
+    monkeypatch.setattr("temples.llm.client.LLMClient", _boom)
+
+    facts = [_deity_fact("明治天皇"), _history_fact("創建された。", question_type=QUESTION_TYPE_FOUNDING)]
+
+    deity_answer = build_deterministic_answer(question_type=QUESTION_TYPE_DEITY_WHO, facts=facts)
+    history_answer = build_deterministic_answer(question_type=QUESTION_TYPE_FOUNDING, facts=facts)
+
+    assert deity_answer == "明治天皇をお祀りしています。"
+    assert history_answer == "創建された。"
+
+
+def test_11b_module_does_not_import_llm_client_at_all():
+    import temples.services.deep_dive_deterministic_answer as mod
+
+    assert "LLMClient" not in vars(mod)
+    assert not hasattr(mod, "LLMClient")
+
+
+# --- Absolute Safety Rules: source_basisはPR-ND1の対象外 ---
+
+
+def test_source_basis_is_out_of_scope_for_pr_nd1_returns_none():
+    facts = [_deity_fact("明治天皇", question_type="source_basis")]
+
+    answer = build_deterministic_answer(question_type="source_basis", facts=facts)
+
+    assert answer is None


### PR DESCRIPTION
## ⚠️ This PR alone does NOT change production behavior

`generate_deep_dive_answer()` is untouched, and the new module has zero call sites anywhere else in the codebase (verified via grep — only the module itself and its own test file reference `build_deterministic_answer()`). This is Foundation only, per [docs/audit/deep-dive-non-llm-runtime-alignment.md](https://github.com/etsu33/jinja_app/blob/develop/docs/audit/deep-dive-non-llm-runtime-alignment.md) (PR #2456)'s PR-ND1/PR-ND2 split. Wiring it into the production answer path is PR-ND2, a separate future PR.

## Summary

Implements the Non-LLM Answer Contract (§5 of PR #2456's design doc): a pure function that builds a Deep Dive answer segment from evidence-gated `DeepDiveFact`s, without any LLM involvement.

## What it does

`build_deterministic_answer(*, question_type, facts) -> str | None` — takes **one** `question_type` and its evidence-gated facts, returns a constructed answer segment or `None` when nothing usable exists (never fabricates).

Covers the 5 types PR-ND1 scopes in: `deity_who`, `deity_nature`, `founding`, `historical_events`, `tradition`. `source_basis`/`other`/anything else returns `None` — no guessing.

- **Templates only quote/concatenate** `DeepDiveFact.label`/`.content` — no new claims are ever generated.
- **`reason_strength` drives wording** (assertive vs. `...と伝わっています。` for weakened) without altering what the Fact actually says.
- **suppressed facts are filtered internally** — the function doesn't trust the caller to have pre-filtered (defense in depth).
- **`deity_nature` safely degrades to `deity_who`'s output**: the function only looks at `type=="deity"` facts. Retrieval passes History as `deity_nature` candidates by original design (relevance judgment was explicitly deferred to the LLM — see `deep_dive_retrieval.py:287-292`), but this builder never lets that History content inform how a deity's nature is described. No `role` field exists on `DeepDiveFact` today either, so role-based differentiation isn't attempted here — that's tracked as PR-ND3 Future work per PR #2456 §5.3, not invented in this PR.
- **Imports nothing from `temples.llm`** — structurally cannot call an LLM, not just behaviorally avoids it.

## Tests

19 tests in `test_deep_dive_deterministic_answer.py` — no `django_db` marker needed, since `DeepDiveFact` instances are constructed directly with no DB access:

- deity_who, deity_nature degradation (asserts the History content string literally never appears in output), historical_events, founding, tradition (including trailing-period trimming before the hedge suffix)
- weakened wording, mixed assertive+weakened kept as separate sentences rather than blended
- zero facts / no matching question_type / unsupported question_type all → `None`
- multiple facts joined correctly (deity names with `・`, history facts with newlines)
- suppressed exclusion, including all-suppressed → `None` (not an empty string)
- identical output across repeated calls (determinism)
- two independent proofs of no LLM construction: a raising monkeypatch stub, and a direct check that the module namespace never binds `LLMClient` at all

## Out of scope (unchanged)

`generate_deep_dive_answer()`, API, Frontend, DB schema, migrations, Ranking, Recommendation Authority — and the existing LLM path itself is untouched, not deleted, not modified.

## Test plan

- [x] New `test_deep_dive_deterministic_answer.py`: 19/19 passed.
- [x] Existing Deep Dive regression suite (`test_deep_dive_retrieval.py`, `test_deep_dive_answer.py`, `test_deep_dive_ask_api.py`): 60/60 passed, unmodified.
- [x] Full backend suite: **1528 passed**, 13 pre-existing skips, 0 failures.
- [x] `python3 manage.py makemigrations --check --dry-run`: "No changes detected".
- [x] `ruff check`: clean.
- [x] Pre-push hook (web suite, unaffected by this backend-only change): 940/940 passed.
- [x] `grep` confirms zero call sites into this module outside itself and its test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)