### PR TITLE
feat: Compass方位なし結果に次行動を追加

### DIFF
--- a/apps/web/src/features/compass/CompassClient.tsx
+++ b/apps/web/src/features/compass/CompassClient.tsx
@@ -9,6 +9,7 @@
 // Compass BFF and renders one of the backend's 5 fail-safe states plus
 // this component's own pre-submit states (birthdate/origin missing).
 import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import DetailSection from "@/components/shrine/DetailSection";
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
@@ -290,9 +291,25 @@ export default function CompassClient() {
 
       {uiState === "no_common_direction" ? (
         <DetailSection title="今月は方位の参考情報がありません" variant="tertiary">
-          <p className="text-sm leading-6 text-[var(--kt-color-text-secondary)]">
-            生年月日・出発地点はどちらも問題ありません。年盤と月盤の共通方位も、今月の月盤単独の参考方位も、今月はいずれもありませんでした。
-          </p>
+          <div className="space-y-3">
+            <p className="text-sm leading-6 text-[var(--kt-color-text-secondary)]">
+              生年月日・出発地点はどちらも問題ありません。年盤と月盤の共通方位も、今月の月盤単独の参考方位も、今月はいずれもありませんでした。
+            </p>
+            {/* Result Experience audit (docs/audit/compass-result-experience.md
+                Section 26-2, P2 finding): a legitimate result must not be a
+                dead end. Reuses the existing, already-established /concierge
+                route (same plain Link pattern app/shrines/page.tsx already
+                uses to point elsewhere in the product toward Concierge) --
+                no new route, no query params, no Compass personal input
+                (birthdate/origin/purpose) forwarded. This is the one primary
+                continuation; retrying identical inputs is never suggested. */}
+            <Link
+              href="/concierge"
+              className="inline-flex min-h-11 items-center rounded-[var(--kt-radius-pill)] border border-[var(--kt-color-border-default)] bg-[var(--kt-color-surface-default)] px-4 py-2 text-sm font-semibold text-[var(--kt-color-text-secondary)] hover:bg-[var(--kt-color-background-subtle)]"
+            >
+              コンシェルジュで相談する
+            </Link>
+          </div>
         </DetailSection>
       ) : null}
 

--- a/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
+++ b/apps/web/src/features/compass/__tests__/CompassClient.test.tsx
@@ -76,6 +76,9 @@ describe("CompassClient", () => {
     expect(await screen.findByText("今月意識したい方向: 北西")).toBeInTheDocument();
     expect(screen.getByText("この方向の参拝候補")).toBeInTheDocument();
     expect(screen.getByText("北西神社")).toBeInTheDocument();
+    // The no_common_direction continuation CTA is specific to that state
+    // and must not appear on a successful result.
+    expect(screen.queryByRole("link", { name: "コンシェルジュで相談する" })).not.toBeInTheDocument();
   });
 
   it("calculationMethodがannual_monthly_kyusei_v1のとき、共通方位の説明文を表示する（fallback文言は出さない）", async () => {
@@ -308,6 +311,16 @@ describe("CompassClient", () => {
     // No direction visual, no recommendation cards -- there is nothing to show.
     expect(screen.queryByText("今月意識したい方向:", { exact: false })).not.toBeInTheDocument();
     expect(screen.queryByText("この方向の参拝候補")).not.toBeInTheDocument();
+
+    // P2 UX fix (docs/audit/compass-result-experience.md Section 26-2):
+    // a legitimate no-direction result must not be a dead end -- exactly
+    // one clear continuation, pointing to the existing /concierge route.
+    const continueLink = screen.getByRole("link", { name: "コンシェルジュで相談する" });
+    expect(continueLink).toBeInTheDocument();
+    expect(continueLink).toHaveAttribute("href", "/concierge");
+    // Retrying identical inputs must never be offered as the (or a) primary CTA.
+    expect(screen.queryByRole("button", { name: /もう一度/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /もう一度/ })).not.toBeInTheDocument();
   });
 
   it("direction_filter_unavailableは引き続き既存のfail-safe文言を表示する", async () => {
@@ -334,6 +347,11 @@ describe("CompassClient", () => {
       screen.getByText("生年月日または出発地点をご確認のうえ、もう一度お試しください。"),
     ).toBeInTheDocument();
     expect(screen.queryByText("今月は方位の参考情報がありません")).not.toBeInTheDocument();
+    // direction_filter_unavailable is a distinct Group A error state --
+    // the no_common_direction continuation CTA must not leak into it
+    // (docs/audit/compass-result-experience.md Section 26-2, Section 11
+    // "error-state separation").
+    expect(screen.queryByRole("link", { name: "コンシェルジュで相談する" })).not.toBeInTheDocument();
   });
 
   it("バックエンドエラー時は落ち着いた文言のエラー状態を表示する", async () => {


### PR DESCRIPTION
## Purpose

Implements PR2 from the canonical Compass Result Experience audit ([docs/audit/compass-result-experience.md](docs/audit/compass-result-experience.md) Section 26-2, P2 finding): `no_common_direction` was correctly explained as a legitimate result, but offered no next action — a dead end.

## Change

One primary CTA added: **「コンシェルジュで相談する」** → `/concierge`

Reuses an existing, already-established pattern — `app/shrines/page.tsx` already links to `/concierge` with a plain `Link`, no query params, when its own flow can't fully serve the user. No new route, no new backend dependency.

```
Destination:         /concierge
Query params:        none
Personal input forwarded: none (birthdate, origin, purpose — nothing)
Retry offered:        NO (never implied as a remedy)
```

## Boundaries respected

- `no_common_direction`'s existing semantic copy is untouched.
- `direction_filter_unavailable` (a distinct Group A error state) does **not** receive this CTA — verified by a dedicated regression test.
- `recommendation_success` does **not** show this CTA — verified by a dedicated regression test.
- PR1's Visual Distinction (「年盤・月盤 共通」/「今月の月盤を参考」badges) — **regression: PASS**, confirmed live.

## Live QA

- COMMON case (real backend, real recommendation cards): confirmed PR1 badge intact at desktop width and 375/390/430px.
- **`no_common_direction` cannot be reproduced with real data for today's date** (verified by scanning a wide range of synthetic birthdates against the current, unmodified `kyusei.py` — none produced this residual state today). Its CTA was therefore visually verified using a **temporary in-page `fetch` override for inspection only** — no source code was changed to force the state, and no natural real-data reproduction is claimed. Confirmed clean at 375/390/430px this way; the underlying behavior is otherwise verified by the component test suite (heading, body copy, CTA text, and `href` all asserted).

## Tests

Focused: 43/43 · Typecheck: clean · Lint: clean (scoped + full) · Full suite: 1040/1040 · Build: `next build` succeeded

## Impact

```
Production code changed:          YES (Frontend only)
Backend production code changed:  NO
Runtime changed:                  NO
Analytics instrumentation changed: NO
Recommendation Ranking changed:   NO
Concierge internal behavior changed: NO (navigating TO Concierge, not modifying it)
DB changed:                       NONE
Migration:                        NONE
```

## Scope

Narrowly limited to `apps/web/src/features/compass/CompassClient.tsx` and its test file — no docs, no other components, no other pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)