### PR TITLE
docs: Batch 18候補の地域Coverageを整理

### DIFF
--- a/docs/audit/shrine-geographic-batch18-candidate-selection.md
+++ b/docs/audit/shrine-geographic-batch18-candidate-selection.md
@@ -1,0 +1,386 @@
+> **Status: `BATCH18_CANDIDATE_SELECTION_AUDIT_COMPLETE_NO_DECISION`。**
+>
+> 本監査はread-only auditである。Shrine/Knowledge/Seed/Importer/
+> Recommendation/Coverage toolingのいずれも変更しない。新しいFact生成・
+> Candidate本番登録・Batch 18対象県の最終決定は行わない。判断材料のみを
+> Mother Shipへ返す。
+
+# Shrine Geographic Expansion — Batch 18 Candidate Selection Audit
+
+## Scope
+
+- Batch 17 Production Import（`docs/audit/knowledge-batch17-production-import.md`、
+  `BATCH17_PRODUCTION_IMPORT_EXECUTED_AND_VERIFIED`）完了後の現行Production
+  状態を正本として、都道府県Coverage空白を再計測する
+- 既存Shrine Discovery / Knowledge Pipelineを変更しない
+- Batch 18対象県は最終決定しない。Production write・Seed作成・Fact生成は
+  行わない
+
+## 作業ブランチ / worktree（Phase 0）
+
+| 項目 | 結果 |
+|---|---|
+| メインworking tree | 変更なし（`docs/shrine-geographic-expansion-rollout-plan`branch、touchしていない） |
+| 既存worktree（他8件） | 変更なし。いずれもtouchしていない |
+| `origin/develop`最新化 | `git fetch origin develop`実行、`origin/develop` SHA=`a90e0db081855ffb6d2947dd5cb2836189a6c089`を記録 |
+| PR #2554（Batch17 Closure）のdevelop反映確認 | `git show origin/develop:docs/audit/knowledge-batch17-production-import.md`で`BATCH17_PRODUCTION_IMPORT_EXECUTED_AND_VERIFIED`を直接確認済み |
+| `audit/shrine-geographic-batch18-candidate-selection`branch/worktree衝突 | なし（事前確認） |
+| worktree作成 | `git worktree add ../jinja_app-batch18-candidate-selection -b audit/shrine-geographic-batch18-candidate-selection origin/develop` |
+| worktree内working tree | clean（作成直後に確認） |
+| Compass branch/worktreeへの変更 | 0（一切touchしていない） |
+
+STOP条件（develop未同期、Batch17 Closure未反映、branch/worktree衝突、
+unrelated変更）はいずれも該当しなかった。
+
+## 正本Fresh Read（Phase 1）
+
+以下を本worktree上でfresh readした。
+
+- `docs/audit/shrine-geographic-knowledge-coverage.md`
+- `docs/audit/shrine-geographic-expansion-rollout-plan.md`
+- `docs/audit/shrine-discovery-automation-readiness.md`
+- `docs/audit/knowledge-batch17-production-import.md`
+- `docs/audit/shrine-base-batch17-production-seed-preflight.md`
+- `backend/temples/management/commands/knowledge_coverage_report.py`
+- `backend/temples/services/knowledge_coverage_report.py`（Coverage集計の
+  唯一の実装。県別集計機能は存在せず、shrine単位の集計のみ）
+
+既存内容の再設計は行っていない。
+
+## Production Baseline（Phase 2）
+
+本セッションにはProduction DB credentialが存在しない
+（`docs/audit/knowledge-batch17-production-import.md` Part 1で確定済みの
+事実、本監査でも新たに再確認していない）。したがってPhase 2はfresh
+read-only再確認を実施せず、Batch17 Closureが既に確認済みの最新値を
+正本として引き継ぐ。
+
+| 指標 | 値 |
+|---|---:|
+| Total DB Shrines | 108 |
+| Audit Target Shrines | 107 |
+| Excluded Test Shrines | 1 |
+| Knowledge Coverage | 89（83.2%） |
+| Zero Knowledge | 18（16.8%） |
+| Deity Coverage | 89（83.2%） |
+| History Coverage | 87（81.3%） |
+| Source Coverage | 89（83.2%） |
+
+## 都道府県別Coverage再計測（Phase 3）
+
+### 方法
+
+`docs/audit/shrine-geographic-knowledge-coverage.md`と同じ定義・同じ
+都道府県判定ロジック（address前方一致、Google Maps形式2件の既知例外
+処理）を再利用する。新しいprefecture parser/masterは作らない。
+
+同監査は2026-08-23（本セッション当日）付でBatch 1〜16のKnowledge Batch
+全件を反映済みのlocal DB実測であり、既存`knowledge_coverage_report`
+実測値（Batch16時点の既存Audit記録: Source109・Deity233・History182）
+と完全一致することを確認済みである。**したがって本監査は都道府県表を
+ゼロから再構築せず、同監査のTable 1（47都道府県別Coverage、Batch16
+時点）に、Batch17の確定済みdelta（北海道神宮・建部大社・波上宮の3社、
+Production実測でDeity 4/3/History3・Deity2/History4・Deity6/History6が
+すべてKnowledge有りと確定済み——`knowledge-batch17-production-import.md`
+Section 5・8・9参照）のみを機械的に適用する。**
+
+### 方法論上の重要な注記（デノミネータの不一致、推測補正しない）
+
+本Phaseの都道府県別集計は、`shrines_seed_clean.json`（Production
+Shrine Seedの正本、canonical shrineのみ、Batch17適用後103件）を分母
+とする。一方、Batch17 Closureが報告した公式aggregate値（Audit Target
+Shrines=107、Knowledge Coverage=89/83.2%）は、Production実データの
+`Shrine.objects.all()`から`exclude_qa_fixture_shrines`で除外した結果を
+分母としており、`shrine-dataset-integrity.md`が特定した3件の重複行
+（長太稲荷神社・給田六所神社・富岡八幡宮、いずれも既に「登録済み」の
+東京都の重複行）と、Coverage tooling自体の除外ロジックが捕捉しない
+1件の残存test相当行を含む（107 = 103canonical + 3重複 + 1未捕捉、
+`knowledge-batch17-production-import.md` Section 11「未解決の観測事項」
+参照）。
+
+**Knowledge有り件数（89）はいずれの分母でも一致する**（重複行・
+未捕捉test行のいずれもKnowledge Coverage判定へ新規の影響を与えない
+ため）。ただし分母が異なるため、canonical分母（103）でのCoverage率は
+86.4%（89/103）となり、公式aggregate値83.2%（89/107）とは一致しない。
+この差異は`shrine-dataset-integrity.md`が既に特定済みの既存問題に起因し、
+本監査で新たに発見したものではなく、推測で補正もしない。**都道府県の
+「空白/登録」判定そのものには影響しない**（重複行・未捕捉test行は
+新規prefectureを生まないことは`shrine-geographic-expansion-rollout-plan.md`
+Phase 1補足で既に確認済み）。
+
+### 1. 47都道府県別Coverage（Batch17適用後）
+
+変更3行のみ抜粋する（残り44都道府県は`shrine-geographic-knowledge-coverage.md`
+Table 1と無変更）。
+
+| 都道府県 | Before（Batch16時点） | After（Batch17適用後） |
+|---|---|---|
+| 北海道 | 0社・Knowledge対象外 | **1社・Knowledgeあり1・Coverage 100.0%** |
+| 滋賀県 | 0社・Knowledge対象外 | **1社・Knowledgeあり1・Coverage 100.0%** |
+| 沖縄県 | 0社・Knowledge対象外 | **1社・Knowledgeあり1・Coverage 100.0%** |
+
+### 2. Summary（Batch17適用後、canonical分母）
+
+| 項目 | Before（Batch16） | After（Batch17） |
+|---|---:|---:|
+| Shrine総数（canonical） | 100 | **103** |
+| 登録済み都道府県数 | 27 | **30** |
+| 登録0社の都道府県数 | 20 | **17** |
+| Knowledgeあり総数 | 86 | **89** |
+| Knowledgeなし総数 | 14 | 14（不変） |
+| Knowledge Coverage率（canonical分母） | 86.0% | **86.4%** |
+
+Knowledge未投入14件のリスト（`shrine-geographic-knowledge-coverage.md`
+Table 6）はBatch17によって変化していない——3新規Shrineはいずれも
+Knowledge有りとして追加されたため。
+
+## 旧20空白県とのdiff（Phase 4）
+
+| 分類 | 都道府県 | 件数 |
+|---|---|---:|
+| **RESOLVED_BY_BATCH17** | 北海道・滋賀県・沖縄県 | 3 |
+| **CURRENT_BLANK**（引き続き空白） | 青森県・岩手県・宮城県・秋田県・山形県・福島県・福井県・山梨県・岐阜県・和歌山県・鳥取県・徳島県・愛媛県・高知県・佐賀県・長崎県・鹿児島県 | 17 |
+| **NEWLY_BLANK**（新たに空白化） | なし | 0 |
+| **DRIFT**（説明不能な不一致） | なし | 0 |
+
+OLD_BLANK（20） = RESOLVED_BY_BATCH17（3） + CURRENT_BLANK（17）。
+期待値へ無理に合わせていない——Batch17の投入対象が旧20空白県のうち
+まさにこの3県だったため、算術上ちょうど一致した（偶然の一致ではなく
+Batch17自体が北海道・滋賀県・沖縄県を対象としていたことの直接的帰結）。
+NEWLY_BLANK・DRIFTはいずれも0件——Batch16からBatch17までの間に他の
+都道府県Shrine数・Knowledge状態が変化した形跡はない（`knowledge-batch17-production-import.md`
+Section 4のBefore値がBatch16実行後値と完全一致することで裏付け済み）。
+
+## 残り空白県の8地方分類（Phase 5）
+
+| Region | 空白県数（Before→After） | Knowledge県数（登録済み県数） | 完全空白地方 |
+|---|---|---:|---|
+| 北海道 | 1→**0** | 1/1 | いいえ（Batch17で解消） |
+| 東北 | 6→6（不変） | 0/6 | **はい（8地方中唯一）** |
+| 関東 | 0→0（不変） | 7/7 | いいえ |
+| 中部 | 3→3（不変） | 6/9 | いいえ |
+| 近畿 | 2→**1**（滋賀県解消） | 6/7 | いいえ |
+| 中国 | 1→1（不変） | 4/5 | いいえ |
+| 四国 | 3→3（不変） | 1/4 | いいえ |
+| 九州・沖縄 | 4→**3**（沖縄県解消） | 5/8 | いいえ |
+| **合計** | 20→**17** | 30/47 | 1地方 |
+
+**東北地方が8地方中唯一「地方まるごと空白」のまま残る。** 北海道地方は
+Batch17により完全登録済みへ移行した。残り空白県一覧（17県）:
+
+- 東北（6）: 青森県, 岩手県, 宮城県, 秋田県, 山形県, 福島県
+- 中部（3）: 福井県, 山梨県, 岐阜県
+- 近畿（1）: 和歌山県
+- 中国（1）: 鳥取県
+- 四国（3）: 徳島県, 愛媛県, 高知県
+- 九州・沖縄（3）: 佐賀県, 長崎県, 鹿児島県
+
+**地域完成まで残り1県のみの地方**: 近畿（和歌山県のみ残存、6/7登録済み）・
+中国（鳥取県のみ残存、4/5登録済み）。この2県は、それぞれ1県のみの
+追加で地方を完全登録済みにできる。
+
+## Existing Discovery Candidate再利用（Phase 6）
+
+`shrine-discovery-automation-readiness.md`・
+`shrine-geographic-expansion-rollout-plan.md`を正本として確認した
+（新規Web調査は本Phaseでは行っていない）。
+
+### 既存の具体的Candidate（shrine名・address・URL）が存在する県
+
+**0県。** 過去のDiscovery Pilot（`shrine-discovery-automation-readiness.md`）
+が扱った9 Candidate（北海道3・滋賀県3・沖縄県3）はすべて、今回
+RESOLVED_BY_BATCH17となった3県に属しており、残り17の空白県には
+Discovery Pilotで具体的に特定されたshrine名・address・URLを持つ
+Candidateが1件も存在しない。
+
+### 「次点候補県」として言及済みだが未Discovery（3県）
+
+`shrine-geographic-expansion-rollout-plan.md` Phase 14「代替候補」が
+以下3県を地方多様化の観点から言及しているが、具体的なshrine
+candidate・address・URLはいずれも未特定（Discovery自体が未実施）。
+
+| 県 | Region | 過去言及の理由 | Candidate shrine | address | Official Source URL | duplicate check | Source availability | 過去Pilot有無 |
+|---|---|---|---|---|---|---|---|---|
+| 宮城県 | 東北 | 東北地方6県すべてが空白という「地方まるごと空白」を最初に解消する候補として言及 | **未特定** | **未特定** | **未確認** | **未実施** | **未検証** | なし |
+| 岐阜県 | 中部 | 中部地方の残り3空白県中、唯一「候補県」として言及 | **未特定** | **未特定** | **未確認** | **未実施** | **未検証** | なし |
+| 鳥取県 | 中国 | 中国地方で唯一の空白県、解消すれば地方完全登録 | **未特定** | **未特定** | **未確認** | **未実施** | **未検証** | なし |
+
+### それ以外の14県
+
+既存Audit・Discovery文書のいずれにも言及がなく、Candidate選定の起点が
+存在しない（青森県・岩手県・秋田県・山形県・福島県・福井県・山梨県・
+和歌山県・徳島県・愛媛県・高知県・佐賀県・長崎県・鹿児島県）。
+
+**不足情報をAIで推測補完していない。** 上記いずれの県についても、
+新しいshrine名・address・URLをこのPhaseで新規作成・推測していない。
+
+## Candidate Readiness Matrix（Phase 7）
+
+17空白県すべてを評価する。既存Candidateが存在しないため、大半の県で
+`Shrine Base Readiness`・`Coordinate Evidence`・`Identity Risk`・
+`Knowledge Complexity`は「未着手」段階の値となる（推測で埋めていない）。
+
+| Prefecture | Region | Production Shrine count | Knowledge Shrine count | Existing Candidate | Official Source | Shrine Base Readiness | Coordinate Evidence | Identity Risk | Knowledge Complexity | Existing Research Reuse | Regional Coverage Benefit | STOP/HOLD |
+|---|---|---:|---:|---|---|---|---|---|---|---|---|---|
+| 宮城県 | 東北 | 0 | 0 | なし（県のみ言及） | 未確認 | Low（Discovery未着手） | unconfirmed | 未評価（Candidate未特定のため判定不能） | 未評価 | Medium（rollout planに選定理由の記述あり） | High（東北の完全空白を最初に破る） | Discovery未実施 |
+| 岐阜県 | 中部 | 0 | 0 | なし（県のみ言及） | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Medium（同上） | Medium（中部は3県中の1、単独では地方完成に届かない） | Discovery未実施 |
+| 鳥取県 | 中国 | 0 | 0 | なし（県のみ言及） | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Medium（同上） | **High（中国地方を単独で完全登録化できる）** | Discovery未実施 |
+| 和歌山県 | 近畿 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low（既存Audit記述なし） | **High（近畿地方を単独で完全登録化できる）** | Discovery未実施 |
+| 青森県 | 東北 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium（東北6県のうちの1） | Discovery未実施 |
+| 岩手県 | 東北 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 秋田県 | 東北 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 山形県 | 東北 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 福島県 | 東北 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 福井県 | 中部 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 山梨県 | 中部 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 徳島県 | 四国 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium（四国は1/4のみ登録、伸び代大） | Discovery未実施 |
+| 愛媛県 | 四国 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 高知県 | 四国 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 佐賀県 | 九州・沖縄 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium（九州沖縄は5/8登録済み、残り3） | Discovery未実施 |
+| 長崎県 | 九州・沖縄 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+| 鹿児島県 | 九州・沖縄 | 0 | 0 | なし | 未確認 | Low | unconfirmed | 未評価 | 未評価 | Low | Medium | Discovery未実施 |
+
+**理由の要約**: Shrine Base Readiness/Coordinate Evidence/Identity
+Risk/Knowledge Complexityは、Batch17までの3県（北海道・滋賀県・沖縄県）
+とは異なり、いずれもDiscovery Pilot自体が未実施のため「未着手/未評価」
+に留まる（Batch17の3県はDiscovery Pilot完了→Fact Pilot完了という
+2段階の既存資産があったが、残り17県にはその資産が一切ない）。
+Regional Coverage Benefitは地方構成から機械的に導出した（Low/Medium/High
+の理由は各行の地方内残存空白県数比較に基づく。鳥取県・和歌山県は
+「1県で地方完全登録化」という明確な定量的根拠を持つためHigh、他は
+Medium/Lowとした）。Identity Risk・Knowledge Complexityは、Candidate
+shrine自体が特定されていないため評価不能であり、推測でLow/Medium/High
+を割り当てていない。
+
+## Batch Size契約確認（Phase 8）
+
+`docs/audit/shrine-geographic-expansion-rollout-plan.md`をfresh確認した
+結果、以下はいずれも**未確定**のまま据え置かれている（Codex側で新たに
+確定させていない）。
+
+| 項目 | 状態 | 根拠 |
+|---|---|---|
+| 1 Batchあたりの県数 | **未確定**（参考所見: 3県/Batch） | rollout plan Phase 6「推奨候補、最終決定ではない」 |
+| 1県あたりShrine数 | **未確定**（参考所見: 段階的アプローチ、まず1社/県） | rollout plan Phase 7「参考所見、最終決定ではない」 |
+| Candidate選定基準 | 6条件が整理済み（確定に近い記述だが、正式契約化はされていない） | rollout plan Phase 8 |
+| Source取得担当 | ChatGPT=Source取得・Codex=Pipeline操作という役割分担が3 Pilotの実績として整理済み | rollout plan Phase 9 |
+| Human Review地点 | **未確定**（参考所見: Fact Candidate生成後） | rollout plan Phase 10「参考所見、最終決定ではない」 |
+| Seed→validate-only→dry-run→Evidence Gateの順序 | 確定済み・3 Pilot+Batch17で実績あり、drift 0 | rollout plan Phase 11、Batch17 Closure |
+| Production Import順序（Shrine base→Knowledge） | 確定済み・Batch17で実績あり | `shrine-base-batch17-production-seed-preflight.md`「次工程」節 |
+
+**Batch数・県数・Human Review地点の3項目は、Batch17実行後も依然として
+未確定のまま。** 本監査ではこれらを勝手に確定させていない。Mother Ship
+へ未確定のまま返す。
+
+## Batch 18候補（Phase 9、最終決定ではない）
+
+Mother Ship用の判断材料として、最大3案を提示する。**Codex自身は
+「Batch18はこれ」と決定しない。**
+
+### Option A: Lowest Incremental Work（既存文書内での言及を最大限再利用）
+
+| 項目 | 内容 |
+|---|---|
+| 対象県 | 宮城県・岐阜県・鳥取県 |
+| Candidate shrine | 未特定（3県ともDiscovery未実施） |
+| 選択理由 | `shrine-geographic-expansion-rollout-plan.md`が既にこの3県を「代替候補」として選定理由付きで言及している——他14県には言及自体が存在しない。ゼロから県選定理由を検討する手間が最小 |
+| 既存資産再利用 | 県選定の理由付けのみ再利用可能。Discovery（Candidate shrine特定）自体はBatch17の3県と異なりゼロから必要 |
+| Source risk | 未検証（過去Pilotなし、公式Source availabilityは北海道/滋賀/沖縄と同水準か不明） |
+| Data risk | 低（Shrine Base Seed追加・Knowledge Seed追加とも既存Pipeline REUSE_AS_IS、drift 0の実績がBatch17まで一貫） |
+| 予想追加作業 | Discovery Pilot（Candidate特定・duplicate check・Source URL確認）を3県分ゼロから実施する必要——Batch17の「Human Reviewのみで最短距離」だった状況とは異なる |
+| STOP条件 | 3県いずれかで公式Source（`shrine_official`）が確認できない場合、既存6条件のCandidate選定基準（rollout plan Phase 8）を満たすまでDiscoveryをやり直す |
+
+### Option B: Regional Balance（地方多様化・弱い地方を優先）
+
+| 項目 | 内容 |
+|---|---|
+| 対象県 | 宮城県（東北）・徳島県（四国）・佐賀県（九州・沖縄） |
+| Candidate shrine | 未特定（3県ともDiscovery未実施） |
+| 選択理由 | 8地方のうち登録率が最も低い3地方（東北0/6・四国1/4・九州沖縄5/8）から1県ずつ選定。東北の完全空白を破ることを最優先とし、次点で登録率の低い四国・九州沖縄を補強する |
+| 既存資産再利用 | 宮城県のみrollout planの言及あり。徳島県・佐賀県は言及なし——Option Aより既存文書再利用が少ない |
+| Source risk | 未検証（3県とも過去Pilotなし） |
+| Data risk | 低（Option Aと同様の理由） |
+| 予想追加作業 | Option Aと同様、Discovery Pilotを3県分ゼロから実施。地方の分散度が高い分、Source Research担当（ChatGPT）が扱う地域文脈の幅がOption Aより広い |
+| STOP条件 | Option Aと同様。加えて、東北地方特有のSource availability（地域神社庁体制の違い等）が北海道/滋賀/沖縄のPilotと異なる可能性があり、Easy/Medium/Difficult区分の再検証が必要になる可能性がある |
+
+### Option C: Coverage Impact（地方完全登録化を最優先）
+
+| 項目 | 内容 |
+|---|---|
+| 対象県 | 鳥取県（中国）・和歌山県（近畿）・宮城県（東北） |
+| Candidate shrine | 未特定（3県ともDiscovery未実施） |
+| 選択理由 | 鳥取県・和歌山県は「1県の追加で地方を完全登録済みにできる」という定量的根拠を持つ最も効率の良い2県（Phase 7 Regional Coverage Benefit=High）。これに、8地方中唯一の完全空白地方である東北を破る宮城県を加え、3件の地方単位マイルストーン（中国完全登録・近畿完全登録・東北空白解消）を同時に達成する |
+| 既存資産再利用 | 宮城県のみrollout planの言及あり。鳥取県は「代替候補」として言及済み（岐阜県の代わりに採用）。和歌山県は言及なし |
+| Source risk | 未検証（3県とも過去Pilotなし） |
+| Data risk | 低（Option A/Bと同様の理由） |
+| 予想追加作業 | Option A/Bと同様、Discovery Pilotを3県分ゼロから実施 |
+| STOP条件 | Option A/Bと同様。加えて、「地方完全登録化」という目標自体の優先順位づけをMother Shipが承認していない場合、この選定基準自体の妥当性から再検討が必要 |
+
+**3案とも共通する事実**: いずれの案も、Batch17までの3県（北海道・
+滋賀県・沖縄県）が持っていた「Discovery Pilot完了→Fact Pilot完了→
+Human Reviewのみで完走可能」という既存資産を持たない。残り17県は
+すべて振り出し（Discovery未着手）に戻る。
+
+## STOP / HOLD
+
+**STOP/HOLDは0件。** 本監査は判断材料の整理のみを目的としており、
+Candidate情報の不足自体（17県すべてでDiscovery未実施）はSTOP条件では
+なく、Phase 6・7・9で事実として記録した参考情報である。
+
+参考記録（新規STOP事項ではない）:
+
+- `shrine-dataset-integrity.md`が指摘した3組の重複Shrine行は、本監査
+  Phase 3の「方法論上の重要な注記」で触れたとおり、都道府県別集計には
+  影響しないが未解消のまま残る
+- Batch Size・1県あたりShrine数・Human Review地点は、Batch17実行後も
+  未確定のまま（Phase 8）
+
+## Mother Ship Decision Inputs
+
+以下を事実として返す。**Batch 18対象県は決定しない。**
+
+- **現在の空白県数**: 17（47都道府県中30登録済み、canonical分母）
+- **Batch17で解消した3県**: 北海道・滋賀県・沖縄県
+- **東北地方が8地方中唯一の完全空白地方**として残存
+- **地方完全登録化まで1県のみの地方**: 近畿（和歌山県のみ）・中国（鳥取県のみ）
+- **既存文書内で「次点候補」として言及済みの3県**: 宮城県・岐阜県・鳥取県
+  （いずれもDiscovery未実施、具体的candidate shrine名は0件）
+- **それ以外14県**: 既存Audit記述が皆無、Candidate選定の起点なし
+- **Batch Size・1県あたりShrine数・Human Review地点**: 引き続き未確定
+- **Option A（Lowest Incremental Work）**: 宮城県・岐阜県・鳥取県
+- **Option B（Regional Balance）**: 宮城県・徳島県・佐賀県
+- **Option C（Coverage Impact）**: 鳥取県・和歌山県・宮城県
+- **3案共通の制約**: Discovery Pilotから完全にやり直す必要があり、
+  Batch17までのような「Human Reviewのみで完走可能」な近道は存在しない
+
+## Repository Change
+
+`docs/audit/shrine-geographic-batch18-candidate-selection.md`（本文書、
+新規）1件のみ。
+
+- Production write = 0
+- Shrine Seed変更 = 0
+- Knowledge Seed変更 = 0
+- Model / Migration変更 = 0
+- 新規Coverage集計コード = 0
+- 新規都道府県マスタ = 0
+- Recommendation変更 = 0
+- Ranking変更 = 0
+- 新しいFact生成 = 0
+- Candidate不足情報のAI推測補完 = 0
+- Batch 18対象の最終決定 = 0
+
+## Validation（Phase 11）
+
+```
+$ git status --short
+?? docs/audit/shrine-geographic-batch18-candidate-selection.md
+$ git diff --check
+（無出力 = 問題なし）
+$ git diff --stat
+（新規ファイルのためstatには表示されない。git status --shortで新規1件のみを確認）
+```
+
+変更は新規Audit文書1件のみ。Model・Migration・Coverage tooling・Seed・
+Recommendation・Ranking・unrelated変更はいずれも0件。main working tree・
+他worktree（Compass含む）はいずれも未変更。


### PR DESCRIPTION
## Summary

Batch 17 Production Import完了後（`docs/audit/knowledge-batch17-production-import.md`、`BATCH17_PRODUCTION_IMPORT_EXECUTED_AND_VERIFIED`）の現行Production状態を正本として、都道府県Knowledge空白を再計測し、Batch 18候補を比較可能な状態まで整理した。**本PRではBatch 18対象県を最終決定しない。Production write・Seed作成・Fact生成は一切行っていない。**

## Key Results

- **旧20空白県 → Batch17で3県（北海道・滋賀県・沖縄県）解消 → 現在17県が空白のまま**。NEWLY_BLANK・DRIFTはいずれも0件
- **東北地方が8地方中唯一の「完全空白地方」として残存**（0/6登録）。北海道地方はBatch17で完全登録済みへ移行
- **地方完全登録化まで残り1県の地方**: 近畿（和歌山県のみ）・中国（鳥取県のみ）
- **既存Discovery Pilotで特定済みのcandidate shrineは残り17県に0件**。宮城県・岐阜県・鳥取県の3県のみ既存文書内で「次点候補」として言及されているが、shrine名・address・URLはいずれも未特定（Discovery自体が未実施）。他14県は既存文書内に言及自体がない
- **不足情報をAI推測で補完していない**（新規Web調査も本PRでは実施していない）
- **Batch Size・1県あたりShrine数・Human Review地点は引き続き未確定**のまま母艦へ返す（`shrine-geographic-expansion-rollout-plan.md`の「最終決定ではない」という位置づけをBatch17実行後も変更していない）

## 都道府県別Coverage再計測の方法

既存`shrine-geographic-knowledge-coverage.md`（Batch16時点、100/27/20、既存Coverage toolingと完全一致確認済み）に、Batch17の確定済みdelta（北海道神宮・建部大社・波上宮の3社追加）のみを機械的に適用した。新しいCoverage集計コード・都道府県マスタは作成していない。canonical Shrine Seed分母（103件）とProduction公式aggregate分母（107件、既知の重複行3件+未捕捉test行1件を含む）の差異は、`shrine-dataset-integrity.md`が既に特定済みの既存問題として透明に記録し、推測補正はしていない（都道府県の空白/登録判定自体には影響しない）。

## Batch 18候補（Mother Ship判断材料、最大3案）

- **Option A（Lowest Incremental Work）**: 宮城県・岐阜県・鳥取県（既存文書内の言及を最大限再利用）
- **Option B（Regional Balance）**: 宮城県・徳島県・佐賀県（登録率最低の3地方から1県ずつ）
- **Option C（Coverage Impact）**: 鳥取県・和歌山県・宮城県（地方完全登録化を最優先）

3案共通の制約: いずれもDiscovery Pilotから完全にやり直す必要があり、Batch17までのような「Human Reviewのみで完走可能」な近道は存在しない。

## Repository Change

`docs/audit/shrine-geographic-batch18-candidate-selection.md`のみ新規追加。**Production write 0。Shrine Seed変更 0。Knowledge Seed変更 0。新規Coverage集計コード 0。新規都道府県マスタ 0。Recommendation/Ranking変更 0。**

詳細はdoc本文（Phase 0〜9、Mother Ship Decision Inputs）を参照。

https://claude.ai/code/session_01TPJSWe9oXFqrznuJetEf6o

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPJSWe9oXFqrznuJetEf6o)_