### PR TITLE
feat: Compass経由の行動計測sourceを接続

### DIFF
--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -449,6 +449,12 @@ export default async function Page({ params, searchParams }: Props) {
   const conciergeRecommendationInstanceId = normalizeRecommendationInstanceId(
     selectedRecommendation?.recommendation_instance_id,
   );
+  // PR-C (docs/analytics/compass-analytics-contract.md): the same merge
+  // ShrineDetailViewTracker already used below, now also reaching the
+  // Favorite/Visit/Reflection action boundary -- same-page-render (session/
+  // navigation-level) attribution only, never synthesized across a later,
+  // separate visit.
+  const detailRecommendationInstanceId = compassRecommendationInstanceId ?? conciergeRecommendationInstanceId;
 
   const model = buildShrineDetailModel({
     shrine: s,
@@ -476,7 +482,7 @@ export default async function Page({ params, searchParams }: Props) {
         ctx={ctx}
         tid={tid}
         analyticsProvenance={analyticsProvenance}
-        recommendationInstanceId={compassRecommendationInstanceId ?? conciergeRecommendationInstanceId}
+        recommendationInstanceId={detailRecommendationInstanceId}
         recommendationRank={compassRecommendationRank}
       />
       <ShrineDetailToast shrineId={numericId} />
@@ -499,22 +505,28 @@ export default async function Page({ params, searchParams }: Props) {
       >
         <ShrineDetailArticle
           {...model}
+          // PR-C: overrides model.ctx (downstreamCtx) for this component
+          // only -- the Favorite/Visit/Reflection action boundary may see
+          // the full ctx, including "compass". buildShrineDetailModel's own
+          // computation above (sections, recommendation meta, etc.) still
+          // uses downstreamCtx, unaffected by this override.
+          ctx={ctx}
           stateDelta={stateDelta}
           isPremiumActive={isPremiumActive}
           historyTheme={historyThemeForAnalytics}
           analyticsProvenance={analyticsProvenance}
-          recommendationInstanceId={conciergeRecommendationInstanceId}
+          recommendationInstanceId={detailRecommendationInstanceId}
           addGoshuinHref={addGoshuinHref}
           saveActionNode={
             <ShrineSaveButton
               key={`shrine-save-${numericId}`}
               shrineId={numericId}
-              ctx={downstreamCtx}
+              ctx={ctx}
               tid={tid}
               nextPath={nextPath}
               guestMode={guestMode}
               analyticsProvenance={analyticsProvenance}
-              recommendationInstanceId={conciergeRecommendationInstanceId}
+              recommendationInstanceId={detailRecommendationInstanceId}
               initial={initialFavorite}
             />
           }

--- a/apps/web/src/components/shrine/ShrineSaveButton.tsx
+++ b/apps/web/src/components/shrine/ShrineSaveButton.tsx
@@ -14,7 +14,7 @@ import {
 
 type Props = {
   shrineId: number;
-  ctx?: "map" | "concierge" | null;
+  ctx?: "map" | "concierge" | "compass" | null;
   tid?: string | null;
   nextPath?: string;
   guestMode?: boolean;
@@ -59,12 +59,17 @@ export default function ShrineSaveButton({
       const prevFav = fav;
       const nextFav = !prevFav;
       await toggle();
+      // PR-C (docs/analytics/compass-analytics-contract.md): source only
+      // distinguishes "compass" from everything else. Concierge/map/direct
+      // keep their existing "shrine_detail" value unchanged -- widening this
+      // to a full ctx-derived value is out of PR-C's scope.
+      const source = ctx === "compass" ? "compass" : "shrine_detail";
       track("favorite_click", {
         shrineId,
         ctx,
         tid,
         nextFav,
-        source: "shrine_detail",
+        source,
         cardId: "saved_record",
         accessLevel,
         recommendationInstanceId,
@@ -77,6 +82,7 @@ export default function ShrineSaveButton({
           action: "save",
           ctx,
           tid,
+          source,
           recommendationInstanceId,
           ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
         });

--- a/apps/web/src/components/shrine/__tests__/ShrineSaveButton.test.tsx
+++ b/apps/web/src/components/shrine/__tests__/ShrineSaveButton.test.tsx
@@ -101,6 +101,102 @@ describe("ShrineSaveButton", () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
+  it("ctx=compassの場合、favorite_click / shrine_decisionともにsource=compassを送る（PR-C）", async () => {
+    const toggleMock = vi.fn().mockResolvedValue(undefined);
+
+    useFavoriteMock.mockImplementation(() => ({
+      fav: false,
+      busy: false,
+      toggle: toggleMock,
+    }));
+
+    render(
+      <ShrineSaveButton
+        shrineId={17}
+        ctx="compass"
+        tid={null}
+        nextPath="/shrines/17?ctx=compass"
+        guestMode={false}
+        recommendationInstanceId="rid-compass-1"
+        initial={{ fav: false, favorite_id: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "あとで見返すために保存" }));
+
+    await waitFor(() => {
+      expect(trackMock).toHaveBeenCalledWith(
+        "favorite_click",
+        expect.objectContaining({ source: "compass", ctx: "compass", recommendationInstanceId: "rid-compass-1" }),
+      );
+    });
+    expect(trackMock).toHaveBeenCalledWith(
+      "shrine_decision",
+      expect.objectContaining({ source: "compass", action: "save", recommendationInstanceId: "rid-compass-1" }),
+    );
+  });
+
+  it("ctx未指定（直接遷移）の場合、Compass由来のsourceは漏れずshrine_detailのままになる（PR-C）", async () => {
+    const toggleMock = vi.fn().mockResolvedValue(undefined);
+
+    useFavoriteMock.mockImplementation(() => ({
+      fav: false,
+      busy: false,
+      toggle: toggleMock,
+    }));
+
+    render(
+      <ShrineSaveButton
+        shrineId={17}
+        nextPath="/shrines/17"
+        guestMode={false}
+        initial={{ fav: false, favorite_id: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "あとで見返すために保存" }));
+
+    await waitFor(() => {
+      expect(trackMock).toHaveBeenCalledWith("favorite_click", expect.objectContaining({ source: "shrine_detail" }));
+    });
+
+    const [, favoritePayload] = trackMock.mock.calls.find(([eventName]) => eventName === "favorite_click") ?? [];
+    expect(favoritePayload?.source).not.toBe("compass");
+  });
+
+  it("favorite_click / shrine_decisionのペイロードにbirthdate・座標・生の位置情報テキストを含めない（PR-C PIIチェック）", async () => {
+    const toggleMock = vi.fn().mockResolvedValue(undefined);
+
+    useFavoriteMock.mockImplementation(() => ({
+      fav: false,
+      busy: false,
+      toggle: toggleMock,
+    }));
+
+    render(
+      <ShrineSaveButton
+        shrineId={17}
+        ctx="compass"
+        nextPath="/shrines/17?ctx=compass"
+        guestMode={false}
+        recommendationInstanceId="rid-compass-1"
+        initial={{ fav: false, favorite_id: null }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "あとで見返すために保存" }));
+
+    await waitFor(() => expect(trackMock).toHaveBeenCalled());
+
+    for (const [, payload] of trackMock.mock.calls) {
+      const serialized = JSON.stringify(payload);
+      expect(payload).not.toHaveProperty("birthdate");
+      expect(payload).not.toHaveProperty("latitude");
+      expect(payload).not.toHaveProperty("longitude");
+      expect(serialized).not.toMatch(/\d{4}-\d{2}-\d{2}/);
+    }
+  });
+
   it("解除失敗時にエラー表示を出す", async () => {
     useFavoriteMock.mockImplementation(() => ({
       fav: true,

--- a/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineDetailArticle.tsx
@@ -756,8 +756,11 @@ export default function ShrineDetailArticle({
                       setVisitError(false);
                       try {
                         await addVisit(cardProps.shrineId, tid);
+                        // PR-C (docs/analytics/compass-analytics-contract.md):
+                        // only "compass" is distinguished; concierge/map/direct
+                        // keep the existing "shrine_detail" value unchanged.
                         trackSearchEvent("visit_done", {
-                          source: "shrine_detail",
+                          source: ctx === "compass" ? "compass" : "shrine_detail",
                           shrineId: cardProps.shrineId,
                           threadId: tid != null ? String(tid) : undefined,
                           historyTheme: historyTheme ?? undefined,

--- a/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
+++ b/apps/web/src/components/shrine/detail/ShrineReflectionPrompt.tsx
@@ -35,6 +35,12 @@ export function ShrineReflectionPrompt({
   recommendationInstanceId = null,
 }: Props) {
   const mode = ctx === "concierge" ? "need" : undefined;
+  // PR-C (docs/analytics/compass-analytics-contract.md): only "compass" is
+  // distinguished; concierge/map/direct keep "shrine_detail" unchanged. A
+  // later, separate page visit (no ctx=compass in that URL) correctly falls
+  // back to "shrine_detail" -- Compass provenance is not persisted, so it
+  // cannot legitimately survive to a Reflection outside the same page render.
+  const source = ctx === "compass" ? "compass" : "shrine_detail";
   const [answer, setAnswer] = useState("");
   const [moodBefore, setMoodBefore] = useState("");
   const [moodAfter, setMoodAfter] = useState("");
@@ -47,7 +53,7 @@ export function ShrineReflectionPrompt({
 
   useEffect(() => {
     trackSearchEvent("reflection_prompt_view", {
-      source: "shrine_detail",
+      source,
       shrineId,
       threadId: threadId ?? undefined,
       historyTheme: historyTheme ?? undefined,
@@ -58,7 +64,7 @@ export function ShrineReflectionPrompt({
       recommendationInstanceId,
       ...(analyticsProvenance ? recommendationAnalyticsProperties(analyticsProvenance) : {}),
     });
-  }, [accessLevel, analyticsProvenance, historyTheme, mode, recommendationInstanceId, shrineId, threadId]);
+  }, [accessLevel, analyticsProvenance, historyTheme, mode, recommendationInstanceId, shrineId, source, threadId]);
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -79,7 +85,7 @@ export function ShrineReflectionPrompt({
       });
 
       trackSearchEvent("reflection_saved", {
-        source: "shrine_detail",
+        source,
         shrineId,
         threadId: threadId ?? undefined,
         historyTheme: historyTheme ?? undefined,

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineDetailArticle.test.tsx
@@ -655,6 +655,52 @@ describe("ShrineDetailArticle", () => {
       });
     });
 
+    it("ctx=compass の場合、visit_doneはsource=compassを送る（PR-C）", async () => {
+      visitsMocks.addVisit.mockResolvedValue({});
+
+      renderWithVisitCta({ ctx: "compass", historyTheme: "静寂", tid: "tid-1" });
+      fireEvent.click(screen.getByRole("button", { name: "参拝しました" }));
+
+      await waitFor(() => {
+        expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+          "visit_done",
+          expect.objectContaining({ source: "compass", shrineId: 17 }),
+        );
+      });
+
+      // Compass is never a Concierge mode -- unaffected, same as ctx=null/map today.
+      const visitDoneCall = analyticsMocks.trackSearchEvent.mock.calls.find(([eventName]) => eventName === "visit_done");
+      expect(visitDoneCall?.[1]?.mode).toBeUndefined();
+    });
+
+    it("ctxが未指定（直接遷移）の場合、visit_doneのsourceはCompassへ漏れずshrine_detailのまま（PR-C）", async () => {
+      visitsMocks.addVisit.mockResolvedValue({});
+
+      renderWithVisitCta();
+      fireEvent.click(screen.getByRole("button", { name: "参拝しました" }));
+
+      await waitFor(() => {
+        expect(analyticsMocks.trackSearchEvent).toHaveBeenCalledWith(
+          "visit_done",
+          expect.objectContaining({ source: "shrine_detail" }),
+        );
+      });
+    });
+
+    it("visit_doneのペイロードにbirthdate・座標を含めない（PR-C PIIチェック）", async () => {
+      visitsMocks.addVisit.mockResolvedValue({});
+
+      renderWithVisitCta({ ctx: "compass" });
+      fireEvent.click(screen.getByRole("button", { name: "参拝しました" }));
+
+      await waitFor(() => expect(analyticsMocks.trackSearchEvent).toHaveBeenCalled());
+
+      const visitDoneCall = analyticsMocks.trackSearchEvent.mock.calls.find(([eventName]) => eventName === "visit_done");
+      expect(visitDoneCall?.[1]).not.toHaveProperty("birthdate");
+      expect(visitDoneCall?.[1]).not.toHaveProperty("latitude");
+      expect(visitDoneCall?.[1]).not.toHaveProperty("longitude");
+    });
+
     it("失敗後はエラー表示になり、再操作可能な状態に戻る", async () => {
       visitsMocks.addVisit.mockRejectedValue(new Error("failed"));
 

--- a/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
+++ b/apps/web/src/components/shrine/detail/__tests__/ShrineReflectionPrompt.test.tsx
@@ -47,6 +47,33 @@ describe("ShrineReflectionPrompt", () => {
     });
   });
 
+  it("ctx=compassの場合、reflection_prompt_viewはsource=compassを送る（PR-C）", () => {
+    render(
+      <ShrineReflectionPrompt
+        shrineId={17}
+        historyTheme="静寂"
+        threadId="tid-1"
+        ctx="compass"
+        accessLevel="free"
+        recommendationInstanceId="rid-compass-1"
+      />,
+    );
+
+    expect(mockedTrackSearchEvent).toHaveBeenCalledWith(
+      "reflection_prompt_view",
+      expect.objectContaining({ source: "compass", recommendationInstanceId: "rid-compass-1" }),
+    );
+  });
+
+  it("ctx未指定（直接遷移）の場合、reflection_prompt_viewのsourceはCompassへ漏れずshrine_detailのまま（PR-C）", () => {
+    render(<ShrineReflectionPrompt shrineId={17} historyTheme="静寂" threadId="tid-1" accessLevel="free" />);
+
+    expect(mockedTrackSearchEvent).toHaveBeenCalledWith(
+      "reflection_prompt_view",
+      expect.objectContaining({ source: "shrine_detail" }),
+    );
+  });
+
   it("入力して保存するとAPIを呼び reflection_saved を送信する", async () => {
     const onSaved = vi.fn();
     mockedCreateShrineReflection.mockResolvedValueOnce({
@@ -109,6 +136,50 @@ describe("ShrineReflectionPrompt", () => {
       recommendationInstanceId: null,
     });
     expect(onSaved).toHaveBeenCalled();
+  });
+
+  it("ctx=compassの場合、reflection_savedはsource=compassを送り、PIIを含まない（PR-C）", async () => {
+    mockedCreateShrineReflection.mockResolvedValueOnce({
+      id: 1,
+      user: 10,
+      shrine: 17,
+      history_theme: "静寂",
+      prompt: "参拝して、今どんな変化がありましたか？",
+      answer: "落ち着きました。",
+      mood_before: "",
+      mood_after: "",
+      created_at: "2026-06-03T00:00:00Z",
+    });
+
+    render(
+      <ShrineReflectionPrompt
+        shrineId={17}
+        historyTheme="静寂"
+        threadId="tid-1"
+        ctx="compass"
+        accessLevel="free"
+        recommendationInstanceId="rid-compass-1"
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/少し落ち着いた/), {
+      target: { value: "落ち着きました。" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "振り返りを保存する" }));
+
+    await waitFor(() => {
+      expect(mockedTrackSearchEvent).toHaveBeenCalledWith(
+        "reflection_saved",
+        expect.objectContaining({ source: "compass", recommendationInstanceId: "rid-compass-1" }),
+      );
+    });
+
+    const [, payload] = mockedTrackSearchEvent.mock.calls.find(([eventName]) => eventName === "reflection_saved") ?? [];
+    expect(payload).not.toHaveProperty("birthdate");
+    expect(payload).not.toHaveProperty("latitude");
+    expect(payload).not.toHaveProperty("longitude");
+    // answer本文そのものは元々送信対象外（answerLengthのみ）-- 回帰確認。
+    expect(payload).not.toHaveProperty("answer");
   });
 
   it("threadIdが数値変換できる場合、createShrineReflectionへthread_idとして渡す", async () => {

--- a/docs/analytics/compass-analytics-contract.md
+++ b/docs/analytics/compass-analytics-contract.md
@@ -2,8 +2,8 @@
 
 > Status: Active
 
-Compass の発見から Recommendation 経由の Shrine Detail 表示までを計測する契約。
-Favorite / Visit / Reflection の source 伝播は本契約の対象外（PR-C）である。
+Compass の発見から Recommendation 経由の Shrine Detail 表示、および
+Favorite / Visit / Reflection への source 伝播までを計測する契約。
 
 ## Lifecycle
 
@@ -30,6 +30,37 @@ CompassからShrine DetailへのURLは `ctx=compass`、
 `recommendation_instance_id`、`recommendation_rank`を運ぶ。直接訪問ではこれらを
 合成しない。`ctx=compass`以外の既存経路、特にConciergeのthread snapshotからの
 Recommendation Instance復元は変更しない。
+
+## Action source propagation（PR-C）
+
+Compass経由でShrine Detailに到達した**同一ページrender**の範囲でのみ、
+Favorite / Visit / Reflectionの既存イベントが`source=compass`を伝播する。新規
+イベントは追加しない（既存event + `source`のみ）。
+
+| Action | event（既存、変更なし） | 変更内容 |
+|---|---|---|
+| Favorite | `favorite_click`, `shrine_decision` | `source`を`ctx===compass`のときのみ`"compass"`、それ以外は既存どおり`"shrine_detail"`のまま |
+| Visit | `visit_done` | 同上 |
+| Reflection | `reflection_prompt_view`, `reflection_saved` | 同上 |
+
+Concierge/map/直接訪問の`source`値は変更しない（既存contractのまま）。
+
+`recommendationInstanceId`も同じ範囲で伝播する
+（`compassRecommendationInstanceId ?? conciergeRecommendationInstanceId`）。
+`recommendationRank`はFavorite/Visit/Reflectionへ伝播しない
+— Concierge経由でも現状これらのactionへrankは渡っておらず、PR-Cはその
+既存アーキテクチャに新しい配線を追加しない。
+
+### Attribution strength（帰属の強さ）
+
+| Action | 分類 | 理由 |
+|---|---|---|
+| Favorite | SESSION / NAVIGATION ATTRIBUTION | 同一Shrine Detail page renderの`ctx`クエリパラメータに限定。DB永続化なし |
+| Visit | SESSION / NAVIGATION ATTRIBUTION | 同上 |
+| Reflection（prompt/saved） | SESSION / NAVIGATION ATTRIBUTION（同一page render時のみ） | 同上。**別セッション・別日にShrine Detailへ再訪問してReflectionを書いた場合はMEASUREMENT GAP** — URLに`ctx=compass`が残らないため`source`は正しく`"shrine_detail"`にfallbackする。これは既知の制約であり、永続化で解消しない（PR-Cのスコープ外） |
+
+Compass runtimeは引き続きephemeral。DB change・migration・Compass History・
+Personal Continuityは本PRで一切実装しない。
 
 ## Privacy
 


### PR DESCRIPTION
## Summary

PR-B（#2489, merged）はShrine Detail viewまでを計測し、`ctx=compass`をFavorite/Visit/Reflectionへ渡す前に意図的に破棄していた（`// PR-B stops at Shrine Detail view. Compass attribution must not enter Favorite/Visit/Reflection/route actions before PR-C.`）。本PRはその境界を越え、Favorite・Visit・Reflectionの既存イベントへ`source=compass`を正しく伝播する。

## Before

- `favorite_click` / `shrine_decision`（`ShrineSaveButton.tsx`）: `source: "shrine_detail"`にハードコード、`ctx`は伝播しても未使用
- `visit_done`（`ShrineDetailArticle.tsx`）: 同様にハードコード
- `reflection_prompt_view` / `reflection_saved`（`ShrineReflectionPrompt.tsx`）: `ctx` propは既に受け取っていたが`source`には未反映
- `page.tsx`は`downstreamCtx = ctx === "compass" ? null : ctx`でCompass由来のctxをFavorite/Visit/Reflection手前で明示的に除去、`recommendationInstanceId`もConcierge由来の値のみ伝播

## After

- 上記5イベントすべて、`ctx === "compass"`のときのみ`source: "compass"`を送信。Concierge/map/直接訪問時の値（`"shrine_detail"`固定）は一切変更しない
- `page.tsx`で`ShrineDetailArticle`・`ShrineSaveButton`にのみ、フルの`ctx`（`downstreamCtx`ではなく）と`compassRecommendationInstanceId ?? conciergeRecommendationInstanceId`をJSX propのoverrideとして渡す。`buildShrineDetailModel`自体の計算・`ShrineDetailShell`（close/route側、PR-Cのスコープ外）は`downstreamCtx`のまま不変
- 新規イベントは追加していない（既存event + `source`条件分岐のみ）
- `recommendationRank`はFavorite/Visit/Reflectionへ伝播しない（Concierge経由でも現状渡っていないため、新規配線を追加しない）

## Attribution Strength

| Action | 分類 |
|---|---|
| Favorite | SESSION / NAVIGATION ATTRIBUTION |
| Visit | SESSION / NAVIGATION ATTRIBUTION |
| Reflection | SESSION / NAVIGATION ATTRIBUTION（同一Shrine Detail page render時のみ）／別セッション・別日の再訪問は **MEASUREMENT GAP**（`ctx=compass`がURLに残らないため`source`は`"shrine_detail"`へ正しくfallback。永続化では解消せず、PR-Cのスコープ外） |

## Regression

- Concierge: `favorite_click`/`shrine_decision`/`visit_done`/`reflection_*`の既存assertion（`source: "shrine_detail"`, `mode: "need"`等）は無変更のまま全green
- 直接Shrine Detail訪問: `ctx`未指定時は従来どおり`source: "shrine_detail"`（Compassへ漏れないことをテストで明示的に確認）
- PR-B recommendation attribution回帰テスト（`recommendationInstanceIdPropagation.test.tsx`）: green

## Privacy

- Birthdate sent: NO
- Coordinates sent: NO
- Raw origin sent: NO
- Free text sent: NO

## Persistence

- DB change: NONE
- Migration: NONE
- Compass History: NOT IMPLEMENTED
- Personal Continuity: NOT IMPLEMENTED

## Verification

- Focused tests (Favorite/Visit/Reflection/Recommendation Instance): 43 passed
- Full frontend suite: 150 files / 1033 tests passed
- Typecheck: passed
- Lint: 0 errors, 2 pre-existing warnings（`MyPageView.tsx`、本PR無関係）
- Production build: passed
- Backend: 未変更のためbackendテストは未実行
- Live browser verification: 実施せず — このセッションのBrowser pane dev serverが別ローカルclone（`/Users/morietsu/Desktop/jinja_app`）に固定されており、本PRの変更を含む`/Users/morietsu/Developer/jinja_app`に対する検証にならないため、誤った検証結果を報告しないよう見送った

## Remaining Measurement Gaps

- クロスセッションのCompass→Favorite/Visit/Reflection帰属（別日の再訪問等）は引き続きMEASUREMENT GAP。永続化なしでは解消不可、PR-Cのスコープ外として`docs/analytics/compass-analytics-contract.md`に明記
- `recommendationRank`のFavorite/Visit/Reflectionへの伝播は未実装（Concierge経由でも同様に未配線のため、既存アーキテクチャの範囲を超える新規追加はしなかった）

🤖 Generated with [Claude Code](https://claude.com/claude-code)