### PR TITLE
feat: Compassの目的選択UIを改善

### DIFF
--- a/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
+++ b/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
@@ -78,6 +78,42 @@ describe("CompassClient", () => {
     expect(screen.getByText("北西神社")).toBeInTheDocument();
   });
 
+  it("「その他の目的」から選んでも送信payloadは折りたたみ表示に影響されず正しいslugになる（Purpose UI Polish回帰確認）", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        state: "recommendation_success",
+        purpose: "travel_safe",
+        direction_context: {
+          targetDate: "2026-09-15",
+          targetYear: 2026,
+          solarMonthIndex: 8,
+          referenceDirections: ["北西"],
+          calculationMethod: "annual_monthly_kyusei_v1",
+          note: "note",
+        },
+        recommendations: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CompassClient />);
+    fireEvent.click(screen.getByRole("button", { name: /その他の目的を見る/ }));
+    fireEvent.click(screen.getByRole("radio", { name: "移動・安全" }));
+    setOriginViaPrefecture();
+    fireEvent.change(screen.getByLabelText("生年月日（方位計算に使用）"), {
+      target: { value: "1990-01-01" },
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "今月の方向を確認する" }));
+    });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body).purpose).toBe("travel_safe");
+  });
+
   it("direction_zero_candidatesとdirection_filter_unavailableを区別して表示する", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/apps/web/src/features/compass/__tests__/compassPurposes.test.ts
+++ b/apps/web/src/features/compass/__tests__/compassPurposes.test.ts
@@ -1,0 +1,24 @@
+import {
+  COMPASS_PRIMARY_PURPOSE_COUNT,
+  COMPASS_PURPOSES,
+  COMPASS_PURPOSES_ORDERED,
+  COMPASS_PURPOSE_LABELS_JA,
+} from "../compassPurposes";
+
+describe("compassPurposes", () => {
+  it("COMPASS_PURPOSES_ORDERED is a reordering of COMPASS_PURPOSES, not a different set", () => {
+    expect(new Set(COMPASS_PURPOSES_ORDERED)).toEqual(new Set(COMPASS_PURPOSES));
+    expect(COMPASS_PURPOSES_ORDERED.length).toBe(COMPASS_PURPOSES.length);
+  });
+
+  it("every ordered purpose has a label", () => {
+    for (const purpose of COMPASS_PURPOSES_ORDERED) {
+      expect(COMPASS_PURPOSE_LABELS_JA[purpose]).toBeTruthy();
+    }
+  });
+
+  it("primary count is smaller than the full taxonomy", () => {
+    expect(COMPASS_PRIMARY_PURPOSE_COUNT).toBeGreaterThan(0);
+    expect(COMPASS_PRIMARY_PURPOSE_COUNT).toBeLessThan(COMPASS_PURPOSES_ORDERED.length);
+  });
+});

--- a/apps/web/src/features/compass/compassPurposes.ts
+++ b/apps/web/src/features/compass/compassPurposes.ts
@@ -49,3 +49,31 @@ export const COMPASS_PURPOSE_LABELS_JA: Record<CompassPurpose, string> = {
 export function isCompassPurpose(value: unknown): value is CompassPurpose {
   return typeof value === "string" && (COMPASS_PURPOSES as readonly string[]).includes(value);
 }
+
+// Presentation-only ordering for CompassPurposeSelector's "show primary N,
+// then expand" layout (docs/audit/compass-purpose-first-view-polish.md):
+// Phase 6 QA found 15 equally-weighted chips dominate the 375px first
+// viewport. This reorders which of the *same* 15 purposes render first --
+// it adds/removes/renames nothing. The order is not invented for Compass;
+// it is copied verbatim from the existing backend priority ranking
+// (backend/temples/domain/need_tags.py NEED_PRIORITY), which Concierge
+// already uses to break ties among multiple matched need_tags.
+export const COMPASS_PURPOSES_ORDERED: readonly CompassPurpose[] = [
+  "protection",
+  "marriage",
+  "love",
+  "family",
+  "study",
+  "career",
+  "money",
+  "health",
+  "mental",
+  "relationship",
+  "communication",
+  "courage",
+  "focus",
+  "rest",
+  "travel_safe",
+];
+
+export const COMPASS_PRIMARY_PURPOSE_COUNT = 6;

--- a/apps/web/src/features/compass/components/CompassPurposeSelector.tsx
+++ b/apps/web/src/features/compass/components/CompassPurposeSelector.tsx
@@ -4,7 +4,17 @@
 // the existing need_tag taxonomy as-is via compassPurposes.ts, and never
 // implies purpose changes the calculated direction -- this component only
 // ever calls onChange(purpose); it has no access to direction state.
-import { COMPASS_PURPOSES, COMPASS_PURPOSE_LABELS_JA } from "../compassPurposes";
+//
+// Primary + More presentation (docs/audit/compass-purpose-first-view-polish.md):
+// Phase 6 QA found all 15 equally-weighted chips dominate the 375px first
+// viewport. Initially shows COMPASS_PRIMARY_PURPOSE_COUNT purposes (ordered
+// by the existing backend NEED_PRIORITY ranking); the rest are one tap away
+// via a toggle mirroring ConciergeEntryCard.tsx's existing expand/collapse
+// chip pattern, never permanently hidden. If the current value lives in the
+// "more" set, the list stays fully expanded and the toggle is not shown --
+// collapsing would otherwise hide the user's own selection with no trace.
+import { useState } from "react";
+import { COMPASS_PRIMARY_PURPOSE_COUNT, COMPASS_PURPOSES_ORDERED, COMPASS_PURPOSE_LABELS_JA } from "../compassPurposes";
 import type { CompassPurpose } from "../types";
 
 export type CompassPurposeSelectorProps = {
@@ -13,11 +23,19 @@ export type CompassPurposeSelectorProps = {
 };
 
 export default function CompassPurposeSelector({ value, onChange }: CompassPurposeSelectorProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const primaryPurposes = COMPASS_PURPOSES_ORDERED.slice(0, COMPASS_PRIMARY_PURPOSE_COUNT);
+  const morePurposes = COMPASS_PURPOSES_ORDERED.slice(COMPASS_PRIMARY_PURPOSE_COUNT);
+  const selectionInMore = value !== null && morePurposes.includes(value);
+  const showAll = expanded || selectionInMore;
+  const visiblePurposes = showAll ? COMPASS_PURPOSES_ORDERED : primaryPurposes;
+
   return (
     <fieldset className="min-w-0">
       <legend className="mb-2 text-sm font-medium text-[var(--kt-color-text-secondary)]">目的</legend>
       <div role="radiogroup" aria-label="参拝の目的" className="flex flex-wrap gap-2">
-        {COMPASS_PURPOSES.map((purpose) => {
+        {visiblePurposes.map((purpose) => {
           const selected = value === purpose;
           return (
             <button
@@ -38,6 +56,17 @@ export default function CompassPurposeSelector({ value, onChange }: CompassPurpo
           );
         })}
       </div>
+
+      {morePurposes.length > 0 && !selectionInMore ? (
+        <button
+          type="button"
+          className="mt-2 text-xs font-medium text-[var(--kt-color-text-muted)] underline-offset-2 hover:text-[var(--kt-color-text-secondary)] hover:underline"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+        >
+          {expanded ? "目的を閉じる" : `その他の目的を見る（他${morePurposes.length}件）`}
+        </button>
+      ) : null}
     </fieldset>
   );
 }

--- a/apps/web/src/features/compass/components/__tests__/CompassPurposeSelector.test.tsx
+++ b/apps/web/src/features/compass/components/__tests__/CompassPurposeSelector.test.tsx
@@ -1,9 +1,10 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 import CompassPurposeSelector from "../CompassPurposeSelector";
+import { COMPASS_PURPOSES, COMPASS_PURPOSES_ORDERED, COMPASS_PURPOSE_LABELS_JA } from "../../compassPurposes";
 
 describe("CompassPurposeSelector", () => {
-  it("目的を1つ選択するとonChangeへ渡す", () => {
+  it("目的を1つ選択するとonChangeへ渡す（値はslugのまま、表示順の影響を受けない）", () => {
     const onChange = vi.fn();
     render(<CompassPurposeSelector value={null} onChange={onChange} />);
 
@@ -18,9 +19,58 @@ describe("CompassPurposeSelector", () => {
     expect(screen.getByRole("radio", { name: "恋愛" })).toHaveAttribute("aria-checked", "false");
   });
 
-  it("15個の既存need_tagすべてが選択肢として表示される", () => {
+  it("初期状態では上位6件のみ表示し、15件すべてを一度には出さない（375px初回ビューポート対策）", () => {
     render(<CompassPurposeSelector value={null} onChange={() => undefined} />);
+    expect(screen.getAllByRole("radio")).toHaveLength(6);
+    expect(screen.getByRole("button", { name: "その他の目的を見る（他9件）" })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+  });
+
+  it("「その他の目的を見る」で残り9件を含む15件すべてが選択可能になる", () => {
+    render(<CompassPurposeSelector value={null} onChange={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "その他の目的を見る（他9件）" }));
+
     expect(screen.getAllByRole("radio")).toHaveLength(15);
+    expect(screen.getByRole("button", { name: "目的を閉じる" })).toHaveAttribute("aria-expanded", "true");
+    for (const purpose of COMPASS_PURPOSES) {
+      expect(screen.getByRole("radio", { name: COMPASS_PURPOSE_LABELS_JA[purpose] })).toBeInTheDocument();
+    }
+  });
+
+  it("展開後に折りたたむと再び6件表示に戻る", () => {
+    render(<CompassPurposeSelector value={null} onChange={() => undefined} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "その他の目的を見る（他9件）" }));
+    fireEvent.click(screen.getByRole("button", { name: "目的を閉じる" }));
+
+    expect(screen.getAllByRole("radio")).toHaveLength(6);
+  });
+
+  it("「その他」側の目的を選んでもonChangeへ正しいslugが渡る", () => {
+    const onChange = vi.fn();
+    render(<CompassPurposeSelector value={null} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "その他の目的を見る（他9件）" }));
+    fireEvent.click(screen.getByRole("radio", { name: "移動・安全" }));
+
+    expect(onChange).toHaveBeenCalledWith("travel_safe");
+  });
+
+  it("選択中の目的が「その他」側にある場合、展開状態を維持しトグルは表示しない（選択が隠れるのを防ぐ）", () => {
+    render(<CompassPurposeSelector value="travel_safe" onChange={() => undefined} />);
+
+    expect(screen.getAllByRole("radio")).toHaveLength(15);
+    expect(screen.getByRole("radio", { name: "移動・安全" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.queryByRole("button", { name: /その他の目的を見る|目的を閉じる/ })).not.toBeInTheDocument();
+  });
+
+  it("表示順序が変わっても15個の既存need_tag全てが最終的に選択肢として存在する", () => {
+    render(<CompassPurposeSelector value={null} onChange={() => undefined} />);
+    fireEvent.click(screen.getByRole("button", { name: /その他の目的を見る/ }));
+    expect(screen.getAllByRole("radio")).toHaveLength(COMPASS_PURPOSES_ORDERED.length);
   });
 
   it("操作要素は44px相当の最小タップ領域を持つ", () => {


### PR DESCRIPTION
## Summary

Implements the `PURPOSE UI POLISH READY` decision from #2481 (docs/audit/compass-purpose-first-view-polish.md). Smallest presentation-only change: `apps/web/src/features/compass/` only, no backend/API/DB/migration/Recommendation/Compass Runtime changes.

- `compassPurposes.ts`: added `COMPASS_PURPOSES_ORDERED` (a reordering of the same 15 values, copied verbatim from the existing backend `NEED_PRIORITY` ranking — nothing invented) and `COMPASS_PRIMARY_PURPOSE_COUNT = 6`. The original `COMPASS_PURPOSES` (canonical taxonomy order) is untouched.
- `CompassPurposeSelector.tsx`: shows the primary 6 by default, with a "その他の目的を見る（他9件）" / "目的を閉じる" toggle mirroring `ConciergeEntryCard.tsx`'s existing expand/collapse chip pattern verbatim (same `aria-expanded`, same text-link styling). If the currently selected purpose is one of the "more" 9, the list stays expanded and the toggle is hidden entirely — collapsing would otherwise hide the user's own selection with no visible trace.
- `onChange(purpose)` still fires the exact same slug regardless of which state (collapsed/expanded) the chip was clicked from — verified explicitly by a new end-to-end test that selects a "more"-set purpose and asserts the submitted API payload's `purpose` field.

## Live verification (375/390/430px)
Ran the full end-to-end flow against the real Django dev server + seeded DB again after this change:
- **375px**: the entire first card — month heading, Promise, 6 purpose chips, origin summary, birthdate, CTA — now fits in one viewport with zero scrolling (previously required multiple scrolls past 15 chips across 5 rows).
- **390px / 430px**: same result, with even more headroom at 430px.
- Expand → 15 chips appear, collapse → back to 6, confirmed live via DOM inspection (not just component tests).
- Selected a "more"-set purpose (移動・安全 / `travel_safe`) through the full flow → correct `purpose` value reached the API, direction result + recommendations rendered normally, chip list correctly stayed expanded post-submit.
- Heading hierarchy (h1 → h2, from the prior Phase 6 fix) still intact.

## Test plan
- [x] 25 Compass frontend tests pass (9 new/rewritten: data-integrity for the reordered list, primary/expanded chip counts, expand/collapse state transitions, "more"-set selection → correct payload, a11y `aria-expanded`).
- [x] Full frontend suite: 1003 passed (147 files), up from 994 baseline.
- [x] `pnpm typecheck` / `pnpm build` — clean.
- [x] Live browser E2E at 375/390/430px against real seeded data.

**Full Experience Recheck: FULL EXPERIENCE READY** for the scope this PR touches (first view, purpose selection, full flow, direction result, recommendations, heading a11y) — the P2 that was the sole blocker in #2480's `NEEDS ITERATION` verdict is resolved. (Broader re-classification of the whole Compass experience is out of scope here; see companion audit PR #2481 §15.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)