### PR TITLE
feat: Compass候補に段階的な距離境界を追加

### DIFF
--- a/apps/web/src/features/compass/CompassClient.tsx
+++ b/apps/web/src/features/compass/CompassClient.tsx
@@ -113,6 +113,9 @@ export default function CompassClient() {
     recommendationCount: number | null = null,
     recommendationInstanceId: string | null = null,
     calculationMethod: CompassDirectionRuntime["calculationMethod"] | null = null,
+    distanceStageKm: 15 | 30 | 60 | null = null,
+    directionCandidateCount: number | null = null,
+    distanceCandidateCount: number | null = null,
   ) => {
     trackSearchEvent("compass_result", {
       result_state: resultState,
@@ -122,6 +125,9 @@ export default function CompassClient() {
       recommendation_count: recommendationCount,
       recommendationInstanceId,
       calculationMethod,
+      distance_stage_km: distanceStageKm,
+      direction_candidate_count: directionCandidateCount,
+      distance_candidate_count: distanceCandidateCount,
     });
   };
 
@@ -184,6 +190,9 @@ export default function CompassClient() {
         body.state === "recommendation_success" ? (body.recommendations?.length ?? 0) : null,
         body.recommendation_instance_id,
         body.direction_context?.calculationMethod ?? null,
+        body.distance_stage_km ?? null,
+        body.direction_candidate_count ?? null,
+        body.distance_candidate_count ?? null,
       );
     } catch {
       setUiState("backend_error");

--- a/apps/web/src/features/compass/__tests__/CompassClient.analytics.test.tsx
+++ b/apps/web/src/features/compass/__tests__/CompassClient.analytics.test.tsx
@@ -115,6 +115,11 @@ describe("CompassClient lifecycle analytics", () => {
               { shrine_id: 1, name: "北西神社", reason: "仕事運との一致" },
               { shrine_id: 2, name: "北西二の宮", reason: "縁結び" },
             ],
+            // Compass Geographic Distance Boundary metadata -- backend
+            // orchestrator is the source of truth, mirrored verbatim.
+            distance_stage_km: 15,
+            direction_candidate_count: 6,
+            distance_candidate_count: 2,
           }),
         }),
       );
@@ -135,6 +140,9 @@ describe("CompassClient lifecycle analytics", () => {
         recommendation_count: 2,
         recommendationInstanceId: "compass01",
         calculationMethod: "annual_monthly_kyusei_v1",
+        distance_stage_km: 15,
+        direction_candidate_count: 6,
+        distance_candidate_count: 2,
       });
 
       // PII / data-minimization contract (task §10, §24 of the readiness audit):
@@ -170,6 +178,11 @@ describe("CompassClient lifecycle analytics", () => {
             },
             recommendation_instance_id: "compass02",
             recommendations: [{ shrine_id: 3, name: "南東神社", reason: "仕事運との一致" }],
+            // Monthly Fallback uses the identical Distance Boundary contract
+            // as COMMON -- same metadata shape, no separate rule.
+            distance_stage_km: 60,
+            direction_candidate_count: 1,
+            distance_candidate_count: 1,
           }),
         }),
       );
@@ -190,6 +203,9 @@ describe("CompassClient lifecycle analytics", () => {
         recommendation_count: 1,
         recommendationInstanceId: "compass02",
         calculationMethod: "monthly_kyusei_v1",
+        distance_stage_km: 60,
+        direction_candidate_count: 1,
+        distance_candidate_count: 1,
       });
 
       // No new event name is ever used for the fallback case.
@@ -212,6 +228,13 @@ describe("CompassClient lifecycle analytics", () => {
           purpose: "career",
           direction_context: null,
           recommendations: [],
+          // Direction Filter found candidates, but none survived the
+          // Distance Stage's 60km outer ring (§ Fail-safe "Direction候補は
+          // あるが60km以内0件"): stage=60, direction count > 0, distance
+          // count = 0. Not fabricated -- mirrors what the backend would send.
+          distance_stage_km: 60,
+          direction_candidate_count: 3,
+          distance_candidate_count: 0,
         }),
       });
       await submit();
@@ -236,8 +259,28 @@ describe("CompassClient lifecycle analytics", () => {
       // recommendation_count must not be fabricated for non-success states.
       const zeroCandidatesPayload = analyticsMocks.trackSearchEvent.mock.calls.find(
         ([name, payload]) => name === "compass_result" && (payload as { result_state: string }).result_state === "direction_zero_candidates",
-      )?.[1] as { recommendation_count: unknown; calculationMethod: unknown };
+      )?.[1] as {
+        recommendation_count: unknown;
+        calculationMethod: unknown;
+        distance_stage_km: unknown;
+        direction_candidate_count: unknown;
+        distance_candidate_count: unknown;
+      };
       expect(zeroCandidatesPayload.recommendation_count).toBeNull();
+      // Distance Boundary metadata forwards verbatim even for a zero-candidate result.
+      expect(zeroCandidatesPayload.distance_stage_km).toBe(60);
+      expect(zeroCandidatesPayload.direction_candidate_count).toBe(3);
+      expect(zeroCandidatesPayload.distance_candidate_count).toBe(0);
+
+      // direction_filter_unavailable never reaches the distance stage --
+      // metadata must stay null, never fabricated from the previous request.
+      const unavailableDistancePayload = analyticsMocks.trackSearchEvent.mock.calls.find(
+        ([name, payload]) =>
+          name === "compass_result" && (payload as { result_state: string }).result_state === "direction_filter_unavailable",
+      )?.[1] as { distance_stage_km: unknown; direction_candidate_count: unknown; distance_candidate_count: unknown };
+      expect(unavailableDistancePayload.distance_stage_km).toBeNull();
+      expect(unavailableDistancePayload.direction_candidate_count).toBeNull();
+      expect(unavailableDistancePayload.distance_candidate_count).toBeNull();
       // direction_context is null for both fixtures above -- calculationMethod
       // must not be fabricated (task §12: direction_filter_unavailable stays
       // ERROR, never gets a fake monthly_kyusei_v1 just because Fallback exists).

--- a/apps/web/src/features/compass/types.ts
+++ b/apps/web/src/features/compass/types.ts
@@ -86,4 +86,12 @@ export type CompassRecommendationsResponse = {
   direction_context: CompassDirectionRuntime | null;
   recommendation_instance_id: string;
   recommendations: CompassRecommendation[];
+  // Compass Geographic Distance Boundary metadata (backend orchestrator is
+  // the source of truth -- never recomputed here). null for every fail-safe
+  // state that never reaches the distance stage (invalid_purpose,
+  // direction_filter_unavailable, no_common_direction); see
+  // temples.services.compass_recommendation_orchestrator.
+  distance_stage_km: 15 | 30 | 60 | null;
+  direction_candidate_count: number | null;
+  distance_candidate_count: number | null;
 };

--- a/apps/web/src/lib/analytics/searchEvents.ts
+++ b/apps/web/src/lib/analytics/searchEvents.ts
@@ -129,6 +129,18 @@ export type SearchAnalyticsPayload = {
    * is not itself a calculation method.
    */
   calculationMethod?: "annual_monthly_kyusei_v1" | "monthly_kyusei_v1" | null;
+  /**
+   * Compass lifecycle only (compass_result). Compass Geographic Distance
+   * Boundary metadata, mirrored verbatim from the backend orchestrator's
+   * CompassRecommendationResult -- never recomputed on the frontend. null
+   * whenever the result carries no direction_context (same absence rule as
+   * calculationMethod above).
+   */
+  distance_stage_km?: 15 | 30 | 60 | null;
+  /** Compass lifecycle only (compass_result). Candidate count immediately after Direction Filter, before the distance stage. */
+  direction_candidate_count?: number | null;
+  /** Compass lifecycle only (compass_result). Candidate count within the adopted distance_stage_km ring. */
+  distance_candidate_count?: number | null;
   [key: string]: SearchAnalyticsPrimitive;
 };
 

--- a/backend/temples/api_views_compass.py
+++ b/backend/temples/api_views_compass.py
@@ -83,6 +83,9 @@ class CompassRecommendationsView(APIView):
             "direction_context": result.direction_context,
             "recommendation_instance_id": recommendation_instance_id,
             "recommendations": recommendations,
+            "distance_stage_km": result.distance_stage_km,
+            "direction_candidate_count": result.direction_candidate_count,
+            "distance_candidate_count": result.distance_candidate_count,
         }
 
         if result.state == STATE_INVALID_PURPOSE:

--- a/backend/temples/services/compass_recommendation_orchestrator.py
+++ b/backend/temples/services/compass_recommendation_orchestrator.py
@@ -26,6 +26,16 @@ Boundary this module deliberately keeps:
   (kyusei.honmei_star et al.) already consumed it upstream to produce
   `direction_context`; CompassRecommendationHandoffContext has no birthdate
   field, so it does not travel further into Recommendation Integration.
+
+Compass Geographic Distance Boundary: `filter_candidates_by_direction` is
+bearing-only and has no distance cap of its own (by design -- distance is
+this module's responsibility, not Direction Filter's). This module applies
+`_apply_compass_distance_stage` (15km -> 30km -> 60km, expanding only when a
+narrower ring is too thin to compare) between Direction Filter and
+Recommendation Ranking, so a candidate merely sharing the right compass
+sector at, say, 90km no longer reaches Recommendation. This is Compass-only:
+it does not touch Concierge, Ranking's own distance decay, or Direction
+Filter's bearing math.
 """
 
 from __future__ import annotations
@@ -61,6 +71,24 @@ STATE_RECOMMENDATION_SUCCESS = "recommendation_success"
 # build_chat_candidates() itself or its default for other callers.
 DEFAULT_CANDIDATE_POOL_LIMIT = 60
 
+# Compass Geographic Distance Boundary (Compass-only; does not touch
+# Recommendation Ranking's existing distance decay, Concierge, or
+# filter_candidates_by_direction's bearing-only responsibility). Direction
+# Filter alone has no distance cap -- any candidate whose bearing falls in
+# an authorized sector passes regardless of distance (docs/audit/
+# shrine-dataset-integrity.md Section 14 confirmed this reaches ~99km in
+# practice). This stage narrows that to a realistic visiting distance,
+# expanding outward only when the narrower ring is too thin to compare.
+DISTANCE_STAGE_1_KM = 15
+DISTANCE_STAGE_2_KM = 30
+DISTANCE_STAGE_3_KM = 60
+
+# Not a minimum candidate count for Recommendation to proceed (1-4 survive
+# happily at Stage 3, see _apply_compass_distance_stage docstring) -- this is
+# only the "is this narrower ring thick enough to compare candidates in"
+# threshold that decides whether to expand to the next stage.
+DISTANCE_STAGE_EXPANSION_THRESHOLD = 5
+
 
 @dataclass(frozen=True)
 class CompassRecommendationResult:
@@ -81,6 +109,66 @@ class CompassRecommendationResult:
     recommendations: list[dict[str, Any]] = field(default_factory=list)
     purpose: Optional[str] = None
     direction_context: Optional[Mapping[str, Any]] = None
+    # Compass Geographic Distance Boundary metadata (None for every fail-safe
+    # state that never reaches the distance stage -- invalid_purpose,
+    # direction_filter_unavailable, no_common_direction -- see
+    # _apply_compass_distance_stage and get_compass_recommendations).
+    distance_stage_km: Optional[int] = None
+    direction_candidate_count: Optional[int] = None
+    distance_candidate_count: Optional[int] = None
+
+
+def _apply_compass_distance_stage(
+    candidates: Sequence[Mapping[str, Any]],
+) -> tuple[list[Mapping[str, Any]], int]:
+    """Compass-only Geographic Distance Boundary, applied after Direction
+    Filter and before Recommendation Ranking.
+
+    Pure, deterministic, order-preserving: returns a subset of `candidates`
+    in their original order, never re-ranked, re-scored, or reshaped -- the
+    same isolation contract filter_candidates_by_direction already follows.
+
+    Tries 15km, then 30km, then 60km, in that order. `5` is not a minimum
+    candidate count for Recommendation to proceed -- it only decides whether
+    the current (narrower) ring has enough candidates to compare, or whether
+    to expand to the next one. Stage 3 (60km) is terminal: 1-4 candidates
+    there is a normal success, and 0 there means genuinely no candidate
+    exists within any realistic visiting distance in this direction -- never
+    backfilled from beyond 60km.
+
+    A candidate with a missing/invalid `distance_m` is excluded from every
+    stage (never eligible at any distance), but never raises -- one bad
+    candidate must not break the whole batch (same isolation pattern as
+    filter_candidates_by_direction).
+
+    Returns (eligible_candidates, distance_stage_km) -- the second value is
+    always the last stage actually reached (15, 30, or 60), even when that
+    stage's result is empty, so callers can tell "Stage 3 tried and failed"
+    apart from "never reached the distance stage at all" (None).
+    """
+
+    def _within(limit_m: int) -> list[Mapping[str, Any]]:
+        eligible: list[Mapping[str, Any]] = []
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                continue
+            distance = candidate.get("distance_m")
+            if not isinstance(distance, (int, float)) or isinstance(distance, bool):
+                continue
+            if distance <= limit_m:
+                eligible.append(candidate)
+        return eligible
+
+    stage_1 = _within(DISTANCE_STAGE_1_KM * 1000)
+    if len(stage_1) >= DISTANCE_STAGE_EXPANSION_THRESHOLD:
+        return stage_1, DISTANCE_STAGE_1_KM
+
+    stage_2 = _within(DISTANCE_STAGE_2_KM * 1000)
+    if len(stage_2) >= DISTANCE_STAGE_EXPANSION_THRESHOLD:
+        return stage_2, DISTANCE_STAGE_2_KM
+
+    stage_3 = _within(DISTANCE_STAGE_3_KM * 1000)
+    return stage_3, DISTANCE_STAGE_3_KM
 
 
 def get_compass_recommendations(
@@ -161,6 +249,27 @@ def get_compass_recommendations(
             state=STATE_DIRECTION_ZERO_CANDIDATES,
             purpose=purpose_slug,
             direction_context=direction_context,
+            direction_candidate_count=0,
+            distance_candidate_count=0,
+            distance_stage_km=None,
+        )
+
+    direction_candidate_count = len(filtered_candidates)
+    distance_filtered_candidates, distance_stage_km = _apply_compass_distance_stage(filtered_candidates)
+    distance_candidate_count = len(distance_filtered_candidates)
+
+    if not distance_filtered_candidates:
+        # Direction Filter found candidates, but none within even the widest
+        # (60km) ring -- distinct from the direction_candidate_count=0 case
+        # above via metadata, not a new result_state (Required Behavior:
+        # "この2状態を新しいresult_stateへ分割しない").
+        return CompassRecommendationResult(
+            state=STATE_DIRECTION_ZERO_CANDIDATES,
+            purpose=purpose_slug,
+            direction_context=direction_context,
+            direction_candidate_count=direction_candidate_count,
+            distance_candidate_count=0,
+            distance_stage_km=distance_stage_km,
         )
 
     bias = (
@@ -172,7 +281,7 @@ def get_compass_recommendations(
     recs = build_chat_recommendations(
         query="",
         language=language,
-        candidates=list(filtered_candidates),
+        candidates=list(distance_filtered_candidates),
         bias=bias,
         need_tags=[purpose_slug],
         public_mode="need",
@@ -193,6 +302,9 @@ def get_compass_recommendations(
             state=STATE_EVIDENCE_ZERO_CANDIDATES,
             purpose=purpose_slug,
             direction_context=direction_context,
+            direction_candidate_count=direction_candidate_count,
+            distance_candidate_count=distance_candidate_count,
+            distance_stage_km=distance_stage_km,
         )
 
     return CompassRecommendationResult(
@@ -200,6 +312,9 @@ def get_compass_recommendations(
         recommendations=recommendations,
         purpose=purpose_slug,
         direction_context=direction_context,
+        direction_candidate_count=direction_candidate_count,
+        distance_candidate_count=distance_candidate_count,
+        distance_stage_km=distance_stage_km,
     )
 
 
@@ -210,6 +325,10 @@ __all__ = [
     "STATE_DIRECTION_ZERO_CANDIDATES",
     "STATE_EVIDENCE_ZERO_CANDIDATES",
     "STATE_RECOMMENDATION_SUCCESS",
+    "DISTANCE_STAGE_1_KM",
+    "DISTANCE_STAGE_2_KM",
+    "DISTANCE_STAGE_3_KM",
+    "DISTANCE_STAGE_EXPANSION_THRESHOLD",
     "CompassRecommendationResult",
     "get_compass_recommendations",
 ]

--- a/backend/temples/tests/api/test_compass_recommendations_api.py
+++ b/backend/temples/tests/api/test_compass_recommendations_api.py
@@ -11,6 +11,13 @@ ORIGIN = {"lat": 35.0, "lng": 135.0}
 BIRTHDATE = "1984-05-15"
 TARGET_DATE = "2026-09-15"
 
+# Shrine fixture coordinates below are chosen to stay within the Compass
+# Geographic Distance Boundary's 60km outer stage while preserving the same
+# direction label as before this feature existed -- verified against the
+# real _bearing()/_direction_label() functions. See
+# test_compass_recommendation_orchestrator.py for the boundary behavior
+# itself (this file only checks the metadata round-trips through the API).
+
 
 @pytest.fixture
 def shrine_factory(db):
@@ -31,7 +38,7 @@ def shrine_factory(db):
 @pytest.mark.django_db
 def test_valid_request_returns_recommendation_success(client, shrine_factory):
     # 2026-09-15 + 1984-05-15 birthdate resolves to 北西 (see test_kyusei_direction.py)
-    shrine_factory(name="北西の神社", latitude=35.5, longitude=134.5, goriyaku="仕事運")
+    shrine_factory(name="北西の神社", latitude=35.25, longitude=134.75, goriyaku="仕事運")
 
     r = client.post(
         URL,
@@ -62,7 +69,7 @@ def test_valid_request_returns_recommendation_success(client, shrine_factory):
 
 @pytest.mark.django_db
 def test_separate_compass_results_get_separate_recommendation_instances(client, shrine_factory):
-    shrine_factory(name="北西の神社", latitude=35.5, longitude=134.5, goriyaku="仕事運")
+    shrine_factory(name="北西の神社", latitude=35.25, longitude=134.75, goriyaku="仕事運")
     payload = json.dumps(
         {
             "purpose": "career",
@@ -158,7 +165,7 @@ def test_monthly_fallback_returns_recommendation_flow_state(client, shrine_facto
     direction_filter_unavailable -- with calculationMethod="monthly_kyusei_v1"
     (never "annual_monthly_kyusei_v1", which would misrepresent this as
     annual/monthly agreement)."""
-    shrine_factory(name="南東の神社", latitude=34.5, longitude=136.0, goriyaku="仕事運")
+    shrine_factory(name="南東の神社", latitude=34.825, longitude=135.35, goriyaku="仕事運")
 
     r = client.post(
         URL,
@@ -238,8 +245,85 @@ def test_missing_purpose_returns_400(client):
 
 
 @pytest.mark.django_db
+def test_recommendation_success_response_includes_distance_stage_metadata(client, shrine_factory):
+    # ~35.9km from ORIGIN, northwest -- the only candidate, so it lands at
+    # Stage 60 (too few candidates within 15km/30km's expansion threshold).
+    shrine_factory(name="北西の神社", latitude=35.25, longitude=134.75, goriyaku="仕事運")
+
+    r = client.post(
+        URL,
+        data=json.dumps(
+            {
+                "purpose": "career",
+                "origin": ORIGIN,
+                "birthdate": BIRTHDATE,
+                "target_date": TARGET_DATE,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["state"] == "recommendation_success"
+    assert body["distance_stage_km"] == 60
+    assert body["direction_candidate_count"] == 1
+    assert body["distance_candidate_count"] == 1
+
+
+@pytest.mark.django_db
+def test_direction_zero_candidates_response_has_null_stage_and_zero_counts(client, shrine_factory):
+    # South of origin -- outside the 北西 (northwest) authorized sector, so
+    # excluded by Direction Filter itself; the distance stage is never
+    # reached.
+    shrine_factory(name="南の神社", latitude=34.0, longitude=135.0)
+
+    r = client.post(
+        URL,
+        data=json.dumps(
+            {
+                "purpose": "career",
+                "origin": ORIGIN,
+                "birthdate": BIRTHDATE,
+                "target_date": TARGET_DATE,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["state"] == "direction_zero_candidates"
+    assert body["distance_stage_km"] is None
+    assert body["direction_candidate_count"] == 0
+    assert body["distance_candidate_count"] == 0
+
+
+@pytest.mark.django_db
+def test_invalid_purpose_response_has_null_distance_stage_metadata(client):
+    r = client.post(
+        URL,
+        data=json.dumps(
+            {
+                "purpose": "not_a_real_tag",
+                "origin": ORIGIN,
+                "birthdate": BIRTHDATE,
+                "target_date": TARGET_DATE,
+            }
+        ),
+        content_type="application/json",
+    )
+
+    assert r.status_code == 400
+    body = r.json()
+    assert body["distance_stage_km"] is None
+    assert body["direction_candidate_count"] is None
+    assert body["distance_candidate_count"] is None
+
+
+@pytest.mark.django_db
 def test_response_never_leaks_internal_direction_fields(client, shrine_factory):
-    shrine_factory(name="北西の神社", latitude=35.5, longitude=134.5, goriyaku="仕事運")
+    shrine_factory(name="北西の神社", latitude=35.25, longitude=134.75, goriyaku="仕事運")
 
     r = client.post(
         URL,

--- a/backend/temples/tests/services/test_compass_recommendation_orchestrator.py
+++ b/backend/temples/tests/services/test_compass_recommendation_orchestrator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from typing import Any
 from unittest.mock import patch
 
@@ -20,6 +21,13 @@ from temples.services.compass_runtime import NoCommonDirectionResult
 
 ORIGIN = {"lat": 35.0, "lng": 135.0}
 NORTH_DIRECTION_CONTEXT = {"referenceDirections": ["北"]}
+
+# Shrine fixture coordinates below are chosen to stay within the Compass
+# Geographic Distance Boundary's 60km outer stage (see
+# TestDistanceStage*/TestDistanceStageBoundaries below for the boundary
+# behavior itself) while preserving the same direction label as before this
+# feature existed -- verified against the real _bearing()/_direction_label()
+# functions, not assumed from the lat/lng ratio alone.
 
 
 @pytest.fixture
@@ -208,7 +216,7 @@ class TestDirectionZeroCandidates:
 @pytest.mark.django_db
 class TestRecommendationSuccess:
     def test_shrine_inside_authorized_sector_is_recommended(self, shrine_factory) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
 
         result = get_compass_recommendations(
             purpose="career",
@@ -220,7 +228,7 @@ class TestRecommendationSuccess:
         assert "北の神社" in names
 
     def test_direction_context_is_passed_through_unmodified(self, shrine_factory) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
 
         result = get_compass_recommendations(
             purpose="career",
@@ -230,7 +238,7 @@ class TestRecommendationSuccess:
         assert result.direction_context == NORTH_DIRECTION_CONTEXT
 
     def test_only_direction_filtered_candidates_are_considered(self, shrine_factory) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
         shrine_factory(name="南の神社", latitude=34.0, longitude=135.0, goriyaku="仕事運")
 
         result = get_compass_recommendations(
@@ -261,7 +269,7 @@ class TestMonthlyFallbackDirectionContext:
     }
 
     def test_fallback_context_reaches_recommendation_success(self, shrine_factory) -> None:
-        shrine_factory(name="南東の神社", latitude=34.5, longitude=136.0, goriyaku="仕事運")
+        shrine_factory(name="南東の神社", latitude=34.825, longitude=135.35, goriyaku="仕事運")
 
         result = get_compass_recommendations(
             purpose="career",
@@ -273,7 +281,7 @@ class TestMonthlyFallbackDirectionContext:
         assert "南東の神社" in names
 
     def test_fallback_context_calculation_method_passed_through_unmodified(self, shrine_factory) -> None:
-        shrine_factory(name="南東の神社", latitude=34.5, longitude=136.0, goriyaku="仕事運")
+        shrine_factory(name="南東の神社", latitude=34.825, longitude=135.35, goriyaku="仕事運")
 
         result = get_compass_recommendations(
             purpose="career",
@@ -286,7 +294,7 @@ class TestMonthlyFallbackDirectionContext:
         self, shrine_factory
     ) -> None:
         # North of origin -- outside the authorized "南東" (southeast) sector.
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
 
         result = get_compass_recommendations(
             purpose="career",
@@ -304,10 +312,10 @@ class TestPurposeIntegration:
         # Both north of origin (same authorized sector), so any ranking
         # difference must come from purpose, not from the direction filter.
         shrine_factory(
-            name="仕事の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運祈願"
+            name="仕事の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運祈願"
         )
         shrine_factory(
-            name="学問の神社", latitude=36.0, longitude=135.05, goriyaku="学問成就"
+            name="学問の神社", latitude=35.3, longitude=135.05, goriyaku="学問成就"
         )
 
         career_result = get_compass_recommendations(
@@ -332,8 +340,8 @@ class TestPurposeIntegration:
     def test_changing_purpose_does_not_change_which_shrines_pass_direction_filter(
         self, shrine_factory
     ) -> None:
-        shrine_factory(name="仕事の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運祈願")
-        shrine_factory(name="学問の神社", latitude=36.0, longitude=135.05, goriyaku="学問成就")
+        shrine_factory(name="仕事の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運祈願")
+        shrine_factory(name="学問の神社", latitude=35.3, longitude=135.05, goriyaku="学問成就")
 
         career_result = get_compass_recommendations(
             purpose="career",
@@ -354,7 +362,7 @@ class TestPurposeIntegration:
     def test_purpose_does_not_alter_direction_filter_call_arguments(
         self, shrine_factory
     ) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
 
         with patch(
             "temples.services.compass_recommendation_orchestrator.filter_candidates_by_direction",
@@ -382,7 +390,7 @@ class TestEvidenceZeroCandidates:
     def test_empty_recommendations_from_domain_maps_to_evidence_zero_candidates(
         self, shrine_factory
     ) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
 
         with patch(
             "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
@@ -401,7 +409,7 @@ class TestEvidenceZeroCandidates:
 @pytest.mark.django_db
 class TestRankingAndReasonAuthorityUnchanged:
     def test_orchestrator_does_not_pass_custom_weights(self, shrine_factory) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運")
 
         with patch(
             "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
@@ -420,7 +428,7 @@ class TestRankingAndReasonAuthorityUnchanged:
     def test_recommendation_reason_field_is_present_and_shrine_grounded(
         self, shrine_factory
     ) -> None:
-        shrine_factory(name="北の神社", latitude=36.0, longitude=135.0, goriyaku="仕事運祈願")
+        shrine_factory(name="北の神社", latitude=35.3, longitude=135.0, goriyaku="仕事運祈願")
 
         result = get_compass_recommendations(
             purpose="career",
@@ -432,6 +440,394 @@ class TestRankingAndReasonAuthorityUnchanged:
         reason = result.recommendations[0].get("reason")
         assert isinstance(reason, str)
         assert reason.strip()
+
+
+def _lat_at_distance_m(distance_m: float, origin_lat: float = ORIGIN["lat"]) -> float:
+    """Latitude due north of ORIGIN (same longitude) at approximately
+    `distance_m`. Good enough for placing candidates clearly inside/outside
+    a distance ring. Exact boundary values are hardcoded separately (see
+    LAT_AT_*M below) because int(...) truncation inside the real
+    _distance_m() can land 1m off the simple formula right at an edge."""
+    delta_phi = distance_m / 6371000.0
+    return origin_lat + math.degrees(delta_phi)
+
+
+# Binary-searched against the real concierge_chat_candidates._distance_m()
+# (haversine, same longitude as ORIGIN) so int(distance_m) equals exactly
+# these meter values -- not approximately -- for the Boundary tests below.
+LAT_AT_15000M = 35.134898240887814
+LAT_AT_15001M = 35.13490723410387
+LAT_AT_30000M = 35.26979648177562
+LAT_AT_60000M = 35.53959296355124
+LAT_AT_60001M = 35.5396019567673
+
+
+def _recommendation_candidate_names(spy) -> set[str]:
+    """Names of the candidates actually passed into build_chat_recommendations
+    -- i.e. what survived the distance stage -- independent of whatever
+    subset Ranking/Presentation later trims to top-3. Distance Stage's
+    Ordering Contract is about this handoff, not the final displayed cards."""
+    _, kwargs = spy.call_args
+    return {c.get("name") for c in kwargs["candidates"]}
+
+
+@pytest.mark.django_db
+class TestDistanceStage15km:
+    def test_five_or_more_within_15km_adopts_stage_15_and_excludes_beyond(
+        self, shrine_factory
+    ) -> None:
+        near_names = set()
+        for i, dist in enumerate([1000, 3000, 5000, 8000, 11000, 14000]):
+            name = f"近傍神社{i}"
+            shrine_factory(name=name, latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運")
+            near_names.add(name)
+        far_names = set()
+        for i, dist in enumerate([20000, 25000]):
+            name = f"遠方神社{i}"
+            shrine_factory(name=name, latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運")
+            far_names.add(name)
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            result = get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_1_KM
+        assert result.direction_candidate_count == 8
+        assert result.distance_candidate_count == 6
+        passed_names = _recommendation_candidate_names(spy)
+        assert passed_names == near_names
+        assert not (passed_names & far_names)
+
+
+@pytest.mark.django_db
+class TestDistanceStage30km:
+    def test_under_5_within_15km_expands_to_30km(self, shrine_factory) -> None:
+        within_30_names = set()
+        for i, dist in enumerate([5000, 8000, 12000]):
+            name = f"15km圏内{i}"
+            shrine_factory(name=name, latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運")
+            within_30_names.add(name)
+        for i, dist in enumerate([18000, 22000, 28000]):
+            name = f"30km圏内{i}"
+            shrine_factory(name=name, latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運")
+            within_30_names.add(name)
+        beyond_30 = "30km超神社"
+        shrine_factory(name=beyond_30, latitude=_lat_at_distance_m(45000), longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            result = get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_2_KM
+        assert result.direction_candidate_count == 7
+        assert result.distance_candidate_count == 6
+        passed_names = _recommendation_candidate_names(spy)
+        assert passed_names == within_30_names
+        assert beyond_30 not in passed_names
+
+
+@pytest.mark.django_db
+class TestDistanceStage60km:
+    def test_1_to_4_within_60km_succeeds_at_stage_60(self, shrine_factory) -> None:
+        within_60_names = set()
+        for i, dist in enumerate([5000, 12000, 25000, 55000]):
+            name = f"60km圏内{i}"
+            shrine_factory(name=name, latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運")
+            within_60_names.add(name)
+        beyond_60 = "60km超神社"
+        shrine_factory(name=beyond_60, latitude=_lat_at_distance_m(90000), longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            result = get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_3_KM
+        assert result.direction_candidate_count == 5
+        assert result.distance_candidate_count == 4
+        passed_names = _recommendation_candidate_names(spy)
+        assert passed_names == within_60_names
+        assert beyond_60 not in passed_names
+
+    def test_single_candidate_within_60km_succeeds_with_that_one_candidate(
+        self, shrine_factory
+    ) -> None:
+        shrine_factory(
+            name="唯一の神社", latitude=_lat_at_distance_m(58000), longitude=135.0, goriyaku="仕事運"
+        )
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_3_KM
+        assert result.direction_candidate_count == 1
+        assert result.distance_candidate_count == 1
+        names = {r.get("name") for r in result.recommendations}
+        assert "唯一の神社" in names
+
+
+@pytest.mark.django_db
+class TestDistanceStageZeroCandidates:
+    def test_direction_filter_empty_has_null_stage_and_zero_counts(self, shrine_factory) -> None:
+        # South of origin -- outside the authorized "北" sector. Excluded by
+        # Direction Filter itself; the distance stage is never reached.
+        shrine_factory(name="南の神社", latitude=34.0, longitude=135.0, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        assert result.state == STATE_DIRECTION_ZERO_CANDIDATES
+        assert result.direction_candidate_count == 0
+        assert result.distance_candidate_count == 0
+        assert result.distance_stage_km is None
+        assert result.recommendations == []
+
+    def test_direction_candidates_exist_but_all_beyond_60km_reports_stage_60(
+        self, shrine_factory
+    ) -> None:
+        # Correct direction (north), but too far for even the widest ring --
+        # must not be backfilled from beyond 60km, and must stay
+        # direction_zero_candidates (not a new result_state) while
+        # metadata distinguishes it from the direction-empty case above.
+        shrine_factory(
+            name="遠すぎる神社", latitude=_lat_at_distance_m(90000), longitude=135.0, goriyaku="仕事運"
+        )
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        assert result.state == STATE_DIRECTION_ZERO_CANDIDATES
+        assert result.direction_candidate_count == 1
+        assert result.distance_candidate_count == 0
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_3_KM
+        assert result.recommendations == []
+
+
+@pytest.mark.django_db
+class TestDistanceStageBoundaries:
+    """Distance boundaries are inclusive (<=)."""
+
+    def test_exactly_15000m_is_eligible_15001m_is_not(self, shrine_factory) -> None:
+        for i, dist in enumerate([1000, 3000, 5000, 8000]):
+            shrine_factory(
+                name=f"圏内{i}", latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運"
+            )
+        shrine_factory(name="境界ちょうど", latitude=LAT_AT_15000M, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="境界超え", latitude=LAT_AT_15001M, longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            result = get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_1_KM
+        assert result.distance_candidate_count == 5
+        passed_names = _recommendation_candidate_names(spy)
+        assert "境界ちょうど" in passed_names
+        assert "境界超え" not in passed_names
+
+    def test_exactly_30000m_is_eligible(self, shrine_factory) -> None:
+        # Only 2 candidates within 15km -- forces expansion to Stage 30,
+        # where the exact-30000m candidate must be included among the 5.
+        for i, dist in enumerate([16000, 18000, 19000, 20000]):
+            shrine_factory(
+                name=f"30km圏内{i}", latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運"
+            )
+        shrine_factory(name="30km境界ちょうど", latitude=LAT_AT_30000M, longitude=135.0, goriyaku="仕事運")
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            result = get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_2_KM
+        assert result.distance_candidate_count == 5
+        passed_names = _recommendation_candidate_names(spy)
+        assert "30km境界ちょうど" in passed_names
+
+    def test_exactly_60000m_is_eligible_60001m_is_not(self, shrine_factory) -> None:
+        shrine_factory(name="60km境界ちょうど", latitude=LAT_AT_60000M, longitude=135.0, goriyaku="仕事運")
+        shrine_factory(name="60km境界超え", latitude=LAT_AT_60001M, longitude=135.0, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=NORTH_DIRECTION_CONTEXT,
+        )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_3_KM
+        assert result.direction_candidate_count == 2
+        assert result.distance_candidate_count == 1
+        names = {r.get("name") for r in result.recommendations}
+        assert "60km境界ちょうど" in names
+        assert "60km境界超え" not in names
+
+
+@pytest.mark.django_db
+class TestDistanceStageOrderingAndFailSafeStates:
+    def test_distance_stage_preserves_direction_filter_order(self, shrine_factory) -> None:
+        """Ordering Contract: the distance stage must not re-rank -- it is a
+        subset in the same order Direction Filter produced, which itself
+        preserves build_chat_candidates' order (distance-sorted when lat/lng
+        are given, per that module's own contract)."""
+        for i, dist in enumerate([1000, 3000, 5000, 8000, 11000]):
+            shrine_factory(
+                name=f"順序神社{i}", latitude=_lat_at_distance_m(dist), longitude=135.0, goriyaku="仕事運"
+            )
+
+        with patch(
+            "temples.services.compass_recommendation_orchestrator.build_chat_recommendations",
+            wraps=orchestrator.build_chat_recommendations,
+        ) as spy:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NORTH_DIRECTION_CONTEXT,
+            )
+
+        _, kwargs = spy.call_args
+        passed = kwargs["candidates"]
+        distances = [c.get("distance_m") for c in passed]
+        assert distances == sorted(distances)
+
+    def test_invalid_distance_m_candidate_is_excluded_but_does_not_break_the_stage(self) -> None:
+        """A candidate missing/invalid distance_m must never be eligible at
+        any stage, and must never raise -- same isolation guarantee
+        filter_candidates_by_direction already provides for bad candidates.
+        Unit-tested directly against the pure helper (Required Behavior:
+        "1件の不正candidateで全処理を落とさない") rather than through the full
+        orchestrator, since a synthetic minimal candidate dict here is not a
+        realistic build_chat_candidates() shape."""
+        candidates = [
+            {"shrine_id": 1, "name": "正常神社0", "distance_m": 1000},
+            {"shrine_id": 2, "name": "距離None", "distance_m": None},
+            {"shrine_id": 3, "name": "距離が文字列", "distance_m": "not-a-number"},
+            {"shrine_id": 4, "name": "distance_m欠落"},
+        ]
+
+        eligible, stage_km = orchestrator._apply_compass_distance_stage(candidates)
+
+        assert stage_km == orchestrator.DISTANCE_STAGE_3_KM
+        assert [c["name"] for c in eligible] == ["正常神社0"]
+
+    def test_bool_distance_m_is_excluded_not_treated_as_0_or_1(self) -> None:
+        """bool is a subclass of int in Python -- a stray `True`/`False`
+        distance_m must not be silently treated as 1/0 meters."""
+        candidates = [{"shrine_id": 1, "name": "bool距離", "distance_m": True}]
+
+        eligible, stage_km = orchestrator._apply_compass_distance_stage(candidates)
+
+        assert eligible == []
+        assert stage_km == orchestrator.DISTANCE_STAGE_3_KM
+
+    def test_common_direction_context_never_calls_distance_stage_short_circuit_states(self) -> None:
+        """invalid_purpose / direction_filter_unavailable / no_common_direction
+        never reach the distance stage -- metadata stays null (Fail-safe
+        contract)."""
+        invalid_purpose = get_compass_recommendations(
+            purpose="not_a_real_need_tag", origin=ORIGIN, direction_context=NORTH_DIRECTION_CONTEXT
+        )
+        assert invalid_purpose.distance_stage_km is None
+        assert invalid_purpose.direction_candidate_count is None
+        assert invalid_purpose.distance_candidate_count is None
+
+        unavailable = get_compass_recommendations(
+            purpose="career", origin=ORIGIN, direction_context=None
+        )
+        assert unavailable.distance_stage_km is None
+        assert unavailable.direction_candidate_count is None
+        assert unavailable.distance_candidate_count is None
+
+        no_common = get_compass_recommendations(
+            purpose="career", origin=ORIGIN, direction_context=NoCommonDirectionResult()
+        )
+        assert no_common.distance_stage_km is None
+        assert no_common.direction_candidate_count is None
+        assert no_common.distance_candidate_count is None
+
+    def test_no_common_direction_never_calls_distance_stage(self) -> None:
+        with patch(
+            "temples.services.compass_recommendation_orchestrator._apply_compass_distance_stage"
+        ) as mock_stage:
+            get_compass_recommendations(
+                purpose="career",
+                origin=ORIGIN,
+                direction_context=NoCommonDirectionResult(),
+            )
+        mock_stage.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestDistanceStageMonthlyFallbackRegression:
+    """Distance Stage applies identically under calculationMethod=
+    'monthly_kyusei_v1' -- never a different 15/30/60 rule."""
+
+    FALLBACK_DIRECTION_CONTEXT = {
+        "referenceDirections": ["南東"],
+        "calculationMethod": "monthly_kyusei_v1",
+    }
+
+    def test_monthly_fallback_reaches_stage_60_same_as_common(self, shrine_factory) -> None:
+        # Southeast of origin, ~37.4km, and the only candidate in the sector
+        # -- too few for Stage 15/30's expansion threshold at any ring
+        # thickness, so it lands at Stage 60 with 1 candidate, same rule as
+        # the COMMON-direction TestDistanceStage60km cases (verified against
+        # the real _bearing()/_direction_label()/_distance_m() functions).
+        shrine_factory(name="南東の神社", latitude=34.825, longitude=135.35, goriyaku="仕事運")
+
+        result = get_compass_recommendations(
+            purpose="career",
+            origin=ORIGIN,
+            direction_context=self.FALLBACK_DIRECTION_CONTEXT,
+        )
+
+        assert result.state == STATE_RECOMMENDATION_SUCCESS
+        assert result.distance_stage_km == orchestrator.DISTANCE_STAGE_3_KM
+        assert result.direction_context == self.FALLBACK_DIRECTION_CONTEXT
+        assert result.direction_context["calculationMethod"] == "monthly_kyusei_v1"
 
 
 class TestConciergeIsolation:


### PR DESCRIPTION
## Before
距離上限なし。方角一致なら60km超・90km級もcandidate eligibilityを持ち得た（docs/audit/shrine-dataset-integrity.md Section 14で実測: 903m〜99,359mが同一のDirection Filterを通過することを確認済み）。

## After
15km → 30km → 60kmの段階的Distance Boundary。5候補を拡張thresholdとし（Recommendation成立最低件数ではない）、60kmでは1件以上で成立。60km超で表示件数を補完しない。

## Ranking
Changed: NO

## Concierge
Changed: NO

## COMMON
Regression result: PASS — 既存Direction Context・Recommendation Reason・recommendation_instance_idを壊さず、Distance Stageが正常適用されることを確認（`TestDistanceStage15/30/60km`、`TestDistanceStageBoundaries`）

## MONTHLY_FALLBACK
Regression result: PASS — `calculationMethod=monthly_kyusei_v1`でもCOMMONと同一のDistance Stage Contractが適用されることを確認（`TestDistanceStageMonthlyFallbackRegression`）。計算MethodをCOMMONへ捏造していない

## no_common_direction
Regression result: PASS — Distance Stageを呼ばないことを確認（`test_no_common_direction_never_calls_distance_stage`）。metadataはnullのまま

## Analytics
既存`compass_result`を拡張（`distance_stage_km` / `direction_candidate_count` / `distance_candidate_count`）。新eventなし。

## Privacy
新PIIなし（座標・住所・生年月日等は追加していない。既存のPIIチェックテストで確認済み）。

## DB / Migration
NONE

## Tests
- Backend focused: 98 passed（compass recommendation orchestrator / compass recommendations API / compass runtime / compass direction filter）
- Backend full `temples` suite: 1632 passed, 15 skipped（既存・環境起因、無関係）
- `makemigrations --check --dry-run`: no changes detected
- Frontend focused: 24 passed（CompassClient / CompassClient analytics）
- Frontend full suite: 151 files / 1049 tests passed
- Typecheck: clean
- Lint: clean
- Production build: succeeded

既存テストの一部fixture座標（36.0,135.0等）は、新しいDistance Boundaryの前提だと60km超の位置にあったため、同じ方角ラベルを保ったまま60km圏内へ調整した（`_bearing()`/`_direction_label()`/`_distance_m()`で個別に検証済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)