### PR TITLE
feat: Compassの方位なし結果を正式表示

### DIFF
--- a/apps/web/src/features/compass/CompassClient.tsx
+++ b/apps/web/src/features/compass/CompassClient.tsx
@@ -29,6 +29,7 @@ import type { CompassPurpose, CompassRecommendationsResponse, CompassUiState } f
 type CompassResultState =
   | "invalid_purpose"
   | "direction_filter_unavailable"
+  | "no_common_direction"
   | "direction_zero_candidates"
   | "evidence_zero_candidates"
   | "recommendation_success"
@@ -226,6 +227,14 @@ export default function CompassClient() {
         <DetailSection title="方向の参考情報を計算できませんでした" variant="tertiary">
           <p className="text-sm leading-6 text-[var(--kt-color-text-secondary)]">
             生年月日または出発地点をご確認のうえ、もう一度お試しください。
+          </p>
+        </DetailSection>
+      ) : null}
+
+      {uiState === "no_common_direction" ? (
+        <DetailSection title="今月は年盤と月盤で重なる方位がありません" variant="tertiary">
+          <p className="text-sm leading-6 text-[var(--kt-color-text-secondary)]">
+            生年月日・出発地点はどちらも問題ありません。年盤と月盤がともに支持する方位が今月はなかった、という結果です。
           </p>
         </DetailSection>
       ) : null}

--- a/apps/web/src/features/compass/__tests__/CompassClient.analytics.test.tsx
+++ b/apps/web/src/features/compass/__tests__/CompassClient.analytics.test.tsx
@@ -189,6 +189,48 @@ describe("CompassClient lifecycle analytics", () => {
       expect(zeroCandidatesPayload.recommendation_count).toBeNull();
     });
 
+    it("no_common_directionとdirection_filter_unavailableをresult_stateとして区別する（collapse禁止）", async () => {
+      // Runtime Contract Section 8 Group A (direction_filter_unavailable)
+      // vs Group B (no_common_direction, a VALID result) -- the generic
+      // trackCompassResult() pipeline forwards whatever backend state
+      // string it receives without transformation, so this is a
+      // type-contract/regression check, not new instrumentation logic.
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+      render(<CompassClient />);
+      fillMinimumValidInput();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          state: "no_common_direction",
+          purpose: "career",
+          direction_context: null,
+          recommendations: [],
+        }),
+      });
+      await submit();
+
+      fetchMock.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          state: "direction_filter_unavailable",
+          purpose: "career",
+          direction_context: null,
+          recommendations: [],
+        }),
+      });
+      await submit();
+
+      const resultStates = analyticsMocks.trackSearchEvent.mock.calls
+        .filter(([name]) => name === "compass_result")
+        .map(([, payload]) => (payload as { result_state: string }).result_state);
+
+      expect(resultStates).toEqual(["no_common_direction", "direction_filter_unavailable"]);
+    });
+
     it("invalid_purpose（HTTP 400）をresult_stateとして正しく表す", async () => {
       vi.stubGlobal(
         "fetch",

--- a/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
+++ b/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
@@ -145,6 +145,62 @@ describe("CompassClient", () => {
     expect(screen.queryByText("この方向の参拝候補")).not.toBeInTheDocument();
   });
 
+  it("no_common_directionは正当な結果として表示し、direction_filter_unavailableの誤解を招く案内文は出さない", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        state: "no_common_direction",
+        purpose: "career",
+        direction_context: null,
+        recommendations: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CompassClient />);
+    fillMinimumValidInput();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "今月の方向を確認する" }));
+    });
+
+    expect(await screen.findByText("今月は年盤と月盤で重なる方位がありません")).toBeInTheDocument();
+    // Must not imply the failure is a calculation error or an input mistake.
+    expect(
+      screen.queryByText("生年月日または出発地点をご確認のうえ、もう一度お試しください。"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("方向の参考情報を計算できませんでした")).not.toBeInTheDocument();
+    // No direction visual, no recommendation cards -- there is nothing to show.
+    expect(screen.queryByText("今月意識したい方向:", { exact: false })).not.toBeInTheDocument();
+    expect(screen.queryByText("この方向の参拝候補")).not.toBeInTheDocument();
+  });
+
+  it("direction_filter_unavailableは引き続き既存のfail-safe文言を表示する", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        state: "direction_filter_unavailable",
+        purpose: "career",
+        direction_context: null,
+        recommendations: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CompassClient />);
+    fillMinimumValidInput();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "今月の方向を確認する" }));
+    });
+
+    expect(await screen.findByText("方向の参考情報を計算できませんでした")).toBeInTheDocument();
+    expect(
+      screen.getByText("生年月日または出発地点をご確認のうえ、もう一度お試しください。"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("今月は年盤と月盤で重なる方位がありません")).not.toBeInTheDocument();
+  });
+
   it("バックエンドエラー時は落ち着いた文言のエラー状態を表示する", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, status: 500 }));
 

--- a/apps/web/src/features/compass/types.ts
+++ b/apps/web/src/features/compass/types.ts
@@ -3,9 +3,14 @@
 // Mirrors docs/product/compass-mvp-runtime-contract.md Section 5
 // (CompassDirectionRuntime) and the response shape of
 // backend/temples/api_views_compass.py::CompassRecommendationsView, which
-// wraps temples.services.compass_recommendation_orchestrator's 5 fail-safe
+// wraps temples.services.compass_recommendation_orchestrator's 6 result
 // states (see that module's docstring). Kept local to the Compass feature
 // rather than packages/shared -- no other app consumes it yet.
+//
+// "no_common_direction" is a VALID result (Runtime Contract Section 8
+// Group B), never collapsed into "direction_filter_unavailable" (Group A --
+// genuinely invalid/unavailable runtime). See compass-product-contract.md
+// Section 2.1.
 
 export type CompassPurpose =
   | "love"
@@ -47,6 +52,7 @@ export type CompassUiState =
   | "loading"
   | "invalid_purpose"
   | "direction_filter_unavailable"
+  | "no_common_direction"
   | "direction_zero_candidates"
   | "evidence_zero_candidates"
   | "recommendation_success"
@@ -68,6 +74,7 @@ export type CompassRecommendationsResponse = {
   state:
     | "invalid_purpose"
     | "direction_filter_unavailable"
+    | "no_common_direction"
     | "direction_zero_candidates"
     | "evidence_zero_candidates"
     | "recommendation_success";

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -99,6 +99,7 @@ export type SearchAnalyticsPayload = {
   result_state?:
     | "invalid_purpose"
     | "direction_filter_unavailable"
+    | "no_common_direction"
     | "direction_zero_candidates"
     | "evidence_zero_candidates"
     | "recommendation_success"

--- a/backend/temples/services/compass_recommendation_orchestrator.py
+++ b/backend/temples/services/compass_recommendation_orchestrator.py
@@ -35,17 +35,20 @@ from typing import Any, Mapping, Optional, Sequence
 
 from temples.domain.need_tags import NEED_TAGS
 from temples.services.compass_direction_filter import filter_candidates_by_direction
+from temples.services.compass_runtime import NoCommonDirectionResult
 from temples.services.concierge_chat import build_chat_recommendations
 from temples.services.concierge_chat_candidates import build_chat_candidates
 from temples.services.consultation_interpreter import interpret_consultation
 from temples.services.direction_reference import _coordinate
 
-# Fail-safe states (Section 11). Kept as distinct string constants -- never
-# collapse two of these into a shared generic "empty" outcome; that is
-# exactly what compass-mvp-runtime-contract.md Section 8 forbids for
-# origin/target_date fail-safes, and the same principle applies here.
+# Fail-safe / result states (Section 11, plus compass-mvp-runtime-contract.md
+# Section 8 Group A/B). Kept as distinct string constants -- never collapse
+# two of these into a shared generic "empty" outcome; that is exactly what
+# Section 8 forbids for origin/target_date fail-safes, and the same
+# principle applies here.
 STATE_INVALID_PURPOSE = "invalid_purpose"
 STATE_DIRECTION_FILTER_UNAVAILABLE = "direction_filter_unavailable"
+STATE_NO_COMMON_DIRECTION = "no_common_direction"
 STATE_DIRECTION_ZERO_CANDIDATES = "direction_zero_candidates"
 STATE_EVIDENCE_ZERO_CANDIDATES = "evidence_zero_candidates"
 STATE_RECOMMENDATION_SUCCESS = "recommendation_success"
@@ -84,7 +87,7 @@ def get_compass_recommendations(
     *,
     purpose: str,
     origin: Optional[Mapping[str, Any]],
-    direction_context: Optional[Mapping[str, Any]],
+    direction_context: Optional[Mapping[str, Any]] | NoCommonDirectionResult,
     language: str = "ja",
     candidate_pool_limit: int = DEFAULT_CANDIDATE_POOL_LIMIT,
 ) -> CompassRecommendationResult:
@@ -94,13 +97,25 @@ def get_compass_recommendations(
     direction filter as a confirmed-empty one -- see
     compass_direction_filter.filter_candidates_by_direction's own
     None-vs-[] contract, which this function preserves rather than collapses.
+
+    `direction_context` being a NoCommonDirectionResult (Group B -- valid
+    input, empty annual/monthly intersection) is likewise never collapsed
+    into the generic STATE_DIRECTION_FILTER_UNAVAILABLE (Group A -- invalid
+    or unavailable runtime); see compass-mvp-runtime-contract.md Section 8.
     """
     purpose_slug = str(purpose or "").strip()
     if purpose_slug not in NEED_TAGS:
         return CompassRecommendationResult(
             state=STATE_INVALID_PURPOSE,
             purpose=purpose_slug or None,
-            direction_context=direction_context,
+            direction_context=direction_context if isinstance(direction_context, Mapping) else None,
+        )
+
+    if isinstance(direction_context, NoCommonDirectionResult):
+        return CompassRecommendationResult(
+            state=STATE_NO_COMMON_DIRECTION,
+            purpose=purpose_slug,
+            direction_context=None,
         )
 
     if not isinstance(direction_context, Mapping):
@@ -191,6 +206,7 @@ def get_compass_recommendations(
 __all__ = [
     "STATE_INVALID_PURPOSE",
     "STATE_DIRECTION_FILTER_UNAVAILABLE",
+    "STATE_NO_COMMON_DIRECTION",
     "STATE_DIRECTION_ZERO_CANDIDATES",
     "STATE_EVIDENCE_ZERO_CANDIDATES",
     "STATE_RECOMMENDATION_SUCCESS",

--- a/backend/temples/services/compass_runtime.py
+++ b/backend/temples/services/compass_runtime.py
@@ -14,11 +14,13 @@ source (Signal Reuse, compass-product-contract.md Section 1: kyusei.py is a
 "product-context-free pure calculation module" Compass may reuse) and
 direction_reference.py's DIRECTION_REFERENCE_NOTE for the safe user-facing
 note text, per Runtime Contract Section 5's requirement that the note be
-"of the same kind as the existing DIRECTION_REFERENCE_NOTE".
+"of the same kind as the existing DIRECTION_REFERENCE_NOTE". kyusei.py
+itself is not modified -- see NoCommonDirectionResult below.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, Optional
 
 from django.utils import timezone
@@ -27,12 +29,37 @@ from temples.domain.kyusei import parse_birthdate, planned_visit_lucky_direction
 from temples.services.direction_reference import DIRECTION_REFERENCE_NOTE
 
 
+@dataclass(frozen=True)
+class NoCommonDirectionResult:
+    """Marks a VALID no-common-direction outcome.
+
+    Runtime Contract Section 8 Group B (docs/product/compass-mvp-runtime-contract.md):
+    birthdate and target_date were both valid, and the annual/monthly kyusei
+    calculation itself completed successfully -- it is only their
+    intersection (planned_visit_lucky_directions()'s own luckyDirections)
+    that is empty. This is a legitimate result, not a fail-safe.
+
+    Deliberately distinct from plain `None`, which remains reserved for
+    Group A (invalid/unavailable runtime -- missing or unparseable
+    birthdate/target_date, or the calculation itself not completing).
+    Carries no fields: there is no direction data to pass along (annual and
+    monthly were each computed, they simply share nothing), so callers only
+    need to know *that* this happened, not any additional payload.
+    """
+
+
 def build_compass_direction_runtime(
     *,
     birthdate: Optional[str],
     target_date: Optional[str],
-) -> Optional[dict[str, Any]]:
-    """Resolve the minimal CompassDirectionRuntime payload, or None.
+) -> Optional[dict[str, Any]] | NoCommonDirectionResult:
+    """Resolve the minimal CompassDirectionRuntime payload.
+
+    Returns one of three distinct shapes:
+      - a CompassDirectionRuntime dict (Section 5) when a reference direction exists
+      - NoCommonDirectionResult() when birthdate/target_date were valid and the
+        calculation completed, but annual ∩ monthly is empty (Group B)
+      - None when the runtime is genuinely invalid/unavailable (Group A)
 
     Fail-safe contract (Runtime Contract Section 8): a missing target_date
     defaults to today's date; an invalid-but-present target_date is NOT
@@ -48,8 +75,10 @@ def build_compass_direction_runtime(
         resolved_target_date = raw_target_date
 
     result = planned_visit_lucky_directions(birthdate, resolved_target_date)
-    if not result or not result.get("luckyDirections"):
+    if not result:
         return None
+    if not result.get("luckyDirections"):
+        return NoCommonDirectionResult()
 
     return {
         "targetDate": result["visitDate"],
@@ -61,4 +90,4 @@ def build_compass_direction_runtime(
     }
 
 
-__all__ = ["build_compass_direction_runtime"]
+__all__ = ["build_compass_direction_runtime", "NoCommonDirectionResult"]

--- a/backend/temples/tests/api/test_compass_recommendations_api.py
+++ b/backend/temples/tests/api/test_compass_recommendations_api.py
@@ -119,6 +119,33 @@ def test_missing_birthdate_returns_direction_filter_unavailable(client):
 
 
 @pytest.mark.django_db
+def test_no_common_direction_returns_dedicated_state_not_unavailable(client):
+    # Synthetic birthdate (not a real user's), reproduced independently in
+    # docs/audit/compass-direction-filter-unavailable-root-cause.md: for
+    # target_date 2026-08-20 this honmei star's annual/monthly lucky
+    # directions share nothing (empty intersection).
+    r = client.post(
+        URL,
+        data=json.dumps(
+            {
+                "purpose": "career",
+                "origin": ORIGIN,
+                "birthdate": "1975-06-15",
+                "target_date": "2026-08-20",
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["state"] == "no_common_direction"
+    assert body["state"] != "direction_filter_unavailable"
+    assert body["direction_context"] is None
+    assert body["recommendations"] == []
+
+
+@pytest.mark.django_db
 def test_missing_origin_returns_direction_filter_unavailable(client):
     r = client.post(
         URL,

--- a/backend/temples/tests/services/test_compass_recommendation_orchestrator.py
+++ b/backend/temples/tests/services/test_compass_recommendation_orchestrator.py
@@ -12,9 +12,11 @@ from temples.services.compass_recommendation_orchestrator import (
     STATE_DIRECTION_ZERO_CANDIDATES,
     STATE_EVIDENCE_ZERO_CANDIDATES,
     STATE_INVALID_PURPOSE,
+    STATE_NO_COMMON_DIRECTION,
     STATE_RECOMMENDATION_SUCCESS,
     get_compass_recommendations,
 )
+from temples.services.compass_runtime import NoCommonDirectionResult
 
 ORIGIN = {"lat": 35.0, "lng": 135.0}
 NORTH_DIRECTION_CONTEXT = {"referenceDirections": ["北"]}
@@ -110,6 +112,67 @@ class TestDirectionFilterUnavailable:
                 direction_context=None,
             )
         mock_recommend.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestNoCommonDirection:
+    """Runtime Contract Section 8 Group B: valid input, calculation
+    completed, but annual ∩ monthly is empty. Distinct from Group A
+    (STATE_DIRECTION_FILTER_UNAVAILABLE, tested above)."""
+
+    def test_no_common_direction_marker_maps_to_its_own_state(self) -> None:
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NoCommonDirectionResult(),
+        )
+        assert result.state == STATE_NO_COMMON_DIRECTION
+        assert result.state != STATE_DIRECTION_FILTER_UNAVAILABLE
+        assert result.recommendations == []
+
+    def test_no_common_direction_never_calls_candidate_filter(self) -> None:
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.filter_candidates_by_direction"
+        ) as mock_filter:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NoCommonDirectionResult(),
+            )
+        mock_filter.assert_not_called()
+
+    def test_no_common_direction_never_calls_recommendation_domain(self) -> None:
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations"
+        ) as mock_recommend:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NoCommonDirectionResult(),
+            )
+        mock_recommend.assert_not_called()
+
+    def test_no_common_direction_response_carries_no_direction_context(self) -> None:
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NoCommonDirectionResult(),
+        )
+        assert result.direction_context is None
+
+    def test_invalid_purpose_with_no_common_direction_marker_stays_json_safe(self) -> None:
+        """Regression: the NoCommonDirectionResult marker must never leak
+        into CompassRecommendationResult.direction_context, even when a
+        different validation (purpose) fails first -- it is not
+        JSON-serializable and api_views_compass.py serializes this field
+        directly into the HTTP response body."""
+        result = get_compass_recommendations(
+            purpose="not_a_real_need_tag",
+            origin=ORIGIN,
+            direction_context=NoCommonDirectionResult(),
+        )
+        assert result.state == STATE_INVALID_PURPOSE
+        assert result.direction_context is None
 
 
 @pytest.mark.django_db

--- a/backend/temples/tests/services/test_compass_runtime.py
+++ b/backend/temples/tests/services/test_compass_runtime.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date
 from unittest.mock import patch
 
-from temples.services.compass_runtime import build_compass_direction_runtime
+from temples.services.compass_runtime import NoCommonDirectionResult, build_compass_direction_runtime
 from temples.services.direction_reference import DIRECTION_REFERENCE_NOTE
 
 BIRTHDATE = "1984-05-15"
@@ -67,7 +67,12 @@ def test_invalid_birthdate_returns_none():
     assert result is None
 
 
-def test_no_lucky_directions_for_period_returns_none():
+def test_no_lucky_directions_for_period_returns_no_common_direction_marker():
+    """Runtime Contract Section 8 Group B: birthdate/target_date were both
+    valid and the calculation completed -- only the annual/monthly
+    intersection is empty. This is NOT the same None used for Group A
+    (invalid/unavailable runtime, see test_missing_birthdate_returns_none
+    and test_invalid_birthdate_returns_none below)."""
     with patch(
         "temples.services.compass_runtime.planned_visit_lucky_directions",
         return_value={
@@ -84,7 +89,17 @@ def test_no_lucky_directions_for_period_returns_none():
     ):
         result = build_compass_direction_runtime(birthdate=BIRTHDATE, target_date="2026-09-15")
 
-    assert result is None
+    assert isinstance(result, NoCommonDirectionResult)
+    assert result is not None
+
+
+def test_no_common_direction_reproducible_against_real_kyusei():
+    """Same case as above, but against the real (unmocked)
+    planned_visit_lucky_directions() -- synthetic birthdate, not a real
+    user's. Confirmed empty for this birthdate/date pair independently in
+    docs/audit/compass-direction-filter-unavailable-root-cause.md."""
+    result = build_compass_direction_runtime(birthdate="1975-06-15", target_date="2026-08-20")
+    assert isinstance(result, NoCommonDirectionResult)
 
 
 def test_does_not_expose_internal_only_fields():


### PR DESCRIPTION
## Summary

canonical契約（[compass-product-contract.md](https://github.com/etsu33/jinja_app/blob/develop/docs/product/compass-product-contract.md) Section 2.1、PR [#2498](https://github.com/etsu33/jinja_app/pull/2498)、merged）が定義した`NO_COMMON_DIRECTION`（年盤∩月盤の共通方位なし＝正当な結果）を実装する。`direction_filter_unavailable`（真に入力が無効/計算不能）とは明確に区別する。

## Mandatory Pre-Implementation Trace

崩壊点を特定: `compass_runtime.py`の`build_compass_direction_runtime()`が、`result is None`（入力無効）と`result.luckyDirections == []`（有効な計算結果だが交差が空）の両方を同じ裸の`None`へ潰していた。`kyusei.py`はこの2ケースをまだ区別可能な形（`None` vs 空リスト入りdict）で返している——情報が失われるのは`compass_runtime.py`の1箇所のみ。

## Architectural Principle

`backend/temples/domain/kyusei.py`は**無変更**。最小の型安全な判別表現として、`compass_runtime.py`に`NoCommonDirectionResult`（フィールドなしのfrozen dataclass marker）を追加し、`compass_recommendation_orchestrator.py`側で`isinstance`判定してから既存の`STATE_DIRECTION_FILTER_UNAVAILABLE`分岐へ到達させないようにした。`api_views_compass.py`は無変更（`result.state`が自然に`"no_common_direction"`となり、既存のHTTP 200分岐にそのまま乗る）。

## State Separation

Before: `direction_context is None` → 原因不問で`STATE_DIRECTION_FILTER_UNAVAILABLE`
After: `direction_context`が`NoCommonDirectionResult`のとき`STATE_NO_COMMON_DIRECTION`、真の`None`のときのみ`STATE_DIRECTION_FILTER_UNAVAILABLE`（既存の5状態taxonomyは無傷、collapseなし）

## Backend Runtime

- `compass_runtime.py`: `NoCommonDirectionResult`追加、`build_compass_direction_runtime()`が3値（dict / marker / None）を返すよう変更
- `compass_recommendation_orchestrator.py`: `STATE_NO_COMMON_DIRECTION`追加、marker判定を追加。`STATE_INVALID_PURPOSE`分岐でmarkerがJSON非対応のまま`direction_context`へ漏れないようガード（回帰テストあり）

## API

`api_views_compass.py`は無変更。HTTP status semanticsも無変更（`no_common_direction`はHTTP 200）。

## Frontend

- `types.ts`: `CompassUiState`・`CompassRecommendationsResponse.state`に`"no_common_direction"`追加
- `CompassClient.tsx`: `CompassResultState`に追加、専用UIブロックを新設（`direction_filter_unavailable`の直後、`variant="tertiary"`——`direction_zero_candidates`/`evidence_zero_candidates`と同じ「正当な空結果」トーン、エラー色なし）

## No-Direction Copy

タイトル「今月は年盤と月盤で重なる方位がありません」、本文「生年月日・出発地点はどちらも問題ありません。年盤と月盤がともに支持する方位が今月はなかった、という結果です。」——`direction_filter_unavailable`の「ご確認のうえ、もう一度お試しください」とは明確に別文言。断定的な占い文言・不吉な示唆は含まない。

## Retry Semantics

再試行を主要remedyとして提示しない（CTAなし）。生年月日・出発地点の訂正示唆なし。既存の`direction_zero_candidates`の「出発地点を変えると見つかることがあります」的な文言も転用しない。

## Recommendation Boundary

未解決のまま維持（[#2498](https://github.com/etsu33/jinja_app/pull/2498) Section 2.1-5のOPEN PRODUCT DECISION）。`no_common_direction`は`direction_filter_unavailable`と同様、`recommendations: []`・`direction_context: null`を返す——候補フィルタ自体を迂回しない、全神社を返さない、フォールバック候補を導入しない。

## Analytics Follow-up

`apps/web/src/lib/analytics/searchEvents.ts`の`result_state`型union**のみ**を拡張（新規イベント・PostHog query変更・bucketingの再設計なし）。`trackSearchEvent()`自体は完全に汎用的（`result_state`値で分岐しない）で、既存の`compass_result`計装がバックエンドの新state文字列を無変更で自動的に送出することを確認済み——テストで検証（`no_common_directionとdirection_filter_unavailableをresult_stateとして区別する`）。この型変更なしではTypeScriptのコンパイル自体が通らないため、§17の「compilation維持のため必要な場合のみ」の例外に該当する。Analytics Query Contract自体（`direction_filter_unavailable`のERRORバケット分類）の更新は本PRのスコープ外、[#2498](https://github.com/etsu33/jinja_app/pull/2498) Section 2.1-6が記録した将来のfollow-up。

## Concierge Regression

`kyusei.py`・`api_views_concierge.py`ともに無変更（`git diff`で確認）。既存の`TestConciergeIsolation`（Compass orchestratorをConciergeがimportしていないことを確認）含む90 backend testsすべて通過。`test_concierge_astrology.py`・`test_concierge_astrology_db.py`・`test_concierge_signals_contract.py`も個別に再実行し通過。

## Ranking

NONE（`compass_recommendation_orchestrator.py`のcandidate scoring/weights/reason authorityは無変更）

## Privacy

Birthdate newly exposed: NO
Coordinates newly exposed: NO
Raw origin newly exposed: NO
Free text newly exposed: NO

`NoCommonDirectionResult`はフィールドを一切持たないmarker——追加のデータ伝播はない。テストで使用した`birthdate="1975-06-15"`は合成値（[#2496](https://github.com/etsu33/jinja_app/pull/2496)で既に使用済みの非実在値）。

## Impact

```
Frontend production code changed: YES
Backend production code changed: YES
DB change: NONE
Migration: NONE
Analytics instrumentation changed: NO（型定義のみ拡張、ロジック変更なし、上記Analytics Follow-up参照）
Recommendation Ranking changed: NO
Concierge behavior changed: NO
kyusei.py changed: NO
```

## Tests

- Backend: ローカルのdocker-compose Postgres（`docker-compose.db.yml`）を起動し、実DBに対して90 backend tests全通過（新規5テスト含む: orchestrator 5件、runtime 2件、API 1件）
- 個別Concierge回帰: `test_concierge_astrology.py`・`test_concierge_astrology_db.py`・`test_concierge_signals_contract.py` 5 tests通過
- Frontend: `pnpm run typecheck`（クリーン）・`pnpm run lint`（0 errors、既存無関係ファイルの2 warningsのみ）・`pnpm run test`（150 files / 1036 tests、新規3テスト含む）・`pnpm run build`（成功）
- `git diff --check`: whitespaceエラーなし
- pre-push hook（OpenAPI lint + Web契約テスト）: すべて通過

## Live QA

スキップ——この環境ではBrowser paneのpreview_start含むシェルのcwdが毎回`/Users/morietsu/Desktop/jinja_app`（別クローン、本diffを含まない）へリセットされることをセッション全体で繰り返し確認しており、`/Users/morietsu/Developer/jinja_app`を確実に対象にできないため、タスク指示§26の通りスキップし開示する。代替として、実際のコンポーネントをレンダーしDOM出力を検証するReact Testing Libraryテスト（上記）で同等の検証を行った。

Draft PR。マージしません。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>