### PR TITLE
feat: Compass神社候補カードの比較情報を改善

### DIFF
--- a/apps/web/src/components/shrines/ShrineCardCompact.tsx
+++ b/apps/web/src/components/shrines/ShrineCardCompact.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import Image from "next/image";
 
-function formatDistance(m?: number | null) {
+export function formatDistance(m?: number | null) {
   if (typeof m !== "number" || !Number.isFinite(m)) return null;
   if (m < 1000) return `${Math.round(m)}m`;
   return `${(m / 1000).toFixed(1)}km`;
@@ -34,6 +34,17 @@ export type ShrineCardCompactProps = {
   trustMetadata?: ShrineCardCompactTrustMetadata | null;
   tags?: string[];
   distanceM?: number | null;
+  // Opt-in only (docs/audit/compass-result-experience.md Section 26-3,
+  // P2 finding): a pre-formatted, already-existing-data comparison label
+  // (e.g. "約1.2km") shown near the shrine name, independent of the
+  // address/distanceM either-or row below. Deliberately a separate prop
+  // from distanceM -- that field already drives the existing address-vs-
+  // distance fallback (line ~107) used by every current caller (Concierge
+  // included); adding a render path gated on distanceM alone would change
+  // Concierge's own cards wherever it already passes distanceM. This prop
+  // defaults to null and no caller other than Compass sets it, so every
+  // other card (Concierge) renders byte-for-byte unchanged.
+  distanceLabel?: string | null;
   onDetailClick?: () => void;
 };
 
@@ -47,6 +58,7 @@ export default function ShrineCardCompact({
   trustMetadata = null,
   tags: _tags = [],
   distanceM = null,
+  distanceLabel = null,
   onDetailClick,
 }: ShrineCardCompactProps) {
   const distText = formatDistance(distanceM);
@@ -70,8 +82,13 @@ export default function ShrineCardCompact({
         <div className="min-w-0 flex-1">
           <div className="space-y-1.5">
             <h3 className="truncate text-sm font-semibold text-[var(--kt-color-text-primary)]">{name}</h3>
-            {visibleTrustLabels.length > 0 ? (
+            {visibleTrustLabels.length > 0 || distanceLabel ? (
               <div className="flex flex-wrap gap-1">
+                {distanceLabel ? (
+                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-semibold text-slate-600">
+                    {distanceLabel}
+                  </span>
+                ) : null}
                 {visibleTrustLabels.map((label) => (
                   <span
                     key={label}

--- a/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
+++ b/apps/web/src/components/shrines/__tests__/ShrineCardCompact.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import ShrineCardCompact from "../ShrineCardCompact";
+import ShrineCardCompact, { formatDistance } from "../ShrineCardCompact";
 
 describe("ShrineCardCompact", () => {
   it("shows address when address is present", () => {
@@ -29,6 +29,39 @@ describe("ShrineCardCompact", () => {
 
     expect(screen.queryByText(/m$/)).not.toBeInTheDocument();
     expect(screen.queryByText(/km$/)).not.toBeInTheDocument();
+  });
+
+  describe("distanceLabel (Compass Result Experience audit Section 26-3, opt-in only)", () => {
+    it("renders distanceLabel alongside address, without disturbing the existing address/distanceM row", () => {
+      render(
+        <ShrineCardCompact
+          name="検証神社"
+          address="東京都千代田区1-1-1"
+          distanceM={500}
+          distanceLabel="約1.2km"
+        />,
+      );
+
+      expect(screen.getByText("約1.2km")).toBeInTheDocument();
+      // The existing address-vs-distanceM row is unchanged: address shown,
+      // the plain "500m" text (derived from distanceM, not distanceLabel)
+      // still does not appear, because address is present.
+      expect(screen.getByText("東京都千代田区1-1-1")).toBeInTheDocument();
+      expect(screen.queryByText("500m")).not.toBeInTheDocument();
+    });
+
+    it("omits the chip when distanceLabel is not provided -- existing callers (e.g. Concierge) are unaffected", () => {
+      render(<ShrineCardCompact name="検証神社" address="東京都千代田区1-1-1" distanceM={500} />);
+
+      expect(screen.queryByText("約1.2km")).not.toBeInTheDocument();
+      expect(screen.queryByText(/km$/)).not.toBeInTheDocument();
+    });
+
+    it("does not fabricate a chip for null/undefined distance (formatDistance fail-safe)", () => {
+      expect(formatDistance(null)).toBeNull();
+      expect(formatDistance(undefined)).toBeNull();
+      expect(formatDistance(NaN)).toBeNull();
+    });
   });
 
   it("renders a single reason block, not tags", () => {

--- a/apps/web/src/features/compass/components/CompassRecommendationsSection.tsx
+++ b/apps/web/src/features/compass/components/CompassRecommendationsSection.tsx
@@ -6,7 +6,7 @@
 // decided fields (name/reason/address/distance) straight through -- it
 // never re-decides or rewrites the shrine-specific reason.
 import DetailSection from "@/components/shrine/DetailSection";
-import ShrineCardCompact from "@/components/shrines/ShrineCardCompact";
+import ShrineCardCompact, { formatDistance } from "@/components/shrines/ShrineCardCompact";
 import { trackCardEvent } from "@/lib/analytics/cardEvents";
 import { trackSearchEvent } from "@/lib/analytics/searchEvents";
 import { buildShrineHref } from "@/lib/nav/buildShrineHref";
@@ -52,12 +52,23 @@ export default function CompassRecommendationsSection({
           const shrineId = rec.shrine_id ?? rec.id;
           const rank = index + 1;
           const key = String(shrineId ?? rec.name ?? Math.random());
+          const distanceM = typeof rec.distance_m === "number" ? rec.distance_m : null;
+          // Result Experience audit (docs/audit/compass-result-experience.md
+          // Section 26-3, P2 finding): distance_m already exists in the
+          // Compass recommendation payload but ShrineCardCompact's own
+          // address-vs-distance row (below) never shows it here, since
+          // Compass candidates always carry a non-empty address
+          // (concierge_chat_candidates.py requires it). No new data is
+          // fetched or derived -- this only surfaces an existing field via
+          // the opt-in distanceLabel prop, which no other caller sets.
+          const formattedDistance = formatDistance(distanceM);
           return (
             <ShrineCardCompact
               key={key}
               name={String(rec.name ?? "")}
               address={typeof rec.address === "string" ? rec.address : null}
-              distanceM={typeof rec.distance_m === "number" ? rec.distance_m : null}
+              distanceM={distanceM}
+              distanceLabel={formattedDistance ? `約${formattedDistance}` : null}
               reason={typeof rec.reason === "string" ? rec.reason : null}
               href={
                 shrineId != null

--- a/apps/web/src/features/compass/components/__tests__/CompassRecommendationsSection.test.tsx
+++ b/apps/web/src/features/compass/components/__tests__/CompassRecommendationsSection.test.tsx
@@ -35,6 +35,47 @@ describe("CompassRecommendationsSection", () => {
     expect(screen.getByText("この方向の参拝候補")).toBeInTheDocument();
     expect(screen.getByText("北西神社")).toBeInTheDocument();
     expect(screen.getByTestId("recommendation-match-reason")).toHaveTextContent("仕事運とのご利益一致");
+    // Result Experience audit Section 26-3 (P2 card differentiation):
+    // distance_m already exists in the payload; surfaced as a compact
+    // comparison chip near the name, in addition to the existing address
+    // row -- not a new field, not a new score.
+    expect(screen.getByText("約1.2km")).toBeInTheDocument();
+    // Existing address row is preserved unchanged.
+    expect(screen.getByText("東京都千代田区")).toBeInTheDocument();
+  });
+
+  it("distance_mが未取得の候補では距離チップを省略する（undefined/nullを表示しない）", () => {
+    render(
+      <CompassRecommendationsSection
+        recommendationInstanceId="compass01"
+        recommendations={[{ shrine_id: 1, name: "北西神社", address: "東京都千代田区" }]}
+      />,
+    );
+
+    expect(screen.getByText("北西神社")).toBeInTheDocument();
+    expect(screen.queryByText(/km|m$/)).not.toBeInTheDocument();
+    expect(screen.queryByText("undefined")).not.toBeInTheDocument();
+    expect(screen.queryByText("null")).not.toBeInTheDocument();
+    expect(screen.queryByText("NaN")).not.toBeInTheDocument();
+  });
+
+  it("複数候補は与えられた順序どおりに描画される（Rankingの並びを変更しない）", () => {
+    render(
+      <CompassRecommendationsSection
+        recommendationInstanceId="compass01"
+        recommendations={[
+          { shrine_id: 1, name: "神社A", distance_m: 500 },
+          { shrine_id: 2, name: "神社B", distance_m: 100 },
+          { shrine_id: 3, name: "神社C", distance_m: 2000 },
+        ]}
+      />,
+    );
+
+    const names = screen.getAllByRole("heading", { level: 3 }).map((el) => el.textContent);
+    // Order reflects input order (the Ranking domain's own output) even
+    // though 神社B has the smallest distance -- this PR never reorders by
+    // distance or any other signal.
+    expect(names).toEqual(["神社A", "神社B", "神社C"]);
   });
 
   it("Shrine Detailへのリンクはctx=compassを付与する", () => {


### PR DESCRIPTION
## Purpose

Implements PR3 from the canonical Compass Result Experience audit ([docs/audit/compass-result-experience.md](docs/audit/compass-result-experience.md) Section 26-3, P2 finding): multiple shrine recommendation cards used identical templated reason text with no distance shown, leaving no visible basis for "why this one over the others."

## Change

Surfaces **existing** `distance_m` (already present in every Compass recommendation, already computed by the backend, never removed or recalculated) as a compact comparison chip near the shrine name — via a new **opt-in** `distanceLabel` prop on `ShrineCardCompact`, defaulting to `null`.

```
No new ranking signal, no new score, no new API field.
```

## Why this is safe for Concierge

`ShrineCardCompact`'s existing `distanceM`/address either-or row (which `ConciergeSectionsRenderer` already relies on) is completely untouched. The new chip only renders when the new `distanceLabel` prop is explicitly passed — and only `CompassRecommendationsSection.tsx` passes it. Concierge's call site never sets it, so its cards render byte-for-byte unchanged. Verified: all 93 existing `ConciergeSectionsRenderer` tests pass unmodified.

## Preserved unchanged

```
Card order (Ranking output):        unchanged
Recommendation reason:              unchanged (same text, same label, same truncation)
Address:                            unchanged
Detail CTA destination:             unchanged (same href, same shrineId/rank)
Missing distance_m:                 chip omitted entirely (never renders
                                     "undefined"/"null"/"NaN")
```

## Live QA

Real backend, real recommendation cards (COMMON case, 3 shrines):

```
乃木神社  約6.9km
日枝神社  約8.2km
愛宕神社  約9.0km
```

Card order preserved (same shrine IDs 59/43/46, same sequence, as before this PR). PR1's visual distinction badge (「年盤・月盤 共通」) confirmed intact alongside the new chips. Verified clean at 375px / 390px / 430px — no overflow, no wrapping issues.

`no_common_direction` (PR2's Concierge continuation CTA) is untouched by this PR's files — no recommendation cards render in that state at all. `MONTHLY_FALLBACK` uses the identical card-rendering path (calculationMethod-independent); its existing test coverage passed unchanged in the full suite run.

## Tests

Focused: 61/61 (5 new) · Typecheck: clean · Lint: clean (scoped + full) · Full suite: 1045/1045 · Build: `next build` succeeded

## Impact

```
Production code changed:          YES (Frontend only)
Backend production code changed:  NO
Recommendation Ranking changed:   NO
Analytics instrumentation changed: NO
Concierge changed:                NO (verified: no visual difference, 93/93 tests unchanged)
DB changed:                       NONE
Migration:                        NONE
```

## Scope

Limited to `ShrineCardCompact.tsx` + its test, and `CompassRecommendationsSection.tsx` + its test. `CompassClient.tsx` was not touched (not required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)