### PR TITLE
feat: wire deterministic answer builder into Deep Dive fallback path (PR-ND2)

### DIFF
--- a/backend/temples/services/deep_dive_answer.py
+++ b/backend/temples/services/deep_dive_answer.py
@@ -29,6 +29,19 @@ promptなので後から集合が変化することもない。
 **LLM統合方式**: 既存のtemples.llm.client.LLMClient / settings.CONCIERGE_USE_LLM
 feature-flagパターン（temples/services/concierge_chat_llm_route.pyが確立した
 パターン）をそのまま再利用する。新規のLLM統合方式・新規feature flagは発明しない。
+
+**Deterministic Runtime Fallback（PR-ND2、
+docs/audit/deep-dive-non-llm-runtime-alignment.md）**: LLMが未使用・失敗
+した場合、`_call_llm()`がNoneを返す。この時、Factを一切反映しない固定の
+謝罪文（`_LLM_FAILURE_MESSAGE`）へ即座に縮退するのではなく、まず
+`temples.services.deep_dive_deterministic_answer.build_deterministic_answer()`
+（PR-ND1）でretrieval済みFactからdeterministic answerを構成する
+（Option C: deterministic default + optional LLM enhancement、LLM成功時は
+引き続きLLM出力を使う。LLM経路自体は削除しない）。deterministic builderも
+回答を構成できない場合（対応外のquestion_type等）にのみ、最終的に
+`_LLM_FAILURE_MESSAGE`へ落ちる（Final Safe Fallback）。facts_used/
+sources_used/limitations/unanswered_aspectsの導出はこの変更の影響を
+受けない（§9のprovenance機械導出ロジックはanswerの生成元と独立）。
 """
 
 from __future__ import annotations
@@ -39,6 +52,7 @@ from typing import Iterable, Optional
 
 from temples.llm.client import PLACEHOLDER, LLMClient
 from temples.services import evidence_gate
+from temples.services.deep_dive_deterministic_answer import build_deterministic_answer
 from temples.services.deep_dive_retrieval import (
     DeepDiveFact,
     DeepDiveSource,
@@ -179,6 +193,27 @@ def _sources_used_for(
     return [source for source in all_sources if source.id in source_ids]
 
 
+def _build_deterministic_fallback(
+    question_types: list[str], facts: list[DeepDiveFact]
+) -> Optional[str]:
+    """LLM未使用/失敗時のfallback(PR-ND2)。build_deterministic_answer()
+    (PR-ND1、pure function)をquestion_typeごとに呼び出しsegmentを連結する。
+
+    build_deterministic_answer()自体はfacts_used/sources_used等の
+    provenanceを一切参照・変更しない(呼び出し元のgenerate_deep_dive_answer()
+    が既存どおり別途導出する)。全question_typeでNoneだった場合(対応外の
+    question_type等)はNoneを返し、呼び出し側でさらに_LLM_FAILURE_MESSAGEへ
+    落ちる(Final Safe Fallback)。
+    """
+    segments = [
+        segment
+        for question_type in question_types
+        if (segment := build_deterministic_answer(question_type=question_type, facts=facts))
+        is not None
+    ]
+    return "\n".join(segments) if segments else None
+
+
 def _empty_answer(readiness: str, limitations: Optional[str]) -> DeepDiveAnswer:
     return DeepDiveAnswer(
         answer="",
@@ -242,30 +277,35 @@ def generate_deep_dive_answer(
     facts_used = _facts_used_from(generation_facts)
     sources_used = _sources_used_for(generation_facts, context.sources)
 
-    if answer_text is None:
-        # LLM未使用/失敗: Factを捏造したfallback文章は作らない。retrieval済みの
-        # facts_used/sources_used(mechanicalに確定済み、safeな情報)はそのまま返し、
-        # answerのみ固定のdeterministicな失敗文言にする(§12)。
+    if answer_text is not None:
         return DeepDiveAnswer(
-            answer=_LLM_FAILURE_MESSAGE,
+            answer=answer_text,
             readiness=context.readiness,
             question_type=context.question_type,
             facts_used=facts_used,
             sources_used=sources_used,
             limitations=context.limitations,
             unanswered_aspects=context.unanswered_aspects,
-            llm_used=False,
+            llm_used=True,
         )
 
+    # LLM未使用/失敗(PR-ND2、Option C): Factを捏造したfallback文章は作らない。
+    # まずdeterministic builder(PR-ND1)で、retrieval済みFactのみから実際の
+    # 回答を構成する。facts_used/sources_used(mechanicalに確定済み、safeな
+    # 情報)は生成元に関わらず不変。deterministic builderも構成できない場合
+    # (対応外のquestion_type等)にのみ、固定のdeterministicな失敗文言にする
+    # (§12、Final Safe Fallback)。
+    deterministic_answer = _build_deterministic_fallback(context.question_type, generation_facts)
+
     return DeepDiveAnswer(
-        answer=answer_text,
+        answer=deterministic_answer if deterministic_answer is not None else _LLM_FAILURE_MESSAGE,
         readiness=context.readiness,
         question_type=context.question_type,
         facts_used=facts_used,
         sources_used=sources_used,
         limitations=context.limitations,
         unanswered_aspects=context.unanswered_aspects,
-        llm_used=True,
+        llm_used=False,
     )
 
 

--- a/backend/temples/tests/api/test_deep_dive_ask_api.py
+++ b/backend/temples/tests/api/test_deep_dive_ask_api.py
@@ -249,7 +249,7 @@ def test_7c_malformed_json_body_returns_400(client):
 # --- 8. LLM Failure ---
 
 
-def test_8_llm_failure_returns_200_with_fixed_message_and_retrieved_facts(client, monkeypatch):
+def test_8_llm_failure_returns_200_with_deterministic_answer_and_retrieved_facts(client, monkeypatch):
     fake_client = _FakeLLMClient(raise_exc=RuntimeError("network down"))
     monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
 
@@ -259,7 +259,10 @@ def test_8_llm_failure_returns_200_with_fixed_message_and_retrieved_facts(client
 
     assert res.status_code == 200
     body = res.json()
-    assert body["answer"] == "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
+    # LLM失敗時はFactを捏造したfallback文章ではなく、deterministic builder
+    # (PR-ND1)による実際のFactに基づく回答が返る(PR-ND2、意図的な契約変更)。
+    assert body["answer"] == "神をお祀りしています。"
+    assert body["answer"] != "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
     # LLMが失敗しても、retrieval済みの安全なfacts_used/sources_usedはそのまま返る。
     assert len(body["facts_used"]) == 1
     assert len(body["sources_used"]) == 1

--- a/backend/temples/tests/services/test_deep_dive_answer.py
+++ b/backend/temples/tests/services/test_deep_dive_answer.py
@@ -264,16 +264,61 @@ def test_full_ready_shrine_with_partial_facts_reports_unanswered_aspects(monkeyp
     assert result.unanswered_aspects == ["tradition"]
 
 
-# --- LLM Failure: Factを捏造せず、retrieval済み情報とfailure stateを安全に返す ---
+# --- LLM Failure/Disabled(PR-ND2): Factを捏造せず、deterministic builder
+# (PR-ND1)からretrieval済みFactに基づく実際の回答を構成する。既存の
+# _LLM_FAILURE_MESSAGEは、deterministic builderも構成できない場合のみに
+# 使われる最終fallbackへ後退する(意図的なcontract変更、
+# docs/audit/deep-dive-non-llm-runtime-alignment.md §8.3)。 ---
 
 
-def test_llm_call_raises_returns_fixed_failure_message_with_retrieved_facts_preserved(
+def test_1_llm_disabled_full_ready_returns_deterministic_answer_not_fixed_message(settings):
+    """1. LLM disabled Full"""
+    settings.CONCIERGE_USE_LLM = False
+    shrine = _create_shrine("LLM無効Full神社")
+    source = _create_source("公式")
+    deity1 = _create_deity(shrine, "明治天皇", sort_order=0)
+    deity2 = _create_deity(shrine, "昭憲皇太后", sort_order=1)
+    history = _create_history(shrine, "由緒")
+    for fact in (deity1, deity2, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.readiness == "full"
+    assert result.llm_used is False
+    assert result.answer == "明治天皇・昭憲皇太后をお祀りしています。"
+    assert result.answer != deep_dive_answer._LLM_FAILURE_MESSAGE
+    assert {f.id for f in result.facts_used} == {deity1.id, deity2.id}
+
+
+def test_2_llm_disabled_limited_ready_returns_deterministic_answer_with_weakened_wording(settings):
+    """2. LLM disabled Limited"""
+    settings.CONCIERGE_USE_LLM = False
+    shrine = _create_shrine("LLM無効Limited神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "大国魂大神", confidence="medium")
+    history = _create_history(shrine, "由緒", confidence="medium")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.readiness == "limited"
+    assert result.llm_used is False
+    assert result.answer == "大国魂大神をお祀りしていると伝わっています。"
+    assert result.answer != deep_dive_answer._LLM_FAILURE_MESSAGE
+    assert result.limitations is not None
+    assert "限られており" in result.limitations
+
+
+def test_3_llm_failure_full_ready_returns_deterministic_answer_with_retrieved_facts_preserved(
     monkeypatch,
 ):
+    """3. LLM failure Full"""
     fake_client = _FakeLLMClient(raise_exc=RuntimeError("network down"))
     monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
 
-    shrine = _create_shrine("LLM失敗神社")
+    shrine = _create_shrine("LLM失敗Full神社")
     source = _create_source("公式")
     deity = _create_deity(shrine, "神")
     history = _create_history(shrine, "由緒")
@@ -282,16 +327,112 @@ def test_llm_call_raises_returns_fixed_failure_message_with_retrieved_facts_pres
 
     result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
 
+    assert result.readiness == "full"
     assert result.llm_used is False
-    assert result.answer == "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
+    assert result.answer == "神をお祀りしています。"
+    assert result.answer != deep_dive_answer._LLM_FAILURE_MESSAGE
     # facts_used/sources_usedはretrieval済みの安全な情報としてそのまま返す(捏造しない)。
     assert {f.id for f in result.facts_used} == {deity.id}
     assert {s.id for s in result.sources_used} == {source.id}
 
 
-def test_llm_disabled_by_feature_flag_returns_safe_fixed_message(settings):
-    settings.CONCIERGE_USE_LLM = False
-    shrine = _create_shrine("LLM無効神社")
+def test_4_llm_failure_limited_ready_returns_deterministic_answer_with_limitations(monkeypatch):
+    """4. LLM failure Limited"""
+    fake_client = _FakeLLMClient(raise_exc=RuntimeError("network down"))
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("LLM失敗Limited神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "大国魂大神", confidence="medium")
+    history = _create_history(shrine, "由緒", confidence="medium")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.readiness == "limited"
+    assert result.llm_used is False
+    assert result.answer == "大国魂大神をお祀りしていると伝わっています。"
+    assert result.limitations is not None
+    assert "限られており" in result.limitations
+
+
+# --- 7. sources provenance維持 / 8. limitations維持: answerの生成元
+# (LLM成功/deterministic fallback/最終fallback)に関わらずfacts_used/
+# sources_used/limitationsは不変。 ---
+
+
+def test_7_sources_provenance_unchanged_between_llm_success_and_deterministic_fallback(
+    monkeypatch,
+):
+    """7. sources provenance維持"""
+    shrine = _create_shrine("Provenance比較神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    fake_client = _FakeLLMClient(content="LLM生成の回答文。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+    llm_success_result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="誰を祀っていますか？"
+    )
+
+    fallback_client = _FakeLLMClient(raise_exc=RuntimeError("down"))
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fallback_client)
+    fallback_result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="誰を祀っていますか？"
+    )
+
+    assert llm_success_result.answer == "LLM生成の回答文。"
+    assert fallback_result.answer == "神をお祀りしています。"
+    assert llm_success_result.answer != fallback_result.answer
+    # answerの生成元が違っても、provenanceは完全に一致する。
+    assert {f.id for f in llm_success_result.facts_used} == {
+        f.id for f in fallback_result.facts_used
+    }
+    assert {s.id for s in llm_success_result.sources_used} == {
+        s.id for s in fallback_result.sources_used
+    }
+
+
+def test_8_limitations_unchanged_between_llm_success_and_deterministic_fallback(monkeypatch):
+    """8. limitations維持"""
+    shrine = _create_shrine("Limitations比較神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神", confidence="medium")
+    history = _create_history(shrine, "由緒", confidence="medium")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    fake_client = _FakeLLMClient(content="LLM生成の回答文。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+    llm_success_result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="誰を祀っていますか？"
+    )
+
+    fallback_client = _FakeLLMClient(raise_exc=RuntimeError("down"))
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fallback_client)
+    fallback_result = generate_deep_dive_answer(
+        shrine_id=shrine.id, question_text="誰を祀っていますか？"
+    )
+
+    assert llm_success_result.limitations == fallback_result.limitations
+    assert llm_success_result.limitations is not None
+    assert "限られており" in llm_success_result.limitations
+
+
+# --- 9. LLM success regression: LLM経路は削除されておらず、成功時は
+# 引き続きLLM出力がそのままanswerになる(Option C、既存挙動の非破壊)。 ---
+
+
+def test_9_llm_success_path_is_not_deleted_llm_output_still_used_when_available(monkeypatch):
+    """9. LLM success regression"""
+    fake_client = _FakeLLMClient(content="LLMによる自然な回答文。")
+    monkeypatch.setattr(deep_dive_answer, "LLMClient", lambda: fake_client)
+
+    shrine = _create_shrine("LLM成功神社")
     source = _create_source("公式")
     deity = _create_deity(shrine, "神")
     history = _create_history(shrine, "由緒")
@@ -300,9 +441,75 @@ def test_llm_disabled_by_feature_flag_returns_safe_fixed_message(settings):
 
     result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
 
+    assert len(fake_client.calls) == 1
+    assert result.llm_used is True
+    # LLMが成功した場合、deterministic answer("神をお祀りしています。")では
+    # なく、LLM出力がそのままanswerになる(deterministic builderが
+    # LLM成功pathを上書きしない)。
+    assert result.answer == "LLMによる自然な回答文。"
+
+
+# --- 10. deterministic builder None: PR-ND1が対応しないquestion_type
+# (source_basis)では、deterministic builderもNoneを返すため、最終的に
+# 既存の_LLM_FAILURE_MESSAGEへfall backする(Final Safe Fallback)。 ---
+
+
+def test_10_deterministic_builder_none_falls_back_to_fixed_failure_message(settings):
+    """10. deterministic builder None"""
+    settings.CONCIERGE_USE_LLM = False
+    shrine = _create_shrine("根拠質問LLM無効神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "神")
+    deity.sources.add(source)
+    history = _create_history(shrine, "由緒")
+    history.sources.add(source)
+
+    from temples.services.deep_dive_retrieval import build_deep_dive_context
+
+    first_context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    # source_basisはPR-ND1のbuild_deterministic_answer()が対応しない
+    # question_type(deep_dive_deterministic_answer.pyのdocstring参照)。
+    result = generate_deep_dive_answer(
+        shrine_id=shrine.id,
+        question_text="その根拠は何ですか？",
+        prior_facts=first_context.facts,
+    )
+
     assert result.llm_used is False
-    assert result.answer == "現在、回答の生成に失敗しました。時間をおいて再度お試しください。"
-    assert {f.id for f in result.facts_used} == {deity.id}
+    assert result.answer == deep_dive_answer._LLM_FAILURE_MESSAGE
+    # facts_used/sources_usedは、最終fallback時も安全な情報としてそのまま返る。
+    assert result.facts_used
+
+
+# --- 11. no hallucinated content: deterministic fallbackのanswerは、
+# build_deterministic_answer()を直接呼んだ場合と完全に一致する(Fact本文の
+# 引用・連結以外の文章が混入していない)。 ---
+
+
+def test_11_deterministic_fallback_answer_contains_no_content_beyond_the_facts(settings):
+    """11. no hallucinated content"""
+    settings.CONCIERGE_USE_LLM = False
+    shrine = _create_shrine("捏造なし確認神社")
+    source = _create_source("公式")
+    deity = _create_deity(shrine, "特定の神名")
+    history = _create_history(shrine, "由緒")
+    for fact in (deity, history):
+        fact.sources.add(source)
+
+    from temples.services.deep_dive_deterministic_answer import build_deterministic_answer
+    from temples.services.deep_dive_retrieval import build_deep_dive_context
+
+    context = build_deep_dive_context(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+    expected = build_deterministic_answer(question_type="deity_who", facts=context.facts)
+
+    result = generate_deep_dive_answer(shrine_id=shrine.id, question_text="誰を祀っていますか？")
+
+    assert result.answer == expected
+    assert result.answer == "特定の神名をお祀りしています。"
+    # Fact(display_name)に無い固有名詞が混入していないことを確認する。
+    assert "一般的" not in result.answer
+    assert "神道" not in result.answer
 
 
 # --- Regression: PR #2450のRetrieval Foundationは変更しない ---


### PR DESCRIPTION
## Summary

[docs/audit/deep-dive-non-llm-runtime-alignment.md](https://github.com/etsu33/jinja_app/blob/develop/docs/audit/deep-dive-non-llm-runtime-alignment.md) Option C implementation. Connects PR #2457's `build_deterministic_answer()` into `generate_deep_dive_answer()`'s **existing fallback path only**. The LLM success path, Call Gate, Not Ready short-circuit, and Zero-Fact short-circuit are all untouched.

**Production fallback behavior changes**: Full/Limited-ready shrines will now get a real, Fact-based answer instead of the generic "回答の生成に失敗しました" message whenever the LLM is disabled or fails — which per [PR #2455](https://github.com/etsu33/jinja_app/pull/2455)'s Runtime QA is the current production state.

## What changed

`temples/services/deep_dive_answer.py`: when `_call_llm()` returns `None` (disabled or failed), the code no longer drops straight to `_LLM_FAILURE_MESSAGE`. It now calls a new `_build_deterministic_fallback()` helper, which runs `build_deterministic_answer()` per `question_type` over the same `generation_facts` already computed for provenance, joining any produced segments. Only when that also yields nothing (an unsupported `question_type` like `source_basis`) does it fall through to the existing fixed message — the **Final Safe Fallback**.

`facts_used`/`sources_used`/`limitations`/`unanswered_aspects` are computed exactly as before, unconditionally, regardless of which of the three paths (LLM success / deterministic fallback / final fallback) produced the answer text.

## Tests

- 2 existing tests that asserted on `_LLM_FAILURE_MESSAGE` for scenarios that now produce real content are **deliberately rewritten** (not accidentally broken) — the design doc's §8.3 called this out in advance as an intentional contract change.
- 7 new tests in `test_deep_dive_answer.py`: LLM disabled Full/Limited, LLM failure Full/Limited, provenance and limitations proven byte-identical between an LLM-success call and a deterministic-fallback call against the same facts, an explicit LLM-success regression test (LLM path is not deleted), deterministic-builder-returns-`None` correctly falling through to the fixed message, and a check that the fallback answer is identical to calling `build_deterministic_answer()` directly on the same facts.
- 1 existing API-level test updated to match (renamed, same rationale).
- **`test_deep_dive_deterministic_answer.py` (PR-ND1's pure-function tests) is untouched** — confirmed via `git status` showing zero changes to that file.

## Out of scope (unchanged)

Frontend, API response shape, DB schema, migrations, Ranking, Recommendation Authority, Knowledge Ranking connections.

## Test plan

- [x] Full Deep Dive regression suite (retrieval + answer + deterministic-answer + API): **67/67 passed**.
- [x] Full backend suite: **1535 passed**, 13 pre-existing skips, 0 failures.
- [x] `python3 manage.py makemigrations --check --dry-run`: no changes.
- [x] `ruff check`: clean.
- [x] Pre-push hook (web suite, unaffected by this backend-only change): 940/940 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)