### PR TITLE
fix: normalize action_suggestion_v4_preview at the raw-payload boundary

### DIFF
--- a/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.actionSuggestionV4Preview.test.ts
+++ b/apps/web/src/features/concierge/__tests__/buildPayloadFromUnified.actionSuggestionV4Preview.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from "vitest";
+import { buildPayloadFromUnified } from "../buildPayloadFromUnified";
+
+const baseFilterState: any = {
+  isOpen: false,
+  birthdate: "",
+  element4: null,
+  goriyakuTags: [],
+  suggestedTags: [],
+  selectedTagIds: [],
+  tagsLoading: false,
+  tagsError: null,
+  extraCondition: "",
+};
+
+function findFirstRecommendationItem(p: ReturnType<typeof buildPayloadFromUnified>): any {
+  const recSec = p?.sections?.find((s: any) => s.type === "recommendations") as any;
+  return recSec?.items?.[0] ?? null;
+}
+
+describe("buildPayloadFromUnified action_suggestion_v4_preview normalization", () => {
+  it("normalizes a raw Backend snake_case action_suggestion_v4_preview into the camelCase ViewModel (regression for Hero crash on preview.primaryAction.label)", () => {
+    const u: any = {
+      data: {
+        recommendations: [
+          {
+            shrine_id: 10,
+            display_name: "S1",
+            reason: "R1",
+            action_suggestion_v4_preview: {
+              primary_action: {
+                label: "まず詳細を見る",
+                description: "候補神社の詳細を見て判断材料を増やします。",
+                action_type: "detail_open",
+                confidence: 0.82,
+              },
+              secondary_action: {
+                label: "保存する",
+                description: "あとで見返します。",
+                action_type: "save",
+                confidence: 0.74,
+              },
+              reflection_prompt: {
+                question: "何を整理したいですか？",
+                prompt_type: "before_visit",
+                source_seed: "fallback",
+              },
+              action_source: {
+                source: "fallback",
+                reason: "安全な初期提案",
+              },
+              preview: true,
+              version: "v4",
+              source_keys: ["recommendation_reason_v4"],
+            },
+          },
+        ],
+      },
+      thread: { id: 1 },
+    };
+
+    const p = buildPayloadFromUnified(u, baseFilterState);
+    const item = findFirstRecommendationItem(p);
+
+    expect(item).not.toBeNull();
+    // The field the Hero component reads directly (preview.primaryAction.label) must exist
+    // in camelCase form -- this is exactly what crashed when the raw snake_case payload was
+    // passed through unnormalized.
+    expect(item.actionSuggestionV4Preview.primaryAction.label).toBe("まず詳細を見る");
+    expect(item.actionSuggestionV4Preview.secondaryAction.actionType).toBe("save");
+    expect(item.actionSuggestionV4Preview.reflectionPrompt.promptType).toBe("before_visit");
+    expect(item.actionSuggestionV4Preview.actionSource.source).toBe("fallback");
+    expect(item.actionSuggestionV4Preview.sourceKeys).toEqual(["recommendation_reason_v4"]);
+  });
+
+  it("normalizes a camelCase action_suggestion_v4_preview payload", () => {
+    const u: any = {
+      data: {
+        recommendations: [
+          {
+            shrine_id: 11,
+            display_name: "S2",
+            reason: "R2",
+            actionSuggestionV4Preview: {
+              primaryAction: {
+                label: "まず詳細を見る",
+                description: "候補神社の詳細を見て判断材料を増やします。",
+                actionType: "detail_open",
+                confidence: 0.82,
+              },
+              secondaryAction: {
+                label: "保存する",
+                description: "あとで見返します。",
+                actionType: "save",
+                confidence: 0.74,
+              },
+              reflectionPrompt: {
+                question: "何を整理したいですか？",
+                promptType: "before_visit",
+                sourceSeed: "fallback",
+              },
+              actionSource: {
+                source: "fallback",
+                reason: "安全な初期提案",
+              },
+              preview: true,
+              version: "v4",
+              sourceKeys: ["recommendation_reason_v4"],
+            },
+          },
+        ],
+      },
+      thread: { id: 2 },
+    };
+
+    const p = buildPayloadFromUnified(u, baseFilterState);
+    const item = findFirstRecommendationItem(p);
+
+    expect(item.actionSuggestionV4Preview.primaryAction.label).toBe("まず詳細を見る");
+  });
+
+  it("normalizes an incomplete preview (missing secondary_action) to null instead of passing the raw object through", () => {
+    const u: any = {
+      data: {
+        recommendations: [
+          {
+            shrine_id: 12,
+            display_name: "S3",
+            reason: "R3",
+            action_suggestion_v4_preview: {
+              primary_action: {
+                label: "まず詳細を見る",
+                description: "説明",
+                action_type: "detail_open",
+                confidence: 0.5,
+              },
+              reflection_prompt: {
+                question: "問い",
+                prompt_type: "before_visit",
+                source_seed: "fallback",
+              },
+              action_source: { source: "fallback", reason: "理由" },
+              preview: true,
+              version: "v4",
+            },
+          },
+        ],
+      },
+      thread: { id: 3 },
+    };
+
+    const p = buildPayloadFromUnified(u, baseFilterState);
+    const item = findFirstRecommendationItem(p);
+
+    expect(item).not.toBeNull();
+    expect(item.actionSuggestionV4Preview).toBeNull();
+  });
+
+  it("does not throw and yields null actionSuggestionV4Preview when the field is entirely absent", () => {
+    const u: any = {
+      data: {
+        recommendations: [{ shrine_id: 13, display_name: "S4", reason: "R4" }],
+      },
+      thread: { id: 4 },
+    };
+
+    expect(() => buildPayloadFromUnified(u, baseFilterState)).not.toThrow();
+    const item = findFirstRecommendationItem(buildPayloadFromUnified(u, baseFilterState));
+    expect(item.actionSuggestionV4Preview).toBeNull();
+  });
+});

--- a/apps/web/src/features/concierge/buildPayloadFromUnified.ts
+++ b/apps/web/src/features/concierge/buildPayloadFromUnified.ts
@@ -6,6 +6,8 @@ import type {
   ConciergeFilterState,
 } from "@/features/concierge/sections/types";
 import type { ConciergeReasonFacts, RecommendationReasonV4Detail } from "@/lib/api/concierge";
+import type { ActionSuggestionV4PreviewViewModel } from "@/viewmodels/conciergeResultItem";
+import { normalizeActionSuggestionV4Preview } from "@/viewmodels/actionSuggestionV4Preview";
 import { validDirectionReferenceOrNull, type DirectionReference } from "../../../../../packages/shared/directionReference";
 import {
   normalizeRecommendationInstanceId,
@@ -44,7 +46,7 @@ type NormalizedItemBase = {
     timeEstimate: string;
     measurementKey: string;
   }>;
-  actionSuggestionV4Preview?: unknown;
+  actionSuggestionV4Preview?: ActionSuggestionV4PreviewViewModel | null;
   detailHref?: string;
   isDummy?: boolean;
   directionReference?: DirectionReference | null;
@@ -163,11 +165,12 @@ function normalizeRecommendation(r: any, tid: string | null, analyticsContext: D
     analyticsContext.consultationAxis,
   );
   const actionSuggestions = normalizeActionSuggestions(r);
-  const actionSuggestionV4Preview = r?.action_suggestion_v4_preview ?? r?.actionSuggestionV4Preview ?? null;
+  const actionSuggestionV4PreviewRaw = r?.action_suggestion_v4_preview ?? r?.actionSuggestionV4Preview ?? null;
+  const actionSuggestionV4Preview = normalizeActionSuggestionV4Preview(actionSuggestionV4PreviewRaw);
   const analyticsProvenance = recommendationAnalyticsProvenance({
     primaryReasonSource: r?.primary_reason_source ?? r?._primary_reason_source,
     reasonFacts,
-    actionSuggestionPreview: actionSuggestionV4Preview,
+    actionSuggestionPreview: actionSuggestionV4PreviewRaw,
   });
   const recommendationInstanceId = normalizeRecommendationInstanceId(
     r?.recommendation_instance_id ?? r?.recommendationInstanceId,

--- a/apps/web/src/viewmodels/__tests__/actionSuggestionV4Preview.test.ts
+++ b/apps/web/src/viewmodels/__tests__/actionSuggestionV4Preview.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { normalizeActionSuggestionV4Preview } from "@/viewmodels/actionSuggestionV4Preview";
+
+function validSnakeCasePreview() {
+  return {
+    primary_action: {
+      label: "まず詳細を見る",
+      description: "候補神社の詳細を見て判断材料を増やします。",
+      action_type: "detail_open",
+      confidence: 0.82,
+    },
+    secondary_action: {
+      label: "保存する",
+      description: "あとで見返します。",
+      action_type: "save",
+      confidence: 0.74,
+    },
+    reflection_prompt: {
+      question: "何を整理したいですか？",
+      prompt_type: "before_visit",
+      source_seed: "fallback",
+    },
+    action_source: {
+      source: "fallback",
+      reason: "安全な初期提案",
+    },
+    preview: true,
+    version: "v4",
+    source_keys: ["recommendation_reason_v4"],
+  };
+}
+
+function validCamelCasePreview() {
+  return {
+    primaryAction: {
+      label: "まず詳細を見る",
+      description: "候補神社の詳細を見て判断材料を増やします。",
+      actionType: "detail_open",
+      confidence: 0.82,
+    },
+    secondaryAction: {
+      label: "保存する",
+      description: "あとで見返します。",
+      actionType: "save",
+      confidence: 0.74,
+    },
+    reflectionPrompt: {
+      question: "何を整理したいですか？",
+      promptType: "before_visit",
+      sourceSeed: "fallback",
+    },
+    actionSource: {
+      source: "fallback",
+      reason: "安全な初期提案",
+    },
+    preview: true,
+    version: "v4",
+    sourceKeys: ["recommendation_reason_v4"],
+  };
+}
+
+describe("normalizeActionSuggestionV4Preview", () => {
+  it("normalizes a valid snake_case (Backend) payload into the camelCase ViewModel", () => {
+    const result = normalizeActionSuggestionV4Preview(validSnakeCasePreview());
+
+    expect(result).not.toBeNull();
+    expect(result?.primaryAction).toEqual({
+      label: "まず詳細を見る",
+      description: "候補神社の詳細を見て判断材料を増やします。",
+      actionType: "detail_open",
+      confidence: 0.82,
+    });
+    expect(result?.secondaryAction.actionType).toBe("save");
+    expect(result?.reflectionPrompt).toEqual({
+      question: "何を整理したいですか？",
+      promptType: "before_visit",
+      sourceSeed: "fallback",
+    });
+    expect(result?.actionSource).toEqual({ source: "fallback", reason: "安全な初期提案" });
+    expect(result?.sourceKeys).toEqual(["recommendation_reason_v4"]);
+    expect(result?.preview).toBe(true);
+    expect(result?.version).toBe("v4");
+  });
+
+  it("normalizes a valid camelCase (legacy) payload into the camelCase ViewModel", () => {
+    const result = normalizeActionSuggestionV4Preview(validCamelCasePreview());
+
+    expect(result).not.toBeNull();
+    expect(result?.primaryAction.label).toBe("まず詳細を見る");
+    expect(result?.secondaryAction.actionType).toBe("save");
+    expect(result?.reflectionPrompt.promptType).toBe("before_visit");
+    expect(result?.actionSource.source).toBe("fallback");
+    expect(result?.sourceKeys).toEqual(["recommendation_reason_v4"]);
+  });
+
+  it("returns null when primary_action is missing", () => {
+    const raw = validSnakeCasePreview();
+    delete (raw as any).primary_action;
+
+    expect(normalizeActionSuggestionV4Preview(raw)).toBeNull();
+  });
+
+  it("returns null when secondary_action is missing", () => {
+    const raw = validSnakeCasePreview();
+    delete (raw as any).secondary_action;
+
+    expect(normalizeActionSuggestionV4Preview(raw)).toBeNull();
+  });
+
+  it("returns null when reflection_prompt is missing", () => {
+    const raw = validSnakeCasePreview();
+    delete (raw as any).reflection_prompt;
+
+    expect(normalizeActionSuggestionV4Preview(raw)).toBeNull();
+  });
+
+  it("returns null when action_source is missing", () => {
+    const raw = validSnakeCasePreview();
+    delete (raw as any).action_source;
+
+    expect(normalizeActionSuggestionV4Preview(raw)).toBeNull();
+  });
+
+  it("accepts an empty description (Backend allows description: \"\", only label is required non-empty)", () => {
+    const raw = validSnakeCasePreview();
+    (raw as any).primary_action.description = "";
+
+    const result = normalizeActionSuggestionV4Preview(raw);
+
+    expect(result).not.toBeNull();
+    expect(result?.primaryAction.description).toBe("");
+    expect(result?.primaryAction.label).toBe("まず詳細を見る");
+  });
+
+  it("returns null for null/undefined/non-object input without throwing", () => {
+    expect(normalizeActionSuggestionV4Preview(null)).toBeNull();
+    expect(normalizeActionSuggestionV4Preview(undefined)).toBeNull();
+    expect(normalizeActionSuggestionV4Preview("not-an-object")).toBeNull();
+    expect(normalizeActionSuggestionV4Preview(42)).toBeNull();
+  });
+});

--- a/apps/web/src/viewmodels/actionSuggestionV4Preview.ts
+++ b/apps/web/src/viewmodels/actionSuggestionV4Preview.ts
@@ -1,0 +1,123 @@
+// actionSuggestionV4Preview.ts
+// raw API payload (snake_case or camelCase, backend or legacy shape) -> ActionSuggestionV4PreviewViewModel
+// boundary normalizer, shared by every call site that reads action_suggestion_v4_preview /
+// actionSuggestionV4Preview off a recommendation so none of them can pass the raw payload
+// through to a component that assumes the ViewModel's camelCase shape.
+import type {
+  ActionSuggestionV4ActionViewModel,
+  ActionSuggestionV4PreviewViewModel,
+  ActionSuggestionV4ReflectionPromptViewModel,
+  ActionSuggestionV4SourceViewModel,
+} from "@/viewmodels/conciergeResultItem";
+
+const ACTION_SUGGESTION_V4_ACTION_TYPES = ["detail_open", "route_open", "save", "visit", "reflect", "pause"] as const;
+const ACTION_SUGGESTION_V4_PROMPT_TYPES = ["before_visit", "after_visit", "decision", "emotion", "constraint"] as const;
+const ACTION_SUGGESTION_V4_SOURCES = [
+  "decision_context",
+  "constraint_profile",
+  "outcome_hint",
+  "action_context",
+  "reflection_question_seed",
+  "fallback",
+] as const;
+
+function isActionSuggestionV4ActionType(value: unknown): value is ActionSuggestionV4ActionViewModel["actionType"] {
+  return typeof value === "string" && ACTION_SUGGESTION_V4_ACTION_TYPES.includes(value as any);
+}
+
+function isActionSuggestionV4PromptType(value: unknown): value is ActionSuggestionV4ReflectionPromptViewModel["promptType"] {
+  return typeof value === "string" && ACTION_SUGGESTION_V4_PROMPT_TYPES.includes(value as any);
+}
+
+function isActionSuggestionV4Source(value: unknown): value is ActionSuggestionV4SourceViewModel["source"] {
+  return typeof value === "string" && ACTION_SUGGESTION_V4_SOURCES.includes(value as any);
+}
+
+function asTrimmedString(val: any): string | null {
+  return typeof val === "string" && val.trim() ? val.trim() : null;
+}
+
+function normalizeActionSuggestionV4Action(raw: any): ActionSuggestionV4ActionViewModel | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const label = asTrimmedString(raw.label);
+  // Backend allows an empty description (action_suggestion_builder.py: `description: str`,
+  // not required non-empty) -- only label is user-facing and required to be non-empty.
+  const description = typeof raw.description === "string" ? raw.description.trim() : null;
+  const actionTypeRaw = raw.action_type ?? raw.actionType;
+  const confidenceRaw = typeof raw.confidence === "number" ? raw.confidence : Number(raw.confidence);
+
+  if (!label || description === null || !isActionSuggestionV4ActionType(actionTypeRaw) || !Number.isFinite(confidenceRaw)) {
+    return null;
+  }
+
+  return {
+    label,
+    description,
+    actionType: actionTypeRaw,
+    confidence: Math.max(0, Math.min(1, confidenceRaw)),
+  };
+}
+
+function normalizeActionSuggestionV4ReflectionPrompt(raw: any): ActionSuggestionV4ReflectionPromptViewModel | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const question = asTrimmedString(raw.question);
+  const promptTypeRaw = raw.prompt_type ?? raw.promptType;
+  const sourceSeed = asTrimmedString(raw.source_seed ?? raw.sourceSeed);
+
+  if (!question || !isActionSuggestionV4PromptType(promptTypeRaw) || !sourceSeed) {
+    return null;
+  }
+
+  return {
+    question,
+    promptType: promptTypeRaw,
+    sourceSeed,
+  };
+}
+
+function normalizeActionSuggestionV4Source(raw: any): ActionSuggestionV4SourceViewModel | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const sourceRaw = raw.source;
+  const reason = asTrimmedString(raw.reason);
+
+  if (!isActionSuggestionV4Source(sourceRaw) || !reason) {
+    return null;
+  }
+
+  return {
+    source: sourceRaw,
+    reason,
+  };
+}
+
+export function normalizeActionSuggestionV4Preview(raw: any): ActionSuggestionV4PreviewViewModel | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const primaryAction = normalizeActionSuggestionV4Action(raw.primary_action ?? raw.primaryAction);
+  const secondaryAction = normalizeActionSuggestionV4Action(raw.secondary_action ?? raw.secondaryAction);
+  const reflectionPrompt = normalizeActionSuggestionV4ReflectionPrompt(raw.reflection_prompt ?? raw.reflectionPrompt);
+  const actionSource = normalizeActionSuggestionV4Source(raw.action_source ?? raw.actionSource);
+  const sourceKeysRaw = raw.source_keys ?? raw.sourceKeys;
+  const sourceKeys = Array.isArray(sourceKeysRaw)
+    ? sourceKeysRaw
+        .map((item) => asTrimmedString(item))
+        .filter((item): item is string => Boolean(item))
+    : [];
+
+  if (!primaryAction || !secondaryAction || !reflectionPrompt || !actionSource) {
+    return null;
+  }
+
+  return {
+    primaryAction,
+    secondaryAction,
+    reflectionPrompt,
+    actionSource,
+    preview: raw.preview === true,
+    version: "v4",
+    sourceKeys,
+  };
+}

--- a/apps/web/src/viewmodels/conciergeToShrineList.ts
+++ b/apps/web/src/viewmodels/conciergeToShrineList.ts
@@ -1,10 +1,5 @@
-import type {
-  ActionSuggestionV4ActionViewModel,
-  ActionSuggestionV4PreviewViewModel,
-  ActionSuggestionV4ReflectionPromptViewModel,
-  ActionSuggestionV4SourceViewModel,
-  ConciergeResultItem,
-} from "@/viewmodels/conciergeResultItem";
+import type { ConciergeResultItem } from "@/viewmodels/conciergeResultItem";
+import { normalizeActionSuggestionV4Preview } from "@/viewmodels/actionSuggestionV4Preview";
 import { buildRecommendationReasonViewModel } from "@/lib/concierge/buildRecommendationReasonViewModel";
 import { buildShrineHref } from "@/lib/nav/buildShrineHref";
 import {
@@ -110,116 +105,6 @@ function normalizeTrustMetadata(raw: any) {
 
 function toDisplayTag(tag: string): string {
   return labelNeedDisplayTag(tag);
-}
-
-const ACTION_SUGGESTION_V4_ACTION_TYPES = ["detail_open", "route_open", "save", "visit", "reflect", "pause"] as const;
-const ACTION_SUGGESTION_V4_PROMPT_TYPES = ["before_visit", "after_visit", "decision", "emotion", "constraint"] as const;
-const ACTION_SUGGESTION_V4_SOURCES = [
-  "decision_context",
-  "constraint_profile",
-  "outcome_hint",
-  "action_context",
-  "reflection_question_seed",
-  "fallback",
-] as const;
-
-function isActionSuggestionV4ActionType(value: unknown): value is ActionSuggestionV4ActionViewModel["actionType"] {
-  return typeof value === "string" && ACTION_SUGGESTION_V4_ACTION_TYPES.includes(value as any);
-}
-
-function isActionSuggestionV4PromptType(value: unknown): value is ActionSuggestionV4ReflectionPromptViewModel["promptType"] {
-  return typeof value === "string" && ACTION_SUGGESTION_V4_PROMPT_TYPES.includes(value as any);
-}
-
-function isActionSuggestionV4Source(value: unknown): value is ActionSuggestionV4SourceViewModel["source"] {
-  return typeof value === "string" && ACTION_SUGGESTION_V4_SOURCES.includes(value as any);
-}
-
-function asTrimmedString(val: any): string | null {
-  return typeof val === "string" && val.trim() ? val.trim() : null;
-}
-
-function normalizeActionSuggestionV4Action(raw: any): ActionSuggestionV4ActionViewModel | null {
-  if (!raw || typeof raw !== "object") return null;
-
-  const label = asTrimmedString(raw.label);
-  const description = asTrimmedString(raw.description);
-  const actionTypeRaw = raw.action_type ?? raw.actionType;
-  const confidenceRaw = typeof raw.confidence === "number" ? raw.confidence : Number(raw.confidence);
-
-  if (!label || !description || !isActionSuggestionV4ActionType(actionTypeRaw) || !Number.isFinite(confidenceRaw)) {
-    return null;
-  }
-
-  return {
-    label,
-    description,
-    actionType: actionTypeRaw,
-    confidence: Math.max(0, Math.min(1, confidenceRaw)),
-  };
-}
-
-function normalizeActionSuggestionV4ReflectionPrompt(raw: any): ActionSuggestionV4ReflectionPromptViewModel | null {
-  if (!raw || typeof raw !== "object") return null;
-
-  const question = asTrimmedString(raw.question);
-  const promptTypeRaw = raw.prompt_type ?? raw.promptType;
-  const sourceSeed = asTrimmedString(raw.source_seed ?? raw.sourceSeed);
-
-  if (!question || !isActionSuggestionV4PromptType(promptTypeRaw) || !sourceSeed) {
-    return null;
-  }
-
-  return {
-    question,
-    promptType: promptTypeRaw,
-    sourceSeed,
-  };
-}
-
-function normalizeActionSuggestionV4Source(raw: any): ActionSuggestionV4SourceViewModel | null {
-  if (!raw || typeof raw !== "object") return null;
-
-  const sourceRaw = raw.source;
-  const reason = asTrimmedString(raw.reason);
-
-  if (!isActionSuggestionV4Source(sourceRaw) || !reason) {
-    return null;
-  }
-
-  return {
-    source: sourceRaw,
-    reason,
-  };
-}
-
-function normalizeActionSuggestionV4Preview(raw: any): ActionSuggestionV4PreviewViewModel | null {
-  if (!raw || typeof raw !== "object") return null;
-
-  const primaryAction = normalizeActionSuggestionV4Action(raw.primary_action ?? raw.primaryAction);
-  const secondaryAction = normalizeActionSuggestionV4Action(raw.secondary_action ?? raw.secondaryAction);
-  const reflectionPrompt = normalizeActionSuggestionV4ReflectionPrompt(raw.reflection_prompt ?? raw.reflectionPrompt);
-  const actionSource = normalizeActionSuggestionV4Source(raw.action_source ?? raw.actionSource);
-  const sourceKeysRaw = raw.source_keys ?? raw.sourceKeys;
-  const sourceKeys = Array.isArray(sourceKeysRaw)
-    ? sourceKeysRaw
-        .map((item) => asTrimmedString(item))
-        .filter((item): item is string => Boolean(item))
-    : [];
-
-  if (!primaryAction || !secondaryAction || !reflectionPrompt || !actionSource) {
-    return null;
-  }
-
-  return {
-    primaryAction,
-    secondaryAction,
-    reflectionPrompt,
-    actionSource,
-    preview: raw.preview === true,
-    version: "v4",
-    sourceKeys,
-  };
 }
 
 export function conciergeToShrineListItems(resp: ConciergeResponse): ConciergeResultItem[] {


### PR DESCRIPTION
## Summary

- Fixes a Recommendation Result Hero runtime crash — `Cannot read properties of undefined (reading 'label')` — reproduced via local anonymous Concierge QA.
- Root cause: `buildPayloadFromUnified.ts` passed the raw `action_suggestion_v4_preview` payload straight through to `ConciergeTopRecommendationHero`, which reads `preview.primaryAction.label` assuming the normalized camelCase ViewModel. The backend sends snake_case (`primary_action`), so on this path the field was always `undefined`.
- `conciergeToShrineList.ts` already normalized correctly via a local `normalizeActionSuggestionV4Preview()`. Extracted that into a shared module, `apps/web/src/viewmodels/actionSuggestionV4Preview.ts`, and wired `buildPayloadFromUnified.ts` to use it too — instead of hiding the crash with optional chaining in the Hero component.
- Also relaxed the action normalizer's `description` check: the backend contract allows an empty `description` (`backend/temples/services/action_suggestion_builder.py`, confirmed by `test_action_suggestion_grounding_alignment.py` / `test_journey_timeline.py` fixtures), but the normalizer previously required it non-empty and silently dropped otherwise-valid previews. Only `label` is user-facing and required non-empty.
- No Backend, Ranking, Recommendation Authority, Analytics contract, or DB/migration changes. `recommendationAnalyticsProvenance` still receives the raw (pre-normalization) preview, unchanged.

## Test plan

- [x] New unit tests for the shared normalizer (`src/viewmodels/__tests__/actionSuggestionV4Preview.test.ts`): snake_case valid, camelCase valid, missing `primary_action`/`secondary_action`/`reflection_prompt`/`action_source`, non-object input, empty `description`.
- [x] New regression tests for `buildPayloadFromUnified` (`src/features/concierge/__tests__/buildPayloadFromUnified.actionSuggestionV4Preview.test.ts`): snake_case and camelCase raw payloads normalize into the camelCase ViewModel the Hero reads; incomplete/absent preview normalizes to `null` instead of passing a raw object through.
- [x] Full web suite: 952/952 passing.
- [x] `tsc --noEmit`: clean.
- [x] `next build`: succeeds.
- [x] Runtime QA (local, anonymous session, real backend on :8000): submitted a consultation → `/concierge?tid=798` → Hero renders (Conclusion / 参考情報 / 参拝前にできること) → compact "ほかの神社" list renders → detail transition to `/shrines/62?ctx=concierge&tid=798` — no runtime crash at any step, only expected anonymous-session 401s in console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)