### PR TITLE
feat: add recommendationInstanceId join key to Result/Detail meaning card_view events

### DIFF
--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -134,6 +134,9 @@ function trackShrineDetailCardView(args: {
   payloadSource?: "v2" | "fallback";
   shrineId?: number | string;
   historyTheme?: string | null;
+  // Result <-> Detail duplicate-exposure join key (with shrineId) -- see
+  // docs/audit/recommendation-result-detail-instrumentation-contract.md §7.
+  recommendationInstanceId?: string | null;
 }) {
   if (args.visibility === "hidden") return;
 
@@ -146,6 +149,7 @@ function trackShrineDetailCardView(args: {
     shrineId: args.shrineId,
     historyTheme: args.historyTheme,
     payloadSource: args.payloadSource,
+    recommendationInstanceId: args.recommendationInstanceId ?? null,
   });
 }
 
@@ -527,6 +531,7 @@ export default function ShrineDetailArticle({
         shrineId: cardProps.shrineId,
         historyTheme,
         payloadSource: meaningPayloadSource,
+        recommendationInstanceId,
       });
     }
 
@@ -538,6 +543,7 @@ export default function ShrineDetailArticle({
         shrineId: cardProps.shrineId,
         historyTheme,
         payloadSource: meaningPayloadSource,
+        recommendationInstanceId,
       });
     });
 
@@ -549,6 +555,7 @@ export default function ShrineDetailArticle({
         shrineId: cardProps.shrineId,
         historyTheme,
         payloadSource: meaningPayloadSource,
+        recommendationInstanceId,
       });
     }
 
@@ -560,6 +567,7 @@ export default function ShrineDetailArticle({
         shrineId: cardProps.shrineId,
         historyTheme,
         payloadSource: meaningPayloadSource,
+        recommendationInstanceId,
       });
     });
 
@@ -571,6 +579,7 @@ export default function ShrineDetailArticle({
         shrineId: cardProps.shrineId,
         historyTheme,
         payloadSource: meaningPayloadSource,
+        recommendationInstanceId,
       });
     }
 
@@ -618,6 +627,7 @@ export default function ShrineDetailArticle({
     premiumMeaningBlockCardIdKey,
     premiumMeaningBlockCardIds,
     previousComparisonVisibility,
+    recommendationInstanceId,
     recommendationMeta?.rankBody,
     recommendationMeta?.rankTitle,
     recommendationMetaVisibility,

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
@@ -422,6 +422,76 @@ describe("ShrineDetailArticle", () => {
     });
   });
 
+  describe("Result <-> Detail duplicate-exposure join (docs/audit/recommendation-result-detail-instrumentation-contract.md §7)", () => {
+    const meaningSection = {
+      kind: "meaning",
+      items: [{ key: "consultation_summary" }, { key: "shrine_meaning" }, { key: "action_meaning" }],
+    } as any;
+
+    function renderWithMeaningSection(recommendationInstanceId?: string | null) {
+      return render(
+        <ShrineDetailArticle
+          cardProps={{
+            shrineId: 17,
+            title: "乃木神社",
+            href: "/shrines/17",
+            imageUrl: null,
+            badges: [],
+            metaChips: [],
+            address: "東京都港区赤坂",
+          } as any}
+          heroImageUrl={null}
+          heroMeaningCopy={null}
+          benefitLabels={[]}
+          tags={[]}
+          publicGoshuinsPreview={[]}
+          publicGoshuinsViewAllHref=""
+          sections={[meaningSection]}
+          isPremiumActive
+          recommendationMeta={null}
+          saveActionNode={null}
+          recommendationInstanceId={recommendationInstanceId}
+        />,
+      );
+    }
+
+    it("shrine_meaning / action_meaning / consultation_summaryのcard_viewがrecommendationInstanceId + shrineIdを送る", async () => {
+      renderWithMeaningSection("a1b2c3d4");
+
+      await waitFor(() => {
+        for (const cardId of ["consultation_summary", "shrine_meaning", "action_meaning"] as const) {
+          expect(analyticsMocks.trackCardEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              event: "card_view",
+              cardId,
+              source: "shrine_detail",
+              shrineId: 17,
+              recommendationInstanceId: "a1b2c3d4",
+            }),
+          );
+        }
+      });
+    });
+
+    it("recommendationInstanceIdが無い場合はnullを送り、クラッシュせず既存fieldは維持される", async () => {
+      expect(() => renderWithMeaningSection(undefined)).not.toThrow();
+
+      await waitFor(() => {
+        expect(analyticsMocks.trackCardEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            event: "card_view",
+            cardId: "shrine_meaning",
+            source: "shrine_detail",
+            accessLevel: "premium",
+            visibility: "visible",
+            shrineId: 17,
+            recommendationInstanceId: null,
+          }),
+        );
+      });
+    });
+  });
+
   it.each([
     [true, "参拝お疲れさまでした"],
     [false, null],

--- a/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
+++ b/apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx
@@ -429,11 +429,14 @@ export default function ConciergeSectionsRenderer({
           source: "concierge_result",
           accessLevel,
           visibility: consultationSummaryRoute.visibility,
+          shrineId: heroItem.shrineId,
+          recommendationRank: heroItem.rank,
           mode: heroItem.mode,
           historyTheme: heroItem.historyTheme ?? analyticsContext?.historyTheme,
           ...consultationAxisAnalytics(heroItem.consultationAxis ?? analyticsContext?.consultationAxis),
           threadId: tid ?? undefined,
           resultSetId,
+          recommendationInstanceId: heroItem.recommendationInstanceId ?? null,
         });
       }
     }
@@ -457,6 +460,7 @@ export default function ConciergeSectionsRenderer({
           ...consultationAxisAnalytics(heroItem.consultationAxis ?? analyticsContext?.consultationAxis),
           threadId: tid ?? undefined,
           resultSetId,
+          recommendationInstanceId: heroItem.recommendationInstanceId ?? null,
         });
       }
     }
@@ -480,6 +484,7 @@ export default function ConciergeSectionsRenderer({
           ...consultationAxisAnalytics(heroItem.consultationAxis ?? analyticsContext?.consultationAxis),
           threadId: tid ?? undefined,
           resultSetId,
+          recommendationInstanceId: heroItem.recommendationInstanceId ?? null,
         });
       }
     }

--- a/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.recommendationInstanceId.test.tsx
+++ b/apps/web/src/features/concierge/components/__tests__/ConciergeSectionsRenderer.recommendationInstanceId.test.tsx
@@ -111,3 +111,53 @@ describe("Recommendation Instance Identity: impression -> click", () => {
     expect(first).toBe("stable-9f8e");
   });
 });
+
+describe("Recommendation Instance Identity: Result-side meaning card_view (Result <-> Detail duplicate-exposure join, docs/audit/recommendation-result-detail-instrumentation-contract.md §7)", () => {
+  beforeEach(() => {
+    analyticsMocks.trackCardEvent.mockClear();
+    // premium+authenticated so shrine_meaning/action_meaning/consultation_summary resolve to
+    // "visible" (CARD_VISIBILITY_POLICIES) instead of "hidden" (anonymous), which would otherwise
+    // filter them out of conciergeCardRoutes entirely and fire no card_view at all.
+    authMock.useAuth.mockReturnValue({ isLoggedIn: true, loading: false });
+    window.localStorage.clear();
+  });
+
+  it("shrine_meaning / action_meaning / consultation_summaryのcard_viewがrecommendationInstanceId + shrineIdを送る", () => {
+    const heroRec = {
+      shrine_id: 9,
+      display_name: "結合検証神社",
+      reason: "理由文",
+      recommendation_instance_id: "join-key-1234",
+    };
+    const payload = buildTestPayload([heroRec]);
+    render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />);
+
+    for (const cardId of ["consultation_summary", "shrine_meaning", "action_meaning"] as const) {
+      const call = analyticsMocks.trackCardEvent.mock.calls.find(([payload]) => payload.cardId === cardId);
+      expect(call?.[0]).toMatchObject({
+        cardId,
+        source: "concierge_result",
+        shrineId: 9,
+        recommendationInstanceId: "join-key-1234",
+      });
+    }
+  });
+
+  it("recommendation_instance_idが無い候補ではrecommendationInstanceIdにnullを送り、既存fieldは維持される", () => {
+    const heroRec = { shrine_id: 10, display_name: "識別子なし神社", reason: "理由文" };
+    const payload = buildTestPayload([heroRec]);
+
+    expect(() =>
+      render(<ConciergeSectionsRenderer payload={payload} threadId={768} isPremiumActive={true} />),
+    ).not.toThrow();
+
+    const call = analyticsMocks.trackCardEvent.mock.calls.find(([payload]) => payload.cardId === "shrine_meaning");
+    expect(call?.[0]).toMatchObject({
+      cardId: "shrine_meaning",
+      source: "concierge_result",
+      shrineId: 10,
+      recommendationRank: 1,
+      recommendationInstanceId: null,
+    });
+  });
+});

--- a/apps/web/src/lib/analytics/cardEvents.ts
+++ b/apps/web/src/lib/analytics/cardEvents.ts
@@ -46,6 +46,10 @@ export type CardAnalyticsPayload = {
   sessionId?: string;
   threadId?: string;
   resultSetId?: string;
+  // Result <-> Detail duplicate-exposure join key (with shrineId), Backend rid
+  // persisted on the thread snapshot -- see docs/audit/
+  // recommendation-result-detail-instrumentation-contract.md §7.
+  recommendationInstanceId?: string | null;
 };
 
 type SerializedCardAnalyticsPayloadInput = Omit<CardAnalyticsPayload, "event">;


### PR DESCRIPTION
## Summary

Implements the `READY FOR INSTRUMENTATION PR` proposal from [`recommendation-result-detail-instrumentation-contract.md`](docs/audit/recommendation-result-detail-instrumentation-contract.md) §7–10. Analytics-only — does **not** authorize or start the Result/Detail Information Responsibility UI redesign, which remains frozen under `recommendation-result-observation-policy.md`.

- Added `recommendationInstanceId?: string | null` to `CardAnalyticsPayload` ([cardEvents.ts](apps/web/src/lib/analytics/cardEvents.ts)) — one new optional field, nothing removed or renamed.
- Result side ([ConciergeSectionsRenderer.tsx](apps/web/src/features/concierge/components/ConciergeSectionsRenderer.tsx)): `shrine_meaning`/`action_meaning`/`consultation_summary` `card_view` calls now send `recommendationInstanceId` (value already in scope, same pattern already used for `concierge_result_impression`/`shrine_detail_transition`). `consultation_summary` also gained `shrineId`/`recommendationRank`, matching the other two cards (it was the one card missing them).
- Detail side ([ShrineDetailArticle.tsx](apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx)): `trackShrineDetailCardView()` now accepts and forwards `recommendationInstanceId` (value already flows into this component as a prop, already re-derived server-side from the Backend-persisted thread snapshot in `page.tsx` — just wasn't threaded into this specific tracking call).
- No event names or cardIds changed. No JSX/rendering changes. No Backend, Ranking, Recommendation Authority, or migration changes.

Per the audit: `recommendationInstanceId` is per-*generation*, shared across every shrine in one chat response — not unique per shrine — so `shrineId` always accompanies it as the join key `(recommendationInstanceId, shrineId)`.

## Test plan

- [x] New/extended tests (`ConciergeSectionsRenderer.recommendationInstanceId.test.tsx`, `ShrineDetailArticle.test.tsx`): Result and Detail `shrine_meaning`/`action_meaning`/`consultation_summary` `card_view` include `recommendationInstanceId` + `shrineId`; missing `recommendationInstanceId` degrades to `null` without throwing; existing event names/cardIds/fields unchanged.
- [x] Full web suite: 956/956 passing (was 952, +4 new tests).
- [x] `tsc --noEmit`: clean.
- [x] `next build`: succeeds.
- [x] `git diff --stat`: 5 files, +139/-0 — additive only, no JSX touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)