### PR TITLE
feat: Compass候補を既存Recommendationへ統合

### DIFF
--- a/backend/temples/services/compass_recommendation_orchestrator.py
+++ b/backend/temples/services/compass_recommendation_orchestrator.py
@@ -1,0 +1,199 @@
+"""Compass Recommendation Orchestrator.
+
+Connects the Compass-authorized direction candidate space (Phase 3,
+temples.services.compass_direction_filter.filter_candidates_by_direction) to
+the existing Recommendation domain (build_chat_candidates +
+build_chat_recommendations) without changing Concierge behavior, Ranking
+weights, or Recommendation Reason authority. See
+docs/product/compass-product-contract.md Section 6 and
+docs/product/compass-mvp-runtime-contract.md Section 6.
+
+Boundary this module deliberately keeps:
+
+- It does NOT compute direction runtime signals (kyusei / direction_reference
+  math). That is Compass Runtime Authority's job and is expected to already
+  be resolved by the caller into `direction_context` (the
+  CompassDirectionRuntime shape from compass-mvp-runtime-contract.md
+  Section 5) before calling this module.
+- It does NOT route through ConciergeChatView or touch its compat-mode
+  heuristics (compass-mvp-runtime-contract.md Section 6, "ConciergeChatView
+  を実装都合で流用しない").
+- `direction_context` / `purpose` / `origin` are kept as separate parameters,
+  never merged into one object -- this mirrors
+  CompassRecommendationHandoffContext (same contract, Section 6) at the code
+  level, not just in documentation.
+- `birthdate` is intentionally NOT a parameter here. Direction-calc
+  (kyusei.honmei_star et al.) already consumed it upstream to produce
+  `direction_context`; CompassRecommendationHandoffContext has no birthdate
+  field, so it does not travel further into Recommendation Integration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional, Sequence
+
+from temples.domain.need_tags import NEED_TAGS
+from temples.services.compass_direction_filter import filter_candidates_by_direction
+from temples.services.concierge_chat import build_chat_recommendations
+from temples.services.concierge_chat_candidates import build_chat_candidates
+from temples.services.consultation_interpreter import interpret_consultation
+from temples.services.direction_reference import _coordinate
+
+# Fail-safe states (Section 11). Kept as distinct string constants -- never
+# collapse two of these into a shared generic "empty" outcome; that is
+# exactly what compass-mvp-runtime-contract.md Section 8 forbids for
+# origin/target_date fail-safes, and the same principle applies here.
+STATE_INVALID_PURPOSE = "invalid_purpose"
+STATE_DIRECTION_FILTER_UNAVAILABLE = "direction_filter_unavailable"
+STATE_DIRECTION_ZERO_CANDIDATES = "direction_zero_candidates"
+STATE_EVIDENCE_ZERO_CANDIDATES = "evidence_zero_candidates"
+STATE_RECOMMENDATION_SUCCESS = "recommendation_success"
+
+# Initial DB candidate pool size before geographic narrowing. Direction
+# filtering typically keeps only 1-2 of 8 sectors, so Compass requests a
+# wider pre-filter pool than Concierge's default (DEFAULT_LIMIT=20) to avoid
+# collapsing to direction_zero_candidates purely from an undersized pool.
+# This is a Compass-side call argument, not a change to
+# build_chat_candidates() itself or its default for other callers.
+DEFAULT_CANDIDATE_POOL_LIMIT = 60
+
+
+@dataclass(frozen=True)
+class CompassRecommendationResult:
+    """Result of Compass Recommendation Integration for one request.
+
+    `recommendations` are the untouched recommendation dicts returned by
+    build_chat_recommendations() -- this module does not reshape, flatten,
+    or relabel their fields (Section 10: direction/purpose/recommendation/
+    shrine-fact evidence must remain separately identifiable for a future
+    Phase 5 Presentation Authority, not flattened here).
+
+    `direction_context` is passed back unmodified purely so a caller has
+    both halves of "why this direction" / "why this shrine" together
+    without this module merging them into recommendation entries.
+    """
+
+    state: str
+    recommendations: list[dict[str, Any]] = field(default_factory=list)
+    purpose: Optional[str] = None
+    direction_context: Optional[Mapping[str, Any]] = None
+
+
+def get_compass_recommendations(
+    *,
+    purpose: str,
+    origin: Optional[Mapping[str, Any]],
+    direction_context: Optional[Mapping[str, Any]],
+    language: str = "ja",
+    candidate_pool_limit: int = DEFAULT_CANDIDATE_POOL_LIMIT,
+) -> CompassRecommendationResult:
+    """Resolve Compass candidates through the existing Recommendation domain.
+
+    Never falls back to "all shrines" or silently treats an unavailable
+    direction filter as a confirmed-empty one -- see
+    compass_direction_filter.filter_candidates_by_direction's own
+    None-vs-[] contract, which this function preserves rather than collapses.
+    """
+    purpose_slug = str(purpose or "").strip()
+    if purpose_slug not in NEED_TAGS:
+        return CompassRecommendationResult(
+            state=STATE_INVALID_PURPOSE,
+            purpose=purpose_slug or None,
+            direction_context=direction_context,
+        )
+
+    if not isinstance(direction_context, Mapping):
+        return CompassRecommendationResult(
+            state=STATE_DIRECTION_FILTER_UNAVAILABLE,
+            purpose=purpose_slug,
+            direction_context=None,
+        )
+
+    reference_directions = direction_context.get("referenceDirections")
+
+    origin_lat = _coordinate(origin, "lat", "latitude") if isinstance(origin, Mapping) else None
+    origin_lng = _coordinate(origin, "lng", "longitude") if isinstance(origin, Mapping) else None
+
+    interpretation_profile = interpret_consultation(
+        query="",
+        need_tags=[purpose_slug],
+        selected_goriyaku_tag_ids=[],
+    )
+
+    candidate_pool = build_chat_candidates(
+        lat=origin_lat,
+        lng=origin_lng,
+        limit=candidate_pool_limit,
+        interpretation_profile=interpretation_profile,
+    )
+
+    filtered_candidates = filter_candidates_by_direction(
+        candidate_pool,
+        origin=origin,
+        reference_directions=reference_directions,
+    )
+
+    if filtered_candidates is None:
+        return CompassRecommendationResult(
+            state=STATE_DIRECTION_FILTER_UNAVAILABLE,
+            purpose=purpose_slug,
+            direction_context=direction_context,
+        )
+
+    if not filtered_candidates:
+        return CompassRecommendationResult(
+            state=STATE_DIRECTION_ZERO_CANDIDATES,
+            purpose=purpose_slug,
+            direction_context=direction_context,
+        )
+
+    bias = (
+        {"lat": origin_lat, "lng": origin_lng, "radius": None, "radius_m": None}
+        if origin_lat is not None and origin_lng is not None
+        else None
+    )
+
+    recs = build_chat_recommendations(
+        query="",
+        language=language,
+        candidates=list(filtered_candidates),
+        bias=bias,
+        need_tags=[purpose_slug],
+        public_mode="need",
+        flow="A",
+        interpretation_profile=interpretation_profile,
+    )
+
+    recommendations = [r for r in (recs.get("recommendations") or []) if isinstance(r, dict)]
+
+    if not recommendations:
+        # Not reachable under the traced Evidence Gate / pool-fill behavior
+        # today (see module docstring in compass_recommendation_orchestrator
+        # tests) -- kept as an explicit branch so a future change to
+        # build_chat_recommendations that *does* start dropping candidates
+        # surfaces as this distinct state rather than silently looking like
+        # direction_zero_candidates.
+        return CompassRecommendationResult(
+            state=STATE_EVIDENCE_ZERO_CANDIDATES,
+            purpose=purpose_slug,
+            direction_context=direction_context,
+        )
+
+    return CompassRecommendationResult(
+        state=STATE_RECOMMENDATION_SUCCESS,
+        recommendations=recommendations,
+        purpose=purpose_slug,
+        direction_context=direction_context,
+    )
+
+
+__all__ = [
+    "STATE_INVALID_PURPOSE",
+    "STATE_DIRECTION_FILTER_UNAVAILABLE",
+    "STATE_DIRECTION_ZERO_CANDIDATES",
+    "STATE_EVIDENCE_ZERO_CANDIDATES",
+    "STATE_RECOMMENDATION_SUCCESS",
+    "CompassRecommendationResult",
+    "get_compass_recommendations",
+]

--- a/backend/temples/tests/services/test_compass_recommendation_orchestrator.py
+++ b/backend/temples/tests/services/test_compass_recommendation_orchestrator.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from temples.models import Shrine
+from temples.services import compass_recommendation_orchestrator as orchestrator
+from temples.services.compass_recommendation_orchestrator import (
+    STATE_DIRECTION_FILTER_UNAVAILABLE,
+    STATE_DIRECTION_ZERO_CANDIDATES,
+    STATE_EVIDENCE_ZERO_CANDIDATES,
+    STATE_INVALID_PURPOSE,
+    STATE_RECOMMENDATION_SUCCESS,
+    get_compass_recommendations,
+)
+
+ORIGIN = {"lat": 35.0, "lng": 135.0}
+NORTH_DIRECTION_CONTEXT = {"referenceDirections": ["北"]}
+
+
+@pytest.fixture
+def shrine_factory(db):
+    def _factory(
+        *,
+        name: str,
+        latitude: float,
+        longitude: float,
+        goriyaku: str = "",
+        address: str = "東京都千代田区",
+        popular_score: float = 0.0,
+    ) -> Shrine:
+        shrine = Shrine(
+            name_jp=name,
+            address=address,
+            latitude=latitude,
+            longitude=longitude,
+            goriyaku=goriyaku,
+            popular_score=popular_score,
+        )
+        Shrine.objects.bulk_create([shrine])
+        return Shrine.objects.get(pk=shrine.pk)
+
+    return _factory
+
+
+@pytest.mark.django_db
+class TestInvalidPurpose:
+    def test_unknown_purpose_returns_invalid_purpose_without_recommendations(self) -> None:
+        result = get_compass_recommendations(
+            purpose="not_a_real_need_tag",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        assert result.state == STATE_INVALID_PURPOSE
+        assert result.recommendations == []
+
+    def test_empty_purpose_returns_invalid_purpose(self) -> None:
+        result = get_compass_recommendations(
+            purpose="",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        assert result.state == STATE_INVALID_PURPOSE
+
+    def test_invalid_purpose_never_queries_shrine_table(self, django_assert_num_queries) -> None:
+        with django_assert_num_queries(0):
+            get_compass_recommendations(
+                purpose="not_a_real_need_tag",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+
+@pytest.mark.django_db
+class TestDirectionFilterUnavailable:
+    def test_missing_direction_context_is_unavailable_not_zero(self) -> None:
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=None,
+        )
+        assert result.state == STATE_DIRECTION_FILTER_UNAVAILABLE
+        assert result.recommendations == []
+
+    def test_missing_origin_is_unavailable_not_zero(self) -> None:
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=None,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        assert result.state == STATE_DIRECTION_FILTER_UNAVAILABLE
+
+    def test_unrecognized_reference_directions_is_unavailable(self) -> None:
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context={"referenceDirections": ["invalid-label"]},
+        )
+        assert result.state == STATE_DIRECTION_FILTER_UNAVAILABLE
+
+    def test_unavailable_state_never_calls_recommendation_domain(self) -> None:
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations"
+        ) as mock_recommend:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=None,
+            )
+        mock_recommend.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestDirectionZeroCandidates:
+    def test_shrine_outside_authorized_sector_yields_zero_candidates_state(
+        self, shrine_factory
+    ) -> None:
+        # South of origin -- outside the authorized "北" (north) sector.
+        shrine_factory(name="南の神社", latitude=34.0, longitude=135.0, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        assert result.state == STATE_DIRECTION_ZERO_CANDIDATES
+        assert result.recommendations == []
+
+    def test_zero_candidates_never_calls_recommendation_domain(self, shrine_factory) -> None:
+        shrine_factory(name="南の神社", latitude=34.0, longitude=135.0)
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations"
+        ) as mock_recommend:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+        mock_recommend.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestRecommendationSuccess:
+    def test_shrine_inside_authorized_sector_is_recommended(self, shrine_factory) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        names = [r.get("name") for r in result.recommendations]
+        assert "北の神社" in names
+
+    def test_direction_context_is_passed_through_unmodified(self, shrine_factory) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        assert result.direction_context == NORTH_DIRECTION_CONTEXT
+
+    def test_only_direction_filtered_candidates_are_considered(self, shrine_factory) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="南の神社", latitude=34.0, longitude=135.0, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        names = [r.get("name") for r in result.recommendations]
+        assert "北の神社" in names
+        assert "南の神社" not in names
+
+
+@pytest.mark.django_db
+class TestPurposeIntegration:
+    def test_changing_purpose_changes_recommendation_order(self, shrine_factory) -> None:
+        # Both north of origin (same authorized sector), so any ranking
+        # difference must come from purpose, not from the direction filter.
+        shrine_factory(
+            name="仕事の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運祈願"
+        )
+        shrine_factory(
+            name="学問の神社", latitude=36.0, longitude=135.05, goriyaku="学問成就"
+        )
+
+        career_result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        study_result = get_compass_recommendations(
+            purpose="study",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        assert career_result.state == STATE_RECOMMENDATION_SUCCESS
+        assert study_result.state == STATE_RECOMMENDATION_SUCCESS
+
+        career_top = career_result.recommendations[0].get("name")
+        study_top = study_result.recommendations[0].get("name")
+        assert career_top == "仕事の神社"
+        assert study_top == "学問の神社"
+
+    def test_changing_purpose_does_not_change_which_shrines_pass_direction_filter(
+        self, shrine_factory
+    ) -> None:
+        shrine_factory(name="仕事の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運祈願")
+        shrine_factory(name="学問の神社", latitude=36.0, longitude=135.05, goriyaku="学問成就")
+
+        career_result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+        study_result = get_compass_recommendations(
+            purpose="study",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        career_names = {r.get("name") for r in career_result.recommendations}
+        study_names = {r.get("name") for r in study_result.recommendations}
+        assert career_names == study_names == {"仕事の神社", "学問の神社"}
+
+    def test_purpose_does_not_alter_direction_filter_call_arguments(
+        self, shrine_factory
+    ) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.filter_candidates_by_direction",
+            wraps=orchestrator.filter_candidates_by_direction,
+        ) as spy:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+            get_compass_recommendations(
+                purpose="study",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert spy.call_count == 2
+        for call in spy.call_args_list:
+            assert call.kwargs["origin"] == ORIGIN
+            assert call.kwargs["reference_directions"] == ["北"]
+
+
+@pytest.mark.django_db
+class TestEvidenceZeroCandidates:
+    def test_empty_recommendations_from_domain_maps_to_evidence_zero_candidates(
+        self, shrine_factory
+    ) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            return_value={"recommendations": []},
+        ):
+            result = get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert result.state == STATE_EVIDENCE_ZERO_CANDIDATES
+        assert result.recommendations == []
+
+
+@pytest.mark.django_db
+class TestRankingAndReasonAuthorityUnchanged:
+    def test_orchestrator_does_not_pass_custom_weights(self, shrine_factory) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        _, kwargs = spy.call_args
+        assert "weights" not in kwargs
+        assert kwargs["public_mode"] == "need"
+
+    def test_recommendation_reason_field_is_present_and_shrine_grounded(
+        self, shrine_factory
+    ) -> None:
+        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運祈願")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        reason = result.recommendations[0].get("reason")
+        assert isinstance(reason, str)
+        assert reason.strip()
+
+
+class TestConciergeIsolation:
+    """Regression proof (Section 13): Concierge orchestration must not import
+    or depend on the new Compass orchestrator."""
+
+    def test_concierge_chat_view_does_not_import_compass_orchestrator(self) -> None:
+        import inspect
+
+        from temples import api_views_concierge
+
+        source = inspect.getsource(api_views_concierge)
+        assert "compass_recommendation_orchestrator" not in source
+
+    def test_concierge_chat_service_does_not_import_compass_orchestrator(self) -> None:
+        import inspect
+
+        from temples.services import concierge_chat
+
+        source = inspect.getsource(concierge_chat)
+        assert "compass_recommendation_orchestrator" not in source


### PR DESCRIPTION
## Summary

Phase 4 (Compass Recommendation Integration) per the current authorization. Connects the Compass-authorized direction candidate space (Phase 3, `compass_direction_filter.filter_candidates_by_direction`, PR #2477) to the existing Recommendation domain without modifying Ranking, Evidence Gate, Recommendation Reason, or Concierge behavior.

- New: `backend/temples/services/compass_recommendation_orchestrator.py` — `get_compass_recommendations(*, purpose, origin, direction_context)`. Sequences three existing, unmodified functions: `build_chat_candidates()` → `filter_candidates_by_direction()` → `build_chat_recommendations(need_tags=[purpose], public_mode="need")`. No new Ranking weights, no new Evidence rule, no ConciergeChatView import.
- Returns one of 5 fail-safe states: `invalid_purpose`, `direction_filter_unavailable`, `direction_zero_candidates`, `evidence_zero_candidates` (defensive branch — not reachable under the current Evidence Gate, which withholds Facts per-candidate rather than emptying the pool; documented in the module), `recommendation_success`.
- Two design decisions worth a second look: (1) no `birthdate` param — matches `CompassRecommendationHandoffContext`'s 3-field shape (direction/purpose/origin only) from the MVP Runtime Contract; birthdate's job ends upstream, at producing `direction_context`. (2) `purpose` maps only into `need_tags`, not `goriyaku_tag_ids` hard-filtering — mirrors how Concierge's own query-derived need_tags behave, the smaller of two legitimate mappings.

## Test plan
- [x] 20 new tests in `test_compass_recommendation_orchestrator.py` covering all 5 states, purpose-changes-outcome, direction-filter-args-unaffected-by-purpose, no-custom-weights, Concierge-non-import isolation.
- [x] Existing Concierge/ranking/direction/kyusei suite: 679 passed, 4 pre-existing skips (unrelated).
- [x] Full backend suite: 1585 passed, 13 pre-existing skips (GDAL/PostGIS unavailable locally).
- [x] `git diff` scope: 2 new files only, no migrations, no frontend files.
- [x] Frontend contract suite + OpenAPI lint (pre-push hook): 976 passed.

Gate Result: COMPASS RECOMMENDATION VERIFIED

🤖 Generated with [Claude Code](https://claude.com/claude-code)