### PR TITLE
docs: Compass PostHog Query Contractを監査

### DIFF
--- a/docs/analytics/compass-posthog-query-contract.md
+++ b/docs/analytics/compass-posthog-query-contract.md
@@ -1,0 +1,815 @@
+# Compass PostHog Query Contract
+
+> Status: Active
+
+This document defines how the already-implemented Compass analytics (PR-A #2488,
+PR-B #2489, PR-C #2490 — all merged) should be **queried** in PostHog. It is a
+companion to `docs/analytics/compass-analytics-contract.md` (the event/payload
+contract) and `docs/audit/compass-analytics-contract-readiness.md` (the
+pre-implementation proposal). This document defines measurement only. It draws
+no product conclusions, executes no production queries, and adds no
+instrumentation.
+
+Every claim below is verified against current `develop` code (post PR-A/B/C),
+re-read directly for this audit — not assumed from prior audit docs.
+
+---
+
+## 1. Pre-Contract Inventory
+
+All rows verified directly against current `develop` source.
+
+| Stage | Event | Required properties | Identifier | Source (file) | Notes |
+|---|---|---|---|---|---|
+| Home → Compass discovery | `home_compass_entry_click` | `source="home"` | PostHog `distinct_id` only | `HomeCompassSection.tsx:34` | Click-only. No impression event exists for the Home section. |
+| Compass entry | `compass_entry` | `referrer_source: "home"\|"direct"` | PostHog `distinct_id` only | `CompassClient.tsx:58-65` | Fires once per mount (`entryTrackedRef` guard). No `recommendationInstanceId` yet — not generated until submit. |
+| Compass result | `compass_result` | `result_state`, `purpose`, `origin_mode`, `has_birthdate`, `recommendation_count`, `recommendationInstanceId` | PostHog `distinct_id`; `recommendationInstanceId` present for every state **except** `backend_error` | `CompassClient.tsx:67-80,127-144` | `result_state` uses the real backend vocabulary + one frontend-only bucket (§3.1). |
+| Recommendation exposure (impression) | `card_view` | `cardId="shrine_compact"`, `source="compass"`, `visibility="visible"`, `shrineId`, `recommendationRank`, `recommendationInstanceId` | `recommendationInstanceId` + `shrineId` | `CompassRecommendationsSection.tsx:36-44` | Deduped client-side via a `Set` keyed `${instanceId}:${shrineId}:${rank}`. Only fires when `result_state==="recommendation_success"` (nothing to show otherwise). |
+| Recommendation → Shrine Detail (click) | `shrine_detail_transition` | `source="compass"`, `shrineId`, `recommendationRank`, `recommendationInstanceId`, `position="compact"` | `recommendationInstanceId` + `shrineId` | `CompassRecommendationsSection.tsx:71-82` | Fires on the card's `onDetailClick`, before navigation. |
+| Shrine Detail view | `shrine_detail_view` | `source` (`"compass"` when `ctx=compass`), `shrineId`, `recommendationInstanceId`, `recommendationRank`, `threadId` | `recommendationInstanceId` + `shrineId` | `ShrineDetailViewTracker.tsx:30-58` | Fires once per mount (`trackedRef` guard). `ctx`/`recommendationInstanceId`/`recommendationRank` arrive via the URL (`/shrines/:id?ctx=compass&recommendation_instance_id=…&recommendation_rank=…`), built by `buildShrineHref` in `CompassRecommendationsSection.tsx`. |
+| Favorite | `favorite_click`, `shrine_decision` | `source` (`"compass"` when `ctx==="compass"` at render time, else unchanged `"shrine_detail"`), `shrineId`, `recommendationInstanceId`, `analyticsSessionId`/`sessionId` (auto, via `track()`) | `recommendationInstanceId` + `shrineId`, when `source="compass"` | `ShrineSaveButton.tsx:62-90` | PR-C. `ctx`/`recommendationInstanceId` only reach this component within the **same Shrine Detail page render** (`page.tsx` overrides them explicitly on this component only). |
+| Visit | `visit_done` | `source` (same rule as Favorite), `shrineId`, `recommendationInstanceId`, `accessLevel`, `historyTheme` | `recommendationInstanceId` + `shrineId`, when `source="compass"` | `ShrineDetailArticle.tsx:759-768` | PR-C. Same same-page-render scope as Favorite. |
+| Reflection prompt | `reflection_prompt_view` | `source` (same rule), `shrineId`, `recommendationInstanceId`, `accessLevel` | `recommendationInstanceId` + `shrineId`, when `source="compass"` | `ShrineReflectionPrompt.tsx:54-67` | PR-C. Only rendered when `hasVisitHistory` is true in the **current** page render. |
+| Reflection saved | `reflection_saved` | same as prompt + `answerLength`, `moodBefore`, `moodAfter` | same | `ShrineReflectionPrompt.tsx:87-100` | Never carries the reflection body itself (`answer` text is never sent — only its length). |
+
+**Property presence confirmed / absent, per §3 of the task:**
+
+| Property | Present on |
+|---|---|
+| `source` | `card_view`, `shrine_detail_transition`, `shrine_detail_view`, `favorite_click`, `shrine_decision`, `visit_done`, `reflection_prompt_view`, `reflection_saved` |
+| `recommendationInstanceId` | All of the above **except** `home_compass_entry_click` and `compass_entry` (not yet generated at that point) |
+| `shrineId` | `card_view` onward — every event from Recommendation exposure through Reflection |
+| `recommendationRank` | `card_view`, `shrine_detail_transition`, `shrine_detail_view` only. **Not propagated to Favorite/Visit/Reflection** (PR-C deliberately did not add new rank plumbing where Concierge itself has none — see `docs/analytics/compass-analytics-contract.md` "Action source propagation") |
+| `result_state` | `compass_result` only |
+| `purpose` | `compass_result` only |
+| `origin_mode` | `compass_result` only |
+| `accessLevel` (Free/Premium/anonymous plan context) | `favorite_click` (as `accessLevel`, computed from guest/login state), `visit_done`, `reflection_prompt_view`, `reflection_saved`. **Absent from the entire Compass discovery→entry→result→impression→click→detail-view chain.** This is a material limitation for §20 (Free/Premium boundary) below. |
+| PostHog-native anonymous/session identifier | Every event carries PostHog's own auto-generated `distinct_id` (via the SDK itself — no app code needed). The app's own custom `analyticsSessionId`/`sessionId` property is **only** explicitly attached to events dispatched through `track()` (`track.ts`) — i.e. `favorite_click`/`shrine_decision`. Every other Compass event (all `trackSearchEvent`/`trackCardEvent` calls) does **not** carry this custom property; they rely solely on PostHog's native identity. |
+
+**Backend `recommendation_instance_id` generation** (`backend/temples/api_views_compass.py:50,76-86`): `uuid.uuid4().hex[:8]`, generated once per request, stateless (no DB write), embedded in the top-level response body **and** every recommendation item. Present in the response for every state that reaches `body = {...}` — i.e. `invalid_purpose`, `direction_filter_unavailable`, `direction_zero_candidates`, `evidence_zero_candidates`, `recommendation_success`. **Absent** for the HTTP 500 `{"state": "error"}` path (returns before `body` is built) — this is the case the frontend labels `result_state: "backend_error"`, and `trackCompassResult` correctly passes `recommendationInstanceId: null` for it.
+
+### 1.1 Result state vocabulary (verified against `backend/temples/services/compass_recommendation_orchestrator.py:47-51`)
+
+```
+STATE_INVALID_PURPOSE               = "invalid_purpose"
+STATE_DIRECTION_FILTER_UNAVAILABLE  = "direction_filter_unavailable"
+STATE_DIRECTION_ZERO_CANDIDATES     = "direction_zero_candidates"
+STATE_EVIDENCE_ZERO_CANDIDATES      = "evidence_zero_candidates"
+STATE_RECOMMENDATION_SUCCESS        = "recommendation_success"
+```
+
+Plus the frontend-only `backend_error` bucket (`CompassClient.tsx`), covering both network exceptions and any non-2xx/non-400 HTTP response. These six values are never renamed or collapsed anywhere in the analytics layer — `compass_result.result_state` uses exactly these strings.
+
+---
+
+## 2. Privacy Inventory
+
+Re-confirmed against current code (not re-derived from the prior readiness audit):
+
+```
+Birthdate required:     NO  (only a boolean has_birthdate, always true given client-side submit gating)
+Coordinates required:   NO  (only categorical origin_mode: "device"|"station"|"address"|"prefecture")
+Raw origin required:    NO
+Free text required:     NO  (purpose is a canonical 15-value slug, never free text)
+Reflection body required: NO  (reflection_saved carries answerLength only, never the answer text)
+```
+
+No Compass-related event anywhere sends `birthdate`, `latitude`, `longitude`, raw address/station text, consultation text, or Reflection body content. The PostHog Query Contract below depends on none of these.
+
+---
+
+## 3. Canonical Compass Funnel
+
+Per the task's explicit instruction not to force every stage into one giant funnel, this is split into four semantically distinct groups:
+
+**A. Lifecycle funnel** (discovery → activation → result):
+```
+home_compass_entry_click → compass_entry → compass_result
+```
+
+**B. Recommendation funnel** (exposure → click → detail view):
+```
+card_view (source=compass) → shrine_detail_transition (source=compass) → shrine_detail_view (source=compass)
+```
+
+**C. Downstream action funnel** (detail view → action, same-page-render scope only):
+```
+shrine_detail_view (source=compass) → favorite_click / visit_done / reflection_prompt_view → reflection_saved
+```
+
+**D. Engagement/Retention metrics** (not funnels — time-bucketed aggregates over `compass_result`):
+```
+Same-Month Repeat Usage, Month-over-Month Return
+```
+
+**Why split, not one funnel:** (A) and (B) are bridged only by the frontend's own render (a `compass_result` success renders `CompassRecommendationsSection`, which then fires `card_view`) — there is no shared event connecting them other than co-occurrence in the same page state, so they compose cleanly as two PostHog Funnels joined conceptually, not as literal funnel steps. (B) and (C) are bridged by navigation (`shrine_detail_view` occurs on a different route than the click), which PostHog Funnels handle natively via distinct_id sequencing — but (C)'s later steps are governed by a **different attribution rule** (same-page-render only, §7 below) that a naive multi-step Funnel spanning A→B→C would silently misrepresent as "reachable in any session," so (C) is kept as its own funnel with its own explicit attribution caveat rather than merged into (B).
+
+---
+
+## 4. Recommendation Join Contract
+
+**Required join keys**: `recommendationInstanceId` **AND** `shrineId`, together.
+
+**Reasoning**: `recommendationInstanceId` alone identifies a single Compass request/result set (which can contain multiple shrines); `shrineId` alone can recur across many unrelated result instances (the same shrine recommended to different users, or to the same user across different months). Only the pair uniquely identifies "this specific shrine, as recommended by this specific Compass result."
+
+**Is `recommendationRank` identity or metadata?** **Metadata (analytical dimension), not identity.** Verified: each `recommendation_instance_id` is generated once per request and its ranking is computed once, server-side, in a single ordered pass (`backend/temples/api_views_compass.py:76-79` enumerates `result.recommendations` once) — a given `shrineId` cannot appear at two different ranks within the same instance. Rank is therefore redundant with `(recommendationInstanceId, shrineId)` for identity purposes in the current architecture, but is still carried as a validation/diagnostic field (§10 rank analysis) and should be used to sanity-check joins, not to define them.
+
+**Missing-key behavior**: if `recommendationInstanceId` is `null` (e.g. any event downstream of a `backend_error` result, which never reaches the recommendation stage at all — moot in practice, since no `card_view`/`shrine_detail_transition` can fire without a successful result), the corresponding row must be **excluded** from any recommendation-level join, never coerced to a synthetic key.
+
+**Duplicate view behavior**: `shrine_detail_view` is deduplicated per mount via `trackedRef` (§5 below) — a single page load cannot emit two `shrine_detail_view` events for the same visit. A user re-loading the same URL (e.g. refresh) produces a **new**, legitimate `shrine_detail_view` with the same `(recommendationInstanceId, shrineId)` pair — this is correct, not a bug; it should count as a separate detail-view event for impression-level CTR (§9 below counts *distinct instance+shrine pairs opened*, so a refresh does not inflate the CTR numerator beyond 1, but does not need to be filtered out of raw event counts either).
+
+**Multiple opens of the same shrine** (user clicks, goes back, clicks again within the same result): produces multiple `shrine_detail_transition`/`shrine_detail_view` event pairs with the identical `(recommendationInstanceId, shrineId, rank)` triple. For CTR purposes (§9), this must be deduplicated to "was this recommendation row opened at least once" — see §5.
+
+**Multiple recommendations of the same shrine across different result instances** (same user, different Compass submissions — e.g. changed purpose): each submission generates a **new** `recommendationInstanceId` (stateless UUID, §1.1), so the same `shrineId` recommended twice across two submissions produces two independent, correctly-distinguishable rows. No special handling needed — the join key pair already disambiguates them.
+
+---
+
+## 5. Deduplication Contract
+
+| Metric | Semantic counting unit | Deduplication rule |
+|---|---|---|
+| Compass Entry count | `compass_entry` event | Already deduplicated client-side (`entryTrackedRef`) — one event per actual mount. React re-render does not produce duplicates. |
+| Compass Result Success Rate | `compass_result` event (one per submit attempt) | No client-side submit-dedup exists — a user double-clicking submit while `isLoading` is `false`... actually the button is `disabled={isLoading}` during the request, so a genuine double-submit before the first request resolves is prevented by the UI. Retries (a resubmission after seeing an error) are **new, legitimate** `compass_result` events — not deduplicated, since each is a real distinct attempt. |
+| Recommendation exposure | Recommendation row = `(recommendationInstanceId, shrineId, rank)` triple | Already deduplicated client-side (`trackedImpressionsRef`, `CompassRecommendationsSection.tsx:25-34`) — one `card_view` per unique triple even across re-renders. |
+| Recommendation → Shrine Detail CTR (numerator) | Recommendation row, **not** raw event count | A recommendation row counts as "opened" if **at least one** `shrine_detail_view{source=compass}` exists with the matching `(recommendationInstanceId, shrineId)` pair — multiple opens of the same row count once for CTR, not N times. |
+| Compass Result → Detail Engagement (§9B) | Compass result instance = `recommendationInstanceId` | A result instance counts as "engaged" if **at least one** of its recommended shrines was opened — multiple shrines opened from the same instance still count once. |
+| Compass-attributed Favorite/Visit/Reflection rate | Shrine Detail view instance (one page render) | A Favorite toggled on then off then on again within the same page render still counts as **one** qualifying detail-view-to-action transition for the rate's numerator (the question is "did this compass-attributed detail view lead to an action," not "how many times was the button pressed"). Toggle-off (`nextFav: false`) events are excluded from the *positive-action* numerator entirely, per §12 below. |
+| Same-Month Repeat Usage | distinct calendar-day-independent `compass_result` events per identity per month | See §16 — counts *instances*, not raw event volume; a user resubmitting after an error within seconds is still a second instance by this definition, since the metric is "did Compass get used more than once," not "was it used flawlessly once." |
+| Month-over-Month Return | one qualifying `compass_result` per identity per month (any `result_state`, see §17) | Presence/absence per month, not a count — a person is either "present in month M" or not, regardless of how many times. |
+
+**General rule**: never deduplicate a metric down to "per distinct person" unless the metric is explicitly person-level (Same-Month Repeat, Month-over-Month Return). Funnel/CTR metrics use the smallest correct unit — the recommendation row or the result instance — not the person, since one person can legitimately generate several independent, equally-valid recommendation rows.
+
+---
+
+## 6. Same-Session vs Cross-Session Attribution Boundary
+
+**SAME-SESSION / SAME-NAVIGATION ATTRIBUTION**: the current implementation's only supported attribution mechanism. `ctx=compass`, `recommendation_instance_id`, and `recommendation_rank` travel exclusively as URL query parameters on the `/shrines/:id` navigation built by `buildShrineHref` (`CompassRecommendationsSection.tsx:62-69`). `page.tsx` reads them server-side per-request (`normalizeCtx`, `normalizeRecommendationInstanceId`) and explicitly overrides them onto `ShrineDetailArticle`/`ShrineSaveButton` for that render only (`page.tsx:500-524`, PR-C). Nothing is written to a database, cookie, or any storage that would survive past this one page load.
+
+**CROSS-SESSION ATTRIBUTION**: **not supported, and not attempted.** A user who discovers a shrine via Compass, closes the tab, and returns to that Shrine Detail page on a different day (no `ctx=compass` in that later URL) will correctly see `source: "shrine_detail"` on any Favorite/Visit/Reflection action taken then — this is the honest, correct behavior, not a bug to fix.
+
+**This document does not, and must not, invent a cross-session join using:**
+- `shrineId` alone (recurs across unrelated users/sessions/months)
+- `userId + shrineId` alone (would fabricate a causal link the data doesn't support — a user could independently rediscover the same shrine via Search or Concierge)
+- nearest-timestamp heuristics
+- Favorite/Visit/Reflection history correlated after the fact
+
+**Correlation is not provenance.** Any future query that reconstructs "this Favorite probably came from that earlier Compass session" via timestamp proximity or shared `shrineId` would be fabricating attribution beyond what this instrumentation actually proves, directly contradicting the design principle established across the Compass audit chain (`docs/audit/compass-runtime-personal-continuity-boundary.md`).
+
+---
+
+## 7. Time Model
+
+**Canonical reporting period: calendar month.** Not Compass's own solar-month (`solarMonthIndex`, used only for the in-product "this month's direction" display, `CompassDirectionRuntime.solarMonthIndex`). This re-affirms the recommendation already made in `docs/audit/compass-analytics-contract-readiness.md` §17: calendar month for analytics/KPI reporting, solar month reserved for in-product display logic. The two serve different consumers and conflating them risks off-by-a-few-days boundary errors in retention counts for a distinction that only matters to the product's own kyusei calculation, not to aggregate measurement.
+
+**Timezone: `Asia/Tokyo` (JST, UTC+9, no DST)** — confirmed as the backend's own canonical timezone (`backend/shrine_project/settings.py:425`, `TIME_ZONE = "Asia/Tokyo"`). Any PostHog query bucketing by calendar month **must** use this timezone explicitly; PostHog's project-level default timezone should be verified to match before any month-boundary query is trusted (this document does not change PostHog project configuration — that verification is an operational prerequisite, flagged as an open item in §14).
+
+**Qualifying event for a "monthly usage instance": `compass_result` with any `result_state`** (not `compass_entry`, and not restricted to `recommendation_success`) — see §16/§17 for the reasoning (an attempted-but-failed Compass usage is still evidence the person engaged with the product that month, and restricting to success-only would understate genuine repeat engagement while also conflating an engagement metric with the separate reliability metric in §8).
+
+---
+
+## 8. KPI Definitions
+
+### KPI — Home Compass Entry Click Count
+
+**Purpose**: measure how many users actively choose Compass from Home.
+
+**Product Question**: are users discovering Compass from Home? (#1)
+
+**Event(s)**: `home_compass_entry_click`
+
+**Numerator**: N/A — this is a raw count metric, not a rate.
+
+**Denominator**: **MEASUREMENT GAP.** No Home page-view or Home-section impression event exists anywhere in the codebase (`HomeMainClient.tsx`, `HomePage.tsx` — no `track`/`trackSearchEvent`/`trackCardEvent` call found). A CTR (clicks ÷ impressions) **cannot be honestly calculated today.** Do not estimate one from Home page-load analytics belonging to an unrelated event family — no such family exists either.
+
+**Counting Unit**: event count, deduplicated by PostHog's standard event de-duplication only (no client-side impression-style dedup exists on this click, since a click is inherently a one-shot user action, not a mount-based tracker).
+
+**Required Properties**: `source="home"` (constant — always this value, since this is the only event of this name).
+
+**Join Keys**: none required — this is a leaf metric, though it can optionally be sequenced into a Funnel with `compass_entry` (§8's "Compass Activation" KPI below) to estimate what fraction of Home clicks result in an actual Compass page load, which is a *different*, answerable question from "how many people who saw Home chose Compass."
+
+**Filters**: none.
+
+**Exclusions**: none currently defined; see §27B for the general non-organic-traffic caveat.
+
+**Deduplication**: standard PostHog event-level only.
+
+**Attribution Window**: N/A (single event).
+
+**Supported Cohorts**: anonymous, authenticated Free, authenticated Premium — all safely includable (event carries no plan-gating logic and Compass is plan-neutral by contract).
+
+**Known Measurement Gaps**: no impression denominator exists; **Home Compass Discovery Rate (CTR) is not currently measurable** and must not be estimated.
+
+**Minimum Observation Requirement**: see §27B (session diversity gate) before treating any count as representative of organic usage.
+
+**Decision Use**: raw volume trend only — "is anyone clicking this at all," not a conversion rate.
+
+**PostHog Representation**: Trends (event count over time), optionally broken down by `referrer` if PostHog captures it natively (not an app-level property here).
+
+---
+
+### KPI — Compass Activation
+
+**Purpose**: distinguish "opened Compass" from "attempted to submit Compass" from "received a usable result."
+
+**Product Question**: are users entering Compass, and are they completing enough input to execute it? (#2, #3)
+
+**Event(s)**: `compass_entry` (entered), `compass_result` (submitted + resolved — see below for why these two are not split further)
+
+**Numerator / Denominator, defined as three distinct measurements, not collapsed:**
+
+1. **Entered Compass** = count of `compass_entry`.
+2. **Submitted Compass** = count of `compass_result` (any `result_state`) — because the current architecture has **no separate "submit attempted" event distinct from "result received"** (`CompassClient.tsx`'s `handleSubmit` fires `trackCompassResult` only after the fetch resolves or throws, §1 of the readiness audit already made this exact design call: Compass's request is synchronous enough that a separate pre-flight "activation" event was judged unnecessary). Submitted and Resolved are therefore the same instant in this architecture — do not invent a distinction the event model does not support.
+3. **Received a usable result** = count of `compass_result{result_state="recommendation_success"}`.
+
+**Counting Unit**: `compass_entry`/`compass_result` event, already deduplicated at entry (§5) and not deduplicated at result (retries are legitimate distinct attempts, §5).
+
+**Required Properties**: `referrer_source` (entry); `result_state` (result).
+
+**Join Keys**: sequencing `compass_entry → compass_result` by `distinct_id` within a bounded window (recommend the same session; PostHog's native session concept can be used here since no custom session property exists on these two events, per §1).
+
+**Filters**: none.
+
+**Exclusions**: none.
+
+**Deduplication**: see §5.
+
+**Attribution Window**: same PostHog session (native), since no custom session id is attached to either event.
+
+**Supported Cohorts**: anonymous, Free, Premium — all safely includable (no `accessLevel` property exists on these events at all, so no gating logic could differ by plan even if desired).
+
+**Known Measurement Gaps**: cannot distinguish "user is still filling the form" from "user abandoned" — there is no client-side pre-submit-attempt event (deliberate, per the readiness audit's event-minimization decision), so a `compass_entry` with no following `compass_result` in a session is ambiguous between "still deciding" and "gave up."
+
+**Minimum Observation Requirement**: §27B.
+
+**Decision Use**: `compass_result` ÷ `compass_entry` (a "did they at least try" rate) is the only honestly derivable ratio here; do not present it as an "activation funnel" implying finer-grained steps that don't exist.
+
+**PostHog Representation**: Funnel (`compass_entry` → `compass_result`), 2-step.
+
+---
+
+### KPI — Compass Result Success Rate (OPERATIONAL)
+
+**Purpose**: answer "is Compass functioning reliably," not "does Compass create value." Deliberately kept separate from engagement/value KPIs per the task's explicit instruction (§21).
+
+**Product Question**: what percentage of executions successfully produce recommendations? (#5, reliability framing)
+
+**Event(s)**: `compass_result`
+
+**Numerator**: `compass_result{result_state="recommendation_success"}` count.
+
+**Denominator**: all `compass_result` events, **including** `backend_error`, `invalid_purpose`, `direction_filter_unavailable`, `direction_zero_candidates`, and `evidence_zero_candidates` — reasoning below.
+
+**Counting Unit**: `compass_result` event (submit attempt, per §5/§8 above — retries are separate, legitimate attempts and each belongs in the denominator).
+
+**Required Properties**: `result_state`.
+
+**Join Keys**: none.
+
+**Filters**: none.
+
+**Exclusions**: none — this is deliberate. Reasoning per state:
+- `backend_error` — **must be in the denominator.** This is exactly the failure mode this metric exists to surface; excluding it would hide system reliability problems.
+- `direction_zero_candidates` / `evidence_zero_candidates` — **must be in the denominator, not counted as success.** A valid, well-formed request that legitimately found nothing is a real outcome the reliability metric should reflect (distinct from an error, but still not "success" for this metric's purpose — see the separate SUCCESS/EMPTY/ERROR breakdown below for the finer distinction).
+- `invalid_purpose` — **must be in the denominator.** Even though normal UI flow (chip selector) makes this state hard to reach organically, the API contract allows it, and any occurrence (malformed request, future UI bug) should count against reliability, not be silently dropped.
+- `direction_filter_unavailable` — **must be in the denominator**, and per §10/§8 of `compass-analytics-contract-readiness.md`, this state specifically represents "the system could not safely complete a computation" — the strongest reliability-relevant signal of the five non-success states.
+
+**Deduplication**: none beyond §5's retry handling (each retry is counted).
+
+**Attribution Window**: N/A (single event).
+
+**Supported Cohorts**: anonymous, Free, Premium — all includable (no plan property on this event).
+
+**Known Measurement Gaps**: none for this specific metric; the states are exhaustive and already verified against current backend code (§1.1).
+
+**Minimum Observation Requirement**: §27B — do not compare success rate across small segments (e.g. by purpose, §22) with a trivial sample.
+
+**Decision Use**: operational health monitoring. A sustained drop signals a backend/data problem, not a product-value problem — do not conflate with engagement metrics below.
+
+**Sub-breakdown (for the separate "operational-quality query" the task requests in §21):**
+
+| Bucket | `result_state` values included |
+|---|---|
+| SUCCESS | `recommendation_success` |
+| EMPTY / NO CANDIDATE | `direction_zero_candidates`, `evidence_zero_candidates` |
+| ERROR | `backend_error`, `direction_filter_unavailable` |
+| OTHER | `invalid_purpose` |
+
+**PostHog Representation**: Trends (event count, breakdown by `result_state`), or a single formula insight (`recommendation_success` count ÷ total `compass_result` count) over a rolling window.
+
+---
+
+### KPI — Recommendation → Shrine Detail CTR (PRIMARY, recommendation-level — the primary Recommendation CTR)
+
+**Purpose**: the headline metric PR-B was built to support — of the shrines Compass recommended, which were actually opened.
+
+**Product Question**: which displayed recommendations are actually opened? (#4)
+
+**Event(s)**: `card_view` (numerator base / denominator), `shrine_detail_view` (numerator qualifier)
+
+**Numerator**: count of distinct `(recommendationInstanceId, shrineId)` pairs from `card_view{source="compass"}` for which **at least one** matching `shrine_detail_view{source="compass", recommendationInstanceId, shrineId}` exists (§5 dedup rule — multiple opens of the same row count once).
+
+**Denominator**: count of distinct `(recommendationInstanceId, shrineId)` pairs from `card_view{source="compass"}`.
+
+**Counting Unit**: recommendation row (`recommendationInstanceId` + `shrineId` pair) — **not** raw event count, **not** person, **not** result instance.
+
+**Required Properties**: `recommendationInstanceId`, `shrineId`, `source="compass"` on both events; `recommendationRank` present but not required for the join (§4).
+
+**Join Keys**: `recommendationInstanceId` AND `shrineId` (§4, required, exact match, both must be present).
+
+**Filters**: `source="compass"` on both sides (excludes Concierge/map-originated impressions and detail views from this Compass-specific metric — Concierge has its own separate, pre-existing CTR measurement, unaffected by this document).
+
+**Exclusions**: rows where `recommendationInstanceId` is null (cannot occur for `card_view`, since it only fires after a successful result, §1) or where `shrineId` is null (cannot occur — `CompassRecommendationsSection.tsx:30` explicitly guards `if (shrineId == null) return`).
+
+**Deduplication**: §5 — impression-side already deduplicated client-side; detail-view-side collapses to "opened at least once" for this metric.
+
+**Attribution Window**: unbounded within the life of the browser tab/session that generated the impression — since both events fire from the same `recommendationInstanceId`-scoped result and the click happens via an in-app navigation from the same recommendation list, there is no realistic scenario where a legitimate open happens outside the immediate session. (This is a same-session metric by construction, not because of an explicit time cutoff.)
+
+**Supported Cohorts**: anonymous, Free, Premium — all includable (no `accessLevel` on Recommendation-stage events).
+
+**Known Measurement Gaps**: none for this specific metric — this is the one KPI the instrumentation is most directly and completely built to support.
+
+**Minimum Observation Requirement**: §27A/B — a handful of impressions is not a reliable CTR.
+
+**Decision Use**: primary signal for "does Compass's recommendation list itself create real interest," independent of what happens after the detail view.
+
+**PostHog Representation**: Funnel (`card_view` → `shrine_detail_view`, both filtered `source=compass`, matched on `recommendationInstanceId` + `shrineId` as the funnel's per-actor grouping key if PostHog's funnel engine is configured to group by a custom property rather than `distinct_id`) — otherwise, a HogQL query directly joining the two event tables on the two required keys is the more precise conceptual approach; provided as pseudocode only, not an executed query:
+
+```
+-- conceptual, not executed
+SELECT
+  card_view.recommendationInstanceId,
+  card_view.shrineId,
+  count(DISTINCT card_view.recommendationInstanceId || ':' || card_view.shrineId) AS impressions,
+  count(DISTINCT CASE WHEN detail.shrineId IS NOT NULL
+        THEN card_view.recommendationInstanceId || ':' || card_view.shrineId END) AS opened
+FROM events card_view
+LEFT JOIN events detail
+  ON detail.event = 'shrine_detail_view'
+  AND detail.properties.source = 'compass'
+  AND detail.properties.recommendationInstanceId = card_view.properties.recommendationInstanceId
+  AND detail.properties.shrineId = card_view.properties.shrineId
+WHERE card_view.event = 'card_view'
+  AND card_view.properties.source = 'compass'
+```
+
+---
+
+### KPI — Result Instance → Detail Engagement Rate (SECONDARY, result-session-level)
+
+**Purpose**: a coarser, complementary view of the same underlying behavior — "did this Compass result create *any* interest," independent of which or how many specific rows were opened.
+
+**Product Question**: do users inspect the recommended shrines, at the level of a whole Compass result? (#3, coarse framing)
+
+**Event(s)**: `compass_result`, `shrine_detail_view`
+
+**Numerator**: count of distinct `recommendationInstanceId` values (from `compass_result{result_state="recommendation_success"}`) for which **at least one** `shrine_detail_view{source="compass", recommendationInstanceId}` exists.
+
+**Denominator**: count of distinct `recommendationInstanceId` values from `compass_result{result_state="recommendation_success", recommendation_count>0}`.
+
+**Counting Unit**: Compass result instance (`recommendationInstanceId`) — coarser than the recommendation-row unit above.
+
+**Required Properties**: `recommendationInstanceId`, `recommendation_count` (to exclude instances with zero recommendations from the denominator, though `recommendation_count>0` should already be implied by `result_state="recommendation_success"` — kept as an explicit filter for defensive correctness).
+
+**Join Keys**: `recommendationInstanceId` only (rank/shrineId not needed at this coarser grain).
+
+**Filters**: `result_state="recommendation_success"` on the denominator side.
+
+**Exclusions**: same null-key exclusions as the recommendation-level KPI above.
+
+**Deduplication**: §5 — one qualifying instance counts once regardless of how many of its shrines were opened.
+
+**Attribution Window**: same as the recommendation-level KPI (same-session, by construction).
+
+**Supported Cohorts**: anonymous, Free, Premium.
+
+**Known Measurement Gaps**: none.
+
+**Minimum Observation Requirement**: §27A/B.
+
+**Decision Use**: **this is the metric nominated as the answer to product question #3 ("do users inspect the recommended shrines") at the aggregate level**; the recommendation-level CTR above remains the **primary** Recommendation CTR (nominated per the task's explicit instruction to nominate one). This metric is a useful secondary cross-check — a low recommendation-level CTR with a high result-level engagement rate would indicate users open exactly one shrine and stop (satisfied quickly), while the reverse pattern would be harder to interpret and worth a follow-up look.
+
+**PostHog Representation**: Funnel (`compass_result` filtered `result_state=recommendation_success` → `shrine_detail_view` filtered `source=compass`, matched by `recommendationInstanceId`).
+
+---
+
+### KPI — Compass-attributed Favorite Rate (PRIMARY)
+
+**Purpose**: the strongest honestly measurable Favorite metric now that PR-C propagates `source=compass` into `favorite_click`.
+
+**Product Question**: do Compass-originated detail views lead to Favorite? (#5)
+
+**Event(s)**: `shrine_detail_view`, `favorite_click`
+
+**Numerator**: count of distinct `shrine_detail_view{source="compass"}` instances (identified by `recommendationInstanceId` + `shrineId`, or failing that, session + shrineId — see below) for which a matching `favorite_click{source="compass", nextFav=true}` exists in the same page render.
+
+**Denominator**: count of `shrine_detail_view{source="compass"}` events.
+
+**Counting Unit**: Shrine Detail view instance (one page render reached via Compass).
+
+**Required Properties**: `source`, `shrineId`, `recommendationInstanceId` (on both events, when present); `nextFav` (on `favorite_click`, to isolate the save action from the unsave action).
+
+**Join Keys**: `recommendationInstanceId` + `shrineId`, **verified available** — PR-C threads the same `detailRecommendationInstanceId` (`compassRecommendationInstanceId ?? conciergeRecommendationInstanceId`) into `ShrineSaveButton` that `ShrineDetailViewTracker` already receives (`page.tsx`), so a **recommendation-level** join is genuinely possible here, not merely a coarser same-session approximation. This is a stronger result than the pre-implementation audit anticipated (`compass-analytics-contract-readiness.md` §13 had flagged Favorite attribution as an open question pending exactly this wiring, which PR-C completed).
+
+**Filters**: `source="compass"` on both sides; `nextFav=true` on `favorite_click` (excludes the toggle-off action from the positive numerator, per §5/§11).
+
+**Exclusions**: `favorite_click{nextFav=false}` (unsave) is excluded from this rate's numerator entirely — it answers a different question (retention-of-save, not conversion-to-save) not defined as a KPI here.
+
+**Deduplication**: §5 — multiple toggles within the same page render still count as one qualifying instance.
+
+**Attribution Window**: **same Shrine Detail page render only** (§6). `ShrineSaveButton.tsx`'s `ctx`/`recommendationInstanceId` props are populated exclusively from `page.tsx`'s per-request override — there is no mechanism for a Favorite click on a *later*, separate page load to carry `source=compass`.
+
+**Supported Cohorts**: anonymous is **excluded by construction** — `Favorite` requires authentication (`ShrineSaveButton`'s guest-mode path redirects to login rather than saving, `useFavorite.ts`). This metric is therefore Free + Premium only, not anonymous. `accessLevel` is present on `favorite_click`, so a Free/Premium breakdown is technically possible (§20 caveat: exploratory only, not a Premium-quality claim).
+
+**Known Measurement Gaps**: **cross-session Compass → Favorite is not measurable** and must not be estimated (§6). A user who returns on a different day and favorites a shrine they first saw via Compass will not be attributed to Compass — this is the honest, by-design limitation, not a bug.
+
+**Minimum Observation Requirement**: §27A/B — Favorite is a rarer action than a detail view; expect a smaller sample than the CTR above.
+
+**Decision Use**: primary signal for "does Compass surface shrines worth intentionally saving," bounded strictly to the same-visit window. Never report this as "X% of Compass users favorite a shrine" without the same-session caveat attached.
+
+**PostHog Representation**: Funnel (`shrine_detail_view` filtered `source=compass` → `favorite_click` filtered `source=compass, nextFav=true`, matched on `recommendationInstanceId` + `shrineId`).
+
+---
+
+### KPI — Compass-attributed Visit Rate (PRIMARY, carefully named)
+
+**Purpose**: the strongest honestly measurable Visit metric, named to avoid implying causality the architecture cannot prove.
+
+**Product Question**: do Compass-originated detail views lead to Visit? (#6)
+
+**Event(s)**: `shrine_detail_view`, `visit_done`
+
+**Numerator**: count of distinct `shrine_detail_view{source="compass"}` instances for which a matching `visit_done{source="compass"}` exists in the same page render.
+
+**Denominator**: count of `shrine_detail_view{source="compass"}` events.
+
+**Counting Unit**: Shrine Detail view instance.
+
+**Required Properties**: `source`, `shrineId`, `recommendationInstanceId` (both events).
+
+**Join Keys**: `recommendationInstanceId` + `shrineId`, same availability as Favorite above (PR-C wiring).
+
+**Filters**: `source="compass"` on both sides.
+
+**Exclusions**: none additional.
+
+**Deduplication**: §5.
+
+**Attribution Window**: **same Shrine Detail page render only**, identical constraint to Favorite (§6).
+
+**Naming discipline — explicit, per the task's instruction**: this metric must be read as **"a Visit was recorded while Compass context remained available (same page render),"** never as **"Compass caused this Visit."** A physical shrine visit is, by nature, far more likely than a Favorite to happen in a *later* browsing session than the initial Compass discovery (the task's own example: discover → leave → return later → visit later) — meaning this metric's *coverage* (what fraction of true Compass-driven visits it can even see) is expected to be **lower** than Favorite's, even though the *mechanism* for computing it is identical. This is a coverage limitation, not a measurement error.
+
+**Supported Cohorts**: anonymous, Free, Premium all included — `Visit` does not require authentication in the current architecture (unlike Favorite; confirmed no guest-mode redirect exists in `ShrineDetailArticle.tsx`'s visit button handler, only Favorite has one).
+
+**Known Measurement Gaps**: cross-session Compass → Visit is not measurable (§6) — and, per the naming discussion above, is expected to be the *majority* of true Compass-driven visits, meaning this metric likely represents a **small, non-representative subset** of actual Compass-driven visiting behavior. Do not extrapolate this rate to estimate "true" Compass-driven visit volume.
+
+**Minimum Observation Requirement**: §27A/B — expect a low sample size by nature; do not draw conclusions from a handful of events.
+
+**Decision Use**: a lower-bound signal only — "at least this many Compass-driven visits happened in the same sitting." Never the numerator for a claimed overall Compass→Visit conversion rate.
+
+**PostHog Representation**: Funnel (`shrine_detail_view` filtered `source=compass` → `visit_done` filtered `source=compass`, matched on `recommendationInstanceId` + `shrineId`).
+
+---
+
+### KPI — Compass-attributed Reflection (SECONDARY / DIAGNOSTIC, same-session only)
+
+**Purpose**: audit what Reflection can actually prove about Compass provenance, per the task's explicit caution against inventing cross-session causality here (#7).
+
+**Product Question**: what downstream Reflection attribution is honestly measurable? (#7)
+
+**Event(s)**: `shrine_detail_view`, `visit_done`, `reflection_prompt_view`, `reflection_saved`
+
+**Attribution classification, per event:**
+
+| Event | Classification | Reasoning |
+|---|---|---|
+| `reflection_prompt_view` | **SESSION/NAVIGATION** (only when it appears within the same page render as a Compass-attributed `visit_done`) | `ShrineReflectionPrompt` only renders when `hasVisitHistory` is true; if that becomes true via the *current* render's own Visit action, `source="compass"` correctly propagates. If `hasVisitHistory` is true from a **prior**, separate visit (page loaded fresh, no `ctx=compass` in this URL), `source` correctly falls back to `"shrine_detail"` — no false attribution. |
+| `reflection_saved` | **SESSION/NAVIGATION** (same rule) | Same mechanism as prompt. |
+| Reflection occurring in a genuinely later, separate session (different day, different page load, no `ctx=compass`) | **NOT AVAILABLE** | Classified as a **MEASUREMENT GAP** below, not a KPI. |
+
+**Numerator (if computed)**: count of `shrine_detail_view{source="compass"}` instances for which a matching `reflection_saved{source="compass"}` exists in the same page render.
+
+**Denominator (if computed)**: count of `shrine_detail_view{source="compass"}` events, or more precisely the subset that also produced a `visit_done{source="compass"}` (since Reflection is gated on Visit).
+
+**Counting Unit**: Shrine Detail view instance.
+
+**Required Properties**: `source`, `shrineId`, `recommendationInstanceId`.
+
+**Join Keys**: `recommendationInstanceId` + `shrineId`.
+
+**Filters**: `source="compass"`.
+
+**Exclusions**: none additional beyond the null-key rule.
+
+**Deduplication**: §5.
+
+**Attribution Window**: same page render only — realistically the narrowest window of any KPI in this document, since it requires Visit **and** Reflection both to occur before the user navigates away.
+
+**Supported Cohorts**: anonymous, Free, Premium (Reflection does not require authentication in current code, `accessLevel` can be `"anonymous"`).
+
+**Known Measurement Gaps**: **the long-term "Compass → Reflection" relationship the product cares about most (does a Compass-driven visit eventually get reflected on, even days later) is explicitly a MEASUREMENT GAP.** Per the task's instruction, no KPI in this document implies that longer-horizon causality. If this same-session variant's volume proves too low to be useful (likely, given how rarely Visit-then-Reflection both happen in one sitting for a physical-world action), do not manufacture a substitute — report it as near-zero-volume and leave the long-horizon question explicitly unanswered pending future instrumentation (out of scope here, §31).
+
+**Minimum Observation Requirement**: §27A/B, with the expectation that this metric may never reach a usable sample size under the current architecture.
+
+**Decision Use**: diagnostic only — not a headline KPI. Useful primarily to confirm the mechanism works at all (non-zero), not to estimate a rate.
+
+**PostHog Representation**: Funnel (4-step: `shrine_detail_view` → `visit_done` → `reflection_prompt_view` → `reflection_saved`, all filtered `source=compass`, matched on `recommendationInstanceId` + `shrineId`) — expect very low counts by construction.
+
+---
+
+### KPI — Same-Month Compass Repeat Usage (SECONDARY — Engagement, explicitly not Retention)
+
+**Purpose**: measure within-month re-use, classified strictly as an engagement diagnostic per the task's explicit instruction (§16), never as a retention signal.
+
+**Product Question**: do users use Compass repeatedly within the same month? (#8)
+
+**Event(s)**: `compass_result`
+
+**Numerator**: count of identities (see cohort note below) with **2 or more** distinct `compass_result` events (any `result_state`) within the same calendar month M.
+
+**Denominator**: count of identities with **at least 1** `compass_result` event within calendar month M.
+
+**Counting Unit**: identity × calendar month (see Identity below).
+
+**Required Properties**: none beyond the event's existence; `result_state` optionally for a "repeat that changed purpose/origin vs. repeat with identical inputs" secondary breakdown (`purpose`, `origin_mode` are available on the event for this — no new property needed).
+
+**Join Keys**: none (single-event aggregate).
+
+**Filters**: calendar month boundary (§7, `Asia/Tokyo`).
+
+**Exclusions**: §27B (non-organic traffic).
+
+**Deduplication**: counts distinct **instances** (events), not deduplicated further — a second `compass_result` seconds after the first (e.g. a quick purpose change) legitimately counts as usage instance #2, per the reasoning in §5.
+
+**Attribution Window**: one calendar month.
+
+**Supported Cohorts — critical limitation, per the task's explicit instruction not to silently treat anonymous `distinct_id` as account identity**: PostHog's `distinct_id` is the only available identity for this metric, for **both** anonymous and logged-in users, **because `posthog.identify()` is never called anywhere in this codebase** (verified: no occurrence in `apps/web/src` or `backend/`, re-confirmed for this audit). Consequently:
+- An anonymous `distinct_id` is a browser/device-local, `localStorage`/cookie-backed identifier via posthog-js's own default behavior — it survives across page loads **on the same browser, same device**, but is lost on cache clear, private browsing, or a different device.
+- A **logged-in** user gets **no stronger identity signal in PostHog than an anonymous one** — logging in does not currently call `identify()`, so a logged-in user on two different devices appears as two unrelated `distinct_id`s in PostHog, indistinguishable from two different anonymous people.
+- This metric is therefore an **undercount** of true repeat usage by real people, not an overcount — the failure mode is losing the identifier (device change, cache clear), never double-counting a single person as two.
+
+**Known Measurement Gaps**: repeated `compass_entry` events without an intervening `compass_result` are **not** counted as "usage instances" for this metric (a `compass_entry` alone, per §8's Activation KPI, only proves the page loaded, not that Compass was used) — this is a deliberate scoping choice, not an oversight.
+
+**Minimum Observation Requirement**: §27A/B/D.
+
+**Decision Use**: engagement diagnostic. **Must never be presented as a retention or Premium-continuity signal** — the task is explicit that repeat same-month use may reflect purpose exploration, origin exploration, retry-after-empty-result, curiosity, or accidental repeat, none of which are retention evidence on their own.
+
+**PostHog Representation**: Trends with a "unique users doing event 2+ times" style aggregation, or a cohort-based breakdown; alternatively Retention with a same-period (day-granularity-within-month) window if PostHog's native Retention insight is repurposed for an intra-month view rather than its default cross-period use (documented here as a conceptual option, not a built query).
+
+---
+
+### KPI — Month-over-Month Compass Return (PRIMARY — the primary Retention concept)
+
+**Purpose**: the primary retention hypothesis for Compass, per the task's explicit framing and consistent with the entire prior Compass audit chain.
+
+**Product Question**: do users return to Compass in a later month? (#9)
+
+**Event(s)**: `compass_result`
+
+**Numerator**: count of identities with a qualifying `compass_result` in calendar month M **and** a qualifying `compass_result` in calendar month M+1 (or, for a looser "eventual return" variant, any month after M).
+
+**Denominator**: count of identities with a qualifying `compass_result` in calendar month M.
+
+**Counting Unit**: identity, presence/absence per month (not a count within the month — see §5).
+
+**Required Properties**: none beyond event existence.
+
+**Join Keys**: none (single-event-type, self-joined across two time windows by identity).
+
+**Filters**: calendar month boundaries, `Asia/Tokyo` (§7).
+
+**Exclusions**: §27B/C.
+
+**Deduplication**: presence-based, not count-based — multiple `compass_result` events within month M+1 still count as one "returned" instance.
+
+**Attribution Window**: exactly two adjacent calendar months for the strict definition; open-ended for the "eventual return" variant.
+
+**Supported Cohorts**: same identity limitation as Same-Month Repeat above — anonymous `distinct_id` only, no `identify()` anywhere, so this metric **structurally undercounts** true person-level return behavior, more severely than the within-month metric since the cross-month window gives more opportunity for the identifier to be lost (device change, cache clear, time elapsed).
+
+**Known Measurement Gaps**: identical identity limitation as above, compounded by elapsed time; and the **mandatory Time Gate below**.
+
+**Minimum Observation Requirement — MANDATORY HARD RULE (§28 of the task, non-negotiable):**
+
+> **MONTH-OVER-MONTH RETURN MUST NOT BE JUDGED WITH LESS THAN TWO ELIGIBLE CALENDAR MONTHS OF REAL USAGE.**
+
+If fewer than two full eligible calendar months of `compass_result` data exist since Measurement Valid From (§9 below), this metric's status is:
+
+```
+Status: INSUFFICIENT OBSERVATION WINDOW
+```
+
+**never** `Status: LOW RETENTION` or a computed `0%`. A zero or near-zero value computed before two eligible months exist is not evidence of low retention — it is definitionally impossible to have observed a return yet, and reporting it as a rate would be actively misleading.
+
+**Decision Use**: this is the metric this document nominates as the **primary Retention signal for Compass**, and — per §29 below — one of the key inputs to any future decision about reopening Personal Continuity. It must not be computed or reported until the Time Gate above is satisfied.
+
+**PostHog Representation**: PostHog's native Retention insight (event-based, `compass_result` as both the "first event" and "returning event," monthly granularity, `Asia/Tokyo` project timezone) is the natural fit — conceptually described here, not configured or executed in this audit.
+
+---
+
+### Diagnostic dimensions (SECONDARY / not standalone KPIs)
+
+**Rank breakdown** (§22 of the task): what fraction of Shrine Detail opens come from rank 1 / 2 / 3 / etc. **Classification: SECONDARY DIAGNOSTIC**, per the task's own steer to prefer this classification absent contrary evidence. `recommendationRank` is available on `card_view`, `shrine_detail_transition`, and `shrine_detail_view` (§1), so this is a straightforward breakdown of the primary Recommendation CTR KPI by the `recommendationRank` property — not a new query mechanism, just a `breakdown` dimension on the existing Funnel/Trends insight. Rank is metadata, not identity (§4) — never used to define "the same recommendation," only to segment an already-defined metric.
+
+**Purpose segmentation** (§23): `purpose` is a coarse, canonical 15-value slug present on `compass_result` — safe as a non-PII breakdown dimension on any of the above KPIs computed from or downstream of `compass_result`. **Do not interpret a CTR/rate difference between purposes as proof one purpose is "better."** This document also preserves, without re-litigating, the previously-documented product caveat that some purpose-taxonomy mappings may currently produce equivalent Recommendation behavior — any purpose-level comparison should be read with that caveat in mind, not treated as clean independent variables. Taxonomy correctness is out of scope for this audit.
+
+**Origin mode segmentation** (§24): `origin_mode` (`"device"|"station"|"address"|"prefecture"`) is present on `compass_result` — safe as a coarse, non-PII breakdown dimension. **Never** use `latitude`/`longitude`/raw address/station text for PostHog segmentation — these are never sent (§2) and must never be added for this purpose.
+
+---
+
+## 9. Existing Data Limitations — Measurement Valid From
+
+Every event in this contract was introduced across three merged PRs. Data recorded **before** each PR's production deployment cannot be joined with data recorded after it, and pre-instrumentation traffic must never be mixed into any of the KPIs above.
+
+| Event(s) | Introduced in | Measurement Valid From |
+|---|---|---|
+| `home_compass_entry_click`, `compass_entry`, `compass_result` (without `recommendationInstanceId`) | PR-A (#2488, merged) | OPEN / DEPLOYMENT DATE REQUIRED — exact production deploy timestamp not available to this audit; merge timestamp (`2026-08-19T04:24:55Z`, PR merge record) is the earliest possible bound, not necessarily the production rollout time. |
+| `compass_result.recommendationInstanceId`, `card_view{source=compass}`, `shrine_detail_transition{source=compass}`, `shrine_detail_view{source=compass}` | PR-B (#2489, merged) | OPEN / DEPLOYMENT DATE REQUIRED — merge timestamp `2026-08-19T08:25:22Z` is the earliest possible bound. |
+| `favorite_click`/`shrine_decision`/`visit_done`/`reflection_prompt_view`/`reflection_saved` carrying `source=compass` | PR-C (#2490, merged) | OPEN / DEPLOYMENT DATE REQUIRED — merge timestamp available in git history, exact production deploy timestamp not verified by this audit. |
+
+Any KPI in this document that spans the PR-A/PR-B boundary (e.g. the Compass Activation funnel, which needs both `compass_entry` and `compass_result`) is valid from PR-A's deployment. Any KPI depending on `recommendationInstanceId`-based joins (Recommendation CTR, Favorite/Visit/Reflection attribution) is valid only from PR-B's deployment onward, **not** from PR-A's. Do not backfill or approximate pre-PR-B data for these.
+
+---
+
+## 10. Anonymous vs Authenticated Users, and the Free/Premium Boundary
+
+**Compass usage itself is Free/Premium neutral by contract, confirmed unaffected**: no Compass lifecycle, Recommendation, or Shrine-Detail-view event (`home_compass_entry_click` through `shrine_detail_view`) carries an `accessLevel`/plan property at all (§1) — there is structurally no way for a query against this stage of the funnel to differ by plan, which is the correct, contract-preserving state.
+
+**`accessLevel` first appears at the action boundary**: `favorite_click`, `visit_done`, `reflection_prompt_view`, `reflection_saved` do carry `accessLevel` (`"anonymous"|"free"|"premium"`). This means:
+- Metrics through Shrine Detail view: safely includable across anonymous/Free/Premium, no segmentation even possible.
+- Favorite/Visit/Reflection-stage metrics: **exploratory** Free-vs-Premium breakdown is technically possible using the existing `accessLevel` property, without adding instrumentation — per the task's explicit allowance (§20) that this may be exploratory only, given current analytics already provides the needed non-PII plan context at this specific stage.
+
+**Do not define Premium success as better Recommendation quality** — there is no mechanism for that claim to even be constructed from this data (Recommendation-stage events carry no plan property, and the underlying Recommendation logic itself is untouched by any of PR-A/B/C, confirmed by all three PRs' own explicit non-goals).
+
+**Identity requirement by metric type**:
+- Funnel/CTR/rate metrics (Recommendation CTR, Favorite/Visit/Reflection rate): do **not** require stable person-level identity — they operate on event-level joins (`recommendationInstanceId`+`shrineId`) or session-scoped attribution, safe for anonymous users.
+- Retention metrics (Same-Month Repeat, Month-over-Month Return): **do** require identity continuity across time, and — per §8 above — this is currently only PostHog's own `distinct_id`, unlinked to real account identity for anyone, authenticated or not.
+
+---
+
+## 11. Observation Gates
+
+**A. Sample Size Gate**: no statistically authoritative numeric threshold is invented here — consistent with this repository's established, repeated pattern (`docs/audit/posthog-recommendation-quality-observation-cadence.md`, `docs/audit/recommendation-quality-observation-operations.md`, `docs/audit/knowledge-recommendation-analytics-baseline-readiness.md`, all explicitly refuse to fabricate a sample-size number). **Classified as: PRODUCT/ANALYTICS DECISION REQUIRED** if a specific threshold is ever needed; until then, treat any KPI computed from a single-digit or low-double-digit event count as non-decision-grade, qualitatively.
+
+**B. Session Diversity Gate**: do not treat Mother Ship QA/developer traffic as organic usage. This document does not define a technical bot/QA-filtering mechanism (none currently exists in the Compass event properties — no `is_test`/`is_internal` flag is sent by any Compass event) — flagged as an **open operational gap**: any future query execution against these KPIs should first confirm whether PostHog project-level internal-traffic filtering (e.g. IP-based) is configured, since app-level filtering is not available.
+
+**C. Time Gate**: §8's Month-over-Month Return hard rule — never judged with fewer than two eligible calendar months.
+
+**D. Identity Gate**: never claim user-level retention when only unstable anonymous `distinct_id` is available (§8, §10) — always state this limitation alongside any Same-Month Repeat or Month-over-Month Return figure.
+
+**E. Attribution Gate**: never claim Compass → Visit/Reflection causal conversion beyond the same-page-render attribution boundary (§6) — the Favorite/Visit/Reflection KPIs above are named and scoped specifically to avoid this.
+
+---
+
+## 12. Personal Continuity Decision Gate
+
+Personal Continuity remains deferred (`docs/audit/compass-runtime-personal-continuity-boundary.md`, `docs/audit/compass-premium-personal-continuity.md`). This document does not reopen that decision. It defines, without asserting any threshold has been met, what evidence a future review would need to draw on:
+
+- A meaningfully non-zero **Month-over-Month Compass Return** (§8), observed only after the mandatory two-month Time Gate has passed.
+- Non-trivial **Recommendation → Shrine Detail CTR** and **Result Instance → Detail Engagement Rate** sustained across enough session diversity to rule out a small-sample artifact.
+- Non-trivial **Compass-attributed Favorite Rate** and (to the extent its low expected coverage allows) **Visit Rate**, specifically the same-session-attributable subset — understanding these almost certainly undercount true Compass-driven action volume (§6).
+- Any qualitative signal (user feedback, support requests) indicating desire for saved/continuous shrine journey — outside this document's data scope entirely.
+
+No specific numeric threshold is set for any of the above — consistent with §27A, this is recorded as a **future Product Decision Gate**, not a rule this audit can pre-resolve. Personal Continuity is **not implemented** by this document, and this document does not recommend implementing it.
+
+---
+
+## 13. Primary KPI Set
+
+Per the task's instruction to target ~4–6 primary metrics, not a 25-number dashboard:
+
+| Metric | Classification |
+|---|---|
+| Compass Result Success Rate | OPERATIONAL |
+| Recommendation → Shrine Detail CTR | **PRIMARY** |
+| Result Instance → Detail Engagement Rate | SECONDARY |
+| Compass-attributed Favorite Rate | **PRIMARY** |
+| Compass-attributed Visit Rate | **PRIMARY** |
+| Month-over-Month Compass Return | **PRIMARY** |
+| Home Compass Entry Click Count | SECONDARY (denominator for a true CTR is a MEASUREMENT GAP) |
+| Compass Activation (`compass_result` ÷ `compass_entry`) | SECONDARY |
+| Same-Month Compass Repeat Usage | SECONDARY (Engagement, explicitly not Retention) |
+| Compass-attributed Reflection (same-session) | SECONDARY / DIAGNOSTIC |
+| Rank breakdown | SECONDARY DIAGNOSTIC |
+| Purpose segmentation | SECONDARY DIAGNOSTIC |
+| Origin mode segmentation | SECONDARY DIAGNOSTIC |
+
+**Four PRIMARY metrics**: Recommendation → Shrine Detail CTR, Compass-attributed Favorite Rate, Compass-attributed Visit Rate, Month-over-Month Compass Return. Compass Result Success Rate is deliberately kept OPERATIONAL rather than PRIMARY, per the task's explicit instruction not to mix reliability and engagement/value KPIs (§21) — it answers "is Compass working," not "is Compass valuable."
+
+---
+
+## 14. Open Items (not resolved by this audit)
+
+1. Exact production deployment timestamps for PR-A/B/C (§9) — merge timestamps are known, rollout timestamps are not verified here.
+2. Whether PostHog's project-level timezone is actually configured to `Asia/Tokyo` — must be confirmed before any calendar-month query is trusted (§7).
+3. Whether PostHog project-level internal/QA-traffic filtering exists (§11B) — no app-level flag currently distinguishes Mother Ship QA traffic from organic usage.
+4. Numeric sample-size thresholds for any of the gates in §11 — explicitly left as PRODUCT/ANALYTICS DECISION REQUIRED, not fabricated here.
+5. Whether/how to eventually attach real account identity to PostHog (`identify()`) — a pre-existing, cross-cutting gap this document surfaces (§8, §10) but cannot resolve; doing so is out of this audit's authorization (would be new instrumentation).
+
+---
+
+## 15. Final Report
+
+```
+Canonical Compass funnel:
+  A. Lifecycle: home_compass_entry_click → compass_entry → compass_result
+  B. Recommendation: card_view(compass) → shrine_detail_transition(compass) → shrine_detail_view(compass)
+  C. Downstream action (same-page-render only): shrine_detail_view(compass) → favorite_click/visit_done/reflection_prompt_view → reflection_saved
+  D. Engagement/Retention: time-bucketed aggregates over compass_result (not a funnel)
+
+Primary KPIs:
+  Recommendation → Shrine Detail CTR
+  Compass-attributed Favorite Rate
+  Compass-attributed Visit Rate
+  Month-over-Month Compass Return
+
+Secondary KPIs:
+  Result Instance → Detail Engagement Rate, Home Compass Entry Click Count,
+  Compass Activation, Same-Month Compass Repeat Usage,
+  Compass-attributed Reflection (same-session), Rank/Purpose/Origin-mode diagnostics
+
+Operational KPIs:
+  Compass Result Success Rate (+ SUCCESS/EMPTY/ERROR/OTHER state breakdown)
+
+Recommendation CTR definition:
+  Numerator = distinct (recommendationInstanceId, shrineId) card_view rows with >=1 matching
+  shrine_detail_view(source=compass); Denominator = distinct (recommendationInstanceId, shrineId)
+  card_view(source=compass) rows. Join keys: recommendationInstanceId + shrineId (required, exact).
+  recommendationRank = validation/diagnostic dimension, not identity.
+
+Favorite attribution definition:
+  shrine_detail_view(compass) -> favorite_click(compass, nextFav=true), joined on
+  recommendationInstanceId + shrineId, same-page-render window only (SESSION/NAVIGATION
+  ATTRIBUTION). Cross-session: MEASUREMENT GAP, not estimated.
+
+Visit attribution definition:
+  Same mechanism as Favorite, same-page-render window only. Explicitly named to avoid causal
+  claims -- "Visit recorded while Compass context available," not "Compass caused this Visit."
+  Expected coverage is lower than Favorite's (physical visits more likely to be cross-session).
+
+Reflection attribution:
+  SESSION/NAVIGATION only, and only when prompt/saved occur in the same page render as the
+  Compass-attributed Visit. Long-horizon Compass -> Reflection: NOT AVAILABLE / MEASUREMENT GAP,
+  not a KPI.
+
+Same-Month Repeat definition:
+  Identities (PostHog distinct_id) with >=2 compass_result events (any result_state) within one
+  calendar month (Asia/Tokyo). Classified ENGAGEMENT, not Retention. distinct_id only -- no
+  identify() exists anywhere in the codebase, so this cannot distinguish authenticated identity
+  from anonymous device identity.
+
+Month-over-Month Return definition:
+  Identities with a qualifying compass_result in calendar month M and again in M+1 (Asia/Tokyo).
+  PRIMARY Retention metric. MUST NOT be judged with fewer than two eligible calendar months --
+  report INSUFFICIENT OBSERVATION WINDOW, never a computed 0%, until that gate is satisfied.
+
+Anonymous-user limitation:
+  No posthog.identify() call exists anywhere in the codebase (frontend or backend, re-verified).
+  Anonymous and logged-in users are equally unlinked in PostHog's own identity graph. Retention
+  metrics structurally undercount true person-level return (failure mode: losing the identifier,
+  never double-counting).
+
+Cross-session limitation:
+  Compass runtime is fully ephemeral (no persistence exists at any stage, PR-A through PR-C).
+  ctx/recommendationInstanceId/recommendationRank travel only as URL query parameters on the
+  single Compass -> Shrine Detail navigation. No cross-session join is defined or permitted using
+  shrineId alone, userId+shrineId alone, timestamp proximity, or post-hoc Favorite/Visit/
+  Reflection history correlation. Correlation is not provenance.
+
+Measurement valid from:
+  PR-A (#2488), PR-B (#2489), PR-C (#2490) merge timestamps are known; exact production
+  deployment timestamps are OPEN / DEPLOYMENT DATE REQUIRED. recommendationInstanceId-based
+  joins are valid only from PR-B onward, not from PR-A.
+
+Minimum observation gates:
+  A. Sample Size -- no threshold invented, PRODUCT/ANALYTICS DECISION REQUIRED if one is needed.
+  B. Session Diversity -- no app-level QA/internal-traffic flag exists; PostHog-level filtering
+     status is an open item.
+  C. Time -- Month-over-Month Return requires >=2 eligible calendar months (hard rule).
+  D. Identity -- never claim retention from unstable anonymous distinct_id without this caveat.
+  E. Attribution -- never claim causal Compass -> Visit/Reflection beyond same-page-render.
+
+Personal Continuity decision gate:
+  Deferred, not reopened. Future evidence inputs (non-zero Month-over-Month Return post-Time-Gate,
+  sustained CTR/engagement/Favorite-Visit rates across real session diversity, qualitative signal)
+  are named without any numeric threshold. Personal Continuity is NOT implemented here and this
+  document does not recommend implementing it.
+
+Production code changed:
+NO
+
+DB change:
+NONE
+
+Migration:
+NONE
+
+New analytics events:
+NONE
+
+New analytics properties:
+NONE
+
+Final Classification:
+B — QUERY CONTRACT READY WITH MEASUREMENT GAPS
+```
+
+**Why B, not A**: several KPIs (Home discovery CTR, cross-session Favorite/Visit/Reflection, long-horizon Compass → Reflection) are honestly and explicitly unmeasurable with the current architecture — not because the contract is unclear, but because the underlying instrumentation was deliberately scoped (PR-A/B/C) not to solve them yet. Every one of these gaps is precisely named, bounded, and distinguished from what *is* measurable, per the task's own instruction not to downgrade merely because a clearly-specified limitation exists. **Why not C**: no part of this contract is ambiguous or contested — every event, property, join key, and exclusion traces to a concrete, re-verified line of current code. **Why not D**: no architecture conflict exists; every KPI that *can* be computed is fully specified and ready to query as-is, with zero new instrumentation required.


### PR DESCRIPTION
## Summary

PR-A/B/C（#2488・#2489・#2490、すべてmerge済み）で実装済みのCompass analyticsを、PostHogでどう計測するかのquery contractとして定義（docs-only、コード変更なし）。イベント一覧の列挙ではなく、KPIごとにnumerator/denominator/join key/deduplication/attribution windowを明記した。

## 主要な結論

- **Recommendation → Shrine Detail CTR**（Primary）: `recommendationInstanceId` + `shrineId`で厳密にjoin可能。rankはidentityではなくvalidation/diagnostic dimension。
- **Favorite/Visit/ReflectionへのCompass帰属**（PR-C由来）: 同一Shrine Detail page render内でのみ成立するSESSION/NAVIGATION ATTRIBUTION。クロスセッションは明示的にMEASUREMENT GAPとし、shrineId単独・timestamp近接・行動履歴の事後相関などの代替推定は導入しない（"Correlation is not provenance."）。
- **Same-Month Repeat Usage**をEngagement、**Month-over-Month Return**をPrimary Retentionとして明確に分離。Month-over-Month Returnは2暦月未満では`INSUFFICIENT OBSERVATION WINDOW`とし、誤った0%を報告しないハードルールを明記。
- **Home discovery CTR**は分母となるimpression eventがHome側に存在しないためMEASUREMENT GAPとし、代替denominatorを捏造しない（`Home Compass Entry Click Count`という生カウントのみ計測可能）。
- **匿名/認証ユーザーの限界**: `posthog.identify()`がコード全体で一度も呼ばれていないことを再確認 — ログイン済みユーザーもPostHog上では匿名と同じ強度のidentityしか持たない。Retention系メトリクスはこの前提を明示せずに報告してはならない。
- **Personal Continuity Decision Gate**を将来の判断材料として定義するのみ。閾値の捏造・実装は行わない。

## Primary KPI Set（4件）

1. Recommendation → Shrine Detail CTR
2. Compass-attributed Favorite Rate
3. Compass-attributed Visit Rate
4. Month-over-Month Compass Return

（Compass Result Success RateはOPERATIONALとして分離 — reliability指標とengagement/value指標を混在させない）

## Scope

- docs/audit専用PR。プロダクションコード差分は0。
- Recommendation logic / Personal Continuity / Premium entitlement / persistence / DB fields / migrationsは一切変更していない。新規analyticsイベント・プロパティも追加していない。
- PostHog本番クエリは未実行、ダッシュボードは未構築。
- Draft PRとして作成。自動マージしない。

## Test plan

- [x] `docs/analytics/compass-posthog-query-contract.md` を追加したのみ（コード差分0）を確認
- [x] pre-pushフックのOpenAPI lint / Web契約テスト（150 files / 1033 tests）が通過

## Final Classification

**B — QUERY CONTRACT READY WITH MEASUREMENT GAPS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)