### PR TITLE
feat: Compass方位結果の状態を視覚的に区別

### DIFF
--- a/apps/web/src/features/compass/CompassClient.tsx
+++ b/apps/web/src/features/compass/CompassClient.tsx
@@ -58,6 +58,29 @@ function getDirectionNote(calculationMethod: CompassDirectionRuntime["calculatio
   return "年盤と月盤の両方で重なる、今月の参考方位です。日盤は使用していません。";
 }
 
+// Result Experience audit (docs/audit/compass-result-experience.md Section
+// 26-1, P1 finding): COMMON and MONTHLY_FALLBACK carry correct but
+// visually-identical copy -- a user who does not read getDirectionNote()
+// closely cannot tell them apart. This small label, derived only from
+// calculationMethod (never from direction count/copy/result_state, per the
+// follow-up definition's own constraint), gives an at-a-glance distinction
+// without reading the note. Deliberately calm/equal-weight for both values
+// -- same pill style, same size -- so neither reads as stronger, more
+// certain, or more alarming than the other; MONTHLY_FALLBACK is a
+// legitimate result, not a degraded one (compass-product-contract.md
+// Section 2.2-3). Returns null (renders nothing) for any value other than
+// the two known ones, rather than defaulting to a COMMON-looking label --
+// unlike getDirectionNote() above, this never fabricates a classification.
+function getDirectionStatusLabel(calculationMethod: CompassDirectionRuntime["calculationMethod"]): string | null {
+  if (calculationMethod === "annual_monthly_kyusei_v1") {
+    return "年盤・月盤 共通";
+  }
+  if (calculationMethod === "monthly_kyusei_v1") {
+    return "今月の月盤を参考";
+  }
+  return null;
+}
+
 export default function CompassClient() {
   const [now] = useState(() => new Date());
   const [purpose, setPurpose] = useState<CompassPurpose | null>(null);
@@ -237,7 +260,17 @@ export default function CompassClient() {
       </DetailSection>
 
       {directionContext ? (
-        <DetailSection title="今月、意識したい方向" variant="secondary">
+        <DetailSection
+          title="今月、意識したい方向"
+          variant="secondary"
+          right={
+            getDirectionStatusLabel(directionContext.calculationMethod) ? (
+              <span className="rounded-full bg-[var(--kt-color-background-subtle)] px-2 py-0.5 text-[11px] font-medium text-[var(--kt-color-text-secondary)]">
+                {getDirectionStatusLabel(directionContext.calculationMethod)}
+              </span>
+            ) : undefined
+          }
+        >
           <div className="space-y-3">
             <CompassDirectionVisual referenceDirections={directionContext.referenceDirections} />
             <p className="text-center text-xs text-[var(--kt-color-text-muted)]">

--- a/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
+++ b/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
@@ -112,6 +112,10 @@ describe("CompassClient", () => {
         "年盤と月盤で重なる方位がないため、今月の月盤を参考にした方位です。日盤は使用していません。（参考情報です）",
       ),
     ).not.toBeInTheDocument();
+    // P1 UX fix (docs/audit/compass-result-experience.md Section 26-1):
+    // at-a-glance visual distinction, not just the explanatory note.
+    expect(screen.getByText("年盤・月盤 共通")).toBeInTheDocument();
+    expect(screen.queryByText("今月の月盤を参考")).not.toBeInTheDocument();
   });
 
   it("calculationMethodがmonthly_kyusei_v1のとき、月盤fallbackの説明文を表示し、共通方位であるかのような文言は出さない", async () => {
@@ -154,6 +158,50 @@ describe("CompassClient", () => {
     // Direction visual and recommendation flow must remain unaffected.
     expect(screen.getByText("今月意識したい方向: 南東")).toBeInTheDocument();
     expect(screen.getByText("南東神社")).toBeInTheDocument();
+    // P1 UX fix (docs/audit/compass-result-experience.md Section 26-1):
+    // at-a-glance visual distinction, not error/warning framed, not the
+    // COMMON label.
+    expect(screen.getByText("今月の月盤を参考")).toBeInTheDocument();
+    expect(screen.queryByText("年盤・月盤 共通")).not.toBeInTheDocument();
+  });
+
+  it("calculationMethodが未知の値のとき、COMMON/FALLBACKいずれのラベルも捏造せず表示を安定させる", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        state: "recommendation_success",
+        purpose: "career",
+        direction_context: {
+          targetDate: "2026-09-15",
+          targetYear: 2026,
+          solarMonthIndex: 8,
+          referenceDirections: ["北西"],
+          // Intentionally not one of the two known contract values --
+          // simulates a future/unexpected calculationMethod reaching the
+          // frontend unchanged.
+          calculationMethod: "unknown_future_method_v1" as never,
+          note: "note",
+        },
+        recommendations: [{ shrine_id: 3, name: "北西神社", reason: "仕事運との一致" }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<CompassClient />);
+    fillMinimumValidInput();
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "今月の方向を確認する" }));
+    });
+
+    // The direction visual and recommendations still render (component
+    // does not crash or hide unrelated content because of an unrecognized
+    // calculationMethod).
+    expect(await screen.findByText("今月意識したい方向: 北西")).toBeInTheDocument();
+    expect(screen.getByText("北西神社")).toBeInTheDocument();
+    // Neither label is fabricated for an unrecognized value.
+    expect(screen.queryByText("年盤・月盤 共通")).not.toBeInTheDocument();
+    expect(screen.queryByText("今月の月盤を参考")).not.toBeInTheDocument();
   });
 
   it("「その他の目的」から選んでも送信payloadは折りたたみ表示に影響されず正しいslugになる（Purpose UI Polish回帰確認）", async () => {


### PR DESCRIPTION
## Purpose

Implements PR1 from the canonical Compass Result Experience audit ([docs/audit/compass-result-experience.md](docs/audit/compass-result-experience.md) Section 26-1, P1 finding): COMMON and MONTHLY_FALLBACK carry correct copy but were visually indistinguishable — a user had to read the explanatory note closely to tell them apart.

## Change

A small pill-style label, derived only from `calculationMethod`, added to `DetailSection`'s existing `right` slot on the direction card — no new component.

```
COMMON            (annual_monthly_kyusei_v1) → 「年盤・月盤 共通」
MONTHLY_FALLBACK  (monthly_kyusei_v1)         → 「今月の月盤を参考」
unrecognized value                            → no label rendered (not fabricated)
```

Both labels use **identical styling** (same pill shape, same muted color, same size) — only the text differs, so neither reads as stronger, more certain, or more alarming than the other. No color-only signal (text carries the meaning). No icon added.

## Verified

- Live QA against the real local backend (not mocked): both COMMON (「東」, real recommendation cards) and MONTHLY_FALLBACK (「東・西」, real recommendation cards) confirmed — the badge renders correctly, calmly, with no error/warning framing.
- 375px / 390px / 430px: no overflow, no collision with the direction wheel, badge stays on the title line at all three widths.
- Unknown/unrecognized `calculationMethod`: dedicated test confirms no label is fabricated and the rest of the UI (wheel, recommendations) still renders normally — no crash.
- Existing `no_common_direction`, `direction_zero_candidates`, `direction_filter_unavailable`, `backend_error` tests: unchanged, still passing.

## Semantic Copy

Unchanged — `getDirectionNote()`'s explanatory text is untouched. This PR only adds an additional, small, at-a-glance signal on top of the already-correct copy.

## Tests

Focused: 43/43 (1 new) · Typecheck: clean · Lint: clean (scoped + full) · Full suite: 1040/1040 · Build: `next build` succeeded

## Impact

```
Production code changed:          YES (Frontend only)
Backend production code changed:  NO
Runtime changed:                  NO
Analytics instrumentation changed: NO
Recommendation Ranking changed:   NO
Concierge changed:                NO
DB changed:                       NONE
Migration:                        NONE
```

## Scope

Narrowly limited to `apps/web/src/features/compass/CompassClient.tsx` and its test file — no docs, no other components, no other pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)