### PR TITLE
fix: Compass起点のルート計測コンテキストを引き継ぐ

### DIFF
--- a/apps/web/src/app/shrines/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/shrines/[id]/__tests__/page.test.tsx
@@ -1,0 +1,150 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// docs/audit/compass-route-attribution-contract.md (PR4) found that
+// route_open never received Compass ctx/recommendationInstanceId, because
+// this page passed downstreamCtx/conciergeRecommendationInstanceId to
+// <ShrineDetailShell> (the ancestor of GoogleMapRouteLink) instead of the
+// same ctx/detailRecommendationInstanceId that the sibling Favorite/Visit/
+// Reflection action boundary already received correctly. PR5 fixes only
+// that propagation -- these tests exercise the real ShrineDetailShell and
+// GoogleMapRouteLink (not mocked) so the actual route_open event is
+// asserted end-to-end, not just the intermediate prop.
+
+const { trackSearchEvent, trackShrineInteraction } = vi.hoisted(() => ({
+  trackSearchEvent: vi.fn(),
+  trackShrineInteraction: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/analytics/searchEvents", () => ({ trackSearchEvent }));
+vi.mock("@/lib/api/shrineInteractions", () => ({ trackShrineInteraction }));
+
+const getShrineDetailServerMock = vi.fn();
+vi.mock("@/lib/api/shrines.server", () => ({
+  getShrineDetailServer: (...args: unknown[]) => getShrineDetailServerMock(...args),
+}));
+
+const getConciergeThreadServerMock = vi.fn();
+const getConciergeThreadsServerMock = vi.fn();
+vi.mock("@/lib/api/concierge.server", () => ({
+  getConciergeThreadServer: (...args: unknown[]) => getConciergeThreadServerMock(...args),
+  getConciergeThreadsServer: (...args: unknown[]) => getConciergeThreadsServerMock(...args),
+}));
+
+vi.mock("@/lib/api/billing.server", () => ({
+  getBillingStatusServer: vi.fn().mockResolvedValue({ plan: "free", is_active: false }),
+}));
+
+vi.mock("@/lib/api/publicGoshuins.server", () => ({
+  fetchPublicGoshuinsForShrineServer: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/server/favorites.server", () => ({
+  getShrineFavoriteInitialState: vi.fn().mockResolvedValue({ fav: false, favorite_id: null, guestMode: true }),
+}));
+
+vi.mock("@/lib/api/shrineMeaning.server", () => ({
+  fetchShrineMeaningPayloadV2Server: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/shrine/buildShrineDetailModel", () => ({
+  buildShrineDetailModel: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("@/components/shrine/detail/ShrineDetailArticle", () => ({
+  default: () => <div data-testid="shrine-detail-article-stub" />,
+}));
+
+const baseShrine = {
+  id: 42,
+  name_jp: "検証神社",
+  latitude: 35.0,
+  longitude: 139.0,
+  goriyaku_tags: [],
+  goriyaku: null,
+} as unknown;
+
+async function renderPage(searchParams: Record<string, string>) {
+  const { default: Page } = await import("../page");
+  const element = await Page({
+    params: Promise.resolve({ id: "42" }),
+    searchParams: Promise.resolve(searchParams),
+  });
+  render(element);
+}
+
+function routeOpenPayload() {
+  const call = trackSearchEvent.mock.calls.find(([name]) => name === "route_open");
+  return call?.[1];
+}
+
+describe("/shrines/[id] page -- route_open Compass attribution (PR5)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getShrineDetailServerMock.mockResolvedValue(baseShrine);
+  });
+
+  it("Compass起点: route_openへctx=compassと同じrecommendationInstanceIdを渡す", async () => {
+    await renderPage({
+      ctx: "compass",
+      recommendation_instance_id: "compass01",
+      recommendation_rank: "2",
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: "Googleマップで経路案内" }));
+
+    expect(routeOpenPayload()).toMatchObject({
+      source: "shrine_detail",
+      ctx: "compass",
+      recommendationInstanceId: "compass01",
+      shrineId: 42,
+    });
+  });
+
+  it("直接アクセス(ctx無し): route_openはctx/recommendationInstanceIdを捏造しない", async () => {
+    await renderPage({});
+
+    fireEvent.click(screen.getByRole("link", { name: "Googleマップで経路案内" }));
+
+    expect(routeOpenPayload()).toMatchObject({
+      ctx: null,
+      recommendationInstanceId: null,
+      shrineId: 42,
+    });
+  });
+
+  it("Concierge起点: 既存のroute_open帰属は変化しない(回帰なし)", async () => {
+    getConciergeThreadServerMock.mockResolvedValue({
+      id: 768,
+      recommendations: [{ shrine_id: 42, id: 42, recommendation_instance_id: "concierge99" }],
+    });
+    getConciergeThreadsServerMock.mockResolvedValue([]);
+
+    await renderPage({ ctx: "concierge", tid: "768" });
+
+    fireEvent.click(screen.getByRole("link", { name: "Googleマップで経路案内" }));
+
+    expect(routeOpenPayload()).toMatchObject({
+      ctx: "concierge",
+      recommendationInstanceId: "concierge99",
+      shrineId: 42,
+    });
+  });
+
+  it("Compass起点でもshrine_detail_view(既存の正しい兄弟属性)は変化しない", async () => {
+    await renderPage({
+      ctx: "compass",
+      recommendation_instance_id: "compass01",
+      recommendation_rank: "2",
+    });
+
+    expect(trackSearchEvent).toHaveBeenCalledWith(
+      "shrine_detail_view",
+      expect.objectContaining({
+        source: "compass",
+        shrineId: 42,
+        recommendationInstanceId: "compass01",
+        recommendationRank: 2,
+      }),
+    );
+  });
+});

--- a/apps/web/src/app/shrines/[id]/page.tsx
+++ b/apps/web/src/app/shrines/[id]/page.tsx
@@ -189,8 +189,10 @@ export default async function Page({ params, searchParams }: Props) {
   const parsedCompassRank = ctx === "compass" ? Number(sp.recommendation_rank) : NaN;
   const compassRecommendationRank =
     Number.isInteger(parsedCompassRank) && parsedCompassRank > 0 ? parsedCompassRank : null;
-  // PR-B stops at Shrine Detail view. Compass attribution must not enter
-  // Favorite/Visit/Reflection/route actions before PR-C.
+  // downstreamCtx feeds only non-action rendering (close link, buildShrineDetailModel).
+  // Favorite/Visit/Reflection (PR-C) and route (PR5) action boundaries each
+  // receive the full, un-nulled ctx explicitly at their own call sites below --
+  // they do not read downstreamCtx.
   const downstreamCtx = ctx === "compass" ? null : ctx;
   const directionRouteContext = parseDirectionRouteContext(sp);
 
@@ -491,11 +493,21 @@ export default async function Page({ params, searchParams }: Props) {
         subtitle={null}
         close={close}
         shrineId={numericId}
-        ctx={downstreamCtx}
+        // PR5 (docs/audit/compass-route-attribution-contract.md): route_open
+        // is fired from inside this shell's GoogleMapRouteLink child. It must
+        // see the same Compass-aware ctx/recommendationInstanceId that the
+        // sibling Favorite/Visit/Reflection boundary already receives below
+        // (PR-C) -- downstreamCtx/conciergeRecommendationInstanceId were
+        // never valid for this specific child, since ctx/recommendationInstanceId
+        // here are used only to build the route_open analytics payload, not
+        // to gate rendering or navigation. For any non-Compass ctx this is a
+        // no-op: downstreamCtx === ctx and detailRecommendationInstanceId ===
+        // conciergeRecommendationInstanceId whenever ctx !== "compass".
+        ctx={ctx}
         tid={tid}
         historyTheme={historyThemeForAnalytics}
         analyticsProvenance={analyticsProvenance}
-        recommendationInstanceId={conciergeRecommendationInstanceId}
+        recommendationInstanceId={detailRecommendationInstanceId}
         directionRouteContext={directionRouteContext}
         addGoshuinHref={null}
         googleDirHref={googleDirHref}


### PR DESCRIPTION
## Summary

PR5 — implements the narrow frontend propagation fix identified by the canonical audit in [docs/audit/compass-route-attribution-contract.md](docs/audit/compass-route-attribution-contract.md) (PR4, [#2524](https://github.com/etsu33/jinja_app/pull/2524)).

- `app/shrines/[id]/page.tsx` was passing `downstreamCtx`/`conciergeRecommendationInstanceId` to `<ShrineDetailShell>` (the ancestor of `GoogleMapRouteLink`), so Compass-originated `route_open` events always received `ctx: null` / `recommendationInstanceId: null`, even though sibling components (`ShrineDetailViewTracker`, `ShrineDetailArticle`, `ShrineSaveButton`) at the exact same point in the tree already received the correct Compass-aware values.
- Fix is a single-call-site prop value change: `ctx={downstreamCtx}` → `ctx={ctx}`, `recommendationInstanceId={conciergeRecommendationInstanceId}` → `recommendationInstanceId={detailRecommendationInstanceId}`.
- For any non-Compass `ctx` (Concierge, direct access), `downstreamCtx === ctx` and `detailRecommendationInstanceId === conciergeRecommendationInstanceId` already hold, so this is a byte-identical no-op for those paths — verified by test and by temporarily reverting the fix to confirm only the Compass-origin test fails.
- No new Analytics event, property, URL param, backend field, or DB change. `route_open`'s schema already supported `ctx`/`recommendationInstanceId`.
- `source` semantics unchanged (`route_open.source` stays `"shrine_detail"`, per the audit's explicit instruction not to conflate `source` with journey origin).

## Non-goals

- No Runtime, Ranking, Concierge, Backend, or DB/migration changes
- No Analytics Query Contract / docs updates (deferred to a separate PR per the audit's own sequencing)
- No Visit Funnel measurement started

## Test plan

- [x] New test file `apps/web/src/app/shrines/[id]/__tests__/page.test.tsx` (4 tests): Compass-origin `route_open` gets `ctx="compass"` + matching `recommendationInstanceId`; direct access does not fabricate either; Concierge-origin attribution is unchanged (no regression); sibling `shrine_detail_view` is unchanged
- [x] Sanity-checked the new tests against the pre-fix code (temporary `git stash` of the one-line prop change) — confirmed only the Compass-origin test fails without the fix, the other 3 stay green
- [x] Focused regression: `src/features/compass`, `recommendationInstanceIdPropagation.test.tsx`, `GoogleMapRouteLink.test.tsx`, all of `src/components/shrine` — all pass
- [x] `tsc --noEmit` — clean
- [x] `eslint` on changed files — clean
- [x] Full frontend suite: 151 files / 1049 tests passed (was 150/1045 before this PR)
- [x] `next build` — succeeds, `/shrines/[id]` compiles as expected
- [x] Diff scope confirmed: exactly `apps/web/src/app/shrines/[id]/page.tsx` (16 insertions / 4 deletions) + the new test file; no analytics schema, backend, or docs files touched; `apps/web/AGENTS.md`/`apps/web/CLAUDE.md` not staged

🤖 Generated with [Claude Code](https://claude.com/claude-code)